### PR TITLE
Install dev requirements in tox by referencing requirements.txt

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,14 +10,7 @@ deps =
     pretend
     pytest
     pytest-dbfixtures>=0.9.0
-    # We need to use a newer version of webob than is available on PyPI.
-    https://github.com/Pylons/webob/archive/master.zip#egg=webob
-    # We need to use a newer version of Pyramid (1.6) which isn't available on
-    # PyPI yet, so we'll install directly from GitHub.
-    https://github.com/Pylons/pyramid/archive/master.zip#egg=pyramid
-    # We need a patched version of Jinja2 which gives access to the context in a
-    # finalize function.
-    https://github.com/dstufft/jinja2/archive/contextfinalize.zip#egg=jinja2
+    -rdev/requirements.txt
 commands =
     python -m coverage run -m pytest --strict --ignore node_modules {posargs}
     python -m coverage report -m --fail-under 100
@@ -30,17 +23,7 @@ deps =
     sphinx
     sphinx_rtd_theme
     sphinxcontrib-httpdomain
-    # We need to use a newer version of webob than is available on PyPI.
-    https://github.com/Pylons/webob/archive/master.zip#egg=webob
-    # We need to use a newer version of Pyramid (1.6) which isn't available on
-    # PyPI yet, so we'll install directly from GitHub.
-    https://github.com/Pylons/pyramid/archive/master.zip#egg=pyramid
-    # We need a patched version of Jinja2 which gives access to the context in a
-    # finalize function.
-    https://github.com/dstufft/jinja2/archive/contextfinalize.zip#egg=jinja2
-    # We need a patched version of pyramid_jinja2 which allows overriding the
-    # GetTextWrapper with one of our own.
-    https://github.com/dstufft/pyramid_jinja2/archive/allow-override-gettext.zip#egg=pyramid_jinja2
+    -rdev/requirements.txt
 commands =
     sphinx-build -W -b html -d {envtmpdir}/doctrees docs docs/_build/html
     sphinx-build -W -b doctest -d {envtmpdir}/doctrees docs docs/_build/html
@@ -52,17 +35,7 @@ basepython = python3.4
 deps =
     flake8
     pep8-naming
-    # We need to use a newer version of webob than is available on PyPI.
-    https://github.com/Pylons/webob/archive/master.zip#egg=webob
-    # We need to use a newer version of Pyramid (1.6) which isn't available on
-    # PyPI yet, so we'll install directly from GitHub.
-    https://github.com/Pylons/pyramid/archive/master.zip#egg=pyramid
-    # We need a patched version of Jinja2 which gives access to the context in a
-    # finalize function.
-    https://github.com/dstufft/jinja2/archive/contextfinalize.zip#egg=jinja2
-    # We need a patched version of pyramid_jinja2 which allows overriding the
-    # GetTextWrapper with one of our own.
-    https://github.com/dstufft/pyramid_jinja2/archive/allow-override-gettext.zip#egg=pyramid_jinja2
+    -rdev/requirements.txt
 commands =
     flake8 .
 
@@ -72,17 +45,7 @@ basepython = python3.4
 deps =
     check-manifest
     readme>=0.5.1
-    # We need to use a newer version of webob than is available on PyPI.
-    https://github.com/Pylons/webob/archive/master.zip#egg=webob
-    # We need to use a newer version of Pyramid (1.6) which isn't available on
-    # PyPI yet, so we'll install directly from GitHub.
-    https://github.com/Pylons/pyramid/archive/master.zip#egg=pyramid
-    # We need a patched version of Jinja2 which gives access to the context in a
-    # finalize function.
-    https://github.com/dstufft/jinja2/archive/contextfinalize.zip#egg=jinja2
-    # We need a patched version of pyramid_jinja2 which allows overriding the
-    # GetTextWrapper with one of our own.
-    https://github.com/dstufft/pyramid_jinja2/archive/allow-override-gettext.zip#egg=pyramid_jinja2
+    -rdev/requirements.txt
 commands =
     check-manifest
     python setup.py check --restructuredtext --strict


### PR DESCRIPTION
This notably changes the semantics of what is included in the tox environments to use all of the requirements in in requirements.txt, even if they aren't being used. Is that acceptable, @dstufft? If not, then perhaps it would be best to create some other *-requirements.txt files so that we can control it more fine-grained, while still not having the duplication.