### PR TITLE
Speed up Deploys

### DIFF
--- a/bin/post_compile
+++ b/bin/post_compile
@@ -6,9 +6,6 @@ set -x
 # have access to our private repository.
 pip install -c requirements.txt -r requirements/theme.txt
 
-# Clean up after ourselves
-rm -rf node_modules .npm .cache .config .local
-
 # Remove items which are not important for Heroku deploys
 rm -rf dev docs requirements requirements.txt tests
 rm -rf .bowerrc .coveragerc .dockerignore .gitignore .travis.yml babel.cfg
@@ -16,4 +13,4 @@ rm -rf bower.json CONTRIBUTING.rst docker-compose.yml Dockerfile Gulpfile.js
 rm -rf package.json README.rst runtime.txt setup.cfg
 
 # We don't need Node installed at runtime, so we'll remove it
-rm -rf .heroku/node
+rm -rf .heroku/node node_modules

--- a/bin/pre_compile
+++ b/bin/pre_compile
@@ -11,9 +11,5 @@ fi
 echo "-r requirements/main.txt" > requirements.txt
 echo "-r requirements/deploy.txt" >> requirements.txt
 
-# We need to install gulp and bower
-npm install -g gulp bower
-npm install
-
 # Build our Static files before doing anything else.
 gulp dist

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "type": "git",
     "url": "https://github.com/pypa/warehouse.git"
   },
-  "devDependencies": {
+  "dependencies": {
     "bower": "",
     "del": "^2.1.0",
     "gulp": "^3.9.0",


### PR DESCRIPTION
This will speed up deploys by relying on Heroku to handle installing our Node.js build dependencies instead of doing it ourselves. This allows us to rely on the fact Heroku will cache ``node_modules`` between deployments and shorten the amount of time a deployment takes.