### PR TITLE
Add more validations to the legacy upload API

### DIFF
--- a/tests/unit/legacy/api/test_pypi.py
+++ b/tests/unit/legacy/api/test_pypi.py
@@ -533,6 +533,7 @@ class TestFileUpload:
             "content": pretend.stub(
                 filename=filename,
                 file=io.BytesIO(b"A fake file."),
+                type="application/tar",
             ),
         })
         db_request.POST.extend([
@@ -602,6 +603,49 @@ class TestFileUpload:
         db_request.db.query(Filename) \
                      .filter(Filename.filename == filename).one()
 
+    @pytest.mark.parametrize("content_type", [None, "image/foobar"])
+    def test_upload_fails_invlaid_content_type(self, tmpdir, monkeypatch,
+                                               pyramid_config, db_request,
+                                               content_type):
+        monkeypatch.setattr(tempfile, "tempdir", str(tmpdir))
+
+        pyramid_config.testing_securitypolicy(userid=1)
+        user = UserFactory.create()
+        project = ProjectFactory.create()
+        release = ReleaseFactory.create(project=project, version="1.0")
+        RoleFactory.create(user=user, project=project)
+
+        db_request.db.add(
+            Classifier(classifier="Environment :: Other Environment"),
+        )
+
+        filename = "{}-{}.tar.gz".format(project.name, release.version)
+
+        db_request.POST = MultiDict({
+            "metadata_version": "1.2",
+            "name": project.name,
+            "version": release.version,
+            "filetype": "sdist",
+            "pyversion": "source",
+            "md5_digest": "335c476dc930b959dda9ec82bd65ef19",
+            "content": pretend.stub(
+                filename=filename,
+                file=io.BytesIO(b"A fake file."),
+                type=content_type,
+            ),
+        })
+        db_request.POST.extend([
+            ("classifiers", "Environment :: Other Environment"),
+        ])
+
+        with pytest.raises(HTTPBadRequest) as excinfo:
+            pypi.file_upload(db_request)
+
+        resp = excinfo.value
+
+        assert resp.status_code == 400
+        assert resp.status == "400 Invalid distribution file."
+
     @pytest.mark.parametrize("sig", [b"lol nope"])
     def test_upload_fails_with_invalid_signature(self, pyramid_config,
                                                  db_request, sig):
@@ -623,6 +667,7 @@ class TestFileUpload:
             "content": pretend.stub(
                 filename=filename,
                 file=io.BytesIO(b"A fake file."),
+                type="application/tar",
             ),
             "gpg_signature": pretend.stub(
                 filename=filename + ".asc",
@@ -658,6 +703,7 @@ class TestFileUpload:
             "content": pretend.stub(
                 filename=filename,
                 file=io.BytesIO(b"A fake file."),
+                type="application/tar",
             ),
         })
         db_request.POST.extend([
@@ -694,6 +740,7 @@ class TestFileUpload:
             "content": pretend.stub(
                 filename=filename,
                 file=io.BytesIO(b"A fake file."),
+                type="application/tar",
             ),
         })
 
@@ -728,6 +775,7 @@ class TestFileUpload:
             "content": pretend.stub(
                 filename=filename,
                 file=io.BytesIO(b"a" * (pypi.MAX_FILESIZE + 1)),
+                type="application/tar",
             ),
         })
 
@@ -759,6 +807,7 @@ class TestFileUpload:
             "content": pretend.stub(
                 filename=filename,
                 file=io.BytesIO(b"a"),
+                type="application/tar",
             ),
             "gpg_signature": pretend.stub(
                 filename=filename + ".asc",
@@ -794,6 +843,7 @@ class TestFileUpload:
             "content": pretend.stub(
                 filename=filename,
                 file=io.BytesIO(b"a" * (pypi.MAX_FILESIZE + 1)),
+                type="application/tar",
             ),
         })
 
@@ -829,6 +879,7 @@ class TestFileUpload:
             "content": pretend.stub(
                 filename=filename,
                 file=io.BytesIO(b"a" * (pypi.MAX_FILESIZE + 1)),
+                type="application/tar",
             ),
         })
 
@@ -862,6 +913,7 @@ class TestFileUpload:
             "content": pretend.stub(
                 filename=filename,
                 file=io.BytesIO(b"a" * (pypi.MAX_FILESIZE + 1)),
+                type="application/tar",
             ),
         })
 
@@ -898,6 +950,7 @@ class TestFileUpload:
             "content": pretend.stub(
                 filename=filename,
                 file=io.BytesIO(b"a" * (pypi.MAX_FILESIZE + 1)),
+                type="application/tar",
             ),
         })
 
