### PR TITLE
Fix HTTPException handling on POST

### DIFF
--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -17,7 +17,6 @@ import pretend
 import pytest
 
 from pyramid import renderers
-from pyramid.httpexceptions import HTTPMovedPermanently
 
 from warehouse import config
 from warehouse.utils.wsgi import ProxyFixer, VhmRootRemover
@@ -250,7 +249,6 @@ def test_configure(monkeypatch, settings, environment):
             lambda d: configurator_settings.update(d)
         ),
         add_tween=pretend.call_recorder(lambda tween_factory: None),
-        add_notfound_view=pretend.call_recorder(lambda append_slash: None),
         add_static_view=pretend.call_recorder(
             lambda name, path, cachebust: None
         ),
@@ -402,9 +400,6 @@ def test_configure(monkeypatch, settings, environment):
     ]
     assert opener.calls == [
         pretend.call("/srv/data/pypi/packages/", create_dir=True),
-    ]
-    assert configurator_obj.add_notfound_view.calls == [
-        pretend.call(append_slash=HTTPMovedPermanently),
     ]
     assert configurator_obj.add_renderer.calls == [
         pretend.call("json", json_renderer_obj),

--- a/tests/unit/test_views.py
+++ b/tests/unit/test_views.py
@@ -14,12 +14,18 @@ import datetime
 
 import pretend
 
-from warehouse.views import forbidden, index
+from warehouse.views import forbidden, index, exception_view
 
 from ..common.db.packaging import (
     ProjectFactory, ReleaseFactory, FileFactory,
 )
 from ..common.db.accounts import UserFactory
+
+
+def test_exception_view():
+    response = context = pretend.stub()
+    request = pretend.stub()
+    assert exception_view(context, request) is response
 
 
 class TestForbiddenView:

--- a/warehouse/config.py
+++ b/warehouse/config.py
@@ -19,7 +19,6 @@ import transaction
 
 from pyramid import renderers
 from pyramid.config import Configurator as _Configurator
-from pyramid.httpexceptions import HTTPMovedPermanently
 from pyramid.response import Response
 from pyramid_rpc.xmlrpc import XMLRPCRenderer
 
@@ -295,10 +294,6 @@ def configure(settings=None):
     # Block non HTTPS requests for the legacy ?:action= routes when they are
     # sent via POST.
     config.add_tween("warehouse.config.require_https_tween_factory")
-
-    # If a route matches with a slash appended to it, redirect to that route
-    # instead of returning a HTTPNotFound.
-    config.add_notfound_view(append_slash=HTTPMovedPermanently)
 
     # Configure the filesystems we use.
     config.registry["filesystems"] = {}

--- a/warehouse/views.py
+++ b/warehouse/views.py
@@ -10,12 +10,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pyramid.httpexceptions import HTTPSeeOther
-from pyramid.view import forbidden_view_config, view_config
+from pyramid.httpexceptions import (
+    HTTPException, HTTPSeeOther, HTTPMovedPermanently,
+)
+from pyramid.view import (
+    notfound_view_config, forbidden_view_config, view_config,
+)
 
 from warehouse.accounts import REDIRECT_FIELD_NAME
+from warehouse.csrf import csrf_exempt
 from warehouse.packaging.models import Project, Release, File
 from warehouse.accounts.models import User
+
+
+@view_config(context=HTTPException, decorator=[csrf_exempt])
+@notfound_view_config(
+    append_slash=HTTPMovedPermanently,
+    decorator=[csrf_exempt],
+)
+def exception_view(exc, request):
+    return exc
 
 
 @forbidden_view_config()


### PR DESCRIPTION
We want to exempt the exception views from CSRF processing so that they are correctly run when a POST request generates a HTTP exception.