### PR TITLE
Implement a Translation System

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.py[co]
+*.mo
 
 *.egg-info/
 *.egg

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
     - TOXENV=pep8
     - TOXENV=docs
     - TOXENV=packaging
+    - TOXENV=translations
 
 install:
   # Build wheels for our entire dependency chain.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -11,8 +11,9 @@ recursive-include warehouse/migrations *.mako
 recursive-include warehouse/migrations/versions *.py
 recursive-include warehouse/static *.css *.json *.scss *.png
 recursive-include warehouse/templates *.html
+recursive-include warehouse/translations warehouse.pot *.po
 
-exclude Gulpfile.js package.json
+exclude babel.cfg Makefile Gulpfile.js package.json
 exclude .dockerignore Dockerfile docker-compose.yml
 
 prune .travis

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,30 @@
+default:
+	@echo "Must call a specific subcommand"
+	@exit 1
+
+.tox/translations:
+	tox -e translations --notest
+
+clean:
+	rm -rf .tox/translations
+
+extract-translations: .tox/translations
+	.tox/translations/bin/pybabel extract -F babel.cfg --sort-output \
+		--project Warehouse --version $(shell python setup.py --version) \
+		--copyright-holder "Individual contributors" \
+		--msgid-bugs-address "distutils-sig@python.org" \
+		-o warehouse/translations/warehouse.pot \
+		warehouse/
+	.tox/translations/bin/pybabel update --ignore-obsolete \
+		-D warehouse \
+		-i warehouse/translations/warehouse.pot -d warehouse/translations
+
+init-translations: .tox/translations
+	.tox/translations/bin/pybabel init \
+		-l $(L) -D warehouse \
+		-i warehouse/translations/warehouse.pot -d warehouse/translations
+
+compile-translations: .tox/translations
+	.tox/translations/bin/pybabel compile -f -D warehouse -d warehouse/translations
+
+.PHONY: clean extract-translations init-translations compile-translations

