### PR TITLE
Use the authenticated userid for request.user

### DIFF
--- a/tests/accounts/test_core.py
+++ b/tests/accounts/test_core.py
@@ -49,7 +49,7 @@ class TestUser:
 
         request = pretend.stub(
             find_service=lambda iface: service,
-            unauthenticated_userid=100,
+            authenticated_userid=100,
         )
 
         assert accounts._user(request) is user
@@ -62,11 +62,15 @@ class TestUser:
 
         request = pretend.stub(
             find_service=lambda iface: service,
-            unauthenticated_userid=100,
+            authenticated_userid=100,
         )
 
         assert accounts._user(request) is None
         assert service.get_user.calls == [pretend.call(100)]
+
+    def test_without_userid(self):
+        request = pretend.stub(authenticated_userid=None)
+        assert accounts._user(request) is None
 
 
 def test_includeme(monkeypatch):

--- a/warehouse/accounts/__init__.py
+++ b/warehouse/accounts/__init__.py
@@ -28,8 +28,13 @@ def _authenticate(userid, request):
 
 
 def _user(request):
+    userid = request.authenticated_userid
+
+    if userid is None:
+        return
+
     login_service = request.find_service(ILoginService)
-    return login_service.get_user(request.unauthenticated_userid)
+    return login_service.get_user(userid)
 
 
 def includeme(config):


### PR DESCRIPTION
The unauthenticated userid might come from a source where the end user can influence it without any attempt to actually verify it, this is the case with the ``BasicAuthAuthenticationPolicy``. Instead we'll ensure that we use the authenticated userid.