### PR TITLE
Use camo in development and restrict CSP img-src

### DIFF
--- a/dev/camo/Dockerfile
+++ b/dev/camo/Dockerfile
@@ -1,0 +1,21 @@
+FROM node:slim
+
+# Install Camo dependencies
+RUN set -x \
+    && apt-get update \
+    && apt-get install ca-certificates --no-install-recommends -y \
+    && apt-get autoremove -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Install Camo
+RUN set -x \
+    && apt-get update \
+    && apt-get install git --no-install-recommends -y \
+    && git clone https://github.com/atmos/camo.git /camo \
+    && apt-get purge git -y \
+    && apt-get autoremove -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+WORKDIR /camo/

--- a/dev/config.yml
+++ b/dev/config.yml
@@ -12,6 +12,10 @@ configurator:
     secret: "an insecure development secret"
     url: "redis://redis:6379/0"
 
+  camo:
+    key: "insecure camo key"
+    url: "{request.scheme}://{request.domain}:9000/"
+
   debugtoolbar:
     hosts:
       - 0.0.0.0/0

--- a/fig.yml
+++ b/fig.yml
@@ -4,6 +4,15 @@ db:
 redis:
   image: redis:latest
 
+camo:
+  build: dev/camo
+  command: node server.js
+  ports:
+    - "9000:9000"
+  environment:
+    PORT: 9000
+    CAMO_KEY: "insecure camo key"
+
 web:
   build: .
   command: warehouse --config dev/config.yml serve -b 0.0.0.0 -w 1 --reload

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,6 +67,8 @@ def database(request, postgresql_proc):
 def app_config(database):
     config = configure(
         settings={
+            "camo.url": "http://localhost:9000/",
+            "camo.key": "insecure key",
             "database.url": database,
             "download_stats.url": "redis://localhost:0/",
             "sessions.secret": "123456",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -74,7 +74,12 @@ class TestCSPTween:
 def test_configure(monkeypatch, settings):
     configurator_settings = {}
     configurator_obj = pretend.stub(
-        registry=pretend.stub(settings={"pyramid.reload_assets": False}),
+        registry=pretend.stub(
+            settings={
+                "camo.url": "http://camo.example.com/",
+                "pyramid.reload_assets": False,
+            },
+        ),
         include=pretend.call_recorder(lambda include: None),
         add_jinja2_renderer=pretend.call_recorder(lambda renderer: None),
         add_jinja2_search_path=pretend.call_recorder(lambda path, name: None),
@@ -143,7 +148,11 @@ def test_configure(monkeypatch, settings):
             "csp": {
                 "default-src": ["'none'"],
                 "frame-ancestors": ["'none'"],
-                "img-src": ["*"],
+                "img-src": [
+                    "'self'",
+                    "http://camo.example.com/",
+                    "https://secure.gravatar.com",
+                ],
                 "referrer": ["cross-origin"],
                 "reflected-xss": ["block"],
                 "script-src": ["'self'"],

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -37,7 +37,16 @@ class TestReadmeRender:
             readme.rst, "render", lambda raw: ("rendered", True)
         )
 
-        ctx = {"request": pretend.stub(registry=pretend.stub(settings={}))}
+        ctx = {
+            "request": pretend.stub(
+                registry=pretend.stub(
+                    settings={
+                        "camo.url": "https://camo.example.net/",
+                        "camo.key": "fake key",
+                    },
+                ),
+            ),
+        }
 
         result = filters.readme_renderer(ctx, "raw thing", format="rst")
 
@@ -48,7 +57,16 @@ class TestReadmeRender:
             readme.rst, "render", lambda raw: ("unrendered\nthing", False)
         )
 
-        ctx = {"request": pretend.stub(registry=pretend.stub(settings={}))}
+        ctx = {
+            "request": pretend.stub(
+                registry=pretend.stub(
+                    settings={
+                        "camo.url": "https://camo.example.net/",
+                        "camo.key": "fake key",
+                    },
+                ),
+            ),
+        }
 
         result = filters.readme_renderer(ctx, "raw thing", format="rst")
 

--- a/warehouse/config.py
+++ b/warehouse/config.py
@@ -29,7 +29,8 @@ def content_security_policy_tween_factory(handler, registry):
         # toolbar, that's not part of our application and it doesn't work with
         # our restrictive CSP.
         if not request.path.startswith("/_debug_toolbar/"):
-            resp.headers["Content-Security-Policy"] = policy
+            resp.headers["Content-Security-Policy"] = \
+                policy.format(request=request)
 
         return resp
 
@@ -109,7 +110,11 @@ def configure(settings=None):
         "csp": {
             "default-src": ["'none'"],
             "frame-ancestors": ["'none'"],
-            "img-src": ["*"],
+            "img-src": [
+                "'self'",
+                config.registry.settings["camo.url"],
+                "https://secure.gravatar.com",
+            ],
             "referrer": ["cross-origin"],
             "reflected-xss": ["block"],
             "script-src": ["'self'"],

--- a/warehouse/filters.py
+++ b/warehouse/filters.py
@@ -39,6 +39,9 @@ def _camo_url(camo_url, camo_key, url):
 def readme_renderer(ctx, value, *, format):
     request = ctx.get("request") or get_current_request()
 
+    camo_url = request.registry.settings["camo.url"].format(request=request)
+    camo_key = request.registry.settings["camo.key"]
+
     # The format parameter is here so we can more easily expand this to cover
     # READMEs which do not use restructuredtext, but for now rst is the only
     # format we support.
@@ -55,21 +58,18 @@ def readme_renderer(ctx, value, *, format):
 
     # Parse the rendered output and replace any inline images that don't point
     # to HTTPS with camouflaged images.
-    camo_url = request.registry.settings.get("camo.url")
-    camo_key = request.registry.settings.get("camo.key")
-    if camo_url is not None and camo_key is not None:
-        tree_builder = html5lib.treebuilders.getTreeBuilder("dom")
-        parser = html5lib.html5parser.HTMLParser(tree=tree_builder)
-        dom = parser.parse(value)
+    tree_builder = html5lib.treebuilders.getTreeBuilder("dom")
+    parser = html5lib.html5parser.HTMLParser(tree=tree_builder)
+    dom = parser.parse(value)
 
-        for element in dom.getElementsByTagName("img"):
-            src = element.getAttribute("src")
-            if src:
-                element.setAttribute("src", _camo_url(camo_url, camo_key, src))
+    for element in dom.getElementsByTagName("img"):
+        src = element.getAttribute("src")
+        if src:
+            element.setAttribute("src", _camo_url(camo_url, camo_key, src))
 
-        tree_walker = html5lib.treewalkers.getTreeWalker("dom")
-        html_serializer = html5lib.serializer.htmlserializer.HTMLSerializer()
-        value = "".join(html_serializer.serialize(tree_walker(dom)))
+    tree_walker = html5lib.treewalkers.getTreeWalker("dom")
+    html_serializer = html5lib.serializer.htmlserializer.HTMLSerializer()
+    value = "".join(html_serializer.serialize(tree_walker(dom)))
 
     return jinja2.Markup(value)
 


### PR DESCRIPTION
To better match a production deployment we're going to run a copy of camo locally and use that even in development. Since all user supplied images go through Camo then, we can also restrict the img-src of the CSP to only use the hosts we expect instead of all hosts.