@@ -933,6 +986,7 @@ class TestFileUpload:
             "content": pretend.stub(
                 filename=filename,
                 file=io.BytesIO(b"a" * (pypi.MAX_FILESIZE + 1)),
+                type="application/tar",
             ),
         })
 
@@ -962,6 +1016,7 @@ class TestFileUpload:
             "content": pretend.stub(
                 filename=filename,
                 file=io.BytesIO(b"a" * (pypi.MAX_FILESIZE + 1)),
+                type="application/tar",
             ),
         })
 
@@ -999,6 +1054,7 @@ class TestFileUpload:
             "content": pretend.stub(
                 filename=filename,
                 file=io.BytesIO(b"A fake file."),
+                type="application/tar",
             ),
         })
 
@@ -1064,6 +1120,7 @@ class TestFileUpload:
             "content": pretend.stub(
                 filename=filename,
                 file=io.BytesIO(b"A fake file."),
+                type="application/tar",
             ),
         })
 
@@ -1101,6 +1158,7 @@ class TestFileUpload:
             "content": pretend.stub(
                 filename=filename,
                 file=io.BytesIO(b"A fake file."),
+                type="application/tar",
             ),
         })
         db_request.POST.extend([
@@ -1164,6 +1222,7 @@ class TestFileUpload:
             "content": pretend.stub(
                 filename=filename,
                 file=io.BytesIO(b"A fake file."),
+                type="application/tar",
             ),
         })
 

--- a/warehouse/legacy/api/pypi.py
+++ b/warehouse/legacy/api/pypi.py
@@ -38,6 +38,7 @@ from warehouse.packaging.models import (
     Project, Release, Dependency, DependencyKind, Role, File, Filename,
     JournalEntry,
 )
+from warehouse.sessions import uses_session
 from warehouse.utils.http import require_POST
 
 
@@ -492,13 +493,10 @@ def _is_valid_dist_file(filename, filetype):
     return True
 
 
-# TODO: Uncomment the below code once the upload view is safe to be used on
-#       warehouse.python.org. For now, we'll disable it so people can't use
-#       Warehouse to upload and get broken or not properly validated data.
-# @view_config(
-#     route_name="legacy.api.pypi.file_upload",
-#     decorator=[require_POST, csrf_exempt, uses_session],
-# )
+@view_config(
+    route_name="legacy.api.pypi.file_upload",
+    decorator=[require_POST, csrf_exempt, uses_session],
+)
 def file_upload(request):
     # Before we do anything, if there isn't an authenticated user with this
     # request, then we'll go ahead and bomb out.

--- a/warehouse/legacy/api/pypi.py
+++ b/warehouse/legacy/api/pypi.py
@@ -590,6 +590,11 @@ def file_upload(request):
             )
         )
 
+    # Check the content type of what is being uploaded
+    if (not request.POST["content"].type
+            or request.POST["content"].type.startswith("image/")):
+        raise _exc_with_message(HTTPBadRequest, "Invalid distribution file.")
+
     # Check to see if the file that was uploaded exists already or not.
     if request.db.query(
             request.db.query(File)

--- a/warehouse/migrations/versions/477bc785c999_add_a_server_default_for_submitted_date.py
+++ b/warehouse/migrations/versions/477bc785c999_add_a_server_default_for_submitted_date.py
@@ -1,0 +1,44 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Add a server default for submitted_date
+
+Revision ID: 477bc785c999
+Revises: 6a03266b2d
+Create Date: 2015-12-16 16:19:59.419186
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "477bc785c999"
+down_revision = "6a03266b2d"
+
+
+def upgrade():
+    op.alter_column(
+        "journals",
+        "submitted_date",
+        server_default=sa.func.now(),
+        nullable=False,
+    )
+
+
+def downgrade():
+    op.alter_column(
+        "journals",
+        "submitted_date",
+        existing_type=postgresql.TIMESTAMP(),
+        server_default=None,
+        nullable=True,
+    )

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -438,7 +438,11 @@ class JournalEntry(db.ModelBase):
     name = Column(Text)
     version = Column(Text)
     action = Column(Text)
-    submitted_date = Column(DateTime(timezone=False))
+    submitted_date = Column(
+        DateTime(timezone=False),
+        nullable=False,
+        server_default=sql.func.now(),
+    )
     _submitted_by = Column(
         "submitted_by",
         CIText,


### PR DESCRIPTION
Fixes #575
Fixes #620
Fixes #601 

Note: This won't issue purge requests to PyPI itself, just to warehouse. So anyone using this will need to do something like ``curl -XPURGE https://pypi.python.org/simple/<foo>/`` manually.