### PR TITLE
Allow uncacheable items in development

### DIFF
--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -283,7 +283,7 @@ def test_configure(monkeypatch, settings, environment, other_settings):
     monkeypatch.setattr(config, "Configurator", configurator_cls)
 
     cachebuster_obj = pretend.stub()
-    cachebuster_cls = pretend.call_recorder(lambda p, reload: cachebuster_obj)
+    cachebuster_cls = pretend.call_recorder(lambda p, **kw: cachebuster_obj)
     monkeypatch.setattr(config, "ManifestCacheBuster", cachebuster_cls)
 
     transaction_manager = pretend.stub()
@@ -452,7 +452,11 @@ def test_configure(monkeypatch, settings, environment, other_settings):
         pretend.call("warehouse:static/dist/", cachebuster_obj),
     ]
     assert cachebuster_cls.calls == [
-        pretend.call("warehouse:static/dist/manifest.json", reload=False),
+        pretend.call(
+            "warehouse:static/dist/manifest.json",
+            reload=False,
+            strict=True,
+        ),
     ]
     assert configurator_obj.scan.calls == [
         pretend.call(ignore=["warehouse.migrations.env", "warehouse.wsgi"]),

--- a/tests/unit/utils/test_static.py
+++ b/tests/unit/utils/test_static.py
@@ -30,3 +30,13 @@ class TestManifestCacheBuster:
 
         with pytest.raises(ValueError):
             cb(None, "/the/path/style.css", {"keyword": "arg"})
+
+    def test_returns_when_invalid_and_not_strict(self):
+        cb = ManifestCacheBuster(
+            "warehouse:static/dist/manifest.json",
+            strict=False,
+        )
+        cb._manifest = {}
+        result = cb(None, "/the/path/style.css", {"keyword": "arg"})
+
+        assert result == ("/the/path/style.css", {"keyword": "arg"})

--- a/warehouse/config.py
+++ b/warehouse/config.py
@@ -358,16 +358,21 @@ def configure(settings=None):
     )
 
     # Enable Warehouse to serve our static files
+    prevent_http_cache = \
+        config.get_settings().get("pyramid.prevent_http_cache", False)
     config.add_static_view(
         "static",
         "warehouse:static/dist/",
-        cache_max_age=10 * 365 * 24 * 60 * 60,  # 10 years
+        # Don't cache at all if prevent_http_cache is true, else we'll cache
+        # the files for 10 years.
+        cache_max_age=0 if prevent_http_cache else 10 * 365 * 24 * 60 * 60,
     )
     config.add_cache_buster(
         "warehouse:static/dist/",
         ManifestCacheBuster(
             "warehouse:static/dist/manifest.json",
             reload=config.registry.settings["pyramid.reload_assets"],
+            strict=not prevent_http_cache,
         ),
     )
 

--- a/warehouse/utils/static.py
+++ b/warehouse/utils/static.py
@@ -16,10 +16,20 @@ from pyramid.static import ManifestCacheBuster as _ManifestCacheBuster
 
 class ManifestCacheBuster(_ManifestCacheBuster):
 
+    def __init__(self, *args, strict=True, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.strict = strict
+
     def __call__(self, request, subpath, kw):
         try:
             return self.manifest[subpath], kw
         except KeyError:
+            # If we're not in strict mode, then we'll allow missing files to
+            # just fall back to the un-cachebusted path.
+            if not self.strict:
+                return subpath, kw
+
             # We raise an error here even though the one from Pyramid does not.
             # This is done because we want to be strict that all static files
             # must be cache busted otherwise it is likely an error of some kind


### PR DESCRIPTION
In development this will make it so all static assets are not cached at all. It will also remove the ``ValueError`` if you refresh the page too quickly and replace it with an un-cachebusted URL in the resulting page. Then when your browser requests the static file it will get:

* The previous version of the static asset (which may be the same as the new version if it hasn't changed) if the HTTP request happens before the static pipeline deletes the previously compiled assets.
* A 404 if the HTTP request happens after the static pipeline deletes the previously compiled assets but before it has compiled the asset you're requesting.
* The correct file, albeit without the cache busting token in the filename, if the HTTP request happens after the static pipeline has deleted and recompiled that asset.

If those caveats are OK with @nlhkabu then we can merge this, or if she'd prefer to get the ``ValueError`` to tell her she needs to refresh to get an accurate view of the page we can just close this PR.