### PR TITLE
Implement logging and log when a missing file is found

### DIFF
--- a/dev/config.yml
+++ b/dev/config.yml
@@ -23,6 +23,9 @@ configurator:
     packages: /app/data/packages/
     documentation: /app/data/documentation/
 
+  logging:
+    level: DEBUG
+
   debugtoolbar:
     hosts:
       - 0.0.0.0/0

--- a/setup.py
+++ b/setup.py
@@ -87,6 +87,7 @@ setuptools.setup(
         "setproctitle",
         "sqlalchemy>=0.9",
         "sqlalchemy-citext",
+        "structlog",
         "transaction",
         "tzf.pyramid_yml",
         "WTForms>=2.0.0",

--- a/tests/packaging/test_views.py
+++ b/tests/packaging/test_views.py
@@ -222,11 +222,17 @@ class TestPackages:
         )
 
         db_request.matchdict["path"] = path
+        db_request.log = pretend.stub(
+            error=pretend.call_recorder(lambda event, **kw: None),
+        )
 
         with pytest.raises(HTTPNotFound):
             views.packages(db_request)
 
         assert opener.calls == [pretend.call(path, mode="rb")]
+        assert db_request.log.error.calls == [
+            pretend.call("missing file data", path=path),
+        ]
 
     def test_serves_package_file(self, db_request, pyramid_config):
         memfs = fs.memoryfs.MemoryFS()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -140,6 +140,7 @@ def test_configure(monkeypatch, settings):
     assert result is configurator_obj
     assert configurator_obj.include.calls == [
         pretend.call("tzf.pyramid_yml"),
+        pretend.call(".logging"),
         pretend.call("pyramid_jinja2"),
         pretend.call("pyramid_tm"),
         pretend.call("pyramid_services"),

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,152 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import logging
+import logging.config
+import uuid
+
+from unittest import mock
+
+import pretend
+import pytest
+import structlog
+import structlog.stdlib
+
+from warehouse import logging as wlogging
+
+
+class TestStructlogFormatter:
+
+    def test_warehouse_logger_no_renderer(self):
+        formatter = wlogging.StructlogFormatter()
+        record = logging.LogRecord(
+            "warehouse.request",
+            logging.INFO,
+            None, None, "the message", None, None,
+        )
+
+        assert formatter.format(record) == "the message"
+
+    def test_non_warehouse_logger_renders(self):
+        formatter = wlogging.StructlogFormatter()
+        record = logging.LogRecord(
+            "another.logger",
+            logging.INFO,
+            None, None, "the message", None, None,
+        )
+
+        assert json.loads(formatter.format(record)) == {
+            "logger": "another.logger",
+            "level": "INFO",
+            "event": "the message",
+        }
+
+
+def test_create_id(monkeypatch):
+    uuid4 = pretend.call_recorder(lambda: "a fake uuid")
+    monkeypatch.setattr(uuid, "uuid4", uuid4)
+
+    request = pretend.stub()
+
+    assert wlogging._create_id(request) == "a fake uuid"
+
+
+def test_create_logging(monkeypatch):
+    bound_logger = pretend.stub()
+    logger = pretend.stub(
+        bind=pretend.call_recorder(lambda **kw: bound_logger),
+    )
+    get_logger = pretend.call_recorder(lambda name: logger)
+    monkeypatch.setattr(structlog, "get_logger", get_logger)
+
+    request = pretend.stub(id="request id")
+
+    assert wlogging._create_logger(request) is bound_logger
+    assert get_logger.calls == [pretend.call("warehouse.request")]
+    assert logger.bind.calls == [pretend.call(**{"request.id": "request id"})]
+
+
+@pytest.mark.parametrize(
+    ("settings", "expected_level"),
+    [
+        ({"logging.level": "DEBUG"}, "DEBUG"),
+        ({}, "INFO"),
+    ],
+)
+def test_includeme(monkeypatch, settings, expected_level):
+    dict_config = pretend.call_recorder(lambda c: None)
+    monkeypatch.setattr(logging.config, "dictConfig", dict_config)
+
+    configure = pretend.call_recorder(lambda **kw: None)
+    monkeypatch.setattr(structlog, "configure", configure)
+
+    config = pretend.stub(
+        registry=pretend.stub(settings=settings),
+        add_request_method=pretend.call_recorder(lambda fn, name, reify: None),
+    )
+
+    wlogging.includeme(config)
+
+    assert dict_config.calls == [
+        pretend.call({
+            "version": 1,
+            "disable_existing_loggers": False,
+            "formatters": {
+                "structlog": {
+                    "()": "warehouse.logging.StructlogFormatter",
+                },
+            },
+            "handlers": {
+                "primary": {
+                    "class": "logging.StreamHandler",
+                    "stream": "ext://sys.stdout",
+                    "formatter": "structlog",
+                },
+            },
+            "root": {
+                "level": expected_level,
+                "handlers": ["primary"],
+            },
+        }),
+    ]
+    assert configure.calls == [
+        pretend.call(
+            processors=[
+                structlog.stdlib.filter_by_level,
+                structlog.stdlib.add_logger_name,
+                structlog.stdlib.add_log_level,
+                mock.ANY,
+                mock.ANY,
+                structlog.processors.format_exc_info,
+                wlogging.RENDERER,
+            ],
+            logger_factory=mock.ANY,
+            wrapper_class=structlog.stdlib.BoundLogger,
+        ),
+    ]
+    assert isinstance(
+        configure.calls[0].kwargs["processors"][3],
+        structlog.stdlib.PositionalArgumentsFormatter,
+    )
+    assert isinstance(
+        configure.calls[0].kwargs["processors"][4],
+        structlog.processors.StackInfoRenderer,
+    )
+    assert isinstance(
+        configure.calls[0].kwargs["logger_factory"],
+        structlog.stdlib.LoggerFactory,
+    )
+    assert config.add_request_method.calls == [
+        pretend.call(wlogging._create_id, name="id", reify=True),
+        pretend.call(wlogging._create_logger, name="log", reify=True),
+    ]

--- a/warehouse/config.py
+++ b/warehouse/config.py
@@ -51,6 +51,9 @@ def configure(settings=None):
     # We want to load configuration from YAML files
     config.include("tzf.pyramid_yml")
 
+    # Register our logging support
+    config.include(".logging")
+
     # We'll want to use Jinja2 as our template system.
     config.include("pyramid_jinja2")
 

--- a/warehouse/logging.py
+++ b/warehouse/logging.py
@@ -1,0 +1,100 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging.config
+import uuid
+
+import structlog
+import structlog.stdlib
+
+
+RENDERER = structlog.processors.JSONRenderer()
+
+
+class StructlogFormatter(logging.Formatter):
+
+    def format(self, record):
+        # TODO: Figure out a better way of handling this besides just looking
+        #       at the logger name, ideally this would have some way to
+        #       really differentiate between log items which were logged by
+        #       structlog and which were not.
+        if not record.name.startswith("warehouse."):
+            # TODO: Is there a better way to handle this? Maybe we can figure
+            #       out a way to pass this through the structlog processors
+            #       instead of manually duplicating the side effects here?
+            event_dict = {
+                "logger": record.name,
+                "level": record.levelname,
+                "event": record.msg,
+            }
+            record.msg = RENDERER(None, None, event_dict)
+
+        return super().format(record)
+
+
+def _create_id(request):
+    return str(uuid.uuid4())
+
+
+def _create_logger(request):
+    logger = structlog.get_logger("warehouse.request")
+
+    # This has to use **{} instead of just a kwarg because request.id is not
+    # an allowed kwarg name.
+    logger = logger.bind(**{"request.id": request.id})
+
+    return logger
+
+
+def includeme(config):
+    # Configure the standard library logging
+    logging.config.dictConfig({
+        "version": 1,
+        "disable_existing_loggers": False,
+        "formatters": {
+            "structlog": {
+                "()": "warehouse.logging.StructlogFormatter",
+            },
+        },
+        "handlers": {
+            "primary": {
+                "class": "logging.StreamHandler",
+                "stream": "ext://sys.stdout",
+                "formatter": "structlog",
+            },
+        },
+        "root": {
+            "level": config.registry.settings.get("logging.level", "INFO"),
+            "handlers": ["primary"],
+        },
+    })
+
+    # Configure structlog
+    structlog.configure(
+        processors=[
+            structlog.stdlib.filter_by_level,
+            structlog.stdlib.add_logger_name,
+            structlog.stdlib.add_log_level,
+            structlog.stdlib.PositionalArgumentsFormatter(),
+            structlog.processors.StackInfoRenderer(),
+            structlog.processors.format_exc_info,
+            RENDERER,
+        ],
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        wrapper_class=structlog.stdlib.BoundLogger,
+    )
+
+    # Give every request a unique identifer
+    config.add_request_method(_create_id, name="id", reify=True)
+
+    # Add a log method to every request.
+    config.add_request_method(_create_logger, name="log", reify=True)

--- a/warehouse/packaging/views.py
+++ b/warehouse/packaging/views.py
@@ -145,8 +145,7 @@ def packages(request):
         #       We need to get S3FS so that it support rb- as well as r-.
         f = request.registry["filesystems"]["packages"].open(path, mode="rb")
     except fs.errors.ResourceNotFoundError:
-        # TODO: Log an error here, this file doesn't exists for some reason,
-        #       but it should because the database thinks it should.
+        request.log.error("missing file data", path=path)
         raise HTTPNotFound from None
 
     # If the path we're accessing is the path for the package itself, as


### PR DESCRIPTION
* Configure logging with [structlog](https://pypi.python.org/pypi/structlog/).
* Add a ``request.log`` attribute which will log with some request specific attributes.
* Have the file view log an error when the expected file data is missing when we think it should be there.

Fixes #421
Fixes #410