### PR TITLE
[Draft] Implement Security Feature

### DIFF
--- a/warehouse/accounts/views.py
+++ b/warehouse/accounts/views.py
@@ -174,7 +174,7 @@ def logout(request, redirect_field_name=REDIRECT_FIELD_NAME):
 @view_config(
     route_name="accounts.mark-insecure",
     renderer="accounts/mark_insecure.html",
-    #decorator=[csrf_protect("accounts.mark-insecure"), uses_session],
+    decorator=[csrf_protect("accounts.mark-insecure"), uses_session],
 )
 def mark_insecure(request):
 

--- a/warehouse/accounts/views.py
+++ b/warehouse/accounts/views.py
@@ -169,3 +169,43 @@ def logout(request, redirect_field_name=REDIRECT_FIELD_NAME):
         return HTTPSeeOther(redirect_to, headers=dict(headers))
 
     return {"redirect": {"field": REDIRECT_FIELD_NAME, "data": redirect_to}}
+
+
+@view_config(
+    route_name="accounts.mark-insecure",
+    renderer="accounts/mark_insecure.html",
+    #decorator=[csrf_protect("accounts.mark-insecure"), uses_session],
+)
+def mark_insecure(request):
+
+    # Todo: write a real view here
+
+    # if the user is not logged in, return a redirect to the login page with
+    # the REDIRECT_URL pointing as parameter that points back to this view.
+    if request.authenticated_userid is None:
+        pass
+
+    projects = [
+        {
+            "name": "Django",
+            "releases": [
+                '1.9rc1', '1.9b1', '1.9a1', '1.8.6', '1.8.5', '1.8.4',
+                '1.8.3', '1.8.2', '1.8.1', '1.8', '1.8c1', '1.8b2',
+                '1.8b1', '1.8a1', '1.7.10', '1.7.9', '1.7.8', '1.7.7',
+                '1.7.6', '1.7.5', '1.7.4', '1.7.3', '1.7.2', '1.7.1',
+                '1.7', '1.6.11', '1.6.10', '1.6.9', '1.6.8', '1.6.7',
+                '1.6.6', '1.6.5', '1.6.4', '1.6.3', '1.6.2', '1.6.1',
+                '1.6', '1.5.12', '1.5.11', '1.5.10', '1.5.9', '1.5.8',
+                '1.5.7', '1.5.6', '1.5.5', '1.5.4', '1.5.3', '1.5.2',
+                '1.5.1', '1.5', '1.4.22', '1.4.21', '1.4.20', '1.4.19',
+                '1.4.18', '1.4.17', '1.4.16',  '1.4.15', '1.4.14',
+                '1.4.13', '1.4.12', '1.4.11', '1.4.10', '1.4.9', '1.4.8',
+                '1.4.7', '1.4.6', '1.4.5', '1.4.4', '1.4.3', '1.4.2',
+                '1.4.1', '1.4'
+            ]
+        },
+        {"name": "Flask", "releases": ["0.1.0"]}
+    ]
+    return {
+        "projects": projects,
+    }

--- a/warehouse/migrations/versions/25cd10eba314_add_insecure_on_release.py
+++ b/warehouse/migrations/versions/25cd10eba314_add_insecure_on_release.py
@@ -1,0 +1,43 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Adds insecure and insecure_url to the release table
+
+Revision ID: 25cd10eba314
+Revises: f392e419ea1b
+Create Date: 2016-01-05 14:44:05.499376
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '25cd10eba314'
+down_revision = 'f392e419ea1b'
+
+
+def upgrade():
+    op.add_column(
+        "releases",
+        sa.Column("insecure", sa.Boolean(), nullable=True),
+    )
+
+    op.add_column(
+        "releases",
+        sa.Column("insecure_url", sa.Text(), nullable=True),
+    )
+
+
+def downgrade():
+    op.drop_column("releases", "insecure")
+    op.drop_column("releases", "insecure_url")
+

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -234,6 +234,8 @@ class Release(db.ModelBase):
     keywords = Column(Text)
     platform = Column(Text)
     download_url = Column(Text)
