### PR TITLE
Warehouse needs Python 3 and it is not mentioned on the Contributing page

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -45,7 +45,7 @@ format (``%s``).
 Development Environment
 -----------------------
 
-Warehouse development requires the installation of several external non-Python
+Warehouse development requires Python3.4 and the installation of several external non-Python
 dependencies. These are:
 
 * `PostgreSQL`_ 9.2+


### PR DESCRIPTION
warehouse code uses Python3 (for example, using urllib.parse), and the only environment set in tox is Python3.4
so it makes sense to put this as a requirement in the 'contributing' doc
