### PR TITLE
Use a short, but still temporary, cache for static files

### DIFF
--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -443,7 +443,7 @@ def test_configure(monkeypatch, settings, environment, other_settings):
         pretend.call(
             name="static",
             path="warehouse:static/dist/",
-            cache_max_age=0,
+            cache_max_age=1,
             cachebust=cachebuster_obj,
         ),
         pretend.call(name="locales", path="warehouse:locales/"),

--- a/warehouse/config.py
+++ b/warehouse/config.py
@@ -361,7 +361,7 @@ def configure(settings=None):
         name="static",
         path="warehouse:static/dist/",
         # TODO: Remove this once we have cache busting completely working
-        cache_max_age=0,
+        cache_max_age=1,
         cachebust=ManifestCacheBuster(
             "warehouse:static/dist/manifest.json",
             reload=config.registry.settings["pyramid.reload_assets"],


### PR DESCRIPTION
Pyramid actively prevents caching if cache_max_age=0 rather than just caching something that expires immediately. Setting it to 1 instead will allow it to be cached for a tiny amount of time.