### PR TITLE
Enable Read Only Transactions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN set -x \
     && pip install -U pip setuptools \
     && pip install pyinotify \
     && pip install -c requirements.txt -r requirements-dev.txt -e . \
+    && pip install -U https://github.com/dstufft/pyramid/archive/route-found.zip#egg=pyramid \
     && find /usr/local -type f -name '*.pyc' -name '*.pyo' -delete \
     && rm -rf ~/.cache/ \
     && apt-get purge gcc libpq-dev libffi-dev -y \

--- a/warehouse/routes.py
+++ b/warehouse/routes.py
@@ -20,6 +20,7 @@ def includeme(config):
         "/user/{username}/",
         factory="warehouse.accounts.models:UserFactory",
         traverse="/{username}",
+        read_only=True,
     )
     config.add_route("accounts.login", "/account/login/")
     config.add_route("accounts.logout", "/account/logout/")
@@ -30,34 +31,39 @@ def includeme(config):
         "/project/{name}/",
         factory="warehouse.packaging.models:ProjectFactory",
         traverse="/{name}",
+        read_only=True,
     )
     config.add_route(
         "packaging.release",
         "/project/{name}/{version}/",
         factory="warehouse.packaging.models:ProjectFactory",
         traverse="/{name}/{version}",
+        read_only=True,
     )
-    config.add_route("packaging.file", "/packages/{path:.*}")
+    config.add_route("packaging.file", "/packages/{path:.*}", read_only=True)
 
     # Legacy URLs
-    config.add_route("legacy.api.simple.index", "/simple/")
+    config.add_route("legacy.api.simple.index", "/simple/", read_only=True)
     config.add_route(
         "legacy.api.simple.detail",
         "/simple/{name}/",
         factory="warehouse.packaging.models:ProjectFactory",
         traverse="/{name}/",
+        read_only=True,
     )
     config.add_route(
         "legacy.api.json.project",
         "/pypi/{name}/json",
         factory="warehouse.packaging.models:ProjectFactory",
         traverse="/{name}",
+        read_only=True,
     )
     config.add_route(
         "legacy.api.json.release",
         "/pypi/{name}/{version}/json",
         factory="warehouse.packaging.models:ProjectFactory",
         traverse="/{name}/{version}",
+        read_only=True,
     )
 
     # Legacy Action URLs
@@ -75,6 +81,7 @@ def includeme(config):
         "pypi",
         pattern="/pypi",
         header="Content-Type:text/xml",
+        read_only=True,
     )
 
     # Legacy Documentation


### PR DESCRIPTION
Some routes are never designed to modify the database, in these cases we can mark these as read only and we'll use a transaction isolation level that is less aggressive about what kind of locks it takes.

Depends on Pylons/pyramid#1876.
Closes #625.