### PR TITLE
Implement the simple installer API

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ setuptools.setup(
         "warehouse.cli.db",
         "warehouse.i18n",
         "warehouse.legacy",
+        "warehouse.legacy.api",
         "warehouse.migrations",
         "warehouse.packaging",
         "warehouse.utils",

--- a/tests/common/db/packaging.py
+++ b/tests/common/db/packaging.py
@@ -17,7 +17,9 @@ import re
 import factory
 import factory.fuzzy
 
-from warehouse.packaging.models import Project, Release, Role, File
+from warehouse.packaging.models import (
+    Project, Release, Role, File, JournalEntry,
+)
 
 from .accounts import UserFactory
 from .base import WarehouseFactory
@@ -62,3 +64,16 @@ class RoleFactory(WarehouseFactory):
     role_name = "Owner"
     user = factory.SubFactory(UserFactory)
     project = factory.SubFactory(ProjectFactory)
+
+
+class JournalEntryFactory(WarehouseFactory):
+    class Meta:
+        model = JournalEntry
+
+    id = factory.fuzzy.FuzzyInteger(low=1)
+    name = factory.fuzzy.FuzzyText(length=12)
+    version = factory.Sequence(lambda n: str(n) + ".0")
+    submitted_date = factory.fuzzy.FuzzyNaiveDateTime(
+        datetime.datetime(2008, 1, 1)
+    )
+    submitted_by = factory.SubFactory(UserFactory)

--- a/tests/legacy/__init__.py
+++ b/tests/legacy/__init__.py
@@ -1,0 +1,11 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/legacy/api/__init__.py
+++ b/tests/legacy/api/__init__.py
@@ -1,0 +1,11 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/legacy/api/test_simple.py
+++ b/tests/legacy/api/test_simple.py
@@ -1,0 +1,58 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from warehouse.legacy.api import simple
+
+from ...common.db.accounts import UserFactory
+from ...common.db.packaging import ProjectFactory, JournalEntryFactory
+
+
+class TestSimpleIndex:
+
+    def test_no_results_no_serial(self, db_request):
+        assert simple.simple_index(db_request) == {"projects": []}
+        assert db_request.response.headers["X-PyPI-Last-Serial"] == 0
+
+    def test_no_results_with_serial(self, db_request):
+        user = UserFactory.create(session=db_request.db)
+        je = JournalEntryFactory.create(
+            session=db_request.db, submitted_by=user.username,
+        )
+        assert simple.simple_index(db_request) == {"projects": []}
+        assert db_request.response.headers["X-PyPI-Last-Serial"] == je.id
+
+    def test_with_results_no_serial(self, db_request):
+        projects = [
+            (x.name, x.normalized_name)
+            for x in
+            [ProjectFactory.create(session=db_request.db) for _ in range(3)]
+        ]
+        assert simple.simple_index(db_request) == {
+            "projects": sorted(projects, key=lambda x: x[1]),
+        }
+        assert db_request.response.headers["X-PyPI-Last-Serial"] == 0
+
+    def test_with_results_with_serial(self, db_request):
+        projects = [
+            (x.name, x.normalized_name)
+            for x in
+            [ProjectFactory.create(session=db_request.db) for _ in range(3)]
+        ]
+        user = UserFactory.create(session=db_request.db)
+        je = JournalEntryFactory.create(
+            session=db_request.db, submitted_by=user.username,
+        )
+
+        assert simple.simple_index(db_request) == {
+            "projects": sorted(projects, key=lambda x: x[1]),
+        }
+        assert db_request.response.headers["X-PyPI-Last-Serial"] == je.id

--- a/tests/legacy/api/test_simple.py
+++ b/tests/legacy/api/test_simple.py
@@ -10,10 +10,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pretend
+
+from pyramid.httpexceptions import HTTPMovedPermanently
+
 from warehouse.legacy.api import simple
 
 from ...common.db.accounts import UserFactory
-from ...common.db.packaging import ProjectFactory, JournalEntryFactory
+from ...common.db.packaging import (
+    ProjectFactory, ReleaseFactory, FileFactory, JournalEntryFactory,
+)
 
 
 class TestSimpleIndex:
@@ -54,5 +60,108 @@ class TestSimpleIndex:
 
         assert simple.simple_index(db_request) == {
             "projects": sorted(projects, key=lambda x: x[1]),
+        }
+        assert db_request.response.headers["X-PyPI-Last-Serial"] == je.id
+
+
+class TestSimpleDetail:
+
+    def test_redirects(self, pyramid_request):
+        project = pretend.stub(normalized_name="foo")
+
+        pyramid_request.matchdict["name"] = "Foo"
+        pyramid_request.current_route_url = pretend.call_recorder(
+            lambda name: "/foobar/"
+        )
+
+        resp = simple.simple_detail(project, pyramid_request)
+
+        assert isinstance(resp, HTTPMovedPermanently)
+        assert resp.headers["Location"] == "/foobar/"
+        assert pyramid_request.current_route_url.calls == [
+            pretend.call(name="foo"),
+        ]
+
+    def test_no_files_no_serial(self, db_request):
+        project = ProjectFactory.create(session=db_request.db)
+        db_request.matchdict["name"] = project.normalized_name
+        user = UserFactory.create(session=db_request.db)
+        JournalEntryFactory.create(
+            session=db_request.db, submitted_by=user.username,
+        )
+
+        assert simple.simple_detail(project, db_request) == {
+            "project": project,
+            "files": [],
+        }
+        assert db_request.response.headers["X-PyPI-Last-Serial"] == 0
+
+    def test_no_files_with_seiral(self, db_request):
+        project = ProjectFactory.create(session=db_request.db)
+        db_request.matchdict["name"] = project.normalized_name
+        user = UserFactory.create(session=db_request.db)
+        je = JournalEntryFactory.create(
+            session=db_request.db,
+            name=project.name,
+            submitted_by=user.username,
+        )
+
+        assert simple.simple_detail(project, db_request) == {
+            "project": project,
+            "files": [],
+        }
+        assert db_request.response.headers["X-PyPI-Last-Serial"] == je.id
+
+    def test_with_files_no_serial(self, db_request):
+        project = ProjectFactory.create(session=db_request.db)
+        releases = [
+            ReleaseFactory.create(session=db_request.db, project=project)
+            for _ in range(3)
+        ]
+        files = [
+            FileFactory.create(
+                session=db_request.db,
+                release=r,
+                filename="{}-{}.tar.gz".format(project.name, r.version),
+            )
+            for r in releases
+        ]
+        db_request.matchdict["name"] = project.normalized_name
+        user = UserFactory.create(session=db_request.db)
+        JournalEntryFactory.create(
+            session=db_request.db, submitted_by=user.username,
+        )
+
+        assert simple.simple_detail(project, db_request) == {
+            "project": project,
+            "files": files,
+        }
+        assert db_request.response.headers["X-PyPI-Last-Serial"] == 0
+
+    def test_with_files_with_seiral(self, db_request):
+        project = ProjectFactory.create(session=db_request.db)
+        releases = [
+            ReleaseFactory.create(session=db_request.db, project=project)
+            for _ in range(3)
+        ]
+        files = [
+            FileFactory.create(
+                session=db_request.db,
+                release=r,
+                filename="{}-{}.tar.gz".format(project.name, r.version),
+            )
+            for r in releases
+        ]
+        db_request.matchdict["name"] = project.normalized_name
+        user = UserFactory.create(session=db_request.db)
+        je = JournalEntryFactory.create(
+            session=db_request.db,
+            name=project.name,
+            submitted_by=user.username,
+        )
+
+        assert simple.simple_detail(project, db_request) == {
+            "project": project,
+            "files": files,
         }
         assert db_request.response.headers["X-PyPI-Last-Serial"] == je.id

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -47,4 +47,11 @@ def test_routes():
             traverse="/{name}/{version}",
         ),
         pretend.call("packaging.file", "/packages/{path:.*}"),
