### PR TITLE
Filesizeformat filter raised error on package description page, fixed!

### DIFF
--- a/warehouse/templates/packaging/detail.html
+++ b/warehouse/templates/packaging/detail.html
@@ -77,12 +77,7 @@
             </td>
             <td>{% if file.python_version != "source" %}{{ file.python_version }}{% endif %}</td>
             <td>{{ file.upload_time|format_date() }}</td>
-            <td>{% if file.size %}
-                  {{ size|filesizeformat() }}
-                {% else %}
-                  0 MB
-              {% endif %}
-            </td>
+            <td>{% if file.size %}{{ size|filesizeformat() }}{% endif %}</td>
           </tr>
           {% endfor %}
         </table>

--- a/warehouse/templates/packaging/detail.html
+++ b/warehouse/templates/packaging/detail.html
@@ -77,7 +77,12 @@
             </td>
             <td>{% if file.python_version != "source" %}{{ file.python_version }}{% endif %}</td>
             <td>{{ file.upload_time|format_date() }}</td>
-            <td>{{ file.size|filesizeformat() }}</td>
+            <td>{% if file.size %}
+                  {{ size|filesizeformat() }}
+                {% else %}
+                  0 MB
+              {% endif %}
+            </td>
           </tr>
           {% endfor %}
         </table>


### PR DESCRIPTION
`filesizeformat` filter in the template raised error when the file.size if None. Check that and put up a 0 when file.size is  None.