### PR TITLE
Update migration instructions

### DIFF
--- a/docs/development/database-migrations.rst
+++ b/docs/development/database-migrations.rst
@@ -4,8 +4,8 @@ Database Migrations
 Modifying database schema will need database migrations (except for removing
 and adding tables). To autogenerate migrations::
 
-    $ docker-compose run web warehouse db revision -m
+    $ docker-compose run web python -m warehouse db revision
 
 Then migrate and test your migration::
 
-    $ docker-compose run web warehouse db upgrade head
+    $ docker-compose run web python -m warehouse db upgrade head


### PR DESCRIPTION
The commands were missing the python module to run

```
docker-compose run web warehouse db upgrade head                                                             !10547
ERROR: Cannot start container 85ec2908a3ef2c3670bccdfab3beff6a72243c66a5e183462565431272642e13: [8] System error: exec: "warehouse": executable file not found in $PATH```