### PR TITLE
Implement a login service to encapsulate login utilities

### DIFF
--- a/tests/accounts/test_core.py
+++ b/tests/accounts/test_core.py
@@ -13,14 +13,10 @@
 import pretend
 
 from warehouse import accounts
+from warehouse.accounts.interfaces import ILoginService
+from warehouse.accounts.services import database_login_factory
 
 from ..common.db.accounts import UserFactory
-
-
-def test_password_hasher_attribute():
-    passwords = pretend.stub()
-    request = pretend.stub(registry={"passwords": passwords})
-    assert accounts._pw_hasher(request) is passwords
 
 
 class TestAuthenticate:
@@ -78,16 +74,20 @@ def test_includeme(monkeypatch):
     monkeypatch.setattr(accounts, "ACLAuthorizationPolicy", authz_cls)
 
     config = pretend.stub(
+        register_service_factory=pretend.call_recorder(
+            lambda factory, iface: None
+        ),
         add_request_method=pretend.call_recorder(lambda f, name, reify: None),
         set_authentication_policy=pretend.call_recorder(lambda p: None),
         set_authorization_policy=pretend.call_recorder(lambda p: None),
-        registry={},
     )
 
     accounts.includeme(config)
 
+    config.register_service_factory.calls == [
+        pretend.call(database_login_factory, ILoginService),
+    ]
     config.add_request_method.calls == [
-        pretend.call(accounts._pw_hasher, name="password_hasher", reify=True),
         pretend.call(accounts._user, name="user", reify=True),
     ]
     config.set_authentication_policy.calls == [pretend.call(authn_obj)]

--- a/tests/accounts/test_core.py
+++ b/tests/accounts/test_core.py
@@ -16,53 +16,57 @@ from warehouse import accounts
 from warehouse.accounts.interfaces import ILoginService
 from warehouse.accounts.services import database_login_factory
 
-from ..common.db.accounts import UserFactory
-
 
 class TestAuthenticate:
 
-    def test_with_user(self, db_request):
-        user = UserFactory.create(session=db_request.db)
-        assert accounts._authenticate(user.id, db_request) == []
+    def test_with_user(self):
+        user = pretend.stub()
+        service = pretend.stub(
+            get_user=pretend.call_recorder(lambda userid: user)
+        )
+        request = pretend.stub(find_service=lambda iface: service)
 
-    def test_without_users(self, db_request):
-        assert accounts._authenticate(1, db_request) is None
+        assert accounts._authenticate(1, request) == []
+        assert service.get_user.calls == [pretend.call(1)]
 
-    def test_wrong_user(self, db_request):
-        user = UserFactory.create(session=db_request.db)
-        assert accounts._authenticate(user.id + 1, db_request) is None
+    def test_without_user(self):
+        service = pretend.stub(
+            get_user=pretend.call_recorder(lambda userid: None)
+        )
+        request = pretend.stub(find_service=lambda iface: service)
+
+        assert accounts._authenticate(1, request) is None
+        assert service.get_user.calls == [pretend.call(1)]
 
 
 class TestUser:
 
