### PR TITLE
Add a decorator that will (sanely) support SQLAlchemy events

### DIFF
--- a/tests/common/db/__init__.py
+++ b/tests/common/db/__init__.py
@@ -12,7 +12,7 @@
 
 from sqlalchemy.orm import scoped_session
 
-from warehouse.db import _Session
+from warehouse.db import Session
 
 
-Session = scoped_session(_Session)
+Session = scoped_session(Session)

--- a/tests/unit/cli/test_shell.py
+++ b/tests/unit/cli/test_shell.py
@@ -78,7 +78,7 @@ class TestCLIShell:
 
         session = pretend.stub()
         session_cls = pretend.call_recorder(lambda bind: session)
-        monkeypatch.setattr(db, "_Session", session_cls)
+        monkeypatch.setattr(db, "Session", session_cls)
 
         plain = pretend.call_recorder(lambda **kw: None)
         monkeypatch.setattr(shell, "plain", plain)
@@ -100,7 +100,7 @@ class TestCLIShell:
 
         session = pretend.stub()
         session_cls = pretend.call_recorder(lambda bind: session)
-        monkeypatch.setattr(db, "_Session", session_cls)
+        monkeypatch.setattr(db, "Session", session_cls)
 
         runner = pretend.call_recorder(lambda **kw: None)
         monkeypatch.setattr(shell, type_, runner)
@@ -122,7 +122,7 @@ class TestCLIShell:
 
         session = pretend.stub()
         session_cls = pretend.call_recorder(lambda bind: session)
-        monkeypatch.setattr(db, "_Session", session_cls)
+        monkeypatch.setattr(db, "Session", session_cls)
 
         @pretend.call_recorder
         def runner(**kw):

--- a/tests/unit/test_db.py
+++ b/tests/unit/test_db.py
@@ -59,7 +59,7 @@ def test_configure_alembic(monkeypatch):
 def test_create_session(monkeypatch):
     session_obj = pretend.stub()
     session_cls = pretend.call_recorder(lambda bind: session_obj)
-    monkeypatch.setattr(db, "_Session", session_cls)
+    monkeypatch.setattr(db, "Session", session_cls)
 
     engine = pretend.stub()
     request = pretend.stub(

--- a/tests/unit/test_db.py
+++ b/tests/unit/test_db.py
@@ -10,10 +10,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from unittest import mock
+
 import alembic.config
 import pretend
 import sqlalchemy
+import venusian
 import zope.sqlalchemy
+
+from sqlalchemy import event
 
 from warehouse import db
 from warehouse.db import (
@@ -31,6 +36,32 @@ def test_model_base_repr():
     assert repr(model) == "Base(foo={})".format(repr("bar"))
     assert model.__repr__ is not original_repr
     assert repr(model) == "Base(foo={})".format(repr("bar"))
+
+
+def test_listens_for(monkeypatch):
+    venusian_attach = pretend.call_recorder(lambda fn, cb: None)
+    monkeypatch.setattr(venusian, "attach", venusian_attach)
+
+    event_listen = pretend.call_recorder(lambda *a, **kw: None)
+    monkeypatch.setattr(event, "listen", event_listen)
+
+    target = pretend.stub()
+    identifier = pretend.stub()
+    args = [pretend.stub()]
+    kwargs = {"my_kwarg": pretend.stub}
+
+    @db.listens_for(target, identifier, *args, **kwargs)
+    def handler(config):
+        pass
+
+    assert venusian_attach.calls == [pretend.call(handler, mock.ANY)]
+
+    scanner = pretend.stub(config=pretend.stub())
+    venusian_attach.calls[0].args[1](scanner, None, handler)
+
+    assert event_listen.calls == [
+        pretend.call(target, identifier, mock.ANY, *args, **kwargs),
+    ]
 
 
 def test_configure_alembic(monkeypatch):

--- a/warehouse/cli/shell.py
+++ b/warehouse/cli/shell.py
@@ -58,14 +58,14 @@ def shell(config, type_):
 
     # Imported here because we don't want to trigger an import from anything
     # but warehouse.cli at the module scope.
-    from warehouse.db import _Session
+    from warehouse.db import Session
 
     if type_ is None:
         type_ = autodetect()
 
     runner = {"bpython": bpython, "ipython": ipython, "plain": plain}[type_]
 
-    session = _Session(bind=config.registry["sqlalchemy.engine"])
+    session = Session(bind=config.registry["sqlalchemy.engine"])
 
     try:
         runner(config=config, db=session)

--- a/warehouse/db.py
+++ b/warehouse/db.py
@@ -52,7 +52,7 @@ class Model(ModelBase):
 # Create our session class here, this will stay stateless as we'll bind the
 # engine to each new state we create instead of binding it to the session
 # class.
-_Session = sessionmaker()
+Session = sessionmaker()
 
 
 def _configure_alembic(config):
@@ -66,7 +66,7 @@ def _configure_alembic(config):
 
 def _create_session(request):
     # Create our session
-    session = _Session(bind=request.registry["sqlalchemy.engine"])
+    session = Session(bind=request.registry["sqlalchemy.engine"])
 
     # Register only this particular session with zope.sqlalchemy
     zope.sqlalchemy.register(session, transaction_manager=request.tm)


### PR DESCRIPTION
This decorator mimics the built in one for SQLAlchemy, but it adds a ``configurator`` instance as the first argument and it works within venusian to handle the registration.