### PR TITLE
Fix Travis failures (Set default ES host of 127.0.0.1:9200)

### DIFF
--- a/warehouse/search/indexes.py
+++ b/warehouse/search/indexes.py
@@ -27,7 +27,7 @@ class Index(object):
         self.db = db
         self.config = config
         self.es = Elasticsearch(
-            hosts=self.config.hosts,
+            hosts=self.config.hosts or ['127.0.0.1:9200'],
             **self.config.get("client_options", {})
         )
 


### PR DESCRIPTION
to prevent a bunch of test failures when doing `tox -e py34`.

Before:

    6 failed, 287 passed, 124 error in 6.70 seconds

After:

    331 passed, 86 error in 6.59 seconds