### PR TITLE
Ensure that a maintainer account only shows up once in the list

### DIFF
--- a/tests/packaging/test_models.py
+++ b/tests/packaging/test_models.py
@@ -308,13 +308,18 @@ def test_get_users_for_project(dbapp):
     ))
     dbapp.engine.execute(roles.insert().values(
         package_name="test-project",
+        user_name="test-user",
+        role_name="Maintainer",
+    ))
+    dbapp.engine.execute(roles.insert().values(
+        package_name="test-project",
         user_name="a-test-user",
         role_name="Maintainer",
     ))
 
     assert dbapp.models.packaging.get_users_for_project("test-project") == [
-        {"username": "test-user", "email": None},
         {"username": "a-test-user", "email": None},
+        {"username": "test-user", "email": None},
         {"username": "test-user2", "email": "test@example.com"},
     ]
 

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -133,6 +133,7 @@ class Model(models.Model):
         query = (
             select(
                 [users.c.username, emails.c.email],
+                distinct=users.c.username,
                 from_obj=users.outerjoin(
                     emails, emails.c.user_id == users.c.id,
                 ),
@@ -141,10 +142,7 @@ class Model(models.Model):
                 users.c.username == roles.c.user_name,
                 roles.c.package_name == project,
             ))
-            .order_by(
-                roles.c.role_name.desc(),
-                func.lower(roles.c.user_name),
-            )
+            .order_by(users.c.username)
         )
 
         with self.engine.connect() as conn:


### PR DESCRIPTION
- Changes ordering from (role_type, username) to just username
- Ensures that usernames are distinct

Fixes #134 
