### PR TITLE
Use RFC 5861 stale-while-revalidate and stale-if-error headers

### DIFF
--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -2,6 +2,10 @@
 # Why requirements.txt?
 # See https://caremad.io/2013/07/setup-vs-requirement/
 
+# We want to use our forked version of Webob to get stale-while-revalidate and
+# stale-if-error support on CacheControl.
+https://github.com/dstufft/webob/archive/support-stale.zip#egg=webob
+
 # We need a newer version of Pyramid (1.6) than what is currently available on
 # PyPI, so we'll install it from GitHub first.
 https://github.com/Pylons/pyramid/archive/master.zip#egg=pyramid

--- a/warehouse/accounts/views.py
+++ b/warehouse/accounts/views.py
@@ -26,7 +26,11 @@ from warehouse.sessions import uses_session
     route_name="accounts.profile",
     renderer="accounts/profile.html",
     decorator=[
-        cache_control(1 * 24 * 60 * 60),  # 1 day
+        cache_control(
+            1 * 24 * 60 * 60,                         # 1 day
+            stale_while_revalidate=1 * 24 * 60 * 60,  # 1 day
+            stale_if_error=1 * 24 * 60 * 60,          # 1 day
+        ),
         origin_cache(30 * 24 * 60 * 60),  # 30 days
     ],
 )

--- a/warehouse/cache/http.py
+++ b/warehouse/cache/http.py
@@ -34,7 +34,8 @@ def add_vary(*varies):
     return inner
 
 
-def cache_control(seconds, public=True):
+def cache_control(seconds, *, public=True, stale_while_revalidate=None,
+                  stale_if_error=None):
     def inner(view):
         @functools.wraps(view)
         def wrapped(context, request):
@@ -48,6 +49,9 @@ def cache_control(seconds, public=True):
                     else:
                         response.cache_control.private = True
 
+                    response.cache_control.stale_while_revalidate = \
+                        stale_while_revalidate
+                    response.cache_control.stale_if_error = stale_if_error
                     response.cache_control.max_age = seconds
                 else:
                     response.cache_control.no_cache = True

--- a/warehouse/legacy/api/json.py
+++ b/warehouse/legacy/api/json.py
@@ -25,7 +25,11 @@ from warehouse.packaging.models import File, Release, JournalEntry
     route_name="legacy.api.json.project",
     renderer="json",
     decorator=[
-        cache_control(1 * 24 * 60 * 60),  # 1 day
+        cache_control(
+            1 * 24 * 60 * 60,                         # 1 day
+            stale_while_revalidate=1 * 24 * 60 * 60,  # 1 day
+            stale_if_error=1 * 24 * 60 * 60,          # 1 day
+        ),
         origin_cache(7 * 24 * 60 * 60),   # 7 days
     ],
 )
@@ -49,7 +53,11 @@ def json_project(project, request):
     route_name="legacy.api.json.release",
     renderer="json",
     decorator=[
-        cache_control(7 * 24 * 60 * 60),  # 7 days
+        cache_control(
+            7 * 24 * 60 * 60,                         # 7 days
+            stale_while_revalidate=1 * 24 * 60 * 60,  # 1 day
+            stale_if_error=1 * 24 * 60 * 60,          # 1 day
+        ),
         origin_cache(30 * 24 * 60 * 60),  # 30 days
     ],
 )

--- a/warehouse/legacy/api/simple.py
+++ b/warehouse/legacy/api/simple.py
@@ -23,7 +23,11 @@ from warehouse.packaging.models import JournalEntry, File, Project, Release
     route_name="legacy.api.simple.index",
     renderer="legacy/api/simple/index.html",
     decorator=[
-        cache_control(10 * 60),  # 10 minutes
+        cache_control(
+            10 * 60,                                  # 10 minutes
+            stale_while_revalidate=1 * 24 * 60 * 60,  # 1 day
+            stale_if_error=1 * 24 * 60 * 60,          # 1 day
+        ),
         origin_cache(7 * 24 * 60 * 60),   # 7 days
     ],
 )
@@ -46,7 +50,11 @@ def simple_index(request):
     route_name="legacy.api.simple.detail",
     renderer="legacy/api/simple/detail.html",
     decorator=[
-        cache_control(10 * 60),  # 10 minutes
+        cache_control(
+            10 * 60,                                  # 10 minutes
+            stale_while_revalidate=1 * 24 * 60 * 60,  # 1 day
+            stale_if_error=1 * 24 * 60 * 60,          # 1 day
+        ),
         origin_cache(7 * 24 * 60 * 60),   # 7 days
     ],
 )

--- a/warehouse/packaging/views.py
+++ b/warehouse/packaging/views.py
@@ -28,7 +28,11 @@ from warehouse.packaging.models import Release, File, Role
     route_name="packaging.project",
     renderer="packaging/detail.html",
     decorator=[
-        cache_control(1 * 24 * 60 * 60),  # 1 day
+        cache_control(
+            1 * 24 * 60 * 60,                         # 1 day
+            stale_while_revalidate=1 * 24 * 60 * 60,  # 1 day
+            stale_if_error=1 * 24 * 60 * 60,          # 1 day
+        ),
         origin_cache(7 * 24 * 60 * 60),   # 7 days
     ],
 )
@@ -52,7 +56,11 @@ def project_detail(project, request):
     route_name="packaging.release",
     renderer="packaging/detail.html",
     decorator=[
-        cache_control(7 * 24 * 60 * 60),  # 7 days
+        cache_control(
+            7 * 24 * 60 * 60,                         # 7 days
+            stale_while_revalidate=1 * 24 * 60 * 60,  # 1 day
+            stale_if_error=1 * 24 * 60 * 60,          # 1 day
+        ),
         origin_cache(30 * 24 * 60 * 60),  # 30 days
     ],
 )
@@ -105,7 +113,11 @@ def release_detail(release, request):
 @view_config(
     route_name="packaging.file",
     decorator=[
-        cache_control(365 * 24 * 60 * 60),  # 1 year
+        cache_control(
+            365 * 24 * 60 * 60,                        # 1 year
+            stale_while_revalidate=30 * 24 * 60 * 60,  # 30 days
+            stale_if_error=30 * 24 * 60 * 60,          # 30 days
+        ),
     ],
 )
 def packages(request):


### PR DESCRIPTION
These will trigger Fastly to serve stale responses while revalidating content or if the origin returns an error. This should make things faster and less error prone.