### PR TITLE
Implement a sitemap.xml

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,7 +9,7 @@ recursive-include tests *.py
 recursive-include warehouse/migrations *.mako
 recursive-include warehouse/migrations/versions *.py
 recursive-include warehouse/static *.css *.json *.scss *.png
-recursive-include warehouse/templates *.html *.txt
+recursive-include warehouse/templates *.html *.txt *.xml
 recursive-include warehouse/translations warehouse.pot *.po
 
 exclude requirements.txt requirements-dev.txt requirements-deploy.txt

--- a/tests/functional/test_basic.py
+++ b/tests/functional/test_basic.py
@@ -16,6 +16,7 @@ def test_robots_txt(webtest):
     assert resp.status_code == 200
     assert resp.content_type == "text/plain"
     assert resp.body.decode(resp.charset) == (
+        "Sitemap: http://localhost/sitemap.xml\n\n"
         "User-agent: *\n"
         "Disallow: /simple/\n"
         "Disallow: /packages/\n"

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -375,10 +375,12 @@ def test_configure(monkeypatch, settings, environment):
     assert configurator_obj.add_jinja2_renderer.calls == [
         pretend.call(".html"),
         pretend.call(".txt"),
+        pretend.call(".xml"),
     ]
     assert configurator_obj.add_jinja2_search_path.calls == [
         pretend.call("warehouse:templates", name=".html"),
         pretend.call("warehouse:templates", name=".txt"),
+        pretend.call("warehouse:templates", name=".xml"),
     ]
     assert configurator_obj.add_settings.calls == [
         pretend.call({"jinja2.newstyle": True}),

--- a/tests/unit/test_routes.py
+++ b/tests/unit/test_routes.py
@@ -49,6 +49,12 @@ def test_routes():
     assert config.add_route.calls == [
         pretend.call('index', '/', read_only=True),
         pretend.call("robots.txt", "/robots.txt", read_only=True),
+        pretend.call("index.sitemap.xml", "/sitemap.xml", read_only=True),
+        pretend.call(
+            "bucket.sitemap.xml",
+            "/{bucket}.sitemap.xml",
+            read_only=True,
+        ),
         pretend.call(
             "esi.current-user-indicator",
             "/_esi/current-user-indicator/",

--- a/tests/unit/test_sitemap.py
+++ b/tests/unit/test_sitemap.py
@@ -1,0 +1,102 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pretend
+import pytest
+
+from warehouse import sitemap
+from ..common.db.accounts import UserFactory
+from ..common.db.packaging import ProjectFactory
+
+
+@pytest.mark.parametrize(
+    ("url", "bucket"),
+    [
+        ("https://example.com/foo/bar/", "9"),
+        ("https://example.com/one/two/", "f"),
+        ("https://example.com/up/down/", "6"),
+        ("https://example.com/left/right/", "1"),
+        ("https://example.com/no/yes/", "2"),
+    ],
+)
+def test_url2bucket(url, bucket):
+    assert sitemap._url2bucket(url) == bucket
+
+
+def test_generate_urls(db_request):
+    expected = ["/", "/project/foobar/", "/user/jarjar/"]
+    expected_iter = iter(expected)
+    db_request.route_url = pretend.call_recorder(
+        lambda *a, **kw: next(expected_iter)
+    )
+
+    project = ProjectFactory.create()
+    user = UserFactory.create()
+
+    urls = list(sitemap._generate_urls(db_request))
+    assert urls == [
+        sitemap.SitemapURL(url="/", modified=None),
+        sitemap.SitemapURL(url="/project/foobar/", modified=project.created),
+        sitemap.SitemapURL(url="/user/jarjar/", modified=user.date_joined),
+    ]
+    assert db_request.route_url.calls == [
+        pretend.call("index"),
+        pretend.call("packaging.project", name=project.normalized_name),
+        pretend.call("accounts.profile", username=user.username),
+    ]
+
+
+def test_sitemap_index(db_request):
+    expected = ["/", "/project/foobar/", "/user/jarjar/"]
+    expected_iter = iter(expected)
+    db_request.route_url = pretend.call_recorder(
+        lambda *a, **kw: next(expected_iter)
+    )
+
+    project = ProjectFactory.create()
+    user = UserFactory.create()
+
+    assert sitemap.sitemap_index(db_request) == {
+        "buckets": [
+            sitemap.Bucket("5", modified=None),
+            sitemap.Bucket("6", modified=user.date_joined),
+            sitemap.Bucket("c", modified=project.created),
+        ],
+    }
+
+
+def test_sitemap_bucket(db_request):
+    expected = ["/", "/project/foobar/", "/user/jarjar/"]
+    expected_iter = iter(expected)
+    db_request.route_url = pretend.call_recorder(
+        lambda *a, **kw: next(expected_iter)
+    )
+
+    db_request.matchdict["bucket"] = "c"
+
+    ProjectFactory.create()
+    UserFactory.create()
+
+    assert sitemap.sitemap_bucket(db_request) == {"urls": ["/project/foobar/"]}
+
+
+def test_sitemap_bucket_too_many(monkeypatch, db_request):
+    db_request.route_url = pretend.call_recorder(lambda *a, **kw: "/")
+    db_request.matchdict["bucket"] = "5"
+
+    monkeypatch.setattr(sitemap, "SITEMAP_MAXSIZE", 2)
+
+    for _ in range(3):
+        ProjectFactory.create()
+
+    with pytest.raises(ValueError):
+        sitemap.sitemap_bucket(db_request)

--- a/warehouse/config.py
+++ b/warehouse/config.py
@@ -225,6 +225,9 @@ def configure(settings=None):
     # render them.
     config.add_jinja2_renderer(".txt")
 
+    # Anytime we want to render a .xml template, we'll also use Jinja.
+    config.add_jinja2_renderer(".xml")
+
     # We'll want to configure some filters for Jinja2 as well.
     filters = config.get_settings().setdefault("jinja2.filters", {})
     filters.setdefault("readme", "warehouse.filters:readme_renderer")
@@ -239,6 +242,7 @@ def configure(settings=None):
     # so we'll go ahead and add that to the Jinja2 search path.
     config.add_jinja2_search_path("warehouse:templates", name=".html")
     config.add_jinja2_search_path("warehouse:templates", name=".txt")
+    config.add_jinja2_search_path("warehouse:templates", name=".xml")
 
     # We want to configure our JSON renderer to sort the keys, and also to use
     # an ultra compact serialization format.

--- a/warehouse/routes.py
+++ b/warehouse/routes.py
@@ -15,6 +15,12 @@ def includeme(config):
     # Basic global routes
     config.add_route("index", "/", read_only=True)
     config.add_route("robots.txt", "/robots.txt", read_only=True)
+    config.add_route("index.sitemap.xml", "/sitemap.xml", read_only=True)
+    config.add_route(
+        "bucket.sitemap.xml",
+        "/{bucket}.sitemap.xml",
+        read_only=True,
+    )
 
     # ESI Routes
     config.add_route(

--- a/warehouse/sitemap.py
+++ b/warehouse/sitemap.py
@@ -1,0 +1,129 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import collections
+import hashlib
+
+from pyramid.view import view_config
+
+from warehouse.accounts.models import User
+from warehouse.cache.origin import origin_cache
+from warehouse.cache.http import cache_control
+from warehouse.packaging.models import Project
+
+
+BUCKET_LEN = 1
+
+SITEMAP_MAXSIZE = 50000
+
+
+Bucket = collections.namedtuple("Bucket", ["name", "modified"])
+
+SitemapURL = collections.namedtuple("SitemapURL", ["url", "modified"])
+
+
+def _url2bucket(url):
+    return hashlib.sha512(url.encode("utf8")).hexdigest()[:BUCKET_LEN]
+
+
+def _generate_urls(request):
+    # Yield our important site URLS like the / page and such.
+    yield SitemapURL(url=request.route_url("index"), modified=None)
+
+    # Collect all of the URLs for all of our Projects.
+    projects = request.db.query(Project.normalized_name, Project.created).all()
+    for project in projects:
+        url = request.route_url(
+            "packaging.project",
+            name=project.normalized_name,
+        )
+        yield SitemapURL(url=url, modified=project.created)
+
+    # Collect all of the URLs for all of our Users.
+    users = request.db.query(User.username, User.date_joined)
+    for user in users:
+        url = request.route_url("accounts.profile", username=user.username)
+        yield SitemapURL(url=url, modified=user.date_joined)
+
+
+@view_config(
+    route_name="index.sitemap.xml",
+    renderer="sitemap/index.xml",
+    decorator=[
+        cache_control(1 * 60 * 60),              # 1 hour
+        origin_cache(
+            1 * 24 * 60 * 60,                    # 1 day
+            stale_while_revalidate=6 * 60 * 60,  # 6 hours
+            stale_if_error=1 * 24 * 60 * 60,     # 1 day
+            keys=["all-projects"],
+        ),
+    ],
+)
+def sitemap_index(request):
+    buckets = {}
+
+    # We have > 50,000 URLs on PyPI and a single sitemap file can only support
+    # a maximum of 50,000 URLs. We need to split our URLs up into multiple
+    # files so we need to stick all of our URLs into buckets, in addition we
+    # want our buckets to remain stable so that an URL won't change what bucket
+    # it is in just because another URL is added or removed. Finally we also
+    # want to minimize the number of buckets we have to reduce the number of
+    # HTTP requests on top of the fact that there is also a 50,000 limit of
+    # buckets in these scheme before we need to nest buckets. In order to
+    # satisfy these requirements we will take the URL and use a SHA512 hash to
+    # pseudo-randomly distribute our URLs amongst many buckets, but we'll only
+    # take the first letter of the hash to serve as our bucket, and if at some
+    # point in the future we need more buckets we can take the first two
+    # characters of the hash instead of just the first. Since the hash is a
+    # property of the URL what bucket an URL goes into won't be influenced by
+    # what other URLs exist in the system.
+    for url in _generate_urls(request):
+        bucket = _url2bucket(url.url)
+        current = buckets.setdefault(bucket, url.modified)
+        if current is None or url.modified > current:
+            buckets[bucket] = url.modified
+
+    buckets = [Bucket(name=k, modified=v) for k, v in buckets.items()]
+    buckets.sort(key=lambda x: x.name)
+
+    return {"buckets": buckets}
+
+
+@view_config(
+    route_name="bucket.sitemap.xml",
+    renderer="sitemap/bucket.xml",
+    decorator=[
+        cache_control(1 * 60 * 60),              # 1 hour
+        origin_cache(
+            1 * 24 * 60 * 60,                    # 1 day
+            stale_while_revalidate=6 * 60 * 60,  # 6 hours
+            stale_if_error=1 * 24 * 60 * 60,     # 1 day
+            keys=["all-projects"],
+        ),
+    ],
+)
+def sitemap_bucket(request):
+    urls = []
+
+    for url in _generate_urls(request):
+        bucket = _url2bucket(url.url)
+        if bucket == request.matchdict["bucket"]:
+            urls.append(url.url)
+
+    if len(urls) > SITEMAP_MAXSIZE:
+        raise ValueError(
+            "Too many URLs in the sitemap for bucket: {!r}.".format(
+                request.matchdict["bucket"],
+            ),
+        )
+
+    return {"urls": sorted(urls)}

--- a/warehouse/templates/robots.txt
+++ b/warehouse/templates/robots.txt
@@ -1,3 +1,5 @@
+Sitemap: {{ request.route_url("index.sitemap.xml") }}
+
 User-agent: *
 Disallow: /simple/
 Disallow: /packages/

--- a/warehouse/templates/sitemap/bucket.xml
+++ b/warehouse/templates/sitemap/bucket.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  {% for url in urls %}
+  <url>
+    <loc>{{ url }}</loc>
+  </url>
+  {% endfor %}
+</urlset>

--- a/warehouse/templates/sitemap/index.xml
+++ b/warehouse/templates/sitemap/index.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  {% for bucket in buckets %}
+  <sitemap>
+    <loc>{{ request.route_url("bucket.sitemap.xml", bucket=bucket.name) }}</loc>
+    {%- if bucket.modified %}
+    <lastmod>{{ bucket.modified.isoformat() }}{% if bucket.modified.utcoffset() == None %}Z{% endif %}</lastmod>
+    {%- endif %}
+  </sitemap>
+  {% endfor %}
+</sitemapindex>


### PR DESCRIPTION
Because a sitemap.xml can only have so many URLs in a particular file we have to use a bucketed approach to split up our URLs across many files.