### PR TITLE
Updated tests/conftest.py: add fixed IPv4 127.0.0.1 and specify /tmp as ...

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -85,7 +85,8 @@ def postgresql(request):
     )
 
     proc = subprocess.Popen(
-        ["postgres", "-D", tmpdir, "-p", str(port), "-h", "127.0.0.1", "-k", tmpdir],
+        ["postgres", "-D", tmpdir, "-p", str(port),
+         "-h", "127.0.0.1", "-k", tmpdir],
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
     )


### PR DESCRIPTION
...socket directory (for Ubuntu 12.04 LTS default config)

Was getting:

```
RuntimeError: Could not start a PostgreSQL instance
```

So I un-caught the `psycopg2.OperationalError` and then:

```
psycopg2.OperationalError: could not connect to server: Connection refused
```

So I printed the second `cmd` and ran it manually:

``` bash
$ postgres -D /tmp/tmpi12312 -p 40109
LOG:  could not bind IPv6 socket: Cannot assign requested address
HINT:  Is another postmaster already running on port 40109? If not, wait a few seconds and retry.
FATAL:  could not create lock file "/var/run/postgresql/.s.PGSQL.40109.lock": Permission denied
```

I'd rather not grant access to `/var/run/postgresql` for tests, and this isn't in a container, so I fixed to `-h 127.0.0.1` (IPv4) and specified the `-D datadir` as the `-k socketdir`; which should be fine for tests when  `var_run_t` isn't necessary.
