### PR TITLE
Add dev-setup-env and dev-start-server scripts

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -21,3 +21,5 @@ graft warehouse/static
 
 recursive-include tests *.py
 recursive-include tests *.yml
+
+recursive-exclude docs/_build *

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,8 @@ include LICENSE
 include README.rst
 include CONTRIBUTING.rst
 include tox.ini
+include dev-setup-env
+include dev-start-server
 
 recursive-include dev *.yml
 

--- a/dev-setup-env
+++ b/dev-setup-env
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+# Create a Database
+createdb warehouse
+
+# Install the CIText extension
+psql warehouse -c 'CREATE EXTENSION IF NOT EXISTS citext'
+
+# Install the UUID extension
+psql warehouse -c 'CREATE EXTENSION IF NOT EXISTS "uuid-ossp"'
+
+# Migrate the database to the latest schema
+warehouse -c dev/config.yml migrate upgrade head
+
+# Initialise the ElasticSearch index
+warehouse -c dev/config.yml search reindex
+
+echo
+echo '-------------------------------------------------'
+echo "Dev environment set up."
+echo "Run ./dev-start-server to start up a dev server."
+echo '-------------------------------------------------'

--- a/dev-start-server
+++ b/dev-start-server
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# Serve Warehouse at http://localhost:9000/
+warehouse -c dev/config.yml serve

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -61,27 +61,12 @@ dependencies, and the Python development dependencies using:
 
     $ pip install -r dev-requirements.txt
 
-Finally you can setup the project:
+Finally you can setup a dev environment and run the dev server:
 
 .. code-block:: console
 
-    $ # Create a Database
-    $ createdb warehouse
-
-    $ # Install the CIText extension
-    $ psql warehouse -c 'CREATE EXTENSION IF NOT EXISTS citext'
-
-    $ # Install the UUID extension
-    $ psql warehouse -c 'CREATE EXTENSION IF NOT EXISTS "uuid-ossp"'
-
-    $ # Migrate the database to the latest schema
-    $ warehouse -c dev/config.yml migrate upgrade head
-
-    $ # Initialise the ElasticSearch index
-    $ warehouse -c dev/config.yml search reindex
-
-    $ # Serve Warehouse at http://localhost:9000/
-    $ warehouse -c dev/config.yml serve
+    $ ./dev-setup-env
+    $ ./dev-start-server
 
 
 Design Development


### PR DESCRIPTION
These make it easier to spin up a dev environment.

```
$ ./dev-setup-env
CREATE EXTENSION
CREATE EXTENSION
...
[2014-12-09 14:39:55 INFO] Running upgrade 4c8b2dd27587 -> 8f38eea7678, Remove the download statistics
[2014-12-09 14:39:55 DEBUG] update 4c8b2dd27587 to 8f38eea7678
[2014-12-09 14:39:55 INFO] Running upgrade 8f38eea7678 -> 416778ef37b, add id index to journals
[2014-12-09 14:39:55 DEBUG] update 8f38eea7678 to 416778ef37b

$ ./dev-start-server
...
[2014-12-09 15:49:53 INFO]  * Running on http://localhost:9000/
[2014-12-09 15:49:53 INFO]  * Restarting with reloader
...
```