### PR TITLE
Make some dependency changes and updates

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-pip-tools==1.0.5
+pip-tools>=1.0
 
 # We need a newer version of pyramid_debugtoolbar than what is currently
 # available on PyPI, so we'll install this from Github. This can be switched

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,8 +5,6 @@
 #    $ invoke pip.compile
 #
 
--f https://github.com/Pylons/webob/archive/master.zip#egg=webob-1.5.dev0
-
 alembic==0.7.7
 babel==1.3
 bcrypt==2.0.0
@@ -49,7 +47,7 @@ structlog==15.2.0
 transaction==1.4.4        # via pyramid-tm, zope.sqlalchemy
 translationstring==1.3    # via pyramid
 venusian==1.0             # via pyramid
-webob==1.5.dev0              # via pyramid
+webob==1.5.0a0            # via pyramid
 wtforms==2.0.2
 zope.deprecation==4.1.2   # via pyramid, pyramid-jinja2
 zope.interface==4.1.2     # via pyramid, pyramid-services, transaction, zope.sqlalchemy

--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,7 @@ setuptools.setup(
         "hiredis",
         "html5lib",
         "itsdangerous",
+        "Jinja2>=2.8",
         "msgpack-python",
         "passlib>=1.6.4",
         "psycopg2",

--- a/setup.py
+++ b/setup.py
@@ -91,6 +91,7 @@ setuptools.setup(
         "sqlalchemy-citext",
         "structlog",
         "transaction",
+        "WebOb>=1.5.0a0",
         "WTForms>=2.0.0",
         "zope.sqlalchemy",
     ],

--- a/tasks/pip.py
+++ b/tasks/pip.py
@@ -24,8 +24,6 @@ REQUIREMENTS_HEADER = """
 #    $ invoke pip.compile
 #
 
--f https://github.com/Pylons/webob/archive/master.zip#egg=webob-1.5.dev0
-
 """.lstrip()
 
 
@@ -42,8 +40,6 @@ def compile():
     lines = [REQUIREMENTS_HEADER]
     with open("requirements.txt", "r") as fp:
         for line in fp:
-            line = re.sub(r"^webob==(\S+)(.*)$", r"webob==1.5.dev0\2", line)
-
             # The boto3 wheel includes a futures==2.2.0 even though that is a
             # Python 2 only dependency. This dependency comes by default on
             # Python 3, so the backport is never needed. See boto/boto3#163.

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,6 @@ deps =
     freezegun
     pretend
     pytest
-    pymlconf!=0.3.12,!=0.3.13,!=0.3.14  # Needed by pytest-dbfixtures
     pytest-dbfixtures>=0.9.0
     webtest
 install_command = pip install -c requirements.txt {opts} {packages}

--- a/tox.ini
+++ b/tox.ini
@@ -11,8 +11,6 @@ deps =
     pymlconf!=0.3.12,!=0.3.13,!=0.3.14  # Needed by pytest-dbfixtures
     pytest-dbfixtures>=0.9.0
     webtest
-    # We need to use a newer version of webob than is available on PyPI.
-    https://github.com/Pylons/webob/archive/master.zip#egg=webob
 install_command = pip install -c requirements.txt {opts} {packages}
 commands = py.test --strict {posargs}
 

--- a/tox.ini
+++ b/tox.ini
@@ -13,11 +13,6 @@ deps =
     webtest
     # We need to use a newer version of webob than is available on PyPI.
     https://github.com/Pylons/webob/archive/master.zip#egg=webob
-    # We need a newer version of Jinja2 which gives access to the context in a
-    # finalize function.
-    https://github.com/mitsuhiko/jinja2/archive/master.zip#egg=jinja2
-    # We need a newer version of passlib which correctly handles bcrypt 2.0
-    https://bitbucket.org/ecollins/passlib/get/default.zip#egg=passlib
 install_command = pip install -c requirements.txt {opts} {packages}
 commands = py.test --strict {posargs}
 


### PR DESCRIPTION
* Remove left over direct links from ``tox.ini`` now that we're using releases from PyPI
* Switch to using the alpha releases of WebOb ``1.5`` from PyPI.
* Explicitly declare we depend on Jinja2 ``>= 2.8`` instead of just relying on the general Jinja2 requirement via pyramid_jinja2.
* Unpin pip-tools because it's just a development dependency so absolute latest versions isn't as important.
* Drop the explicit pin of ``pymlconf`` since it works by default now.

Closes #566