+    insecure = Column(Boolean)
+    insecure_url = Column(Text)
     _pypi_ordering = Column(Integer)
     _pypi_hidden = Column(Boolean)
     cheesecake_installability_id = Column(

--- a/warehouse/packaging/views.py
+++ b/warehouse/packaging/views.py
@@ -79,7 +79,7 @@ def release_detail(release, request):
     all_releases = (
         request.db.query(Release)
                   .filter(Release.project == project)
-                  .with_entities(Release.version, Release.created)
+                  .with_entities(Release.version, Release.created, Release.insecure)
                   .order_by(Release._pypi_ordering.desc())
                   .all()
     )

--- a/warehouse/routes.py
+++ b/warehouse/routes.py
@@ -49,6 +49,7 @@ def includeme(config):
     )
     config.add_route("accounts.login", "/account/login/")
     config.add_route("accounts.logout", "/account/logout/")
+    config.add_route("accounts.mark-insecure", "/account/mark-insecure/")
 
     # Packaging
     config.add_route(

--- a/warehouse/static/sass/components/_highlight-badge.scss
+++ b/warehouse/static/sass/components/_highlight-badge.scss
@@ -6,3 +6,9 @@
   padding: 2px 7px;
   border-radius: 3px;
 }
+
+.highlight-badge.-bad {
+  background-color: $danger-color;
+  border: 1px solid darken($danger-color, 7);
+  color: $white;
+}

--- a/warehouse/static/sass/components/_horizontal-section.scss
+++ b/warehouse/static/sass/components/_horizontal-section.scss
@@ -16,6 +16,16 @@
   border-top: 1px solid darken($base-grey, 10);
 }
 
+.horizontal-section.-bad {
+  background-color: $danger-color;
+  color: $white;
+}
+
+.horizontal-section.-bad a{
+  color: $white;
+  text-decoration: underline;
+}
+
 .horizontal-section.-medium {
   padding: 40px 0;
 }

--- a/warehouse/static/sass/components/_selection-badge.scss
+++ b/warehouse/static/sass/components/_selection-badge.scss
@@ -1,0 +1,14 @@
+.selection-badge {
+    cursor: pointer;
+    margin-right: 2%;
+    width: 10%;
+    box-sizing: border-box;
+    border-radius: 3px;
+    display: inline-block;
+    font-size: 17.6px;
+    margin-bottom: 10px;
+    background-color: #fff;
+    border: 2px solid darken($base-grey, 10);
+    color: lighten($text-color, 10);
+    padding: 0.4em;
+}

--- a/warehouse/static/sass/main.scss
+++ b/warehouse/static/sass/main.scss
@@ -93,6 +93,7 @@
 @import "components/search-form";
 @import "components/sidebar-section";
 @import "components/site-header"; // refactor
+@import "components/selection-badge";
 @import "components/sponsor-footer";
 @import "components/statistics-bar";
 @import "components/vertical-tabs";

