### PR TITLE
MANIFEST.in: Exclude docs/_build

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -11,6 +11,7 @@ recursive-include docs *.py
 recursive-include docs *.rst
 recursive-include docs *.txt
 recursive-include docs Makefile
+recursive-exclude docs/_build *
 
 recursive-include warehouse *.html
 recursive-include warehouse *.mako


### PR DESCRIPTION
Fixes tox `packaging` target which was giving this:

    $ tox -e packaging
    GLOB sdist-make: /Users/marca/dev/git-repos/warehouse/setup.py
    packaging inst-nodeps: /Users/marca/dev/git-repos/warehouse/.tox/dist/warehouse-14.2.1.zip
    packaging runtests: PYTHONHASHSEED='284200353'
    packaging runtests: commands[0] | check-manifest
    lists of files in version control and sdist do not match!
    missing from VCS:
      docs/_build
      docs/_build/html
      docs/_build/html/_sources
      docs/_build/html/_sources/api-reference
      docs/_build/html/_sources/api-reference/index.txt
      docs/_build/html/_sources/api-reference/legacy.txt
      docs/_build/html/_sources/api-reference/xml-rpc.txt
      docs/_build/html/_sources/application.txt
      docs/_build/html/_sources/configuration.txt
      docs/_build/html/_sources/contributing.txt
      docs/_build/html/_sources/index.txt
      docs/_build/html/_sources/reference
      docs/_build/html/_sources/reference/csrf.txt
      docs/_build/html/_sources/reference/index.txt
      docs/_build/html/_sources/reference/sessions.txt
      docs/_build/html/_sources/testing.txt
      docs/_build/html/output.txt
    ERROR: InvocationError: '/Users/marca/dev/git-repos/warehouse/.tox/packaging/bin/check-manifest'