--- a/babel.cfg
+++ b/babel.cfg
@@ -1,0 +1,4 @@
+[python: **.py]
+
+[jinja2: **/templates/**.html]
+extensions=jinja2.ext.autoescape,jinja2.ext.with_

--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -6,6 +6,14 @@
 # PyPI, so we'll install it from GitHub first.
 https://github.com/Pylons/pyramid/archive/master.zip#egg=pyramid
 
+# We need a patched version of Jinja2 which gives access to the context in a
+# finalize function.
+https://github.com/dstufft/jinja2/archive/contextfinalize.zip#egg=jinja2
+
+# We need a patched version of pyramid_jinja2 which allows overriding the
+# GetTextWrapper with one of our own.
+https://github.com/dstufft/pyramid_jinja2/archive/allow-override-gettext.zip#egg=pyramid_jinja2
+
 # Install Warehouse itself.
 -e .
 

--- a/docs/development/index.rst
+++ b/docs/development/index.rst
@@ -12,6 +12,7 @@ bug check out `what to put in your bug report`_.
 
     getting-started
     submitting-patches
+    translations
     patterns
     reviewing-patches
 

--- a/docs/development/reviewing-patches.rst
+++ b/docs/development/reviewing-patches.rst
@@ -46,5 +46,7 @@ Merge requirements
   backwards incompatible release of a dependency) no pull requests may be
   merged until this is rectified.
 * All merged patches must have 100% test coverage.
+* All user facing strings must be marked for translation and the ``.pot`` and
+  ``.po`` files must be updated.
 
 .. _`excellent to one another`: https://speakerdeck.com/ohrite/better-code-review

--- a/docs/development/submitting-patches.rst
+++ b/docs/development/submitting-patches.rst
@@ -49,6 +49,18 @@ Tests
 All code changes must be accompanied by unit tests with 100% code coverage (as
 measured by `coverage.py`_).
 
+
+Translations
+------------
+
+All user facing content must be marked for translation and anytime content is
+updated the ``.pot`` and ``.po``must be regenerated using the
+``make extract-translations`` commands and committed as part of the patch.
+
+More details about the Warehouse translation mechanism can be found in
+:doc:`translations`.
+
+
 Documentation
 -------------
 

--- a/docs/development/translations.rst
+++ b/docs/development/translations.rst
@@ -1,0 +1,80 @@
+Translations
+============
+
+Warehouse has been written to enable translation of the UI elements into
+languages other than English. It uses a few small utilities to make this all
+work however the interface should be familiar for anyone whose ever worked
+with translations.
+
+
+Marking Strings for Translation
+-------------------------------
+
+In Python
+~~~~~~~~~
+
+Inside of Python code, you can easily translate using either the ``gettext`` or
+the ``ngettext`` functions from ``warehouse.i18n``. These functions will return
+a ``TranslationString`` instance. This does not act like a normal string,
+you cannot combine it with other translated or untranslated content except
+through the string formatting via ``%`` interface. This is because you cannot
+build up a string iteratively by combining multiple separately translated
+strings. Unlike normal strings, you can use the ``%`` multiple times and it
+will combine all of the given results until it is finally rendered. Another
+difference is the only type of formatting allowed is the named parameter style
+(``"%(foo)s"``) and not the positional style(``"%s"``).
+
+It is important to note that the actual translation of a ``TranslationString``
+is delayed until ``TranslationString().translate(translation)`` on it passing
+in the value of ``request.translation``. If a ``TranslationString`` is being
+used inside of a template this can be ignored as the template system will
+automatically handle this for you. This means that, unlike many other
+translation systems, there is no distinction between lazy and eager strings.
+
+Example:
+
+.. code:: python
+
+    # It is customary to name the gettext function _
+    from warehouse.i18n import gettext as _
+
+    MESSAGE = _("This is Translated Message.")
+
+    @view_config(route_name="myroute", renderer="mytemplate.html")
+    def my_view(request):
+        return {
+            "msg": MESSAGE,
+            "other": _("This is another translated message"),
+        }
+
+
+In Templates
+~~~~~~~~~~~~
+
+Inside of Jinja2 templates the standard
+`Jinja2 i18n extension <http://jinja.pocoo.org/docs/dev/extensions/#newstyle-gettext>`_
+configured with ``newstyle=True``.
+
+
+Working with Translation Files
+------------------------------
+
+Extracting New Strings
+~~~~~~~~~~~~~~~~~~~~~~
+
+New strings can be extracted from all sources by executing
+``make extract-translations`` and committing the resulting updates to the
+``.pot`` and ``.po`` files.
+
+
+Translating Strings
+~~~~~~~~~~~~~~~~~~~
+
+TODO: Figure out how this works exactly.
+
+
+Compiling Translations
+~~~~~~~~~~~~~~~~~~~~~~
+
+The ``.po`` files inside of ``warehouse/locale`` can be translated to ``.mo``
+files by executing ``make compile-translations``.

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ setuptools.setup(
         "passlib>=1.6",
         "psycopg2",
         "pyramid>=1.6.dev0",
-        "pyramid_jinja2",
+        "pyramid_jinja2>=2.4",
         "pyramid_multiauth",
         "pyramid_services",
         "pyramid_tm>=0.11",

--- a/tests/i18n/test_init.py
+++ b/tests/i18n/test_init.py
@@ -27,6 +27,21 @@ def test_sets_locale(monkeypatch):
     assert locale_cls.parse.calls == [pretend.call(request.locale_name)]
 
 
+def test_loads_translations(monkeypatch):
+    translation = pretend.stub()
+    translations = pretend.stub(
+        load=pretend.call_recorder(lambda d, l, domain: translation)
+    )
+    monkeypatch.setattr(i18n, "Translations", translations)
+
+    request = pretend.stub(locale=pretend.stub())
+
+    assert i18n._translation(request) is translation
+    assert translations.load.calls == [
+        pretend.call(i18n.LOCALE_DIR, request.locale, domain="warehouse"),
+    ]
+
+
 def test_includeme():
     config_settings = {}
     config = pretend.stub(
@@ -38,9 +53,13 @@ def test_includeme():
 
     assert config.add_request_method.calls == [
         pretend.call(i18n._locale, name="locale", reify=True),
+        pretend.call(i18n._translation, name="translation", reify=True),
     ]
     assert config_settings == {
         "jinja2.filters": {
             "format_date": "warehouse.i18n.filters:format_date",
         },
+        "jinja2.finalize": i18n.translate_value,
+        "jinja2.i18n.domain": "warehouse",
+        "jinja2.i18n.gettext": i18n.JinjaRequestTranslation,
     }

--- a/tests/i18n/test_translations.py
+++ b/tests/i18n/test_translations.py
@@ -1,0 +1,206 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pretend
+import pytest
+
+from warehouse.i18n import translations
+
+
+class TestTranslationString:
+
+    def test_stores_values(self):
+        message_id = pretend.stub()
+        plural = pretend.stub()
+        n = pretend.stub()
+
+        ts = translations.TranslationString(message_id, plural, n)
+
+        assert ts.message_id is message_id
+        assert ts.plural is plural
+        assert ts.n is n
+
+    def test_cant_specify_only_plural(self):
+        message_id = pretend.stub()
+        plural = pretend.stub()
+
+        with pytest.raises(ValueError):
+            translations.TranslationString(message_id, plural)
+
+    def test_cant_specify_only_n(self):
+        message_id = pretend.stub()
+        n = pretend.stub()
+
+        with pytest.raises(ValueError):
+            translations.TranslationString(message_id, n=n)
+
+    @pytest.mark.parametrize(
+        ("args", "expected"),
+        [
+            (
+                ("A Message",),
+                "<TranslationString: message_id={!r}>".format("A Message"),
+            ),
+            (
+                ("A Message", "Messages", 3),
+                "<TranslationString: message_id={!r} plural={!r} "
+                "n={!r}>".format("A Message", "Messages", 3),
+            ),
+        ],
+    )
+    def test_repr(self, args, expected):
+        ts = translations.TranslationString(*args)
+        assert repr(ts) == expected
+
+    def test_mod_errors_non_mapping(self):
+        ts = translations.TranslationString("Name is %(name)s")
+
+        with pytest.raises(TypeError):
+            ts % (1,)
+
+    def test_mod_adds_mapping_creates(self):
+        ts1 = translations.TranslationString("Name is %(name)s")
+        ts2 = ts1 % {"name": "MyName"}
+        ts3 = ts2 % {"name": "AnotherName"}
+
+        assert ts1.mapping == {}
+        assert ts2.mapping == {"name": "MyName"}
+        assert ts3.mapping == {"name": "AnotherName"}
+
+    def test_translate_gettext(self):
+        ts = translations.TranslationString("Test %(foo)s")
+        ts = ts % {"foo": "bar"}
+
+        translation = pretend.stub(
+            gettext=pretend.call_recorder(lambda m: "Translated %(foo)s")
+        )
+
+        assert ts.translate(translation) == "Translated bar"
+        assert translation.gettext.calls == [pretend.call("Test %(foo)s")]
+
+    def test_translate_ngettext(self):
+        ts = translations.TranslationString(
+            "Test %(foo)s", "Plural %(foos)s", 1,
+        )
+        ts = ts % {"foo": "bar"}
+
+        translation = pretend.stub(
+            ngettext=pretend.call_recorder(
+                lambda m, p, n: "Translated %(foo)s"
+            ),
+        )
+
+        assert ts.translate(translation) == "Translated bar"
+        assert translation.ngettext.calls == [
+            pretend.call("Test %(foo)s", "Plural %(foos)s", 1),
+        ]
+
+
+class TestJinjaRequestTranslation:
+
+    def test_stores_domain(self):
+        domain = pretend.stub()
+        assert translations.JinjaRequestTranslation(domain).domain is domain
+
+    def test_calls_translation_gettext(self):
+        gettext = pretend.call_recorder(lambda m: "A translated message")
+
+        context = {
+            "request": pretend.stub(translation=pretend.stub(gettext=gettext)),
+        }
+
+        rt = translations.JinjaRequestTranslation(pretend.stub())
+        translated = rt.gettext(context, "A testing message")
+
+        assert translated == "A translated message"
+        assert gettext.calls == [pretend.call("A testing message")]
+
+    def test_calls_translation_ngettext(self):
+        ngettext = pretend.call_recorder(lambda m, p, n: "translated message")
+
+        context = {
+            "request": pretend.stub(
+                translation=pretend.stub(ngettext=ngettext),
+            ),
+        }
+
+        rt = translations.JinjaRequestTranslation(pretend.stub())
+        translated = rt.ngettext(
+            context, "A testing message", "Another testing message", 4,
+        )
+
+        assert translated == "translated message"
+        assert ngettext.calls == [
+            pretend.call("A testing message", "Another testing message", 4),
+        ]
+
+
+class TestTranslateValue:
+
+    def test_with_non_translate_string(self):
+        value = pretend.stub()
+        assert translations.translate_value(None, value) is value
+
+    def test_with_translate_string(self):
+        translation = pretend.stub()
+        context = {"request": pretend.stub(translation=translation)}
+        ts = translations.TranslationString("A Message")
+        ts.translate = pretend.call_recorder(lambda t: "translated message")
+
+        translated = translations.translate_value(context, ts)
+
+        assert translated == "translated message"
+        assert ts.translate.calls == [pretend.call(translation)]
+
+
+class TestSimpleAPI:
+
+    def test_gettext_no_kwargs(self):
+        ts = translations.gettext("My Message")
+        assert isinstance(ts, translations.TranslationString)
+        assert ts.message_id == "My Message"
+        assert ts.plural is None
+        assert ts.n is None
+        assert ts.mapping == {}
+
+    def test_gettext_with_kwargs(self):
+        ts = translations.gettext("My Message", foo="bar")
+        assert isinstance(ts, translations.TranslationString)
+        assert ts.message_id == "My Message"
+        assert ts.plural is None
+        assert ts.n is None
+        assert ts.mapping == {"foo": "bar"}
+
+    def test_ngettext_no_n(self):
+        ts_p = translations.ngettext("M1", "M2")
+        ts = ts_p(3)
+        assert isinstance(ts, translations.TranslationString)
+        assert ts.message_id == "M1"
+        assert ts.plural == "M2"
+        assert ts.n == 3
+        assert ts.mapping == {}
+
+    def test_ngettext_with_n(self):
+        ts = translations.ngettext("M1", "M2", 6)
+        assert isinstance(ts, translations.TranslationString)
+        assert ts.message_id == "M1"
+        assert ts.plural == "M2"
+        assert ts.n == 6
+        assert ts.mapping == {}
+
+    def test_ngettext_with_kwargs(self):
+        ts = translations.ngettext("M1", "M2", 6, foo="bar")
+        assert isinstance(ts, translations.TranslationString)
+        assert ts.message_id == "M1"
+        assert ts.plural == "M2"
+        assert ts.n == 6
+        assert ts.mapping == {"foo": "bar"}

--- a/tox.ini
+++ b/tox.ini
@@ -58,6 +58,19 @@ commands =
     check-manifest
     python setup.py check --restructuredtext --strict
 
+[testenv:translations]
+basepython = python2.7
+whitelist_externals =
+    make
+    git
+skip_install = True
+deps =
+    jinja2
+    babel
+commands =
+    make extract-translations
+    git --no-pager diff --exit-code -G "^(msg.*|.: )" warehouse/translations/warehouse.pot
+
 
 [flake8]
 exclude = .tox,*.egg,*/interfaces.py

--- a/warehouse/config.py
+++ b/warehouse/config.py
@@ -17,6 +17,7 @@ from pyramid import renderers
 from pyramid.config import Configurator
 from pyramid.httpexceptions import HTTPMovedPermanently
 from tzf.pyramid_yml import config_defaults
+
 from warehouse.utils.static import WarehouseCacheBuster
 
 

--- a/warehouse/i18n/__init__.py
+++ b/warehouse/i18n/__init__.py
@@ -10,7 +10,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os.path
+
 from babel.core import Locale
+from babel.support import Translations
+
+from warehouse.i18n.translations import (
+    JinjaRequestTranslation, translate_value, gettext, ngettext,
+)
+
+
+__all__ = ["gettext", "ngettext", "includeme"]
+
+
+GETTEXT_DOMAIN = "warehouse"
+
+LOCALE_DIR = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "translations")
+)
 
 
 def _locale(request):
