### PR TITLE
Rearchitect file serving to better utilize S3

### DIFF
--- a/dev/config.yml
+++ b/dev/config.yml
@@ -19,8 +19,11 @@ configurator:
   docs:
     url: "https://pythonhosted.org/{project}/"
 
+  files:
+    backend: warehouse.packaging.services.LocalFileStorage
+    path: /app/data/packages/
+
   dirs:
-    packages: /app/data/packages/
     documentation: /app/data/documentation/
 
   debugtoolbar:

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ setuptools.setup(
         "alembic>=0.7.0",
         "Babel",
         "bcrypt",
+        "boto3",
         "click",
         "fs",
         "gunicorn",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -97,6 +97,7 @@ def app_config(database):
             "database.url": database,
             "docs.url": "http://docs.example.com/",
             "download_stats.url": "redis://localhost:0/",
+            "files.backend": "warehouse.packaging.services.LocalFileStorage",
             "sessions.secret": "123456",
             "sessions.url": "redis://localhost:0/",
         },

--- a/tests/unit/test_aws.py
+++ b/tests/unit/test_aws.py
@@ -1,0 +1,59 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import boto3.session
+import pretend
+import pytest
+
+from warehouse import aws
+
+
+@pytest.mark.parametrize("region", [None, "us-west-2"])
+def test_aws_session_factory(monkeypatch, region):
+    boto_session_obj = pretend.stub()
+    boto_session_cls = pretend.call_recorder(lambda **kw: boto_session_obj)
+    monkeypatch.setattr(boto3.session, "Session", boto_session_cls)
+
+    request = pretend.stub(
+        registry=pretend.stub(
+            settings={
+                "aws.key_id": "my key",
+                "aws.secret_key": "my secret",
+            },
+        ),
+    )
+
+    if region is not None:
+        request.registry.settings["aws.region"] = region
+
+    assert aws.aws_session_factory(None, request) is boto_session_obj
+    assert boto_session_cls.calls == [
+        pretend.call(
+            aws_access_key_id="my key",
+            aws_secret_access_key="my secret",
+            **({} if region is None else {"region_name": region})
+        )
+    ]
+
+
+def test_includeme():
+    config = pretend.stub(
+        register_service_factory=pretend.call_recorder(
+            lambda factory, name: None
+        )
+    )
+
+    aws.includeme(config)
+
+    assert config.register_service_factory.calls == [
+        pretend.call(aws.aws_session_factory, name="aws.session"),
+    ]

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -160,6 +160,7 @@ def test_configure(monkeypatch, settings):
         pretend.call(".legacy.action_routing"),
         pretend.call(".i18n"),
         pretend.call(".db"),
+        pretend.call(".aws"),
         pretend.call(".sessions"),
         pretend.call(".cache.http"),
         pretend.call(".cache.origin"),

--- a/warehouse/aws.py
+++ b/warehouse/aws.py
@@ -1,0 +1,31 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import boto3.session
+
+
+def aws_session_factory(context, request):
+    kwargs = {}
+
+    # If we've been given a specific region, then connect to that.
+    if request.registry.settings.get("aws.region") is not None:
+        kwargs["region_name"] = request.registry.settings["aws.region"]
+
+    return boto3.session.Session(
+        aws_access_key_id=request.registry.settings["aws.key_id"],
+        aws_secret_access_key=request.registry.settings["aws.secret_key"],
+        **kwargs
+    )
+
+
+def includeme(config):
+    config.register_service_factory(aws_session_factory, name="aws.session")

--- a/warehouse/config.py
+++ b/warehouse/config.py
@@ -110,6 +110,9 @@ def configure(settings=None):
     # Register the configuration for the PostgreSQL database.
     config.include(".db")
 
+    # Register the support for AWS
+    config.include(".aws")
+
     # Register our session support
     config.include(".sessions")
 

--- a/warehouse/packaging/__init__.py
+++ b/warehouse/packaging/__init__.py
@@ -10,12 +10,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from warehouse.packaging.interfaces import IDownloadStatService
+from warehouse.packaging.interfaces import IDownloadStatService, IFileStorage
 from warehouse.packaging.services import RedisDownloadStatService
 from warehouse.packaging.models import Project, Release
 
 
 def includeme(config):
+    # Register whatever file storage backend has been configured for storing
+    # our package files.
+    storage_class = config.maybe_dotted(
+        config.registry.settings["files.backend"],
+    )
+    config.register_service_factory(storage_class.create_service, IFileStorage)
+
     # Register our service which will handle get the download statistics for
     # a project.
     config.register_service(

--- a/warehouse/packaging/interfaces.py
+++ b/warehouse/packaging/interfaces.py
@@ -29,3 +29,18 @@ class IDownloadStatService(Interface):
         """
         Return the monthly download counts for the given project.
         """
+
+
+class IFileStorage(Interface):
+
+    def create_service(context, request):
+        """
+        Create the service, given the context and request for which it is being
+        created for.
+        """
+
+    def get(path):
+        """
+        Return a file like object that can be read to access the file located
+        at the given path.
+        """


### PR DESCRIPTION
Originally we used the pyfilesystem library to implement file storage. However when migrating PyPI to S3 it was determined that this library is extremely inefficient when it comes to what API calls it makes to S3. Instead we'll utilize boto3 directly and create our own storage classes to act as an abstraction for where files are being stored.