### PR TITLE
Cache the user on request to prevent from getting garbage collected

### DIFF
--- a/warehouse/accounts/__init__.py
+++ b/warehouse/accounts/__init__.py
@@ -24,6 +24,11 @@ def _authenticate(userid, request):
     if user is None:
         return
 
+    # Since we've already authenticated the user and fetched the user from the
+    # database, we'll go ahead and stash the user. This will keep the user
+    # inside of the SQLAlchemy identity map.
+    request._user = user
+
     return []  # TODO: Add other principles.
 
 


### PR DESCRIPTION
SQLAlchemy will optimize lookups to the user using it's identity map, however that uses a weakref so we need to ensure we keep this object around somewhere.