+        pretend.call("legacy.api.simple.index", "/simple/"),
+        pretend.call(
+            "legacy.api.simple.detail",
+            "/simple/{name}/",
+            factory="warehouse.packaging.models:ProjectFactory",
+            traverse="/{name}/",
+        ),
     ]

--- a/warehouse/legacy/api/__init__.py
+++ b/warehouse/legacy/api/__init__.py
@@ -1,0 +1,11 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/warehouse/legacy/api/simple.py
+++ b/warehouse/legacy/api/simple.py
@@ -1,0 +1,41 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pyramid.view import view_config
+from sqlalchemy import func
+
+from warehouse.cache.http import cache_control
+from warehouse.cache.origin import origin_cache
+from warehouse.packaging.models import JournalEntry, Project
+
+
+@view_config(
+    route_name="legacy.api.simple.index",
+    renderer="legacy/api/simple/index.html",
+    decorator=[
+        cache_control(10 * 60),  # 10 minutes
+        origin_cache(7 * 24 * 60 * 60),   # 7 days
+    ],
+)
+def simple_index(request):
+    # Get the latest serial number
+    serial = request.db.query(func.max(JournalEntry.id)).scalar() or 0
+    request.response.headers["X-PyPI-Last-Serial"] = serial
+
+    # Fetch the name and normalized name for all of our projects
+    projects = (
+        request.db.query(Project.name, Project.normalized_name)
+                  .order_by(Project.normalized_name)
+                  .all()
+    )
+
+    return {"projects": projects}

