### PR TITLE
Don't include futures in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,6 @@ cffi==1.1.2               # via bcrypt
 click==4.0
 docutils==0.12            # via botocore, readme
 fs==0.5.2
-futures==2.2.0            # via boto3
 gunicorn==19.3.0
 hiredis==0.2.0
 html5lib==0.99999         # via bleach

--- a/tasks/pip.py
+++ b/tasks/pip.py
@@ -46,6 +46,12 @@ def compile():
             line = re.sub(r"^jinja2==(\S+)(.*)$", r"jinja2==2.8.dev0\2", line)
             line = re.sub(r"^webob==(\S+)(.*)$", r"webob==1.5.dev0\2", line)
 
+            # The boto3 wheel includes a futures==2.2.0 even though that is a
+            # Python 2 only dependency. This dependency comes by default on
+            # Python 3, so the backport is never needed. See boto/boto3#163.
+            if re.search(r"^futures==2\.2\.0", line.strip()) is not None:
+                continue
+
             if re.search(r"^-e file:///.+/warehouse$", line.strip()) is None:
                 lines.append(line)
 


### PR DESCRIPTION
This gets pulled in because boto3 has an incorrectly created Wheel that claims to be Python 3 and Python 2, but whose dependencies are Python 2. Since this always exists on Python 3 we'll just ignore it.