### PR TITLE
Efficiently handle file uploads

### DIFF
--- a/tests/unit/packaging/test_services.py
+++ b/tests/unit/packaging/test_services.py
@@ -144,18 +144,35 @@ class TestLocalFileStorage:
             storage.get("file.txt")
 
     def test_stores_file(self, tmpdir):
-        storage = LocalFileStorage(str(tmpdir))
-        storage.store("foo/bar.txt", io.BytesIO(b"Test File!"))
-        with open(os.path.join(str(tmpdir), "foo/bar.txt"), "rb") as fp:
+        filename = str(tmpdir.join("testfile.txt"))
+        with open(filename, "wb") as fp:
+            fp.write(b"Test File!")
+
+        storage_dir = str(tmpdir.join("storage"))
+        storage = LocalFileStorage(storage_dir)
+        storage.store("foo/bar.txt", filename)
+
+        with open(os.path.join(storage_dir, "foo/bar.txt"), "rb") as fp:
             assert fp.read() == b"Test File!"
 
     def test_stores_two_files(self, tmpdir):
-        storage = LocalFileStorage(str(tmpdir))
-        storage.store("foo/first.txt", io.BytesIO(b"First Test File!"))
-        storage.store("foo/second.txt", io.BytesIO(b"Second Test File!"))
-        with open(os.path.join(str(tmpdir), "foo/first.txt"), "rb") as fp:
+        filename1 = str(tmpdir.join("testfile1.txt"))
+        with open(filename1, "wb") as fp:
+            fp.write(b"First Test File!")
+
+        filename2 = str(tmpdir.join("testfile2.txt"))
+        with open(filename2, "wb") as fp:
+            fp.write(b"Second Test File!")
+
+        storage_dir = str(tmpdir.join("storage"))
+        storage = LocalFileStorage(storage_dir)
+        storage.store("foo/first.txt", filename1)
+        storage.store("foo/second.txt", filename2)
+
+        with open(os.path.join(storage_dir, "foo/first.txt"), "rb") as fp:
             assert fp.read() == b"First Test File!"
-        with open(os.path.join(str(tmpdir), "foo/second.txt"), "rb") as fp:
+
+        with open(os.path.join(storage_dir, "foo/second.txt"), "rb") as fp:
             assert fp.read() == b"Second Test File!"
 
 
@@ -220,20 +237,33 @@ class TestS3FileStorage:
         with pytest.raises(botocore.exceptions.ClientError):
             storage.get("file.txt")
 
-    def test_stores_file(self):
+    def test_stores_file(self, tmpdir):
+        filename = str(tmpdir.join("testfile.txt"))
+        with open(filename, "wb") as fp:
+            fp.write(b"Test File!")
+
         obj = pretend.stub(put=pretend.call_recorder(lambda Body: None))
         bucket = pretend.stub(Object=pretend.call_recorder(lambda path: obj))
         storage = S3FileStorage(bucket)
-        storage.store("foo/bar.txt", io.BytesIO(b"Test File!"))
+        storage.store("foo/bar.txt", filename)
         assert bucket.Object.calls == [pretend.call("foo/bar.txt")]
         assert obj.put.calls == [pretend.call(Body=b"Test File!")]
 
-    def test_stores_two_files(self):
+    def test_stores_two_files(self, tmpdir):
+        filename1 = str(tmpdir.join("testfile1.txt"))
+        with open(filename1, "wb") as fp:
+            fp.write(b"First Test File!")
+
+        filename2 = str(tmpdir.join("testfile2.txt"))
+        with open(filename2, "wb") as fp:
+            fp.write(b"Second Test File!")
+
         obj = pretend.stub(put=pretend.call_recorder(lambda Body: None))
         bucket = pretend.stub(Object=pretend.call_recorder(lambda path: obj))
         storage = S3FileStorage(bucket)
