### PR TITLE
Store some additional metadata in the file storage

### DIFF
--- a/tests/unit/legacy/api/test_pypi.py
+++ b/tests/unit/legacy/api/test_pypi.py
@@ -734,7 +734,7 @@ class TestFileUpload:
             )
 
         @pretend.call_recorder
-        def storage_service_store(path, file_path):
+        def storage_service_store(path, file_path, *, meta):
             if file_path.endswith(".asc"):
                 expected = (
                     b"-----BEGIN PGP SIGNATURE-----\n"
@@ -764,6 +764,11 @@ class TestFileUpload:
                 filename,
             ),
             mock.ANY,
+            meta={
+                "project": project.normalized_name,
+                "version": release.version,
+                "package_type": "sdist",
+            },
         )
 
         if has_signature:
@@ -775,6 +780,11 @@ class TestFileUpload:
                     filename + ".asc",
                 ),
                 mock.ANY,
+                meta={
+                    "project": project.normalized_name,
+                    "version": release.version,
+                    "package_type": "sdist",
+                },
             )
 
         # Ensure that a File object has been created.
@@ -1337,7 +1347,7 @@ class TestFileUpload:
         })
 
         @pretend.call_recorder
-        def storage_service_store(path, file_path):
+        def storage_service_store(path, file_path, *, meta):
             with open(file_path, "rb") as fp:
                 assert fp.read() == b"A fake file."
 
@@ -1361,6 +1371,11 @@ class TestFileUpload:
                     filename,
                 ),
                 mock.ANY,
+                meta={
+                    "project": project.normalized_name,
+                    "version": release.version,
+                    "package_type": "bdist_wheel",
+                },
             ),
         ]
 
@@ -1475,7 +1490,7 @@ class TestFileUpload:
             ("provides", "testing"),
         ])
 
-        storage_service = pretend.stub(store=lambda path, content: None)
+        storage_service = pretend.stub(store=lambda path, filepath, meta: None)
         db_request.find_service = lambda svc: storage_service
 
         resp = pypi.file_upload(db_request)
@@ -1556,7 +1571,7 @@ class TestFileUpload:
             ),
         })
 
-        storage_service = pretend.stub(store=lambda path, content: None)
+        storage_service = pretend.stub(store=lambda path, filepath, meta: None)
         db_request.find_service = lambda svc: storage_service
         db_request.client_addr = "10.10.10.10"
 

--- a/tests/unit/packaging/test_services.py
+++ b/tests/unit/packaging/test_services.py
@@ -243,13 +243,15 @@ class TestS3FileStorage:
             fp.write(b"Test File!")
 
         bucket = pretend.stub(
-            upload_file=pretend.call_recorder(lambda filename, key: None),
+            upload_file=pretend.call_recorder(
+                lambda filename, key, extra_args: None,
+            ),
         )
         storage = S3FileStorage(bucket)
         storage.store("foo/bar.txt", filename)
 
         assert bucket.upload_file.calls == [
-            pretend.call(filename, "foo/bar.txt"),
+            pretend.call(filename, "foo/bar.txt", extra_args={}),
         ]
 
     def test_stores_two_files(self, tmpdir):
@@ -262,13 +264,36 @@ class TestS3FileStorage:
             fp.write(b"Second Test File!")
 
         bucket = pretend.stub(
-            upload_file=pretend.call_recorder(lambda filename, key: None),
+            upload_file=pretend.call_recorder(
+                lambda filename, key, extra_args: None,
+            ),
         )
         storage = S3FileStorage(bucket)
         storage.store("foo/first.txt", filename1)
         storage.store("foo/second.txt", filename2)
 
         assert bucket.upload_file.calls == [
-            pretend.call(filename1, "foo/first.txt"),
-            pretend.call(filename2, "foo/second.txt"),
+            pretend.call(filename1, "foo/first.txt", extra_args={}),
+            pretend.call(filename2, "foo/second.txt", extra_args={}),
+        ]
+
+    def test_stores_metadata(self, tmpdir):
+        filename = str(tmpdir.join("testfile.txt"))
+        with open(filename, "wb") as fp:
+            fp.write(b"Test File!")
+
+        bucket = pretend.stub(
+            upload_file=pretend.call_recorder(
+                lambda filename, key, extra_args: None,
+            ),
+        )
+        storage = S3FileStorage(bucket)
+        storage.store("foo/bar.txt", filename, meta={"foo": "bar"})
+
+        assert bucket.upload_file.calls == [
+            pretend.call(
+                filename,
+                "foo/bar.txt",
+                extra_args={"Metadata": {"foo": "bar"}},
+            ),
         ]

--- a/warehouse/legacy/api/pypi.py
+++ b/warehouse/legacy/api/pypi.py
@@ -864,11 +864,24 @@ def file_upload(request):
         #       now we'll just ignore it and save it before the transaction is
         #       committed.
         storage = request.find_service(IFileStorage)
-        storage.store(file_.path, os.path.join(tmpdir, filename))
+        storage.store(
+            file_.path,
+            os.path.join(tmpdir, filename),
+            meta={
+                "project": file_.release.project.normalized_name,
+                "version": file_.release.version,
+                "package_type": file_.packagetype,
+            },
+        )
         if has_signature:
             storage.store(
                 file_.pgp_path,
                 os.path.join(tmpdir, filename + ".asc"),
+                meta={
+                    "project": file_.release.project.normalized_name,
+                    "version": file_.release.version,
+                    "package_type": file_.packagetype,
+                },
             )
 
     return Response()

--- a/warehouse/packaging/interfaces.py
+++ b/warehouse/packaging/interfaces.py
@@ -45,8 +45,9 @@ class IFileStorage(Interface):
         at the given path.
         """
 
-    def store(path, file_path):
+    def store(path, file_path, *, meta=None):
         """
         Save the file located at file_path to the file storage at the location
-        specified by path.
+        specified by path. An additional meta keyword argument may contain
+        extra information that an implementation may or may not store.
         """

--- a/warehouse/packaging/services.py
+++ b/warehouse/packaging/services.py
@@ -105,7 +105,7 @@ class LocalFileStorage:
     def get(self, path):
         return open(os.path.join(self.base, path), "rb")
 
-    def store(self, path, file_path):
+    def store(self, path, file_path, *, meta=None):
         destination = os.path.join(self.base, path)
         os.makedirs(os.path.dirname(destination), exist_ok=True)
         with open(destination, "wb") as dest_fp:
@@ -134,5 +134,10 @@ class S3FileStorage:
                 raise
             raise FileNotFoundError("No such key: {!r}".format(path)) from None
 
-    def store(self, path, file_path):
-        self.bucket.upload_file(file_path, path)
+    def store(self, path, file_path, *, meta=None):
+        extra_args = {}
+
+        if meta is not None:
+            extra_args["Metadata"] = meta
+
+        self.bucket.upload_file(file_path, path, extra_args=extra_args)


### PR DESCRIPTION
This will allow us to save things like project name, version, package_type, etc in the storage. Ultimately this should allow us to expose this to Fastly logging without having to parse it from the URL.