### PR TITLE
Miscellaneous Fixes

### DIFF
--- a/dev/config.yml
+++ b/dev/config.yml
@@ -23,9 +23,6 @@ configurator:
     packages: /app/data/packages/
     documentation: /app/data/documentation/
 
-  logging:
-    level: DEBUG
-
   debugtoolbar:
     hosts:
       - 0.0.0.0/0

--- a/tests/accounts/test_core.py
+++ b/tests/accounts/test_core.py
@@ -24,10 +24,12 @@ class TestLogin:
             find_userid=pretend.call_recorder(lambda username: None),
         )
         request = pretend.stub(
-            find_service=pretend.call_recorder(lambda iface: service),
+            find_service=pretend.call_recorder(lambda iface, context: service),
         )
         assert accounts._login("myuser", "mypass", request) is None
-        assert request.find_service.calls == [pretend.call(ILoginService)]
+        assert request.find_service.calls == [
+            pretend.call(ILoginService, context=None),
+        ]
         assert service.find_userid.calls == [pretend.call("myuser")]
 
     def test_with_invalid_password(self):
@@ -39,10 +41,12 @@ class TestLogin:
             ),
         )
         request = pretend.stub(
-            find_service=pretend.call_recorder(lambda iface: service),
+            find_service=pretend.call_recorder(lambda iface, context: service),
         )
         assert accounts._login("myuser", "mypass", request) is None
-        assert request.find_service.calls == [pretend.call(ILoginService)]
+        assert request.find_service.calls == [
+            pretend.call(ILoginService, context=None),
+        ]
         assert service.find_userid.calls == [pretend.call("myuser")]
         assert service.check_password.calls == [pretend.call(userid, "mypass")]
 
@@ -61,11 +65,13 @@ class TestLogin:
             ),
         )
         request = pretend.stub(
-            find_service=pretend.call_recorder(lambda iface: service),
+            find_service=pretend.call_recorder(lambda iface, context: service),
         )
 
         assert accounts._login("myuser", "mypass", request) is principals
-        assert request.find_service.calls == [pretend.call(ILoginService)]
+        assert request.find_service.calls == [
+            pretend.call(ILoginService, context=None),
+        ]
         assert service.find_userid.calls == [pretend.call("myuser")]
         assert service.check_password.calls == [pretend.call(userid, "mypass")]
         assert authenticate.calls == [pretend.call(userid, request)]
@@ -78,7 +84,7 @@ class TestAuthenticate:
         service = pretend.stub(
             get_user=pretend.call_recorder(lambda userid: user)
         )
-        request = pretend.stub(find_service=lambda iface: service)
+        request = pretend.stub(find_service=lambda iface, context: service)
 
         assert accounts._authenticate(1, request) == []
         assert service.get_user.calls == [pretend.call(1)]
@@ -87,7 +93,7 @@ class TestAuthenticate:
         service = pretend.stub(
             get_user=pretend.call_recorder(lambda userid: None)
         )
-        request = pretend.stub(find_service=lambda iface: service)
+        request = pretend.stub(find_service=lambda iface, context: service)
 
         assert accounts._authenticate(1, request) is None
         assert service.get_user.calls == [pretend.call(1)]
@@ -102,7 +108,7 @@ class TestUser:
         )
 
         request = pretend.stub(
-            find_service=lambda iface: service,
+            find_service=lambda iface, context: service,
             authenticated_userid=100,
         )
 
@@ -115,7 +121,7 @@ class TestUser:
         )
 
         request = pretend.stub(
-            find_service=lambda iface: service,
+            find_service=lambda iface, context: service,
             authenticated_userid=100,
         )
 

--- a/tests/accounts/test_views.py
+++ b/tests/accounts/test_views.py
@@ -54,7 +54,7 @@ class TestLogin:
     def test_get_returns_form(self, pyramid_request):
         login_service = pretend.stub()
         pyramid_request.find_service = pretend.call_recorder(
-            lambda iface: login_service
+            lambda iface, context: login_service
         )
         form_obj = pretend.stub()
         form_class = pretend.call_recorder(lambda d, login_service: form_obj)
