### PR TITLE
Ignore static dirs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -102,7 +102,7 @@ commands =
 
 
 [flake8]
-exclude = .tox,*.egg,*/interfaces.py
+exclude = .tox,*.egg,*/interfaces.py,node_modules
 select = E,W,F,N
 
 [pytest]

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ deps =
     # finalize function.
     https://github.com/dstufft/jinja2/archive/contextfinalize.zip#egg=jinja2
 commands =
-    python -m coverage run -m pytest --strict {posargs}
+    python -m coverage run -m pytest --strict --ignore node_modules {posargs}
     python -m coverage report -m --fail-under 100
 
 


### PR DESCRIPTION
This ignores the `node_modules` directory in both tests and linting.

This is necessary because some python is pulled down from npm inside the node-sass lib and both pytest and flake8 get run over it.