### PR TITLE
Replaced TODO links in footer with actual links

### DIFF
--- a/warehouse/templates/base.html
+++ b/warehouse/templates/base.html
@@ -84,9 +84,9 @@
       <div class="footer-links">
         <ul>
           <li><h3 {{ l20n("getHelp") }}>Get Help</h3></li>
-          <li><a {{ l20n("installingPackages") }} href="TODO">Installing Packages</a></li>
-          <li><a {{ l20n("uploadingPackages") }} href="TODO">Uploading Packages</a></li>
-          <li><a {{ l20n("referenceGuide") }} href="TODO">Reference Guide</a></li>
+          <li><a {{ l20n("installingPackages") }} href="https://packaging.python.org/en/latest/installing/">Installing Packages</a></li>
+          <li><a {{ l20n("uploadingPackages") }} href="https://packaging.python.org/en/latest/distributing/">Uploading Packages</a></li>
+          <li><a {{ l20n("referenceGuide") }} href="https://pip.pypa.io/en/latest/reference/">Reference Guide</a></li>
         </ul>
 
         <ul>
@@ -98,9 +98,9 @@
 
         <ul>
           <li><h3 {{ l20n("contributingToPyPI") }}>Contributing to PyPI</h3></li>
-          <li><a {{ l20n("reportABug") }} href="TODO">Report a Bug</a></li>
-          <li><a {{ l20n("contributeOnGithub") }} href="TODO">Contribute on Github</a></li>
-          <li><a {{ l20n("devCredits") }} href="TODO">Development Credits</a></li>
+          <li><a {{ l20n("reportABug") }} href="https://github.com/pypa/warehouse/issues">Report a Bug</a></li>
+          <li><a {{ l20n("contributeOnGithub") }} href="https://github.com/pypa/warehouse">Contribute on Github</a></li>
+          <li><a {{ l20n("devCredits") }} href="https://github.com/pypa/warehouse/graphs/contributors">Development Credits</a></li>
         </ul>
       </div>
 


### PR DESCRIPTION
Not sure how Develoment Credits are tracked as there is no AUTHORS file. I just linked to the [github contributors page](https://github.com/pypa/warehouse/graphs/contributors).