@@ -20,10 +37,26 @@ def _locale(request):
     return Locale.parse(request.locale_name)
 
 
+def _translation(request):
+    """
+    Loads a translation object for this request.
+    """
+    # TODO: Should we cache these in memory?
+    return Translations.load(LOCALE_DIR, request.locale, domain=GETTEXT_DOMAIN)
+
+
 def includeme(config):
-    # Add the request.locale attribute
+    # Add the request attributes
     config.add_request_method(_locale, name="locale", reify=True)
+    config.add_request_method(_translation, name="translation", reify=True)
 
     # Register our i18n/l10n filters for Jinja2
     filters = config.get_settings().setdefault("jinja2.filters", {})
     filters.setdefault("format_date", "warehouse.i18n.filters:format_date")
+
+    # Register our finalize function for Jinja2
+    config.get_settings()["jinja2.finalize"] = translate_value
+
+    # Configure Jinja2 for translation
+    config.get_settings()["jinja2.i18n.domain"] = GETTEXT_DOMAIN
+    config.get_settings()["jinja2.i18n.gettext"] = JinjaRequestTranslation

--- a/warehouse/i18n/translations.py
+++ b/warehouse/i18n/translations.py
@@ -1,0 +1,97 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import collections.abc
+import functools
+
+from jinja2 import contextfunction
+from pyramid.threadlocal import get_current_request
+
+
+class TranslationString:
+
+    def __init__(self, message_id, plural=None, n=None, mapping=None):
+        if mapping is None:
+            mapping = {}
+
+        self.message_id = message_id
+        self.plural = plural
+        self.n = n
+        self.mapping = mapping
+
+        if bool(self.plural) != bool(self.n):
+            raise ValueError("Must specify plural and n together.")
+
+    def __repr__(self):
+        extra = ""
+        if self.plural is not None:
+            extra = " plural={!r} n={!r}".format(self.plural, self.n)
+        return "<TranslationString: message_id={!r}{}>".format(
+            self.message_id,
+            extra,
+        )
+
+    def __mod__(self, mapping):
+        if not isinstance(mapping, collections.abc.Mapping):
+            raise TypeError("Only mappings are supported.")
+
+        vals = self.mapping.copy()
+        vals.update(mapping)
+
+        return TranslationString(
+            self.message_id, self.plural, self.n, mapping=vals,
+        )
+
+    def translate(self, translation):
+        if self.plural is not None:
+            result = translation.ngettext(self.message_id, self.plural, self.n)
+        else:
+            result = translation.gettext(self.message_id)
+
+        return result % self.mapping
+
+
+class JinjaRequestTranslation:
+
+    def __init__(self, domain):
+        self.domain = domain
+
+    @contextfunction
+    def gettext(self, ctx, *args, **kwargs):
+        request = ctx.get("request") or get_current_request()
+        return request.translation.gettext(*args, **kwargs)
+
+    @contextfunction
+    def ngettext(self, ctx, *args, **kwargs):
+        request = ctx.get("request") or get_current_request()
+        return request.translation.ngettext(*args, **kwargs)
+
+
+@contextfunction
+def translate_value(ctx, value):
+    if isinstance(value, TranslationString):
+        return value.translate(ctx["request"].translation)
+
+    return value
+
+
+def gettext(message_id, **kwargs):
+    return TranslationString(message_id, mapping=kwargs)
+
+
+def ngettext(message_id, plural, n=None, **kwargs):
+    if n is None:
+        return functools.partial(
+            TranslationString, message_id, plural, mapping=kwargs
+        )
+
+    return TranslationString(message_id, plural, n, mapping=kwargs)

