### PR TITLE
Only restart on 502 and 503 errors

### DIFF
--- a/vcl/main.vcl
+++ b/vcl/main.vcl
@@ -108,9 +108,9 @@ sub vcl_fetch {
         error 803 "SSL is required";
     }
 
-    # If we've gotten a 500 or a 503 from the backend, we'll go ahead and retry
+    # If we've gotten a 502 or a 503 from the backend, we'll go ahead and retry
     # the request.
-    if ((beresp.status == 500 || beresp.status == 503) &&
+    if ((beresp.status == 502 || beresp.status == 503) &&
             req.restarts < 1 &&
             (req.request == "GET" || req.request == "HEAD")) {
         restart;


### PR DESCRIPTION
If our app is sending 500 errors we don't want to increase the traffic to it incase it's a load issue.