### PR TITLE
Use a computed instead of denormalized column for Project.normalized_name

### DIFF
--- a/tests/common/db/packaging.py
+++ b/tests/common/db/packaging.py
@@ -12,7 +12,6 @@
 
 import datetime
 import hashlib
-import re
 
 import factory
 import factory.fuzzy
@@ -30,9 +29,6 @@ class ProjectFactory(WarehouseFactory):
         model = Project
 
     name = factory.fuzzy.FuzzyText(length=12)
-    normalized_name = factory.LazyAttribute(
-        lambda o: re.sub("[^A-Za-z0-9.]+", "-", o.name).lower()
-    )
 
 
 class ReleaseFactory(WarehouseFactory):

--- a/tests/packaging/test_models.py
+++ b/tests/packaging/test_models.py
@@ -32,9 +32,7 @@ class TestProjectFactory:
         ],
     )
     def test_traversal_finds(self, db_request, name, normalized):
-        project = DBProjectFactory.create(
-            name=name, normalized_name=normalized,
-        )
+        project = DBProjectFactory.create(name=name)
         root = ProjectFactory(db_request)
 
         assert root[normalized] == project

--- a/warehouse/migrations/versions/20f4dbe11e9_normalize_function.py
+++ b/warehouse/migrations/versions/20f4dbe11e9_normalize_function.py
@@ -1,0 +1,46 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Create a Normalize Function for PEP 426 names.
+
+Revision ID: 20f4dbe11e9
+Revises: 111d8fc0443
+Create Date: 2015-04-04 23:29:58.373217
+"""
+
+from alembic import op
+
+revision = "20f4dbe11e9"
+down_revision = "111d8fc0443"
+
+
+def upgrade():
+    op.execute("""
+        CREATE FUNCTION normalize_pep426_name(text) RETURNS text AS $$
+                SELECT lower(
+                    regexp_replace(
+                        regexp_replace(
+                            regexp_replace($1, '[^a-z0-9]+', '-', 'ig'),
+                            '(1|l|I)', '1', 'ig'
+                        ),
+                        '(0|0)', '0', 'ig'
+                    )
+                )
+            $$
+            LANGUAGE SQL
+            IMMUTABLE
+            RETURNS NULL ON NULL INPUT;
+    """)
+
+
+def downgrade():
+    op.execute("DROP FUNCTION normalize_pep426_name(text)")

--- a/warehouse/migrations/versions/28a7e805fd0_drop_denormalized_normalized_name_field.py
+++ b/warehouse/migrations/versions/28a7e805fd0_drop_denormalized_normalized_name_field.py
@@ -1,0 +1,32 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Drop denormalized normalized_name field
+
+Revision ID: 28a7e805fd0
+Revises: 91508cc5c2
+Create Date: 2015-04-05 00:45:54.649441
+"""
+
+from alembic import op
+
+
+revision = "28a7e805fd0"
+down_revision = "91508cc5c2"
+
+
+def upgrade():
+    op.drop_column("packages", "normalized_name")
+
+
+def downgrade():
+    raise RuntimeError("Cannot downgrade past revision: {!r}".format(revision))

--- a/warehouse/migrations/versions/91508cc5c2_add_pep_426_normalize_index.py
+++ b/warehouse/migrations/versions/91508cc5c2_add_pep_426_normalize_index.py
@@ -1,0 +1,36 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Add Index for normalized PEP 426 names which enforces uniqueness.
+
+Revision ID: 91508cc5c2
+Revises: 20f4dbe11e9
+Create Date: 2015-04-04 23:55:27.024988
+"""
+
+from alembic import op
+
+
+revision = "91508cc5c2"
+down_revision = "20f4dbe11e9"
+
+
+def upgrade():
+    op.execute("""
+        CREATE UNIQUE INDEX project_name_pep426_normalized
+            ON packages
+            (normalize_pep426_name(name))
+    """)
+
+
+def downgrade():
+    op.execute("DROP INDEX project_name_pep426_normalized")

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -62,9 +62,7 @@ class ProjectFactory:
     def __getitem__(self, project):
         try:
             return self.request.db.query(Project).filter(
-                Project.normalized_name == func.lower(
-                    func.regexp_replace(project, "_", "-", "ig")
-                )
+                Project.normalized_name == func.normalize_pep426_name(project)
             ).one()
         except NoResultFound:
             raise KeyError from None
@@ -83,7 +81,7 @@ class Project(db.ModelBase):
     __repr__ = make_repr("name")
 
     name = Column(Text, primary_key=True, nullable=False)
-    normalized_name = Column(Text)
+    normalized_name = orm.column_property(func.normalize_pep426_name(name))
     stable_version = Column(Text)
     autohide = Column(Boolean, server_default=sql.true())
     comments = Column(Boolean, server_default=sql.true())


### PR DESCRIPTION
Instead of storing ``Project.name`` twice, once as itself and once as ``Project.normalized_name``, instead we'll store it once and simply compute the normalized version on the fly. We'll use a ``computed_column`` to make it act functionality the same for querying but enable the source of truth for normalization to still live within the database.