### PR TITLE
Mark some routes as read only

### DIFF
--- a/tests/unit/test_routes.py
+++ b/tests/unit/test_routes.py
@@ -40,19 +40,20 @@ def test_routes():
 
         @staticmethod
         @pretend.call_recorder
-        def add_xmlrpc_endpoint(endpoint, pattern, header):
+        def add_xmlrpc_endpoint(endpoint, pattern, header, read_only=False):
             pass
 
     config = FakeConfig()
     includeme(config)
 
     assert config.add_route.calls == [
-        pretend.call('index', '/'),
+        pretend.call('index', '/', read_only=True),
         pretend.call(
             "accounts.profile",
             "/user/{username}/",
             factory="warehouse.accounts.models:UserFactory",
             traverse="/{username}",
+            read_only=True,
         ),
         pretend.call("accounts.login", "/account/login/"),
         pretend.call("accounts.logout", "/account/logout/"),
@@ -61,32 +62,37 @@ def test_routes():
             "/project/{name}/",
             factory="warehouse.packaging.models:ProjectFactory",
             traverse="/{name}",
+            read_only=True,
         ),
         pretend.call(
             "packaging.release",
             "/project/{name}/{version}/",
             factory="warehouse.packaging.models:ProjectFactory",
             traverse="/{name}/{version}",
+            read_only=True,
         ),
-        pretend.call("packaging.file", "/packages/{path:.*}"),
-        pretend.call("legacy.api.simple.index", "/simple/"),
+        pretend.call("packaging.file", "/packages/{path:.*}", read_only=True),
+        pretend.call("legacy.api.simple.index", "/simple/", read_only=True),
         pretend.call(
             "legacy.api.simple.detail",
             "/simple/{name}/",
             factory="warehouse.packaging.models:ProjectFactory",
             traverse="/{name}/",
+            read_only=True,
         ),
         pretend.call(
             "legacy.api.json.project",
             "/pypi/{name}/json",
             factory="warehouse.packaging.models:ProjectFactory",
             traverse="/{name}",
+            read_only=True,
         ),
         pretend.call(
             "legacy.api.json.release",
             "/pypi/{name}/{version}/json",
             factory="warehouse.packaging.models:ProjectFactory",
             traverse="/{name}/{version}",
+            read_only=True,
         ),
         pretend.call("legacy.docs", docs_route_url),
     ]
@@ -105,5 +111,10 @@ def test_routes():
     ]
 
     assert config.add_xmlrpc_endpoint.calls == [
-        pretend.call("pypi", pattern="/pypi", header="Content-Type:text/xml"),
+        pretend.call(
+            "pypi",
+            pattern="/pypi",
+            header="Content-Type:text/xml",
+            read_only=True,
+        ),
     ]

--- a/warehouse/routes.py
+++ b/warehouse/routes.py
@@ -12,7 +12,7 @@
 
 
 def includeme(config):
-    config.add_route("index", "/")
+    config.add_route("index", "/", read_only=True)
 
     # Accounts
     config.add_route(
@@ -20,6 +20,7 @@ def includeme(config):
         "/user/{username}/",
         factory="warehouse.accounts.models:UserFactory",
         traverse="/{username}",
+        read_only=True,
     )
     config.add_route("accounts.login", "/account/login/")
     config.add_route("accounts.logout", "/account/logout/")
@@ -30,34 +31,39 @@ def includeme(config):
         "/project/{name}/",
         factory="warehouse.packaging.models:ProjectFactory",
         traverse="/{name}",
+        read_only=True,
     )
     config.add_route(
         "packaging.release",
         "/project/{name}/{version}/",
         factory="warehouse.packaging.models:ProjectFactory",
         traverse="/{name}/{version}",
+        read_only=True,
     )
-    config.add_route("packaging.file", "/packages/{path:.*}")
+    config.add_route("packaging.file", "/packages/{path:.*}", read_only=True)
 
     # Legacy URLs
-    config.add_route("legacy.api.simple.index", "/simple/")
+    config.add_route("legacy.api.simple.index", "/simple/", read_only=True)
     config.add_route(
         "legacy.api.simple.detail",
         "/simple/{name}/",
         factory="warehouse.packaging.models:ProjectFactory",
         traverse="/{name}/",
+        read_only=True,
     )
     config.add_route(
         "legacy.api.json.project",
         "/pypi/{name}/json",
         factory="warehouse.packaging.models:ProjectFactory",
         traverse="/{name}",
+        read_only=True,
     )
     config.add_route(
         "legacy.api.json.release",
         "/pypi/{name}/{version}/json",
         factory="warehouse.packaging.models:ProjectFactory",
         traverse="/{name}/{version}",
+        read_only=True,
     )
 
     # Legacy Action URLs
@@ -75,6 +81,7 @@ def includeme(config):
         "pypi",
         pattern="/pypi",
         header="Content-Type:text/xml",
+        read_only=True,
     )
 
     # Legacy Documentation


### PR DESCRIPTION
If a route isn't going to modify data, then we can use a read only deferrable transaction so that we don't need to take SIRead locks and we skip some of the overhead of having a serializable transaction.

Closes #623
Closes #625