@@ -63,7 +63,7 @@ class TestLogin:
 
         assert result == {"form": form_obj}
         assert pyramid_request.find_service.calls == [
-            pretend.call(ILoginService),
+            pretend.call(ILoginService, context=None),
         ]
         assert form_class.calls == [
             pretend.call(pyramid_request.POST, login_service=login_service),
@@ -72,7 +72,7 @@ class TestLogin:
     def test_post_invalid_returns_form(self, pyramid_request):
         login_service = pretend.stub()
         pyramid_request.find_service = pretend.call_recorder(
-            lambda iface: login_service
+            lambda iface, context: login_service
         )
         pyramid_request.method = "POST"
         form_obj = pretend.stub(validate=pretend.call_recorder(lambda: False))
@@ -82,7 +82,7 @@ class TestLogin:
 
         assert result == {"form": form_obj}
         assert pyramid_request.find_service.calls == [
-            pretend.call(ILoginService),
+            pretend.call(ILoginService, context=None),
         ]
         assert form_class.calls == [
             pretend.call(pyramid_request.POST, login_service=login_service),
@@ -103,7 +103,7 @@ class TestLogin:
             find_userid=pretend.call_recorder(lambda username: 1),
         )
         pyramid_request.find_service = pretend.call_recorder(
-            lambda iface: login_service
+            lambda iface, context: login_service
         )
         pyramid_request.method = "POST"
         pyramid_request.session = pretend.stub(
@@ -130,7 +130,7 @@ class TestLogin:
         assert result.headers["Location"] == "/"
         assert result.headers["foo"] == "bar"
         assert pyramid_request.find_service.calls == [
-            pretend.call(ILoginService),
+            pretend.call(ILoginService, context=None),
         ]
         assert form_class.calls == [
             pretend.call(pyramid_request.POST, login_service=login_service),

--- a/warehouse/accounts/__init__.py
+++ b/warehouse/accounts/__init__.py
@@ -35,11 +35,6 @@ def _authenticate(userid, request):
     if user is None:
         return
 
-    # Since we've already authenticated the user and fetched the user from the
-    # database, we'll go ahead and stash the user. This will keep the user
-    # inside of the SQLAlchemy identity map.
-    request._user = user
-
     return []  # TODO: Add other principles.
 
 

--- a/warehouse/accounts/__init__.py
+++ b/warehouse/accounts/__init__.py
@@ -10,13 +10,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pyramid.authentication import SessionAuthenticationPolicy
 from pyramid.authorization import ACLAuthorizationPolicy
 from pyramid_multiauth import MultiAuthenticationPolicy
 
 from warehouse.accounts.interfaces import ILoginService
 from warehouse.accounts.services import database_login_factory
-from warehouse.accounts.auth_policy import BasicAuthAuthenticationPolicy
+from warehouse.accounts.auth_policy import (
+    BasicAuthAuthenticationPolicy, SessionAuthenticationPolicy,
+)
 
 
 def _login(username, password, request):

--- a/warehouse/accounts/__init__.py
+++ b/warehouse/accounts/__init__.py
@@ -21,7 +21,7 @@ from warehouse.accounts.auth_policy import (
 
 
 def _login(username, password, request):
-    login_service = request.find_service(ILoginService)
+    login_service = request.find_service(ILoginService, context=None)
     userid = login_service.find_userid(username)
     if userid is not None:
         if login_service.check_password(userid, password):
@@ -29,7 +29,7 @@ def _login(username, password, request):
 
 
 def _authenticate(userid, request):
-    login_service = request.find_service(ILoginService)
+    login_service = request.find_service(ILoginService, context=None)
     user = login_service.get_user(userid)
 
     if user is None:
@@ -49,7 +49,7 @@ def _user(request):
     if userid is None:
         return
 
-    login_service = request.find_service(ILoginService)
+    login_service = request.find_service(ILoginService, context=None)
     return login_service.get_user(userid)
 
 

--- a/warehouse/accounts/services.py
+++ b/warehouse/accounts/services.py
@@ -10,6 +10,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import functools
+
 from passlib.context import CryptContext
 from sqlalchemy.orm.exc import NoResultFound
 from zope.interface import implementer
@@ -33,12 +35,14 @@ class DatabaseLoginService:
             deprecated=["auto"],
         )
 
+    @functools.lru_cache()
     def get_user(self, userid):
         # TODO: We probably don't actually want to just return the database
         #       object here.
         # TODO: We need some sort of Anonymous User.
         return self.db.query(User).get(userid)
 
+    @functools.lru_cache()
     def find_userid(self, username):
         try:
             user = (

--- a/warehouse/accounts/views.py
+++ b/warehouse/accounts/views.py
@@ -50,7 +50,7 @@ def login(request, _form_class=LoginForm):
     # TODO: Configure the login view as the default view for not having
     #       permission to view something.
 
-    login_service = request.find_service(ILoginService)
+    login_service = request.find_service(ILoginService, context=None)
 
     form = _form_class(request.POST, login_service=login_service)
 


### PR DESCRIPTION
* Ensure that accessing an authentication policy triggers ``Vary`` headers.
* Switch session enforcement to an on by default decorator instead of a tween.
* Pass an explicit ``None`` for the ``context`` to all the ``request.find_service`` calls to find the ``ILoginService``, the context is not meaningful for it and we want to use it in locations where we can't access the context. If we don't pass ``None`` everywhere then multiple instances will be created for each request.
* Use the default logging level instead of ``DEBUG``.
* Use ``functools.lru_cache()`` to cache function call results instead of stashing them as random request attributes.