### PR TITLE
Updated links to point to active documentation at warehouse.readthedocs.org

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -12,4 +12,4 @@ Examples of contributions include:
 
 Extensive contribution guidelines are available in the repository at
 ``docs/development/index.rst`` or
-`online <http://warehouse.readthedocs.org/en/latest/development/>`_.
+`online <https://warehouse.readthedocs.org/development/>`_.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -12,4 +12,4 @@ Examples of contributions include:
 
 Extensive contribution guidelines are available in the repository at
 ``docs/development/index.rst`` or
-`online <https://warehouse.pypa.io/en/latest/development/>`_.
+`online <http://warehouse.readthedocs.org/en/latest/development/>`_.

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@ Warehouse
 =========
 
 .. image:: https://readthedocs.org/projects/warehouse/badge/?version=latest
-    :target: https://warehouse.pypa.io/
+    :target: https://warehouse.readthedocs.org/
     :alt: Latest Docs
 
 .. image:: https://travis-ci.org/pypa/warehouse.svg?branch=master


### PR DESCRIPTION
Very minor fix of links in text files.