-        storage.store("foo/first.txt", io.BytesIO(b"First Test File!"))
-        storage.store("foo/second.txt", io.BytesIO(b"Second Test File!"))
+        storage.store("foo/first.txt", filename1)
+        storage.store("foo/second.txt", filename2)
+
         assert bucket.Object.calls == [
             pretend.call("foo/first.txt"),
             pretend.call("foo/second.txt"),

--- a/tests/unit/packaging/test_services.py
+++ b/tests/unit/packaging/test_services.py
@@ -242,12 +242,15 @@ class TestS3FileStorage:
         with open(filename, "wb") as fp:
             fp.write(b"Test File!")
 
-        obj = pretend.stub(put=pretend.call_recorder(lambda Body: None))
-        bucket = pretend.stub(Object=pretend.call_recorder(lambda path: obj))
+        bucket = pretend.stub(
+            upload_file=pretend.call_recorder(lambda filename, key: None),
+        )
         storage = S3FileStorage(bucket)
         storage.store("foo/bar.txt", filename)
-        assert bucket.Object.calls == [pretend.call("foo/bar.txt")]
-        assert obj.put.calls == [pretend.call(Body=b"Test File!")]
+
+        assert bucket.upload_file.calls == [
+            pretend.call(filename, "foo/bar.txt"),
+        ]
 
     def test_stores_two_files(self, tmpdir):
         filename1 = str(tmpdir.join("testfile1.txt"))
@@ -258,17 +261,14 @@ class TestS3FileStorage:
         with open(filename2, "wb") as fp:
             fp.write(b"Second Test File!")
 
-        obj = pretend.stub(put=pretend.call_recorder(lambda Body: None))
-        bucket = pretend.stub(Object=pretend.call_recorder(lambda path: obj))
+        bucket = pretend.stub(
+            upload_file=pretend.call_recorder(lambda filename, key: None),
+        )
         storage = S3FileStorage(bucket)
         storage.store("foo/first.txt", filename1)
         storage.store("foo/second.txt", filename2)
 
-        assert bucket.Object.calls == [
-            pretend.call("foo/first.txt"),
-            pretend.call("foo/second.txt"),
-        ]
-        assert obj.put.calls == [
-            pretend.call(Body=b"First Test File!"),
-            pretend.call(Body=b"Second Test File!"),
+        assert bucket.upload_file.calls == [
+            pretend.call(filename1, "foo/first.txt"),
+            pretend.call(filename2, "foo/second.txt"),
         ]

--- a/warehouse/packaging/interfaces.py
+++ b/warehouse/packaging/interfaces.py
@@ -45,7 +45,8 @@ class IFileStorage(Interface):
         at the given path.
         """
 
-    def store(path, file_obj):
+    def store(path, file_path):
         """
-        Save the file object to path.
+        Save the file located at file_path to the file storage at the location
+        specified by path.
         """

--- a/warehouse/packaging/services.py
+++ b/warehouse/packaging/services.py
@@ -105,11 +105,12 @@ class LocalFileStorage:
     def get(self, path):
         return open(os.path.join(self.base, path), "rb")
 
-    def store(self, path, file_obj):
+    def store(self, path, file_path):
         destination = os.path.join(self.base, path)
         os.makedirs(os.path.dirname(destination), exist_ok=True)
-        with open(destination, "wb") as fp:
-            fp.write(file_obj.read())
+        with open(destination, "wb") as dest_fp:
+            with open(file_path, "rb") as src_fp:
+                dest_fp.write(src_fp.read())
 
 
 @implementer(IFileStorage)
@@ -133,8 +134,9 @@ class S3FileStorage:
                 raise
             raise FileNotFoundError("No such key: {!r}".format(path)) from None
 
-    def store(self, path, file_obj):
+    def store(self, path, file_path):
         # TODO: This should ideally be using multipart uploading which will
         #       enable "commiting" and "rollingback" the upload based on the
         #       transaction state.
-        self.bucket.Object(path).put(Body=file_obj.read())
+        with open(file_path, "rb") as fp:
+            self.bucket.Object(path).put(Body=fp.read())

--- a/warehouse/packaging/services.py
+++ b/warehouse/packaging/services.py
@@ -135,8 +135,4 @@ class S3FileStorage:
             raise FileNotFoundError("No such key: {!r}".format(path)) from None
 
     def store(self, path, file_path):
-        # TODO: This should ideally be using multipart uploading which will
-        #       enable "commiting" and "rollingback" the upload based on the
-        #       transaction state.
-        with open(file_path, "rb") as fp:
-            self.bucket.Object(path).put(Body=fp.read())
+        self.bucket.upload_file(file_path, path)


### PR DESCRIPTION
Currently we buffer the uploaded file entirely in memory. This works fine, except it's pretty heavy on the memory use, up to 60MB per upload by default. This doesn't work out so well when we're in a memory constrained environment like a Heroku dyno.

Instead we'll buffer the files to a temporary location on disk. Once they are there we'll also utilize boto3's ``upload_file`` helper which will efficiently upload the file without loading the entire thing into memory, and will also transparently switch to using multipart uploading (with retries!) when the file size gets too large.