### PR TITLE
Edit development introduction doc to reference security doc. Fix #519

### DIFF
--- a/docs/development/index.rst
+++ b/docs/development/index.rst
@@ -1,11 +1,18 @@
 Development
 ===========
 
-As an open source project, Warehouse welcomes contributions of all forms. The
-sections below will help you get started.
+Warehouse, as an open source project, welcomes contributions of all forms. The
+sections below will help you get started with development, testing, and
+documentation.
 
-File bugs and feature requests on our issue tracker on `GitHub`_. If it is a
-bug check out `what to put in your bug report`_.
+Please contribute issues, submit bug reports, and file feature requests on our
+issue tracker on `GitHub`_. If submitting a bug report for the first time,
+please check out `what to put in your bug report`_ for guidance.
+
+.. important:: We take security very seriously. As such, security issues should
+               be emailed to the maintainers instead of being submitted on the
+               GitHub issue tracker. Please read the :ref:`security` documentation
+               for details.
 
 .. toctree::
     :maxdepth: 2

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -1,3 +1,5 @@
+.. _security:
+
 Security
 ========
 


### PR DESCRIPTION
Minor edits to developer intro doc. Adds a note at the first mention of the issue tracker to advise contributors that security issues are reported by email instead of issue tracker.