### PR TITLE
Use lists instead of "a b c".split()

### DIFF
--- a/tests/legacy/test_xmlrpc.py
+++ b/tests/legacy/test_xmlrpc.py
@@ -30,7 +30,7 @@ def test_xmlrpc_handler(monkeypatch):
     monkeypatch.setattr(xmlrpc, "Response", Response)
 
     interface = pretend.stub(
-        list_packages=pretend.call_recorder(lambda *a, **k: 'one two'.split())
+        list_packages=pretend.call_recorder(lambda *a, **k: ['one', 'two'])
     )
     Interface = lambda a, r: interface
     monkeypatch.setattr(xmlrpc, "Interface", Interface)

--- a/warehouse/legacy/xmlrpc.py
+++ b/warehouse/legacy/xmlrpc.py
@@ -82,7 +82,7 @@ class Interface(object):
     def changelog(self, since, with_ids=False):
         since = arrow.get(since).datetime
         result = self.app.models.packaging.get_changelog(since)
-        keys = 'name version submitted_date action'.split()
+        keys = ['name', 'version', 'submitted_date', 'action']
         if with_ids:
             keys.append('id')
         mapped = []
@@ -96,7 +96,7 @@ class Interface(object):
 
     def changelog_since_serial(self, since):
         result = self.app.models.packaging.get_changelog_serial(since)
-        keys = 'name version submitted_date action id'.split()
+        keys = ['name', 'version', 'submitted_date', 'action', 'id']
         mapped = []
         for row in result:
             row['submitted_date'] = arrow.get(row['submitted_date']).timestamp


### PR DESCRIPTION
This is a pet peeve of mine.
