### PR TITLE
Fix download url in detail page

### DIFF
--- a/warehouse/templates/projects/detail.html
+++ b/warehouse/templates/projects/detail.html
@@ -147,7 +147,7 @@
 
                 {% if release.download_url %}
                   <li>
-                    <a rel="nofollow" href="{{ release.download_url }}">
+                    <a rel="nofollow" href="{{ download.url }}">
                       {{ gettext('Download URL') }}
                     </a>
                   </li>


### PR DESCRIPTION
Download URL under `Project URLS` in detail page doesn't point to right link. It looks like `https://warehouse.python.org/project/django-postgrespool/UNKNOWN`. So make `Download URL` same as Download button url.