--- a/warehouse/translations/en/LC_MESSAGES/warehouse.po
+++ b/warehouse/translations/en/LC_MESSAGES/warehouse.po
@@ -1,0 +1,152 @@
+# English translations for Warehouse.
+# Copyright (C) 2015 Individual contributors
+# This file is distributed under the same license as the Warehouse project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2015.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Warehouse 15.0.dev0\n"
+"Report-Msgid-Bugs-To: distutils-sig@python.org\n"
+"POT-Creation-Date: 2015-03-27 23:58-0400\n"
+"PO-Revision-Date: 2015-03-27 23:41-0400\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: en <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 1.3\n"
+
+#: warehouse/templates/packaging/detail.html:87
+msgid "Author"
+msgstr ""
+
+#: warehouse/templates/packaging/detail.html:131
+msgid "Classifiers"
+msgstr ""
+
+#: warehouse/templates/packaging/detail.html:144
+msgid "Daily"
+msgstr ""
+
+#: warehouse/templates/packaging/detail.html:141
+msgid "Download Stats"
+msgstr ""
+
+#: warehouse/templates/packaging/detail.html:108
+msgid "Download URL"
+msgstr ""
+
+#: warehouse/templates/base.html:37
+msgid "Enter Search"
+msgstr ""
+
+#: warehouse/templates/packaging/detail.html:36
+msgid "File"
+msgstr ""
+
+#: warehouse/templates/packaging/detail.html:33
+msgid "Files"
+msgstr ""
+
+#: warehouse/templates/packaging/detail.html:102
+msgid "Home page"
+msgstr ""
+
+#: warehouse/templates/packaging/detail.html:121
+msgid "Keywords"
+msgstr ""
+
+#: warehouse/templates/packaging/detail.html:116
+msgid "License"
+msgstr ""
+
+#: warehouse/templates/legacy/api/simple/detail.html:3
+#: warehouse/templates/legacy/api/simple/detail.html:7
+#, python-format
+msgid "Links for %(project)s"
+msgstr ""
+
+#: warehouse/templates/base.html:31
+msgid "Logo Image"
+msgstr ""
+
+#: warehouse/templates/packaging/detail.html:92
+msgid "Maintainer"
+msgstr ""
+
+#: warehouse/templates/packaging/detail.html:162
+msgid "Maintainers"
+msgstr ""
+
+#: warehouse/templates/packaging/detail.html:146
+msgid "Monthly"
+msgstr ""
+
+#: warehouse/templates/packaging/detail.html:126
+msgid "Platform"
+msgstr ""
+
+#: warehouse/templates/packaging/detail.html:84
+msgid "Project Information"
+msgstr ""
+
+#: warehouse/templates/packaging/detail.html:97
+msgid "Project URLs"
+msgstr ""
+
+#: warehouse/templates/packaging/detail.html:38
+msgid "Python Version"
+msgstr ""
+
+#: warehouse/templates/base.html:39
+msgid "Search"
+msgstr ""
+
+#: warehouse/templates/base.html:43
+msgid "Sign In"
+msgstr ""
+
+#: warehouse/templates/base.html:44
+msgid "Sign Up"
+msgstr ""
+
+#: warehouse/templates/accounts/login.html:3
+msgid "Sign in"
+msgstr ""
+
+#: warehouse/templates/accounts/logout.html:3
+#: warehouse/templates/accounts/logout.html:9
+msgid "Sign out"
+msgstr ""
+
+#: warehouse/templates/accounts/logout.html:6
+#, python-format
+msgid "Sign out of %(username)s"
+msgstr ""
+
+#: warehouse/templates/legacy/api/simple/index.html:3
+msgid "Simple Index"
+msgstr ""
+
+#: warehouse/templates/packaging/detail.html:40
+msgid "Size"
+msgstr ""
+
+#: warehouse/templates/packaging/detail.html:37
+msgid "Type"
+msgstr ""
+
+#: warehouse/templates/packaging/detail.html:39
+msgid "Uploaded On"
+msgstr ""
+
+#: warehouse/templates/packaging/detail.html:149
+msgid "Versions"
+msgstr ""
+
+#: warehouse/templates/packaging/detail.html:145
+msgid "Weekly"
+msgstr ""
+

