### PR TITLE
Intelligently compress our HTTP responses

### DIFF
--- a/tests/functional/test_caching.py
+++ b/tests/functional/test_caching.py
@@ -16,4 +16,4 @@ import pytest
 @pytest.mark.parametrize("path", ["/"])
 def test_basic_views_dont_vary(webtest, path):
     resp = webtest.get(path)
-    assert "Vary" not in resp.headers
+    assert resp.headers["Vary"] == "Accept-Encoding"

--- a/tests/unit/cache/test_http.py
+++ b/tests/unit/cache/test_http.py
@@ -13,8 +13,6 @@
 import pretend
 import pytest
 
-from pyramid.tweens import EXCVIEW
-
 from warehouse.cache.http import (
     add_vary, cache_control, conditional_http_tween_factory, includeme,
 )
@@ -271,13 +269,10 @@ class TestConditionalHTTPTween:
 
 def test_includeme():
     config = pretend.stub(
-        add_tween=pretend.call_recorder(lambda t, under: None),
+        add_tween=pretend.call_recorder(lambda t: None),
     )
     includeme(config)
 
     assert config.add_tween.calls == [
-        pretend.call(
-            "warehouse.cache.http.conditional_http_tween_factory",
-            under=EXCVIEW,
-        ),
+        pretend.call("warehouse.cache.http.conditional_http_tween_factory"),
     ]

--- a/tests/unit/test_raven.py
+++ b/tests/unit/test_raven.py
@@ -14,7 +14,7 @@ import pretend
 import pytest
 import raven as real_raven
 
-from pyramid.tweens import EXCVIEW
+from pyramid.tweens import EXCVIEW, INGRESS
 from raven.middleware import Sentry as SentryMiddleware
 from unittest import mock
 
