### PR TITLE
Use the Uploader instead of the Author

### DIFF
--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -290,6 +290,25 @@ class Release(db.ModelBase):
     _project_urls = _dependency_relation(DependencyKind.project_url)
     project_urls = association_proxy("_project_urls", "specifier")
 
+    uploader = orm.relationship(
+        "User",
+        secondary=lambda: JournalEntry.__table__,
+        primaryjoin=lambda: (
+            (JournalEntry.name == orm.foreign(Release.name)) &
+            (JournalEntry.version == orm.foreign(Release.version)) &
+            (JournalEntry.action == "new release")),
+        secondaryjoin=lambda: (
+            (User.username == orm.foreign(JournalEntry._submitted_by))
+        ),
+        order_by=lambda: JournalEntry.submitted_date.desc(),
+        # TODO: We have uselist=False here which raises a warning because
+        # multiple items were returned. This should only be temporary because
+        # we should add a nullable FK to JournalEntry so we don't need to rely
+        # on ordering and implicitly selecting the first object to make this
+        # happen,
+        uselist=False,
+    )
+
 
 class File(db.Model):
 

--- a/warehouse/templates/index.html
+++ b/warehouse/templates/index.html
@@ -30,7 +30,7 @@
         {% for release in latest_updated_releases %}
         <div class="comment">
           <div class="comment-image">
-                <img src="{{ gravatar(release.author_email, size=50) }}" alt="{{ release.author}}" height="50" width="50">
+                <img src="{{ gravatar(release.uploader.email, size=50) }}" alt="{{ release.uploader.name|default(release.uploader.username, true) }}" height="50" width="50">
           </div>
           <div class="comment-content">
             <h1><a href="{{ request.route_path('packaging.project', name=release.project.normalized_name) }}">
@@ -38,7 +38,7 @@
             </h1>
             {% if release.summary %}<p>{{ release.summary }}</p>{% endif %}
             <p class="comment-detail">
-              {{ _('<strong>%(version)s</strong> by %(author)s', version=release.version, author=release.author) }}
+              {{ _('<strong>%(version)s</strong> by %(author)s', version=release.version, author=release.uploader.name|default(release.uploader.username, true)) }}
             </p>
           </div>
         </div>

--- a/warehouse/views.py
+++ b/warehouse/views.py
@@ -87,7 +87,8 @@ def robotstxt(request):
 def index(request):
     latest_updated_releases = (
         request.db.query(Release)
-                  .options(joinedload(Release.project))
+                  .options(joinedload(Release.project),
+                           joinedload(Release.uploader))
                   .order_by(Release.created.desc())
                   .limit(20)
                   .all()


### PR DESCRIPTION
This is currently really inefficient because it generates an extra query each time we access the uploader property. Ideally this will be some sort of SQLAlchemy relationship.