### PR TITLE
Allow whitelisting the CDN for trusting the X-Forwarded-* headers

### DIFF
--- a/dev/config.yml
+++ b/dev/config.yml
@@ -4,6 +4,7 @@ site:
     name: Warehouse (dev)
     hosts:
         - "localhost:9000"
+    access_token: development
 
 database:
     url: "postgresql://localhost/warehouse"

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -41,6 +41,23 @@ site.hosts
 :Description:
     A list of strings that Warehouse will trust in the Host header.
 
+site.access_token
+~~~~~~~~~~~~~~~~~
+
+:Type: String
+:Required: Yes
+:Description:
+    A string that must be sent as part of the request in order for Warehouse
+    to trust the ``X-Forwarded-*`` headers sent in the request. This is
+    designed to allow the Fastly CDN to "authenticate" it's ``X-Forwarded-*``
+    headers.
+
+    This setting requires that any trusted front end sets a header named
+    ``X-Warehouse-Access-Token`` with the value set to whatever the
+    ``site.access_token`` value is. If the header is unset, or the token does
+    not match, then Warehouse will strip any ``X-Forwarded-*`` headers from
+    the request before processing.
+
 site.url
 ~~~~~~~~
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -231,7 +231,10 @@ def dbapp(database, engine):
 
     return Warehouse.from_yaml(
         override={
-            "site": {"hosts": "localhost"},
+            "site": {
+                "access_token": "testing",
+                "hosts": "localhost",
+            },
             "database": {"url": database},
             "redis": {
                 "downloads": "redis://nonexistant/0",
@@ -257,7 +260,10 @@ def app():
 
     return Warehouse.from_yaml(
         override={
-            "site": {"hosts": "localhost"},
+            "site": {
+                "access_token": "testing",
+                "hosts": "localhost",
+            },
             "database": {"url": "postgresql:///nonexistant"},
             "redis": {
                 "downloads": "redis://nonexistant/0",

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -32,6 +32,9 @@ from warehouse.application import Warehouse
 def test_basic_instantiation():
     Warehouse({
         "debug": False,
+        "site": {
+            "access_token": "testing",
+        },
         "database": {
             "url": "postgres:///test_warehouse",
         },

--- a/tests/test_config.yml
+++ b/tests/test_config.yml
@@ -1,3 +1,6 @@
+site:
+    access_token: testing
+
 assets:
     directory: "static"
 

--- a/tests/test_middlewares.py
+++ b/tests/test_middlewares.py
@@ -1,0 +1,58 @@
+# Copyright 2014 Donald Stufft
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pretend
+
+from warehouse.middlewares import XForwardedTokenMiddleware
+
+
+def test_xforwardedtokenmiddleware_valid():
+    response = pretend.stub()
+    start_response = pretend.stub()
+    app = pretend.call_recorder(lambda environ, start_response: response)
+
+    middleware = XForwardedTokenMiddleware(app, "1234")
+    resp = middleware(
+        {
+            "HTTP_X_WAREHOUSE_ACCESS_TOKEN": "1234",
+            "HTTP_X_FORWARDED_FOR": "192.168.1.1",
+        },
+        start_response,
+    )
+
+    assert resp is response
+    assert app.calls == [
+        pretend.call(
+            {"HTTP_X_FORWARDED_FOR": "192.168.1.1"},
+            start_response,
+        ),
+    ]
+
+
+def test_xforwardedtokenmiddleware_invalid():
+    response = pretend.stub()
+    start_response = pretend.stub()
+    app = pretend.call_recorder(lambda environ, start_response: response)
+
+    middleware = XForwardedTokenMiddleware(app, "1234")
+    resp = middleware(
+        {
+            "HTTP_X_WAREHOUSE_ACCESS_TOKEN": "invalid",
+            "HTTP_X_FORWARDED_FOR": "192.168.1.1",
+        },
+        start_response,
+    )
+
+    assert resp is response
+    assert app.calls == [pretend.call({}, start_response)]

--- a/warehouse/middlewares.py
+++ b/warehouse/middlewares.py
@@ -1,0 +1,33 @@
+# Copyright 2014 Donald Stufft
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import hmac
+
+
+class XForwardedTokenMiddleware:
+
+    header = "HTTP_X_WAREHOUSE_ACCESS_TOKEN"
+
+    def __init__(self, app, token):
+        self.app = app
+        self.token = token
+
+    def __call__(self, environ, start_response):
+        # Filter out X-Forwarded-* headers from the request if the secret token
+        # does not exist or does not match.
+        if not hmac.compare_digest(environ.pop(self.header, ""), self.token):
+            for key in set(environ.keys()):
+                if key.startswith("HTTP_X_FORWARDED_"):
+                    del environ[key]
+
+        return self.app(environ, start_response)


### PR DESCRIPTION
This fixes #256

This will require config changes @ewdurbin.
