### PR TITLE
Fix doc link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,5 +22,5 @@ You can also join ``#pypa`` or ``#pypa-dev`` on Freenode to ask questions or
 get involved.
 
 
-.. _`documentation`: https://warehouse.pypa.io/
+.. _`documentation`: https://warehouse.readthedocs.org/
 .. _`issue tracker`: https://github.com/pypa/warehouse/issues


### PR DESCRIPTION
warehouse.pypi.io return a 404