--- a/warehouse/translations/warehouse.pot
+++ b/warehouse/translations/warehouse.pot
@@ -1,0 +1,151 @@
+# Translations template for Warehouse.
+# Copyright (C) 2015 Individual contributors
+# This file is distributed under the same license as the Warehouse project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2015.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Warehouse 15.0.dev0\n"
+"Report-Msgid-Bugs-To: distutils-sig@python.org\n"
+"POT-Creation-Date: 2015-03-27 23:58-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 1.3\n"
+
+#: warehouse/templates/packaging/detail.html:87
+msgid "Author"
+msgstr ""
+
+#: warehouse/templates/packaging/detail.html:131
+msgid "Classifiers"
+msgstr ""
+
+#: warehouse/templates/packaging/detail.html:144
+msgid "Daily"
+msgstr ""
+
+#: warehouse/templates/packaging/detail.html:141
+msgid "Download Stats"
+msgstr ""
+
+#: warehouse/templates/packaging/detail.html:108
+msgid "Download URL"
+msgstr ""
+
+#: warehouse/templates/base.html:37
+msgid "Enter Search"
+msgstr ""
+
+#: warehouse/templates/packaging/detail.html:36
+msgid "File"
+msgstr ""
+
+#: warehouse/templates/packaging/detail.html:33
+msgid "Files"
+msgstr ""
+
+#: warehouse/templates/packaging/detail.html:102
+msgid "Home page"
+msgstr ""
+
+#: warehouse/templates/packaging/detail.html:121
+msgid "Keywords"
+msgstr ""
+
+#: warehouse/templates/packaging/detail.html:116
+msgid "License"
+msgstr ""
+
+#: warehouse/templates/legacy/api/simple/detail.html:3
+#: warehouse/templates/legacy/api/simple/detail.html:7
+#, python-format
+msgid "Links for %(project)s"
+msgstr ""
+
+#: warehouse/templates/base.html:31
+msgid "Logo Image"
+msgstr ""
+
+#: warehouse/templates/packaging/detail.html:92
+msgid "Maintainer"
+msgstr ""
+
+#: warehouse/templates/packaging/detail.html:162
+msgid "Maintainers"
+msgstr ""
+
+#: warehouse/templates/packaging/detail.html:146
+msgid "Monthly"
+msgstr ""
+
+#: warehouse/templates/packaging/detail.html:126
+msgid "Platform"
+msgstr ""
+
+#: warehouse/templates/packaging/detail.html:84
+msgid "Project Information"
+msgstr ""
+
+#: warehouse/templates/packaging/detail.html:97
+msgid "Project URLs"
+msgstr ""
+
+#: warehouse/templates/packaging/detail.html:38
+msgid "Python Version"
+msgstr ""
+
+#: warehouse/templates/base.html:39
+msgid "Search"
+msgstr ""
+
+#: warehouse/templates/base.html:43
+msgid "Sign In"
+msgstr ""
+
+#: warehouse/templates/base.html:44
+msgid "Sign Up"
+msgstr ""
+
+#: warehouse/templates/accounts/login.html:3
+msgid "Sign in"
+msgstr ""
+
+#: warehouse/templates/accounts/logout.html:3
+#: warehouse/templates/accounts/logout.html:9
+msgid "Sign out"
+msgstr ""
+
+#: warehouse/templates/accounts/logout.html:6
+#, python-format
+msgid "Sign out of %(username)s"
+msgstr ""
+
+#: warehouse/templates/legacy/api/simple/index.html:3
+msgid "Simple Index"
+msgstr ""
+
+#: warehouse/templates/packaging/detail.html:40
+msgid "Size"
+msgstr ""
+
+#: warehouse/templates/packaging/detail.html:37
+msgid "Type"
+msgstr ""
+
+#: warehouse/templates/packaging/detail.html:39
+msgid "Uploaded On"
+msgstr ""
+
+#: warehouse/templates/packaging/detail.html:149
+msgid "Versions"
+msgstr ""
+
+#: warehouse/templates/packaging/detail.html:145
+msgid "Weekly"
+msgstr ""
+


### PR DESCRIPTION
* Implements a translation system that creates a fairly standard ``gettext`` and ``ngettext`` API.
* Works without thread locals by delaying translation until templates are rendered.
* Tests that changes to translation strings in source files includes updated ``.pot`` and ``.po`` files.
* Documentation about the requirements for pull requests to mark strings for translation and how this translation system works.

This does not include any sort of automatic compilation, so translations won't actually be active. Eventually compiling translations should be part of the build process of turning an sdist into a wheel, however that isn't important for this PR.

/cc @jezdez @tiran