### PR TITLE
Relax the normalization rules

### DIFF
--- a/warehouse/migrations/versions/1ce6d45d7ef_readd_the_unique_constraint_on_pep426_.py
+++ b/warehouse/migrations/versions/1ce6d45d7ef_readd_the_unique_constraint_on_pep426_.py
@@ -1,0 +1,37 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+readd the unique constraint on pep426 normalization
+
+Revision ID: 1ce6d45d7ef
+Revises: 23a3c4ffe5d
+Create Date: 2015-06-04 23:09:11.612200
+"""
+
+from alembic import op
+
+
+revision = "1ce6d45d7ef"
+down_revision = "23a3c4ffe5d"
+
+
+def upgrade():
+    op.execute(
+        """ CREATE UNIQUE INDEX project_name_pep426_normalized
+            ON packages
+            (normalize_pep426_name(name))
+        """
+    )
+
+
+def downgrade():
+    op.execute("DROP INDEX project_name_pep426_normalized")

--- a/warehouse/migrations/versions/23a3c4ffe5d_relax_normalization_rules.py
+++ b/warehouse/migrations/versions/23a3c4ffe5d_relax_normalization_rules.py
@@ -1,0 +1,69 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+relax normalization rules
+
+Revision ID: 23a3c4ffe5d
+Revises: 91508cc5c2
+Create Date: 2015-06-04 22:44:16.490470
+"""
+
+from alembic import op
+
+
+revision = "23a3c4ffe5d"
+down_revision = "91508cc5c2"
+
+
+def upgrade():
+    op.execute("DROP INDEX project_name_pep426_normalized")
+
+    op.execute(
+        """ CREATE OR REPLACE FUNCTION normalize_pep426_name(text)
+            RETURNS text AS
+            $$
+                SELECT lower(regexp_replace($1, '(\.|_)', '-', 'ig'))
+            $$
+            LANGUAGE SQL
+            IMMUTABLE
+            RETURNS NULL ON NULL INPUT;
+        """
+    )
+
+
+def downgrade():
+    op.execute(
+        """ CREATE OR REPLACE FUNCTION normalize_pep426_name(text)
+            RETURNS text AS
+            $$
+                SELECT lower(
+                    regexp_replace(
+                        regexp_replace(
+                            regexp_replace($1, '(\.|_)', '-', 'ig'),
+                            '(1|l|I)', '1', 'ig'
+                        ),
+                        '(0|0)', '0', 'ig'
+                    )
+                )
+            $$
+            LANGUAGE SQL
+            IMMUTABLE
+            RETURNS NULL ON NULL INPUT;
+        """
+    )
+
+    op.execute(
+        """ CREATE UNIQUE INDEX project_name_pep426_normalized
+            ON packages
+            (normalize_pep426_name(name))
+        """
+    )

--- a/warehouse/migrations/versions/57b1053998d_merge_41e9207fbe5_and_1ce6d45d7ef.py
+++ b/warehouse/migrations/versions/57b1053998d_merge_41e9207fbe5_and_1ce6d45d7ef.py
@@ -1,0 +1,29 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+merge 41e9207fbe5 and 1ce6d45d7ef
+
+Revision ID: 57b1053998d
+Revises: ('41e9207fbe5', '1ce6d45d7ef')
+Create Date: 2015-06-04 23:13:50.680431
+"""
+
+revision = "57b1053998d"
+down_revision = ("41e9207fbe5", "1ce6d45d7ef")
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
PEP426 suggested changing the normalization so that the Unicode Consortium's "confusable" characters are considered the same. There are roughly 137 projects on PyPI that fail this check currently so we cannot apply that rule (currently at least) so we'll do a dance to make the database less restrictive.