### PR TITLE
Reword statements to not make derogatory remarks

### DIFF
--- a/docs/application.rst
+++ b/docs/application.rst
@@ -49,9 +49,9 @@ though some actions are also POST actions.
     `password_reset`, `pw_reset` and `pw_reset_change` will most likely be
     replaced by newer mechanisms in warehouse
   - `openid_endpoint`, `openid_decide_post` could also be replaced by something
-    saner
+    else.
   - `home` is the old home page thing and completely unnecessary
-  - `index` is just stupid given the number of packages
+  - `index` is overwhelming given the number of projects now.
   - `browse` and `search` are *probably* only referenced by internal links so
     should be safe to nuke
   - `submit_pkg_info` and `display_pkginfo` probably aren't used
@@ -60,16 +60,16 @@ though some actions are also POST actions.
   - `list_classifiers` .. this might actually only be used by Richard :)
   - `claim`, `openid`, `openid_return`, `dropid` are legacy openid login
     support and will be changing
-  - `clear_auth` yeah, lol ("clears" Basic Auth)
+  - `clear_auth` "clears" Basic Auth
   - `addkey`, `delkey` will be changing if we even keep supporting ssh submit
   - `verify` probably isn't actually used by anyone
   - `lasthour` is a pubsubhubbub thing - does this even exist any longer?
   - `json` is never used as a :action invocation, only ever /<package>/json
   - `gae_file` I'm pretty sure this is not necessary
   - `rss_regen` manually regens the RSS cached files, not needed
-  - `about` can die
-  - `delete_user` yes, you can die too
-  - `exception` heh
+  - `about` No longer needed.
+  - `delete_user` No longer needed.
+  - `exception` No longer needed.
 
 **will need to retain**
   - `rss` and `packages_rss` will be in a bunch of peoples` RSS readers


### PR DESCRIPTION
It was requested that the documentation for Warehouse not make derogatory jokes about the legacy code base, so we'll go ahead and remove them.