### PR TITLE
Use redis-py's native TLS support instead of stunnel

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: bin/start-stunnel bin/fastly-config && bin/start-stunnel newrelic-admin run-program uwsgi --ini=uwsgi.ini --processes=${WEB_CONCURRENCY:=1}
-worker: bin/start-stunnel newrelic-admin run-program celery -A warehouse worker -l info
+web: bin/redis-tls bin/fastly-config && bin/redis-tls newrelic-admin run-program uwsgi --ini=uwsgi.ini --processes=${WEB_CONCURRENCY:=1}
+worker: bin/redis-tls newrelic-admin run-program celery -A warehouse worker -l info

--- a/bin/redis-tls
+++ b/bin/redis-tls
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Switch to using rediss:// instead of redis://
+REDIS_URL="$(echo $REDIS_URL | sed 's/^redis:/rediss:/g')"
+
+# We need to pull out the port and increment it by one.
+REDIS_PORT="$(echo $REDIS_URL | cut -d ':' -f 4)"
+REDIS_PORT=$((REDIS_PORT + 1))
+
+# Replace the PORT in the URL with the incremented one.
+REDIS_URL="$(echo $REDIS_URL | sed "s/:[0-9][0-9]*$/:$REDIS_PORT/g" )"
+
+# Unset our temporary REDIS_PORT variable since we've now moved it into the
+# REDIS_URL.
+unset REDIS_PORT
+
+# Configure the TLS settings for our Redis connection
+REDIS_URL="$REDIS_URL?ssl_cert_reqs=required&ssl_ca_certs=$(python -m certifi)"
+
+# Finally, go ahead and execute the given command.
+exec "$@"


### PR DESCRIPTION
Our redis library natively supports TLS, so we'll use that and remove the extra complexity of running Redis through stunnel on the client side.