### PR TITLE
Use Wheels to make the tests run much much faster

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ commands =
     coverage run --source warehouse -m pytest --strict []
     coverage report -m --fail-under 100
 install_command =
-    pip install --use-wheel --no-allow-external {opts} {packages}
+    pip install --find-links https://wheels.caremad.io/ --use-wheel --no-allow-external {opts} {packages}
 
 [testenv:docs]
 deps =


### PR DESCRIPTION
Speed up installation into the testing virtual environment by creating Wheels for pure python distributions that don't already have Wheels on PyPI. Anything that requires a C compiler will still get compiled, so all these wheels are still cross platform.
#### Before:

``` console
$ time tox
tox  575.18s user 28.32s system 94% cpu 10:35.57 total
```
#### After:

``` console
$ time tox
tox  111.03s user 15.49s system 82% cpu 2:32.49 total
```