-    def test_with_user(self, db_request):
-        UserFactory.create(session=db_request.db)
-        user = UserFactory.create(session=db_request.db)
-        UserFactory.create(session=db_request.db)
-
-        db_request.set_property(
-            lambda r: user.id, name="unauthenticated_userid"
+    def test_with_user(self):
+        user = pretend.stub()
+        service = pretend.stub(
+            get_user=pretend.call_recorder(lambda userid: user)
         )
 
-        assert accounts._user(db_request) is user
-
-    def test_without_users(self, db_request):
-        db_request.set_property(lambda r: 1, name="unauthenticated_userid")
-        assert accounts._user(db_request) is None
-
-    def test_wrong_user(self, db_request):
-        users = [
-            UserFactory.create(session=db_request.db),
-            UserFactory.create(session=db_request.db),
-            UserFactory.create(session=db_request.db),
-        ]
-        user_id = max(*[u.id for u in users]) + 1
-
-        db_request.set_property(
-            lambda r: user_id, name="unauthenticated_userid"
+        request = pretend.stub(
+            find_service=lambda iface: service,
+            unauthenticated_userid=100,
         )
 
-        assert accounts._user(db_request) is None
+        assert accounts._user(request) is user
+        assert service.get_user.calls == [pretend.call(100)]
+
+    def test_without_users(self):
+        service = pretend.stub(
+            get_user=pretend.call_recorder(lambda userid: None)
+        )
+
+        request = pretend.stub(
+            find_service=lambda iface: service,
+            unauthenticated_userid=100,
+        )
+
+        assert accounts._user(request) is None
+        assert service.get_user.calls == [pretend.call(100)]
 
 
 def test_includeme(monkeypatch):

--- a/tests/accounts/test_services.py
+++ b/tests/accounts/test_services.py
@@ -1,0 +1,117 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pretend
+
+from zope.interface.verify import verifyClass
+
+from warehouse.accounts import services
+from warehouse.accounts.interfaces import ILoginService
+
+from ..common.db.accounts import UserFactory
+
+
+class TestDatabaseLoginService:
+
+    def test_verify_service(self):
+        assert verifyClass(ILoginService, services.DatabaseLoginService)
+
+    def test_service_creation(self, monkeypatch):
+        crypt_context_obj = pretend.stub()
+        crypt_context_cls = pretend.call_recorder(
+            lambda schemes, deprecated: crypt_context_obj
+        )
+        monkeypatch.setattr(services, "CryptContext", crypt_context_cls)
+
+        session = pretend.stub()
+        service = services.DatabaseLoginService(session)
+
+        assert service.db is session
+        assert service.hasher is crypt_context_obj
+        assert crypt_context_cls.calls == [
+            pretend.call(
+                schemes=[
+                    "bcrypt_sha256",
+                    "bcrypt",
+                    "django_bcrypt",
+                    "unix_disabled",
+                ],
+                deprecated=["auto"],
+            ),
+        ]
+
+    def test_find_userid_nonexistant_user(self, db_session):
+        service = services.DatabaseLoginService(db_session)
+        assert service.find_userid("my_username") is None
+
+    def test_find_userid_existing_user(self, db_session):
+        user = UserFactory.create(session=db_session)
+        service = services.DatabaseLoginService(db_session)
+        assert service.find_userid(user.username) == user.id
+
+    def test_check_password_nonexistant_user(self, db_session):
+        service = services.DatabaseLoginService(db_session)
+        assert not service.check_password(1, None)
+
+    def test_check_password_invalid(self, db_session):
+        user = UserFactory.create(session=db_session)
+        service = services.DatabaseLoginService(db_session)
+        service.hasher = pretend.stub(
+            verify_and_update=pretend.call_recorder(
+                lambda l, r: (False, None)
+            ),
+        )
+
+        assert not service.check_password(user.id, "user password")
+        assert service.hasher.verify_and_update.calls == [
+            pretend.call("user password", user.password),
+        ]
+
+    def test_check_password_valid(self, db_session):
+        user = UserFactory.create(session=db_session)
+        service = services.DatabaseLoginService(db_session)
+        service.hasher = pretend.stub(
+            verify_and_update=pretend.call_recorder(lambda l, r: (True, None)),
+        )
+
+        assert service.check_password(user.id, "user password")
+        assert service.hasher.verify_and_update.calls == [
+            pretend.call("user password", user.password),
+        ]
+
+    def test_check_password_updates(self, db_session):
+        user = UserFactory.create(session=db_session)
+        password = user.password
+        service = services.DatabaseLoginService(db_session)
+        service.hasher = pretend.stub(
+            verify_and_update=pretend.call_recorder(
+                lambda l, r: (True, "new password")
+            ),
+        )
+
+        assert service.check_password(user.id, "user password")
+        assert service.hasher.verify_and_update.calls == [
+            pretend.call("user password", password),
+        ]
+        assert user.password == "new password"
+
+
+def test_database_login_factory(monkeypatch):
+    service_obj = pretend.stub()
+    service_cls = pretend.call_recorder(lambda session: service_obj)
+    monkeypatch.setattr(services, "DatabaseLoginService", service_cls)
+
+    context = pretend.stub()
+    request = pretend.stub(db=pretend.stub())
+
+    assert services.database_login_factory(context, request) is service_obj
+    assert service_cls.calls == [pretend.call(request.db)]

--- a/warehouse/accounts/__init__.py
+++ b/warehouse/accounts/__init__.py
@@ -10,15 +10,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from passlib.context import CryptContext
 from pyramid.authentication import SessionAuthenticationPolicy
 from pyramid.authorization import ACLAuthorizationPolicy
 
+from warehouse.accounts.interfaces import ILoginService
 from warehouse.accounts.models import User
-
-
-def _pw_hasher(request):
-    return request.registry["passwords"]
+from warehouse.accounts.services import database_login_factory
 
 
 def _authenticate(userid, request):
@@ -42,12 +39,8 @@ def _user(request):
 
 
 def includeme(config):
-    # Register our Password Handling
-    config.registry["passwords"] = CryptContext(
-        schemes=["bcrypt_sha256", "bcrypt", "django_bcrypt", "unix_disabled"],
-        deprecated=["auto"],
-    )
-    config.add_request_method(_pw_hasher, name="password_hasher", reify=True)
+    # Register our login service
+    config.register_service_factory(database_login_factory, ILoginService)
 
     # Register our authentication and authorization policies
     config.set_authentication_policy(

--- a/warehouse/accounts/__init__.py
+++ b/warehouse/accounts/__init__.py
@@ -14,28 +14,22 @@ from pyramid.authentication import SessionAuthenticationPolicy
 from pyramid.authorization import ACLAuthorizationPolicy
 
 from warehouse.accounts.interfaces import ILoginService
-from warehouse.accounts.models import User
 from warehouse.accounts.services import database_login_factory
 
 
 def _authenticate(userid, request):
-    user = request.db.query(User).filter(User.id == userid).first()
+    login_service = request.find_service(ILoginService)
+    user = login_service.get_user(userid)
+
     if user is None:
         return
+
     return []  # TODO: Add other principles.
 
 
 def _user(request):
-    user = request.db.query(User).filter(
-        User.id == request.unauthenticated_userid
-    ).first()
-
-    if user is None:
-        return  # TODO: We need some sort of Anonymous User.
-
-    # TODO: We probably don't want to actually just return the database object,
-    #       here.
-    return user
+    login_service = request.find_service(ILoginService)
+    return login_service.get_user(request.unauthenticated_userid)
 
 
 def includeme(config):

--- a/warehouse/accounts/interfaces.py
+++ b/warehouse/accounts/interfaces.py
@@ -15,6 +15,12 @@ from zope.interface import Interface
 
 class ILoginService(Interface):
 
+    def get_user(userid):
+        """
+        Return the user object that represents the given userid, or None if
+        there is no user for that ID.
+        """
+
     def find_userid(username):
         """
         Find the unique user identifier for the given username or None if there

--- a/warehouse/accounts/interfaces.py
+++ b/warehouse/accounts/interfaces.py
@@ -1,0 +1,28 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from zope.interface import Interface
+
+
+class ILoginService(Interface):
+
+    def find_userid(username):
+        """
+        Find the unique user identifier for the given username or None if there
+        is no user with the given username.
+        """
+
+    def check_password(userid, password):
+        """
+        Returns a boolean representing whether the given password is valid for
+        the given userid.
+        """

--- a/warehouse/accounts/services.py
+++ b/warehouse/accounts/services.py
@@ -33,6 +33,12 @@ class DatabaseLoginService:
             deprecated=["auto"],
         )
 
+    def get_user(self, userid):
+        # TODO: We probably don't actually want to just return the database
+        #       object here.
+        # TODO: We need some sort of Anonymous User.
+        return self.db.query(User).get(userid)
+
     def find_userid(self, username):
         try:
             user = (
@@ -46,7 +52,7 @@ class DatabaseLoginService:
         return user.id
 
     def check_password(self, userid, password):
-        user = self.db.query(User).get(userid)
+        user = self.get_user(userid)
         if user is None:
             return False
 

--- a/warehouse/accounts/services.py
+++ b/warehouse/accounts/services.py
@@ -1,0 +1,70 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from passlib.context import CryptContext
+from sqlalchemy.orm.exc import NoResultFound
+from zope.interface import implementer
+
+from warehouse.accounts.interfaces import ILoginService
+from warehouse.accounts.models import User
+
+
+@implementer(ILoginService)
+class DatabaseLoginService:
+
+    def __init__(self, session):
+        self.db = session
+        self.hasher = CryptContext(
+            schemes=[
+                "bcrypt_sha256",
+                "bcrypt",
+                "django_bcrypt",
+                "unix_disabled",
+            ],
+            deprecated=["auto"],
+        )
+
+    def find_userid(self, username):
+        try:
+            user = (
+                self.db.query(User.id)
+                    .filter(User.username == username)
+                    .one()
+            )
+        except NoResultFound:
+            return
+
+        return user.id
+
+    def check_password(self, userid, password):
+        user = self.db.query(User).get(userid)
+        if user is None:
+            return False
+
+        # Actually check our hash, optionally getting a new hash for it if
+        # we should upgrade our saved hashed.
+        ok, new_hash = self.hasher.verify_and_update(password, user.password)
+
+        # Check if the password itself was OK or not.
+        if not ok:
+            return False
+
+        # If we've gotten a new password hash from the hasher, then we'll want
+        # to save that hash.
+        if new_hash:
+            user.password = new_hash
+
+        return True
+
+
+def database_login_factory(context, request):
+    return DatabaseLoginService(request.db)


### PR DESCRIPTION
* The ``LoginForm`` no longer has any concept of the database or the password hasher, that is all encapsulated inside of the ``ILoginService``.
* There is no longer an attribute on request for the password hasher which is rarely used for anything but the login.
* No longer implicitly depending on the order that the validation methods of the ``LoginForm`` get called in.
* Logic for getting the user from an ID for ``request.user`` and the authn callback is refactored into one location.