### PR TITLE
Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,60 @@
+# --------------------------------------------------------------------------
+# This is a Dockerfile to build an Ubuntu 14.04 Docker image with
+# Warehouse
+#
+# Use a command like:
+#     docker build -t <user>/warehouse .
+# --------------------------------------------------------------------------
+
+FROM  orchardup/python:3.4
+MAINTAINER  Marc Abramowitz <marc@marc-abramowitz.com> (@msabramo)
+
+ENV DEBIAN_FRONTEND noninteractive
+ENV LC_ALL C
+
+RUN apt-get update && apt-get install -y software-properties-common && add-apt-repository ppa:chris-lea/node.js
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    curl \
+    git \
+    libffi-dev \
+    libpq-dev \
+    libyaml-dev \
+    nodejs \
+    openjdk-7-jre-headless \
+    postgresql \
+    postgresql-contrib \
+    redis-server \
+    ruby \
+    ruby-dev \
+    tree \
+    vim-nox \
+    wget
+RUN wget --no-verbose https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-1.4.2.deb
+RUN dpkg -i elasticsearch-1.4.2.deb
+RUN gem install compass
+RUN npm install -g grunt-cli
+RUN wget --no-verbose https://bootstrap.pypa.io/get-pip.py
+RUN python3 get-pip.py
+ADD . warehouse
+WORKDIR warehouse
+RUN pip install -r dev-requirements.txt
+RUN pip install \
+    honcho \
+    httpie \
+    ipython \
+    ptpython
+RUN /etc/init.d/postgresql start && \
+    sudo -u postgres createuser --superuser root && \
+    sudo -u postgres createdb warehouse && \
+    sudo -u postgres psql warehouse -c 'CREATE EXTENSION IF NOT EXISTS citext' && \
+    sudo -u postgres psql warehouse -c 'CREATE EXTENSION IF NOT EXISTS "uuid-ossp"' && \
+    warehouse -c dev/config.yml migrate upgrade head
+# RUN /etc/init.d/elasticsearch start && \
+#     /etc/init.d/postgresql start && \
+#     sleep 5 && \
+#     warehouse -c dev/config.yml search reindex
+
+EXPOSE 5432 6379 9000 9200
+
+CMD ["honcho", "start"]

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,4 @@
+elasticsearch: /usr/share/elasticsearch/bin/elasticsearch
+postgresql: sudo -u postgres /usr/lib/postgresql/9.3/bin/postgres -D /var/lib/postgresql/9.3/main -c config_file=/etc/postgresql/9.3/main/postgresql.conf
+redis: redis-server
+warehouse: warehouse -c dev/config.yml serve --host 0.0.0.0

--- a/dev/config.yml
+++ b/dev/config.yml
@@ -7,7 +7,7 @@ site:
     access_token: development
 
 database:
-    url: "postgresql://localhost/warehouse"
+    url: "postgresql:///warehouse"
 
 redis:
     downloads: "redis://localhost:6379/0"

--- a/dev/config.yml
+++ b/dev/config.yml
@@ -2,8 +2,6 @@ debug: true
 
 site:
     name: Warehouse (dev)
-    hosts:
-        - "localhost:9000"
     access_token: development
 
 database:

--- a/warehouse/application.py
+++ b/warehouse/application.py
@@ -327,8 +327,9 @@ class Warehouse(object):
             request = Request(environ)
             request.url_adapter = urls
 
-            # Attach our trusted hosts to this request
-            request.trusted_hosts = self.config.site.hosts
+            if self.config.site.hosts:
+                # Attach our trusted hosts to this request
+                request.trusted_hosts = self.config.site.hosts
 
             # Access request.host to trigger a check against our trusted_hosts
             request.host


### PR DESCRIPTION
Changes to make it possible to package up a warehouse development environment with Docker. This makes it much easier to get started with Warehouse development, because it bundles PostgreSQL, Redis, Elasticsearch and it has pre-built cffi and such.

I have a pre-built image at https://registry.hub.docker.com/u/msabramo/warehouse/

So one could run warehouse by doing:

- `docker pull msabramo/warehouse`
- `docker run -i -t -P msabramo/warehouse`