### PR TITLE
Add project links to project's dependencies

### DIFF
--- a/tests/packaging/test_views.py
+++ b/tests/packaging/test_views.py
@@ -224,6 +224,7 @@ def test_project_detail_invalid_version():
 def test_project_detail_valid(version, description, camo):
     release = {
         "description": description,
+        "requires_dist": ["foo", "xyz > 0.1"]
     }
 
     template = pretend.stub(
@@ -269,7 +270,10 @@ def test_project_detail_valid(version, description, camo):
             get_template=pretend.call_recorder(lambda t: template),
         ),
     )
-    request = pretend.stub()
+    request = pretend.stub(
+        url_adapter=pretend.stub(build=lambda *a,
+                                 **kw: "/projects/test-project/")
+    )
 
     project_name = "test-project"
     normalized = "test-project"

--- a/warehouse/packaging/views.py
+++ b/warehouse/packaging/views.py
@@ -92,11 +92,24 @@ def project_detail(app, request, project_name, version=None):
     # Mark our description_html as safe as it's already been cleaned by bleach
     description_html = jinja2.Markup(description_html)
 
+    # Split the requirement string to (project name, the rest)
+    requirements = []
+    for req in release.get('requires_dist', []):
+        project_name, *other = req.split(' ', 1)
+        url = url_for(request, 'warehouse.packaging.views.project_detail',
+                      project_name=project_name)
+        requirements.append({
+            'project_name': project_name,
+            'project_url': url,
+            'other': other[0] if other else ''
+        })
+
     return render_response(
         app, request, "projects/detail.html",
         project=project,
         release=release,
         releases=releases,
+        requirements=requirements,
         description_html=description_html,
         download_counts=app.db.packaging.get_download_counts(project),
         downloads=app.db.packaging.get_downloads(project, version),

--- a/warehouse/templates/projects/detail.html
+++ b/warehouse/templates/projects/detail.html
@@ -179,12 +179,15 @@
             <dd>{{ release.platform|replace("\n", ", ") }}</dd>
           {% endif %}
 
-          {% if release.requires_dist %}
+          {% if requirements %}
             <dt>{{ gettext('Requires Distribution') }}</dt>
             <dd>
               <ul class="list-unstyled">
-                {% for requires in release.requires_dist %}
-                  <li>{{ requires }}</li>
+                {% for requirement in requirements %}
+                  <li>
+                      <a href="{{ requirement.project_url }}">{{ requirement.project_name }}</a>
+                      {{ requirement.other }}
+                  </li>
                 {% endfor %}
               </ul>
             </dd>


### PR DESCRIPTION
This linkifies the requires-dist listing on the project details page so that each requirement points to the appropriate PyPI project. No checking is done to ensure that the projects actually exist though, nor does it check for proper casing but Warehouse redirects automatically anyway if the case is wrong.
Fixes #122.
