### PR TITLE
Remove the Continous Deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ addons:
 env:
     global:
         - WAREHOUSE_DATABASE_URL=postgresql://postgres@localhost/warehouse
-        - secure: "gf4gNhmaicVY8/6OTZZcc8TCtIpZO58M0N+vAdT/KmsMBOxZY6PakuMQV8DmDfWskSImQQXdaLGE+Um5KanXsPvE4MyaZ7VpRTd7xJ646uoNdFcmMPKasdR8xz+k5ioTbZ4i2iSxgXhMixaEt1aiT7JsaKHhAmOSVltAp4IW8Bg="
     matrix:
         - TOXENV=py27
         - TOXENV=pypy
@@ -24,9 +23,6 @@ before_script:
 
 script:
     - tox
-
-after_success:
-    - "if [[ $TRAVIS_BRANCH == 'master' ]] && [[ $TOXENV == 'pypy' ]]; then curl $WAREHOUSE_DEPLOY_URL > /dev/null 2>&1; fi"
 
 branches:
     only:


### PR DESCRIPTION
The existing infrastructure has changed, the Continous Deployment is no longer going to a real production box. This removes this for now until we get a better feel for what a deployment looks like.