@@ -125,7 +125,14 @@ def test_includeme(monkeypatch):
         pretend.call(raven._raven, name="raven", reify=True),
     ]
     assert config.add_tween.calls == [
-        pretend.call("warehouse.raven.raven_tween_factory", over=EXCVIEW),
+        pretend.call(
+            "warehouse.raven.raven_tween_factory",
+            over=EXCVIEW,
+            under=[
+                "pyramid_debugtoolbar.toolbar_tween_factory",
+                INGRESS,
+            ],
+        ),
     ]
     assert config.add_wsgi_middleware.calls == [
         pretend.call(SentryMiddleware, client=client_obj),

--- a/tests/unit/utils/test_compression.py
+++ b/tests/unit/utils/test_compression.py
@@ -1,0 +1,151 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pretend
+import pytest
+
+from pyramid.response import Response
+from webob.acceptparse import Accept, NoAccept
+from webob.response import gzip_app_iter
+
+from warehouse.utils.compression import _compressor as compressor
+from warehouse.utils.compression import compression_tween_factory
+
+
+class TestCompressor:
+
+    @pytest.mark.parametrize(
+        "vary",
+        [
+            ["Cookie"],
+            ["Authorization"],
+            ["Cookie", "Authorization"],
+        ],
+    )
+    def test_bails_if_vary(self, vary):
+        request = pretend.stub()
+        response = pretend.stub(vary=vary)
+
+        compressor(request, response)
+
+    def test_bails_if_content_encoding(self):
+        request = pretend.stub()
+        response = pretend.stub(
+            headers={"Content-Encoding": "something"},
+            vary=None,
+        )
+
+        compressor(request, response)
+
+    @pytest.mark.parametrize(
+        ("vary", "expected"),
+        [
+            (None, {"Accept-Encoding"}),
+            (["Something-Else"], {"Accept-Encoding", "Something-Else"}),
+        ],
+    )
+    def test_sets_vary(self, vary, expected):
+        request = pretend.stub(accept_encoding=NoAccept())
+        response = Response(body=b"foo")
+        response.vary = vary
+
+        compressor(request, response)
+
+        assert set(response.vary) == expected
+
+    def test_compresses_non_streaming(self):
+        decompressed_body = b"foofoofoofoofoofoofoofoofoofoofoofoofoofoo"
+        compressed_body = b"".join(list(gzip_app_iter([decompressed_body])))
+
+        request = pretend.stub(accept_encoding=Accept("gzip"))
+        response = Response(body=decompressed_body)
+        response.md5_etag()
+
+        original_etag = response.etag
+
+        compressor(request, response)
+
+        assert response.content_encoding == "gzip"
+        assert response.content_length == len(compressed_body)
+        assert response.body == compressed_body
+        assert response.etag != original_etag
+
+    def test_compresses_streaming(self):
+        decompressed_body = b"foofoofoofoofoofoofoofoofoofoofoofoofoofoo"
+        compressed_body = b"".join(list(gzip_app_iter([decompressed_body])))
+
+        request = pretend.stub(accept_encoding=Accept("gzip"))
+        response = Response(app_iter=iter([decompressed_body]))
+
+        compressor(request, response)
+
+        assert response.content_encoding == "gzip"
+        assert response.content_length is None
+        assert response.body == compressed_body
+
+    def test_compresses_streaming_with_etag(self):
+        decompressed_body = b"foofoofoofoofoofoofoofoofoofoofoofoofoofoo"
+        compressed_body = b"".join(list(gzip_app_iter([decompressed_body])))
+
+        request = pretend.stub(accept_encoding=Accept("gzip"))
+        response = Response(app_iter=iter([decompressed_body]))
+        response.etag = "foo"
+
+        compressor(request, response)
+
+        assert response.content_encoding == "gzip"
+        assert response.content_length is None
+        assert response.body == compressed_body
+        assert response.etag == "rfbezwKUdGjz6VPWDLDTvA"
+
+    def test_buffers_small_streaming(self):
+        decompressed_body = b"foofoofoofoofoofoofoofoofoofoofoofoofoofoo"
+        compressed_body = b"".join(list(gzip_app_iter([decompressed_body])))
+
+        request = pretend.stub(accept_encoding=Accept("gzip"))
+        response = Response(
+            app_iter=iter([decompressed_body]),
+            content_length=len(decompressed_body),
+        )
+
+        compressor(request, response)
+
+        assert response.content_encoding == "gzip"
+        assert response.content_length == len(compressed_body)
+        assert response.body == compressed_body
+
+    def test_doesnt_compress_too_small(self):
+        request = pretend.stub(accept_encoding=Accept("gzip"))
+        response = Response(body=b"foo")
+
+        compressor(request, response)
+
+        assert response.content_encoding is None
+        assert response.content_length == 3
+        assert response.body == b"foo"
+
+
+def test_compression_tween_factory():
+    callbacks = []
+
+    registry = pretend.stub()
+    request = pretend.stub(add_response_callback=callbacks.append)
+    response = pretend.stub()
+
+    def handler(inner_request):
+        assert inner_request is request
+        return response
+
+    tween = compression_tween_factory(handler, registry)
+
+    assert tween(request) is response
+    assert callbacks == [compressor]

--- a/warehouse/cache/http.py
+++ b/warehouse/cache/http.py
@@ -16,6 +16,9 @@ import functools
 from pyramid.tweens import EXCVIEW
 
 
+BUFFER_MAX = 1 * 1024 * 1024  # We'll buffer up to 1MB
+
+
 def add_vary_callback(*varies):
     def inner(request, response):
         vary = set(response.vary if response.vary is not None else [])
@@ -72,22 +75,34 @@ def conditional_http_tween_factory(handler, registry):
         if response.last_modified is not None:
             response.conditional_response = True
 
+        streaming = not isinstance(response.app_iter, collections.abc.Sequence)
+
         # We want to only enable the conditional machinery if either we
         # were given an explicit ETag header by the view or we have a
         # buffered response and can generate the ETag header ourself.
         if response.etag is not None:
             response.conditional_response = True
-        elif (isinstance(response.app_iter, collections.abc.Sequence) and
-                len(response.app_iter) == 1):
-            # We can only reasonably implement automatic ETags on 200 responses
-            # to GET or HEAD requests. The subtles of doing it in other cases
-            # are too hard to get right.
-            if (request.method in {"GET", "HEAD"} and
-                    response.status_code == 200):
+        # We can only reasonably implement automatic ETags on 200 responses
+        # to GET or HEAD requests. The subtles of doing it in other cases
+        # are too hard to get right.
+        elif request.method in {"GET", "HEAD"} and response.status_code == 200:
+            # If we have a streaming response, but it's small enough, we'll
+            # just go ahead and buffer it in memory so that we can generate a
+            # ETag for it.
+            if (streaming and response.content_length is not None
+                    and response.content_length <= BUFFER_MAX):
+                response.body
+                streaming = False
+
+            # Anything that has survived as a streaming response at this point
+            # and doesn't have an ETag header already, we'll go ahead and give
+            # it one.
+            if not streaming:
                 response.conditional_response = True
                 response.md5_etag()
 
         return response
+
     return conditional_http_tween
 
 

--- a/warehouse/cache/http.py
+++ b/warehouse/cache/http.py
@@ -13,8 +13,6 @@
 import collections.abc
 import functools
 
-from pyramid.tweens import EXCVIEW
-
 
 BUFFER_MAX = 1 * 1024 * 1024  # We'll buffer up to 1MB
 
@@ -107,7 +105,4 @@ def conditional_http_tween_factory(handler, registry):
 
 
 def includeme(config):
-    config.add_tween(
-        "warehouse.cache.http.conditional_http_tween_factory",
-        under=EXCVIEW,
-    )
+    config.add_tween("warehouse.cache.http.conditional_http_tween_factory")

--- a/warehouse/cache/origin/__init__.py
+++ b/warehouse/cache/origin/__init__.py
@@ -34,6 +34,7 @@ def esi_include(ctx, path, cookies=False):
         cacher = request.find_service(IOriginCache)
     except ValueError:
         subreq = Request.blank(path)
+        subreq.accept_encoding = "identity"
         if cookies:
             subreq.cookies.update(request.cookies)
             request.add_response_callback(add_vary_callback("Cookie"))

--- a/warehouse/config.py
+++ b/warehouse/config.py
@@ -22,6 +22,7 @@ from pyramid import renderers
 from pyramid.config import Configurator as _Configurator
 from pyramid.response import Response
 from pyramid.static import ManifestCacheBuster
+from pyramid.tweens import EXCVIEW
 from pyramid_rpc.xmlrpc import XMLRPCRenderer
 
 from warehouse import __commit__
@@ -343,6 +344,17 @@ def configure(settings=None):
     # Block non HTTPS requests for the legacy ?:action= routes when they are
     # sent via POST.
     config.add_tween("warehouse.config.require_https_tween_factory")
+
+    # Enable compression of our HTTP responses
+    config.add_tween(
+        "warehouse.utils.compression.compression_tween_factory",
+        over=[
+            "warehouse.cache.http.conditional_http_tween_factory",
+            "pyramid_debugtoolbar.toolbar_tween_factory",
+            "warehouse.raven.raven_tween_factory",
+            EXCVIEW,
+        ],
+    )
 
     # Enable Warehouse to service our static files
     config.add_static_view(

--- a/warehouse/raven.py
+++ b/warehouse/raven.py
@@ -13,7 +13,7 @@
 import raven
 import raven.middleware
 
-from pyramid.tweens import EXCVIEW
+from pyramid.tweens import EXCVIEW, INGRESS
 from raven.utils.serializer.base import Serializer
 from raven.utils.serializer.manager import manager as serialization_manager
 
@@ -65,7 +65,14 @@ def includeme(config):
     config.add_request_method(_raven, name="raven", reify=True)
 
     # Add a tween that will handle catching any exceptions that get raised.
-    config.add_tween("warehouse.raven.raven_tween_factory", over=EXCVIEW)
+    config.add_tween(
+        "warehouse.raven.raven_tween_factory",
+        under=[
+            "pyramid_debugtoolbar.toolbar_tween_factory",
+            INGRESS,
+        ],
+        over=EXCVIEW,
+    )
 
     # Wrap the WSGI object with the middle to catch any exceptions we don't
     # catch elsewhere.

--- a/warehouse/utils/compression.py
+++ b/warehouse/utils/compression.py
@@ -1,0 +1,103 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import base64
+import hashlib
+
+from collections.abc import Sequence
+
+
+ENCODINGS = ["identity", "gzip"]
+DEFAULT_ENCODING = "identity"
+BUFFER_MAX = 1 * 1024 * 1024  # We'll buffer up to 1MB
+
+
+def _compressor(request, response):
+    # Skip items with a Vary: Cookie/Authorization Header because we don't know
+    # if they are safe from the CRIME attack.
+    if (response.vary is not None
+            and (set(response.vary) & {"Cookie", "Authorization"})):
+        return
+
+    # Avoid compression if we've already got a Content-Encoding.
+    if "Content-Encoding" in response.headers:
+        return
+
+    # Ensure that the Accept-Encoding header gets added to the response.
+    vary = set(response.vary if response.vary is not None else [])
+    vary.add("Accept-Encoding")
+    response.vary = vary
+
+    # Negotiate the correct encoding from our request.
+    target_encoding = request.accept_encoding.best_match(
+        ENCODINGS,
+        default_match=DEFAULT_ENCODING,
+    )
+
+    # If we have a Sequence, we'll assume that we aren't streaming the
+    # response because it's probably a list or similar.
+    streaming = not isinstance(response.app_iter, Sequence)
+
+    # If our streaming content is small enough to easily buffer in memory
+    # then we'll just convert it to a non streaming response.
+    if (streaming and response.content_length is not None
+            and response.content_length <= BUFFER_MAX):
+        response.body
+        streaming = False
+
+    if streaming:
+        response.encode_content(encoding=target_encoding, lazy=True)
+
+        # We need to remove the content_length from this response, since
+        # we no longer know what the length of the content will be.
+        response.content_length = None
+
+        # If this has a streaming response, then we need to adjust the ETag
+        # header, if it has one, so that it reflects this. We don't just append
+        # ;gzip to this because we don't want people to try and use it to infer
+        # any information about it.
+        if response.etag is not None:
+            md5_digest = hashlib.md5((response.etag + ";gzip").encode("utf8"))
+            md5_digest = md5_digest.digest()
+            md5_digest = base64.b64encode(md5_digest)
+            md5_digest = md5_digest.replace(b"\n", b"").decode("utf8")
+            response.etag = md5_digest.strip("=")
+    else:
+        original_length = len(response.body)
+        response.encode_content(encoding=target_encoding, lazy=False)
+
+        # If the original length is less than our new, compressed length
+        # then we'll go back to the original. There is no reason to encode
+        # the content if it increases the length of the body.
+        if original_length < len(response.body):
+            response.decode_content()
+
+        # If we've added an encoding to the content, then we'll want to
+        # recompute the ETag.
+        if response.content_encoding is not None:
+            response.md5_etag()
+
+
+def compression_tween_factory(handler, registry):
+
+    def compression_tween(request):
+        response = handler(request)
+
+        # We use a response callback here so that it happens after all of the
+        # other response callbacks are called. This is important because
+        # otherwise we won't be able to check Vary headers and such that are
+        # set by response callbacks.
+        request.add_response_callback(_compressor)
+
+        return response
+
+    return compression_tween


### PR DESCRIPTION
* Skips compression when there is a ``Vary`` header for either ``Cookie`` or ``Authorization`` because they may be vulnerable to CRIME.
* Skips compression when there is already a ``Content-Encoding`` as we don't want to modify it if someone has already set it.
* Buffers small (under 1MB) streaming content in memory for both conditional and streaming responses.
* Compresses non streaming responses in memory and uses the new, compressed, response if it is smaller than the original.
* Compresses streaming responses as they are streamed.
* Updates the ETag headers.
* Ensures a ``Vary: Accept-Encoding`` is accepted.

Fixes #769