--- a/warehouse/legacy/tables.py
+++ b/warehouse/legacy/tables.py
@@ -229,58 +229,6 @@ file_registry = Table(
 )
 
 
-journals = Table(
-    "journals",
-    db.metadata,
-
-    Column("id", Integer(), primary_key=True, nullable=False),
-    Column("name", Text()),
-    Column("version", Text()),
-    Column("action", Text()),
-    Column("submitted_date", DateTime(timezone=False)),
-    Column(
-        "submitted_by",
-        CIText(),
-        ForeignKey(
-            "accounts_user.username",
-            onupdate="CASCADE",
-        ),
-    ),
-    Column("submitted_from", Text()),
-)
-
-
-Index(
-    "journals_changelog",
-
-    journals.c.submitted_date,
-    journals.c.name,
-    journals.c.version,
-    journals.c.action,
-)
-
-
-Index("journals_id_idx", journals.c.id)
-
-
-Index(
-    "journals_latest_releases",
-
-    journals.c.submitted_date,
-    journals.c.name,
-    journals.c.version,
-    postgresql_where=(
-        (journals.c.version != None) & (journals.c.action == "new release")  # noqa
-    ),
-)
-
-
-Index("journals_name_idx", journals.c.name)
-
-
-Index("journals_version_idx", journals.c.version)
-
-
 mirrors = Table(
     "mirrors",
     db.metadata,

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -278,3 +278,41 @@ release_classifiers = Table(
     Index("rel_class_trove_id_idx", "trove_id"),
     Index("rel_class_version_id_idx", "version"),
 )
+
+
+class JournalEntry(db.ModelBase):
+
+    __tablename__ = "journals"
+
+    @declared_attr
+    def __table_args__(cls):  # noqa
+        return (
+            Index(
+                "journals_changelog",
+                "submitted_date", "name", "version", "action",
+            ),
+            Index("journals_id_idx", "id"),
+            Index("journals_name_idx", "name"),
+            Index("journals_version_idx", "version"),
+            Index(
+                "journals_latest_releases",
+                "submitted_date", "name", "version",
+                postgresql_where=(
+                    (cls.version != None) & (cls.action == "new release")  # noqa
+                ),
+            ),
+        )
+
+    id = Column(Integer, primary_key=True, nullable=False)
+    name = Column(Text)
+    version = Column(Text)
+    action = Column(Text)
+    submitted_date = Column(DateTime(timezone=False))
+    submitted_by = Column(
+        CIText,
+        ForeignKey(
+            "accounts_user.username",
+            onupdate="CASCADE",
+        ),
+    )
+    submitted_from = Column(Text)

--- a/warehouse/routes.py
+++ b/warehouse/routes.py
@@ -36,3 +36,12 @@ def includeme(config):
         traverse="/{name}/{version}",
     )
     config.add_route("packaging.file", "/packages/{path:.*}")
+
+    # Legacy URLs
+    config.add_route("legacy.api.simple.index", "/simple/")
+    config.add_route(
+        "legacy.api.simple.detail",
+        "/simple/{name}/",
+        factory="warehouse.packaging.models:ProjectFactory",
+        traverse="/{name}/",
+    )

--- a/warehouse/templates/legacy/api/simple/detail.html
+++ b/warehouse/templates/legacy/api/simple/detail.html
@@ -1,0 +1,12 @@
+<html>
+  <head>
+    <title>{{ _('Links for %(project)s', project=project.name) }}</title>
+    <meta name="api-version" value="2" />
+  </head>
+  <body>
+    <h1>{{ _('Links for %(project)s', project=project.name) }}</h1>
+    {% for file in files -%}
+    <a href="{{ request.route_path('packaging.file', path=file.path) }}#md5={{ file.md5_digest }}">{{ file.filename }}</a>
+    {% endfor %}
+  </body>
+</html>

--- a/warehouse/templates/legacy/api/simple/index.html
+++ b/warehouse/templates/legacy/api/simple/index.html
@@ -1,0 +1,11 @@
+<html>
+  <head>
+    <title>{{ _('Simple Index') }}</title>
+    <meta name="api-version" value="2" />
+  </head>
+  <body>
+    {% for project in projects -%}
+    <a href="{{ request.route_path('legacy.api.simple.detail', name=project.normalized_name) }}">{{ project.name }}</a>
+    {% endfor %}
+  </body>
+</html>


### PR DESCRIPTION
This adds the /simple/ and the /simple/<foo>/ views which
installers will use to fetch projects which have been
hosted on PyPI.

Fixes #387