### PR TITLE
Fix `packaging` tox target by exclude built docs

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -21,3 +21,5 @@ graft warehouse/static
 
 recursive-include tests *.py
 recursive-include tests *.yml
+
+recursive-exclude docs/_build *


### PR DESCRIPTION
Fixes: GH-339

```
❯ tox -e packaging
GLOB sdist-make: /Users/marca/dev/git-repos/warehouse/setup.py
packaging inst-nodeps: /Users/marca/dev/git-repos/warehouse/.tox/dist/warehouse-14.2.1.zip
packaging runtests: PYTHONHASHSEED='1955751483'
packaging runtests: commands[0] | check-manifest
listing source files under version control: 212 files and directories
building an sdist: warehouse-14.2.1.tar.gz: 212 files and directories
copying source files to a temporary directory
building a clean sdist: warehouse-14.2.1.tar.gz: 212 files and directories
files in version control match files in the sdist(s)
___________________________________________________________________________________ summary ____________________________________________________________________________________
  packaging: commands succeeded
  congratulations :)
```