--- a/warehouse/templates/accounts/mark_insecure.html
+++ b/warehouse/templates/accounts/mark_insecure.html
@@ -1,0 +1,58 @@
+{#
+ # Licensed under the Apache License, Version 2.0 (the "License");
+ # you may not use this file except in compliance with the License.
+ # You may obtain a copy of the License at
+ #
+ # http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+-#}
+{% extends "base.html" %}
+
+
+
+
+{% block title %}Mark Insecure{% endblock %}
+
+{% block content %}
+<section>
+  <div class="site-container">
+    <div class="vertical-tabs-container">
+      <div class="vertical-tabs">
+        <div class="sidebar-section">
+          <h3 {{ l20n("projectNavigation") }}>Select Project</h3>
+            {% for project in projects %}
+            <a class="js-vertical-tab vertical-tab {% if loop.index == 1 %}is-active{% endif %}" rel="tab{{ loop.index }}">{{ project.name }}</a>
+            {% endfor %}
+        </div>
+      </div>
+      <div class="vertical-tab-content-container">
+      {% for project in projects %}
+        <a class="js-vertical-tab-accordion-heading vertical-tab-accordion-heading {% if loop.index == 1 %}is-active{% endif %}" rel="tab{{ loop.index }}" {{ l20n("projectDescription") }}>Project Description</a>
+        <div id="tab{{ loop.index }}" class="js-vertical-tab-content vertical-tab-content">
+          <h2 {{ l20n("selectVersion") }}>Select Version</h2>
+            <div class="button-set">
+              <a class="wh-button" href="#" data-l10n-id="allVersions">All versions</a>
+              <a class="wh-button -highlight" href="#" data-l10n-id="selectVersion">Select one or more</a>
+            </div>
+            <p>
+            {% for release in project.releases %}
+              <span class="selection-badge">{{ release }}</span>
+            {% endfor %}
+            </p>
+            <p>
+              <strong><label for="insecure-url">URL</label></strong><br/>
+              <input id="insecure-url" type="text" name="insecure-url" data-l10n-id="insecureURL" size="80" placeholder="URL (to a CVE or an explanation)">
+            </p>
+            <input type="submit" value="Submit">
+         </div>
+      {% endfor %}
+      </div>
+    </div>
+  </div>
+</section>
+{% endblock %}

--- a/warehouse/templates/packaging/detail.html
+++ b/warehouse/templates/packaging/detail.html
@@ -80,7 +80,16 @@
     <p class="help-link"><a href="#" {{ l20n("howToInstall") }}>How do I install this?</a></p>
   </div>
 </section>
-
+{% if release.insecure %}
+<section class="horizontal-section -bad -medium">
+  <div class="site-container">
+    <p {{ l20n("versionInsecure") }}>
+            This version has been marked insecure by the package maintainers. You can read more
+            about the vulnerabilites <a href="{{ release.insecure_url }}">here</a>.
+    </p>
+  </div>
+</section>
+{% endif %}
 <section class="package-status">
   <div class="site-container">
     {% if release.version != all_releases[0].version %}
@@ -206,6 +215,9 @@
                     <span class="highlight-badge" {{ l20n("thisVersion") }}>This version</span>
                   {% else %}
                     <p><a href="{{ request.route_path('packaging.release', name=release.project.name, version=hrelease.version) }}">{{ hrelease.version }}</a></p>
+                  {% endif %}
+                  {% if hrelease.insecure %}
+                    <span class="highlight-badge -bad" {{ l20n("insecure") }}>Insecure</span>
                   {% endif %}
                 </div>
 


### PR DESCRIPTION
This is a first draft about how a package security feature might look like.

The basic idea is that package maintainers can mark a release as insecure and provide a URL to a CVE or a blog post describing the vulnerability as a first step to implement something like the suggestion in https://github.com/pypa/warehouse/issues/798
# Styles
I've borrowed a lot of the excellent styles that are already in the codebase and added a few new style classes. 

If you take a look at the attached screenshots, you'll see that I've added a big red banner on top and a smaller label on the *Version History & Changelog* tab.

![screen shot 2016-01-06 at 10 13 31](https://cloud.githubusercontent.com/assets/2930472/12217373/6e20cc80-b6fe-11e5-94b3-96b5dccddaa7.png)

![screen shot 2016-01-06 at 10 13 16](https://cloud.githubusercontent.com/assets/2930472/12217376/78d83a78-b6fe-11e5-892f-d80061f0553a.png)

# Workflow

A maintainer that wants to mark a release is insecure would go to a new page where all the packages he or she maintains are listed, select one or multiple releases and provide a URL for further explanation.

![screen shot 2016-01-09 at 18 39 07](https://cloud.githubusercontent.com/assets/2930472/12217432/60b6f504-b700-11e5-8f15-8aad5abc5d89.png)

# Implementation

This draft adds two new fields to the `packaging.Release` model:

- insecure *Boolean*
- insecure_url *Text*

And a new view to `accounts.views` that I've called `mark_insecure`. In its current form, the view does nothing other than passing a `dict` containing two example projects to the template.

Is this something you would consider to add to the new codebase? I'm open to all feedback for this draft and I'm willing to go down a completely different route if this doesn't fit.

If this is something you'd consider, I'd be happy to continue to work on this to fill the missing parts.
 