### PR TITLE
Implement Origin Cache Purging

### DIFF
--- a/requirements-deploy.txt
+++ b/requirements-deploy.txt
@@ -1,4 +1,0 @@
-# These requirements are only needed during the actual deployment phase and are
-# not actually a dependency of Warehouse itself.
-
-requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,8 +5,6 @@
 #    $ invoke pip.compile
 #
 
--r requirements-deploy.txt
-
 alembic==0.8.1
 amqp==1.4.6               # via kombu
 anyjson==0.3.3            # via kombu
@@ -51,6 +49,7 @@ pytz==2015.4              # via babel, celery
 readme==0.5.1
 redis==2.10.3
 repoze.lru==0.6           # via pyramid
+requests==2.7.0
 rfc3986==0.2.2
 setproctitle==1.1.9
 six==1.9.0                # via bcrypt, bleach, fs, html5lib, python-dateutil, readme

--- a/setup.py
+++ b/setup.py
@@ -90,6 +90,7 @@ setuptools.setup(
         "pyramid_services",
         "pyramid_tm>=0.12",
         "readme>=0.5.1",
+        "requests",
         "redis>=2.8.0",
         "rfc3986",
         "setproctitle",

--- a/tasks/pip.py
+++ b/tasks/pip.py
@@ -31,8 +31,6 @@ REQUIREMENTS_HEADER = """
 #    $ invoke pip.compile
 #
 
--r requirements-deploy.txt
-
 """.lstrip()
 
 

--- a/tests/unit/cache/origin/test_fastly.py
+++ b/tests/unit/cache/origin/test_fastly.py
@@ -11,7 +11,7 @@
 # limitations under the License.
 
 import pretend
-import pytest
+import requests
 
 from zope.interface.verify import verifyClass
 
@@ -24,11 +24,25 @@ class TestFastlyCache:
     def test_verify_service(self):
         assert verifyClass(IOriginCache, fastly.FastlyCache)
 
+    def test_create_service(self):
+        request = pretend.stub(
+            registry=pretend.stub(
+                settings={
+                    "origin_cache.api_key": "the api key",
+                    "origin_cache.service_id": "the service id",
+                },
+            ),
+        )
+        cacher = fastly.FastlyCache.create_service(None, request)
+        assert isinstance(cacher, fastly.FastlyCache)
+        assert cacher.api_key == "the api key"
+        assert cacher.service_id == "the service id"
+
     def test_adds_surrogate_key(self):
         request = pretend.stub()
         response = pretend.stub(headers={})
 
-        cacher = fastly.FastlyCache()
+        cacher = fastly.FastlyCache(api_key=None, service_id=None)
         cacher.cache(["abc", "defg"], request, response)
 
         assert response.headers == {"Surrogate-Key": "abc defg"}
@@ -37,7 +51,7 @@ class TestFastlyCache:
         request = pretend.stub()
         response = pretend.stub(headers={})
 
-        cacher = fastly.FastlyCache()
+        cacher = fastly.FastlyCache(api_key=None, service_id=None)
         cacher.cache(["abc", "defg"], request, response, seconds=9123)
 
         assert response.headers == {
@@ -45,27 +59,45 @@ class TestFastlyCache:
             "Surrogate-Control": "max-age=9123",
         }
 
-    def test_purge_not_implemented(self):
-        cacher = fastly.FastlyCache()
+    def test_purge(self, monkeypatch):
+        cacher = fastly.FastlyCache(
+            api_key="an api key",
+            service_id="the-service-id",
+        )
 
-        with pytest.raises(NotImplementedError):
-            cacher.purge(["one", "two"])
+        response = pretend.stub(
+            raise_for_status=pretend.call_recorder(lambda: None),
+        )
+        session_obj = pretend.stub(
+            post=pretend.call_recorder(lambda *a, **kw: response),
+            __enter__=lambda: session_obj,
+            __exit__=lambda *a, **kw: None,
+        )
+        session_cls = pretend.call_recorder(lambda: session_obj)
+        monkeypatch.setattr(requests, "session", session_cls)
 
+        cacher.purge(["one", "two"])
 
-def test_includeme(monkeypatch):
-    fastly_cache_obj = pretend.stub()
-    fastly_cache_cls = pretend.call_recorder(lambda: fastly_cache_obj)
-    monkeypatch.setattr(fastly, "FastlyCache", fastly_cache_cls)
-
-    config = pretend.stub(
-        include=pretend.call_recorder(lambda inc: None),
-        register_service=pretend.call_recorder(lambda svc, iface: None),
-    )
-
-    fastly.includeme(config)
-
-    assert config.include.calls == [pretend.call("pyramid_services")]
-    assert config.register_service.calls == [
-        pretend.call(fastly_cache_obj, IOriginCache),
-    ]
-    assert fastly_cache_cls.calls == [pretend.call()]
+        assert session_cls.calls == [pretend.call()]
+        assert session_obj.post.calls == [
+            pretend.call(
+                "https://api.fastly.com/service/the-service-id/purge/one",
+                headers={
+                    "Accept": "application/json",
+                    "Fastly-Key": "an api key",
+                    "Fastly-Soft-Purge": "1",
+                },
+            ),
+            pretend.call(
+                "https://api.fastly.com/service/the-service-id/purge/two",
+                headers={
+                    "Accept": "application/json",
+                    "Fastly-Key": "an api key",
+                    "Fastly-Soft-Purge": "1",
+                },
+            ),
+        ]
+        assert response.raise_for_status.calls == [
+            pretend.call(),
+            pretend.call(),
+        ]

--- a/tests/unit/packaging/test_init.py
+++ b/tests/unit/packaging/test_init.py
@@ -64,9 +64,14 @@ def test_includme(monkeypatch):
         pretend.call(
             Project,
             cache_keys=["project/{obj.normalized_name}"],
+            purge_keys=["project/{obj.normalized_name}", "all-projects"],
         ),
         pretend.call(
             Release,
             cache_keys=["project/{obj.project.normalized_name}"],
+            purge_keys=[
+                "project/{obj.project.normalized_name}",
+                "all-projects",
+            ],
         ),
     ]

