### PR TITLE
Adds plugin to flake8 to make sure flask.session is not abused. 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -94,6 +94,9 @@ setup(
         "console_scripts": [
             "warehouse = warehouse.__main__:main",
         ],
+        "flake8.extension": [
+            "E4 = warehouse.styleguide:FlaskSessionCheck",
+        ],
     },
 
     zip_safe=False,

--- a/tests/test_styleguide.py
+++ b/tests/test_styleguide.py
@@ -1,0 +1,32 @@
+from warehouse.styleguide import FlaskSessionCheck
+
+import pep8
+
+# These are sadly globals -- there is no unregister_check.
+pep8.register_check(FlaskSessionCheck)
+
+
+def test_flask_absolute_session_import_fails():
+    TEST_IMPORT = "import flask.session\n\n"
+    checker = pep8.Checker(lines=TEST_IMPORT, quiet=True)
+    checker.check_all()
+    assert checker.report.get_count(FlaskSessionCheck.CODE) == 1
+
+
+def test_flask_relative_session_import_fails():
+    TEST_IMPORT_FROM = [
+        "from foo import bar\n",
+        "from flask import session\n",
+        "import foo\n",
+        "\n"
+    ]
+    checker = pep8.Checker(lines=TEST_IMPORT_FROM, quiet=True)
+    checker.check_all()
+    assert checker.report.get_count(FlaskSessionCheck.CODE) == 1
+
+
+def test_ordinary_imports_fine():
+    TEST_SAFE_IMPORT = "from warehouse.foo import bar\n\n"
+    checker = pep8.Checker(lines=TEST_SAFE_IMPORT, quiet=True)
+    checker.check_all()
+    assert checker.report.get_count(FlaskSessionCheck.CODE) == 0

--- a/tests/test_styleguide.py
+++ b/tests/test_styleguide.py
@@ -26,7 +26,18 @@ def test_flask_relative_session_import_fails():
 
 
 def test_ordinary_imports_fine():
-    TEST_SAFE_IMPORT = "from warehouse.foo import bar\n\n"
+    TEST_SAFE_IMPORT = [
+        "from warehouse.foo import bar\n",
+        "import foo\n",
+        "\n"
+    ]
     checker = pep8.Checker(lines=TEST_SAFE_IMPORT, quiet=True)
+    checker.check_all()
+    assert checker.report.get_count(FlaskSessionCheck.CODE) == 0
+
+
+def test_non_imports_pass():
+    TEST_NON_IMPORT = "a = 1\n\n"
+    checker = pep8.Checker(lines=TEST_NON_IMPORT, quiet=True)
     checker.check_all()
     assert checker.report.get_count(FlaskSessionCheck.CODE) == 0

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist = py34,pep8,docs,packaging
 basepython = python3.4
 deps =
     coverage
+    pep8
     pretend
     pytest
 commands =

--- a/warehouse/styleguide.py
+++ b/warehouse/styleguide.py
@@ -1,0 +1,34 @@
+import ast
+
+
+class FlaskSessionCheck(object):
+    CODE = 'E498'
+    ERROR_TEXT = 'Using Flask sessions is not allowed!'
+    name = 'FlaskSessionCheck'
+    version = '0.1.0'
+
+    @classmethod
+    def error_text(cls):
+        return '{} {}'.format(cls.CODE, cls.ERROR_TEXT)
+
+    def __init__(self, tree, filename):
+        self.tree = tree
+        self.filename = filename
+
+    def run(self):
+        # PEP8 expects yields of (lineno, offset, text, <ignored>)
+        def error_from_leaf(leaf):
+            return (leaf.lineno, leaf.col_offset, self.error_text(), None)
+
+        for leaf in self.tree.body:
+            if not isinstance(leaf, (ast.Import, ast.ImportFrom)):
+                continue
+
+            import_names = [alias.name for alias in leaf.names]
+
+            if isinstance(leaf, ast.Import):
+                if 'flask.session' in import_names:
+                    yield error_from_leaf(leaf)
+            elif isinstance(leaf, ast.ImportFrom):
+                if leaf.module == 'flask' and 'session' in import_names:
+                    yield error_from_leaf(leaf)

--- a/warehouse/styleguide.py
+++ b/warehouse/styleguide.py
@@ -29,6 +29,7 @@ class FlaskSessionCheck(object):
             if isinstance(leaf, ast.Import):
                 if 'flask.session' in import_names:
                     yield error_from_leaf(leaf)
-            elif isinstance(leaf, ast.ImportFrom):
+            else:
+                # The only remaining case: isinstance(leaf, ast.ImportFrom)
                 if leaf.module == 'flask' and 'session' in import_names:
                     yield error_from_leaf(leaf)


### PR DESCRIPTION
Add onto @wickman's work to build a flake8 plugin that checks for flask.session abuse.  wickman's branch didn't pass in travis due to not checking all of the code branches.