### PR TITLE
Reworking database fixtures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,16 +5,23 @@ addons:
   postgresql: 9.3
 
 env:
-  - TOXENV=py34
-  - TOXENV=pep8
-  - TOXENV=docs
-  - TOXENV=packaging
+  global:
+    - WAREHOUSE_DATABASE_URL=postgresql://postgres@localhost/warehouse
+  matrix:
+    - TOXENV=py34
+    - TOXENV=pep8
+    - TOXENV=docs
+    - TOXENV=packaging
 
 before_install:
   - sudo apt-get update
   - sudo apt-get install python3.4 python3.4-dev
 
 install: pip install tox
+
+before_script:
+  - psql --version
+  - psql -c "CREATE DATABASE warehouse ENCODING 'UTF8';" -U postgres
 
 script: tox
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -149,7 +149,20 @@ database, you can run:
 
 .. code-block:: console
 
-  $ tox -e py34 -- -k "not db"
+    $ tox -e py34 -- -k "not db"
+
+By default the database driven tests will attempt to create an isolated
+PostgreSQL instance using ``initdb`` and ``postgres`` which it will tear down
+at the end of the test run. If you wish to specify an already running
+PostgreSQL instead of this, you can simply do:
+
+.. code-block:: console
+
+    $ # via command line
+    $ tox -e py34 -- --database-url postgresql:///test_warehouse
+    $ $ via environment variable
+    $ WAREHOUSE_DATABASE_URL='postgresql:///test_warehouse' tox -e py34
+
 
 Building Documentation
 ----------------------


### PR DESCRIPTION
Reworkings our database fixtures so that:
- Self contained, a brand new database is spun up and tore down at the end
- Fixes transactions so that each test is actually ran inside it's own transaction
- Greatly simplifies our database related fixtures
- Marks all tests that require the database with the `db` mark, making it easy to exclude them.

You can run all of the tests except for those that need the DB by doing:

``` console
$ tox -e py34 -- -k "not db"
```