--- a/tests/unit/packaging/test_init.py
+++ b/tests/unit/packaging/test_init.py
@@ -42,7 +42,7 @@ def test_includme(monkeypatch):
                 "files.backend": "foo.bar",
             },
         ),
-        register_origin_cache_keys=pretend.call_recorder(lambda c, *k: None),
+        register_origin_cache_keys=pretend.call_recorder(lambda c, **kw: None),
     )
 
     packaging.includeme(config)
@@ -63,12 +63,10 @@ def test_includme(monkeypatch):
     assert config.register_origin_cache_keys.calls == [
         pretend.call(
             Project,
-            "project",
-            "project/{obj.normalized_name}",
+            cache_keys=["project/{obj.normalized_name}"],
         ),
         pretend.call(
             Release,
-            "project",
-            "project/{obj.project.normalized_name}",
+            cache_keys=["project/{obj.project.normalized_name}"],
         ),
     ]

--- a/warehouse/cache/origin/__init__.py
+++ b/warehouse/cache/origin/__init__.py
@@ -56,6 +56,15 @@ def register_origin_cache_keys(config, klass, *keys):
 
 
 def includeme(config):
+    if "origin_cache.backend" in config.registry.settings:
+        cache_class = config.maybe_dotted(
+            config.registry.settings["origin_cache.backend"],
+        )
+        config.register_service_factory(
+            cache_class.create_service,
+            IOriginCache,
+        )
+
     config.add_directive(
         "register_origin_cache_keys",
         register_origin_cache_keys,

--- a/warehouse/cache/origin/interfaces.py
+++ b/warehouse/cache/origin/interfaces.py
@@ -15,6 +15,12 @@ from zope.interface import Interface
 
 class IOriginCache(Interface):
 
+    def create_service(context, request):
+        """
+        Create the service, given the context and request for which it is being
+        created for.
+        """
+
     def cache(keys, request, response, *, seconds=None):
         """
         A hook that will be called after the request has been processed, used

--- a/warehouse/config.py
+++ b/warehouse/config.py
@@ -148,6 +148,7 @@ def configure(settings=None):
     maybe_set(settings, "docs.url", "DOCS_URL")
     maybe_set(settings, "dirs.documentation", "DOCS_DIR")
     maybe_set_compound(settings, "files", "backend", "FILES_BACKEND")
+    maybe_set_compound(settings, "origin_cache", "backend", "ORIGIN_CACHE")
 
     # Add the settings we use when the environment is set to development.
     if settings["warehouse.env"] == Environment.development:

--- a/warehouse/packaging/__init__.py
+++ b/warehouse/packaging/__init__.py
@@ -35,11 +35,9 @@ def includeme(config):
     # Register our origin cache keys
     config.register_origin_cache_keys(
         Project,
-        "project",
-        "project/{obj.normalized_name}",
+        cache_keys=["project/{obj.normalized_name}"],
     )
     config.register_origin_cache_keys(
         Release,
-        "project",
-        "project/{obj.project.normalized_name}",
+        cache_keys=["project/{obj.project.normalized_name}"],
     )

--- a/warehouse/packaging/__init__.py
+++ b/warehouse/packaging/__init__.py
@@ -36,8 +36,10 @@ def includeme(config):
     config.register_origin_cache_keys(
         Project,
         cache_keys=["project/{obj.normalized_name}"],
+        purge_keys=["project/{obj.normalized_name}", "all-projects"],
     )
     config.register_origin_cache_keys(
         Release,
         cache_keys=["project/{obj.project.normalized_name}"],
+        purge_keys=["project/{obj.project.normalized_name}", "all-projects"],
     )

--- a/warehouse/views.py
+++ b/warehouse/views.py
@@ -18,6 +18,7 @@ from pyramid.view import (
 )
 
 from warehouse.accounts import REDIRECT_FIELD_NAME
+from warehouse.cache.origin import origin_cache
 from warehouse.csrf import csrf_exempt
 from warehouse.packaging.models import Project, Release, File
 from warehouse.accounts.models import User
@@ -52,6 +53,9 @@ def forbidden(exc, request):
 @view_config(
     route_name="index",
     renderer="index.html",
+    decorator=[
+        origin_cache(1 * 60 * 60, keys=["all-projects"]),  # 1 Hour.
+    ]
 )
 def index(request):
     latest_updated_releases = request.db.query(Release)\


### PR DESCRIPTION
Using SQLAlchemy's event system we will automatically trigger an origin cache purge whenever an object is created, modified, or deleted. In particular, this will use the ``after_flush`` event to record the cache keys for all objects that were created, modified, or deleted in this particular batch of work and the ``after_commit`` hook will be used to take that list of cache keys and trigger an origin cache purge with them.

Fixes #394