### PR TITLE
We tell requires.io to ignore the 0.0.10 release

### DIFF
--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -19,7 +19,7 @@ cffi==1.5.0               # via bcrypt
 click==6.2
 contextlib2==0.5.1        # via raven
 docutils==0.12            # via botocore, readme-renderer
-elasticsearch-dsl==0.0.9
+elasticsearch-dsl==0.0.9  # rq.filter: !=0.0.10
 elasticsearch==2.2.0
 hiredis==0.2.0
 html5lib==0.9999999


### PR DESCRIPTION
This breaks the installation of elasticsearch 2.0 until some time in the future when elasticsearch-dsl has a 2.0 release as well.