### PR TITLE
Display a relative timestamp for when a project was released

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,8 @@
   ],
   "dependencies": {
     "jquery": "2.1.4",
-    "font-awesome": "4.4.0"
+    "font-awesome": "4.4.0",
+    "jquery-timeago": "1.4.3"
   },
   "overrides": {
     "font-awesome": {

--- a/tests/unit/i18n/test_filters.py
+++ b/tests/unit/i18n/test_filters.py
@@ -31,3 +31,20 @@ def test_format_date(monkeypatch):
 
     kwargs.update({"locale": request.locale})
     assert format_date.calls == [pretend.call(*args, **kwargs)]
+
+
+def test_format_datetime(monkeypatch):
+    formatted = pretend.stub()
+    format_datetime = pretend.call_recorder(lambda *a, **kw: formatted)
+    monkeypatch.setattr(babel.dates, "format_datetime", format_datetime)
+
+    request = pretend.stub(locale=pretend.stub())
+    ctx = pretend.stub(get=pretend.call_recorder(lambda k: request))
+
+    args = [pretend.stub(), pretend.stub()]
+    kwargs = {"foo": pretend.stub()}
+
+    assert filters.format_datetime(ctx, *args, **kwargs) is formatted
+
+    kwargs.update({"locale": request.locale})
+    assert format_datetime.calls == [pretend.call(*args, **kwargs)]

--- a/tests/unit/i18n/test_init.py
+++ b/tests/unit/i18n/test_init.py
@@ -58,6 +58,7 @@ def test_includeme():
     assert config_settings == {
         "jinja2.filters": {
             "format_date": "warehouse.i18n.filters:format_date",
+            "format_datetime": "warehouse.i18n.filters:format_datetime",
         },
         "jinja2.finalize": i18n.translate_value,
         "jinja2.i18n.domain": "warehouse",

--- a/warehouse/i18n/__init__.py
+++ b/warehouse/i18n/__init__.py
@@ -53,6 +53,10 @@ def includeme(config):
     # Register our i18n/l10n filters for Jinja2
     filters = config.get_settings().setdefault("jinja2.filters", {})
     filters.setdefault("format_date", "warehouse.i18n.filters:format_date")
+    filters.setdefault(
+        "format_datetime",
+        "warehouse.i18n.filters:format_datetime",
+    )
 
     # Register our finalize function for Jinja2
     config.get_settings()["jinja2.finalize"] = translate_value

--- a/warehouse/i18n/filters.py
+++ b/warehouse/i18n/filters.py
@@ -21,3 +21,10 @@ def format_date(ctx, *args, **kwargs):
     request = ctx.get("request") or get_current_request()
     kwargs.setdefault("locale", request.locale)
     return babel.dates.format_date(*args, **kwargs)
+
+
+@jinja2.contextfilter
+def format_datetime(ctx, *args, **kwargs):
+    request = ctx.get("request") or get_current_request()
+    kwargs.setdefault("locale", request.locale)
+    return babel.dates.format_datetime(*args, **kwargs)

--- a/warehouse/static/js/main.js
+++ b/warehouse/static/js/main.js
@@ -63,4 +63,7 @@ $(document).ready(function() {
     positionWarning();
   });
 
+  // Format all of the time.relative tags to display relative time.
+  $(".-js-relative-time").timeago();
+
 });

--- a/warehouse/templates/base.html
+++ b/warehouse/templates/base.html
@@ -109,6 +109,7 @@
     </footer>
 
     <script src="{{ request.static_path('warehouse:static/dist/components/jquery/dist/jquery.js') }}"></script>
+    <script src="{{ request.static_path('warehouse:static/dist/components/jquery-timeago/jquery.timeago.js') }}"></script>
     <script src="{{ request.static_path('warehouse:static/dist/js/plugins.js') }}"></script>
     <script src="{{ request.static_path('warehouse:static/dist/js/main.js') }}"></script>
   </body>

--- a/warehouse/templates/packaging/detail.html
+++ b/warehouse/templates/packaging/detail.html
@@ -78,7 +78,7 @@
         {% endif %}
       </nav>
       <p class="author-info">
-        <span>Released TODO months ago by <a href="{{ request.route_path('accounts.profile', username=release.uploader.username) }}">{{ release.uploader.name|default(release.uploader.username, true) }}</a></span>
+        <span>Released <time class="-js-relative-time" datetime="{{ release.created|format_datetime('yyyy-MM-ddTHH:mm:ss') }}Z">on {{ release.created|format_date() }}</time> by <a href="{{ request.route_path('accounts.profile', username=release.uploader.username) }}">{{ release.uploader.name|default(release.uploader.username, true) }}</a></span>
         <a href="{{ request.route_path('accounts.profile', username=release.uploader.username) }}"><img src="{{ gravatar(release.uploader.email, size=40) }}" height="40" width="40" alt="{{ release.uploader.name|default(release.uploader.username, true) }}"></a>
       </p>
     </div>


### PR DESCRIPTION
Show how long ago a release was made in the project detail page. This uses the [http://timeago.yarp.com/](timeago) js module to do the formatting in javascript. This means that we do not need to worry about caching these values nor the wrong value being displayed in an old tab.

This looks like:

<img width="235" alt="screen-shot-2015-11-22-11-58-53" src="https://cloud.githubusercontent.com/assets/145979/11325005/76aada76-9110-11e5-82a9-8feb08667e24.png">

It will search for any HTML5 ``<time>`` tags with a class of ``relative`` to apply the relative display too. I'd like it if @nlhkabu could verify this is OK with her to use that class name and tag, and if it is it'd be great if she could either merge this PR or +1 it so I can.

Fixes #791