### PR TITLE
Customize tox install command

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,8 @@ deps =
 commands =
     coverage run --source warehouse -m pytest tests []
     coverage report -m --fail-under 100
+install_command =
+    pip install --use-wheel --no-allow-external {opts} {packages}
 
 [testenv:pep8]
 deps = flake8


### PR DESCRIPTION
- Do not allow pre-releases of dependencies
- Do not allow externally hosted files
- Allow the use of Wheels
