### PR TITLE
Lint HTML

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ tests:
 lint: .state/env/pyvenv.cfg
 	$(BINDIR)/flake8 .
 	$(BINDIR)/doc8 --allow-long-titles README.rst CONTRIBUTING.rst docs/ --ignore-path docs/_build/
+	$(BINDIR)/html_lint.py --disable=optional_tag `find ./warehouse/templates -path ./warehouse/templates/legacy -prune -o -name '*.html' -print`
 
 
 docs: .state/env/pyvenv.cfg

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -1,3 +1,4 @@
 doc8
 flake8
+html-linter
 pep8-naming

--- a/warehouse/templates/accounts/login.html
+++ b/warehouse/templates/accounts/login.html
@@ -11,16 +11,28 @@
     {% endif %}
 
     {% if form.errors.__all__ %}
-    <ul class="errors">{% for error in form.errors.__all__ %}<li>{{ error }}</li>{% endfor %}</ul>
+    <ul class="errors">
+      {% for error in form.errors.__all__ %}
+      <li>{{ error }}</li>
+      {% endfor %}
+    </ul>
     {% endif %}
 
     {% if form.username.errors %}
-    <ul class="errors">{% for error in form.username.errors %}<li>{{ error }}</li>{% endfor %}</ul>
+    <ul class="errors">
+      {% for error in form.username.errors %}
+      <li>{{ error }}</li>
+      {% endfor %}
+    </ul>
     {% endif %}
     {{ form.username(placeholder="Username") }}
 
     {% if form.password.errors %}
-    <ul class="errors">{% for error in form.password.errors %}<li>{{ error }}</li>{% endfor %}</ul>
+    <ul class="errors">
+      {% for error in form.password.errors %}
+      <li>{{ error }}</li>
+      {% endfor %}
+    </ul>
     {% endif %}
     {{ form.password(placeholder="Password") }}
 

--- a/warehouse/templates/accounts/profile.html
+++ b/warehouse/templates/accounts/profile.html
@@ -7,7 +7,7 @@
   <div class="site-container">
     <div class="author-details">
       <div class="profile-img">
-        <img src="{{ gravatar(user.email, size=110) }}" height="110" width="110" alt="{{ user.name|default(user.username, true) }}" />
+        <img src="{{ gravatar(user.email, size=110) }}" height="110" width="110" alt="{{ user.name|default(user.username, true) }}">
       </div>
       <div class="author-meta">
         <h1>{{ user.name|default(user.username, true) }}{% if user.name %}({{ user.username }}){% endif %}</h1>
@@ -29,13 +29,13 @@
   <div class="site-container">
     <div class="package-list">
       {% for release in projects %}
-        <div class="package-snippet">
-          <h3 class="title"><a href="{{ request.route_path('packaging.project', name=release.project.normalized_name) }}">{{ release.project.name }}</a></h3>
-          <p class="meta">
-            <em {{ l20n("lastReleasedOn", when=release.created|format_date()) }}>Last released on {{ release.created|format_date() }}</em>
-          </p>
-          <p class="description">{{ release.summary }}</p>
-        </div>
+      <div class="package-snippet">
+        <h3 class="title"><a href="{{ request.route_path('packaging.project', name=release.project.normalized_name) }}">{{ release.project.name }}</a></h3>
+        <p class="meta">
+          <em {{ l20n("lastReleasedOn", when=release.created|format_date()) }}>Last released on {{ release.created|format_date() }}</em>
+        </p>
+        <p class="description">{{ release.summary }}</p>
+      </div>
       {% endfor %}
     </div>
   </div>

--- a/warehouse/templates/base.html
+++ b/warehouse/templates/base.html
@@ -89,9 +89,9 @@
           <li>
             <h3 {{ l20n("getHelp") }}>Get Help</h3>
           </li>
-          <li><a {{ l20n("installingPackages") }} href="https://packaging.python.org/en/latest/installing/">Installing Packages</a></li>
-          <li><a {{ l20n("uploadingPackages") }} href="https://packaging.python.org/en/latest/distributing/">Uploading Packages</a></li>
-          <li><a {{ l20n("referenceGuide") }} href="https://pip.pypa.io/en/latest/reference/">Reference Guide</a></li>
+          <li><a {{ l20n("installingPackages") }} href="//packaging.python.org/en/latest/installing/">Installing Packages</a></li>
+          <li><a {{ l20n("uploadingPackages") }} href="//packaging.python.org/en/latest/distributing/">Uploading Packages</a></li>
+          <li><a {{ l20n("referenceGuide") }} href="//pip.pypa.io/en/latest/reference/">Reference Guide</a></li>
         </ul>
 
         <ul>
@@ -107,9 +107,9 @@
           <li>
             <h3 {{ l20n("contributingToPyPI") }}>Contributing to PyPI</h3>
           </li>
-          <li><a {{ l20n("reportABug") }} href="https://github.com/pypa/warehouse/issues">Report a Bug</a></li>
-          <li><a {{ l20n("contributeOnGithub") }} href="https://github.com/pypa/warehouse">Contribute on Github</a></li>
-          <li><a {{ l20n("devCredits") }} href="https://github.com/pypa/warehouse/graphs/contributors">Development Credits</a></li>
+          <li><a {{ l20n("reportABug") }} href="//github.com/pypa/warehouse/issues">Report a Bug</a></li>
+          <li><a {{ l20n("contributeOnGithub") }} href="//github.com/pypa/warehouse">Contribute on Github</a></li>
+          <li><a {{ l20n("devCredits") }} href="//github.com/pypa/warehouse/graphs/contributors">Development Credits</a></li>
         </ul>
       </div>
 

--- a/warehouse/templates/base.html
+++ b/warehouse/templates/base.html
@@ -24,9 +24,9 @@
     <meta name="defaultLanguage" content="en">
     <meta name="availableLanguages" content="en">
 
-    <title>{% block title_base %}{% block title %}{% endblock %} &middot; {{ request.registry.settings['site.name'] }}{% endblock %}</title>
+    <title>{% block title_base %}{% block title %}{% endblock %} · {{ request.registry.settings['site.name'] }}{% endblock %}</title>
 
-    <link rel="stylesheet" href='//fonts.googleapis.com/css?family=Source+Sans+Pro:400,400italic,600,600italic,700,700italic|Source+Code+Pro:500'>
+    <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Source+Sans+Pro:400,400italic,600,600italic,700,700italic|Source+Code+Pro:500">
     <link rel="stylesheet" href="{{ request.static_path('warehouse:static/dist/components/font-awesome/css/font-awesome.css') }}">
     <link rel="stylesheet" href="{{ request.static_path('warehouse:static/dist/css/main.css') }}">
 
@@ -86,21 +86,27 @@
 
       <div class="footer-links">
         <ul>
-          <li><h3 {{ l20n("getHelp") }}>Get Help</h3></li>
+          <li>
+            <h3 {{ l20n("getHelp") }}>Get Help</h3>
+          </li>
           <li><a {{ l20n("installingPackages") }} href="https://packaging.python.org/en/latest/installing/">Installing Packages</a></li>
           <li><a {{ l20n("uploadingPackages") }} href="https://packaging.python.org/en/latest/distributing/">Uploading Packages</a></li>
           <li><a {{ l20n("referenceGuide") }} href="https://pip.pypa.io/en/latest/reference/">Reference Guide</a></li>
         </ul>
 
         <ul>
-          <li><h3 {{ l20n("aboutPyPI") }}>About PyPI</h3></li>
+          <li>
+            <h3 {{ l20n("aboutPyPI") }}>About PyPI</h3>
+          </li>
           <li><a href="TODO">Status: Operational</a></li>
           <li><a {{ l20n("securityPolicy") }} href="TODO">Security Policy</a></li>
           <li><a {{ l20n("ourSponsors") }} href="TODO">Our Sponsors</a></li>
         </ul>
 
         <ul>
-          <li><h3 {{ l20n("contributingToPyPI") }}>Contributing to PyPI</h3></li>
+          <li>
+            <h3 {{ l20n("contributingToPyPI") }}>Contributing to PyPI</h3>
+          </li>
           <li><a {{ l20n("reportABug") }} href="https://github.com/pypa/warehouse/issues">Report a Bug</a></li>
           <li><a {{ l20n("contributeOnGithub") }} href="https://github.com/pypa/warehouse">Contribute on Github</a></li>
           <li><a {{ l20n("devCredits") }} href="https://github.com/pypa/warehouse/graphs/contributors">Development Credits</a></li>

--- a/warehouse/templates/packaging/detail.html
+++ b/warehouse/templates/packaging/detail.html
@@ -131,7 +131,7 @@
         <div class="sidebar-section maintainers">
           <h3 {{ l20n("projectMaintainers") }}>Maintainers</h3>
           {% for maintainer in maintainers %}
-          <a href="{{ request.route_path('accounts.profile', username=maintainer.username) }}"><img src="{{ gravatar(maintainer.email, size=50) }}" height="50" width="50" alt="{{ maintainer.username}}"></a>
+            <a href="{{ request.route_path('accounts.profile', username=maintainer.username) }}"><img src="{{ gravatar(maintainer.email, size=50) }}" height="50" width="50" alt="{{ maintainer.username}}"></a>
           {% endfor %}
         </div>
 
@@ -198,37 +198,37 @@
 
           <section class="version-history-graphic">
             {% for hrelease in all_releases %}
-              {% set is_current = (hrelease.version == release.version) %}
-              <div class="history-section{% if loop.first %} latest{% elif loop.last %} oldest{% endif %}{% if is_current %} current{% endif %}">
-                <div class="version">
-                  {% if is_current %}
-                    <p>{{ hrelease.version }}</p>
-                    <span class="highlight-badge" {{ l20n("thisVersion") }}>This version</span>
-                  {% else %}
-                    <p><a href="{{ request.route_path('packaging.release', name=release.project.name, version=hrelease.version) }}">{{ hrelease.version }}</a></p>
-                  {% endif %}
-                </div>
+            {% set is_current = (hrelease.version == release.version) %}
+            <div class="history-section{{ ' latest' if loop.first else ' oldest' if loop.last }}{{ ' current' if is_current }}">
+              <div class="version">
+                {% if is_current %}
+                <p>{{ hrelease.version }}</p>
+                <span class="highlight-badge" {{ l20n("thisVersion") }}>This version</span>
+                {% else %}
+                <p><a href="{{ request.route_path('packaging.release', name=release.project.name, version=hrelease.version) }}">{{ hrelease.version }}</a></p>
+                {% endif %}
+              </div>
 
-                <div class="graphic">
-                  {% if loop.length > 1 %}
-                    <div class="line"></div>
-                  {% endif %}
-                  {% if is_current %}
-                    <img class="history-node" {{ l20n("historyNode") }} alt="History Node" src="{{ request.static_url('warehouse:static/dist/images/white-cube-small.png') }}">
-                  {% else %}
-                    <img class="history-node" {{ l20n("historyNode") }} alt="History Node" src="{{ request.static_url('warehouse:static/dist/images/blue-cube-small.png') }}">
-                  {% endif %}
-                </div>
+              <div class="graphic">
+                {% if loop.length > 1 %}
+                <div class="line"></div>
+                {% endif %}
+                {% if is_current %}
+                <img class="history-node" {{ l20n("historyNode") }} alt="History Node" src="{{ request.static_url('warehouse:static/dist/images/white-cube-small.png') }}">
+                {% else %}
+                <img class="history-node" {{ l20n("historyNode") }} alt="History Node" src="{{ request.static_url('warehouse:static/dist/images/blue-cube-small.png') }}">
+                {% endif %}
+              </div>
 
-                <div class="changelog">
-                  <div class="card">
-                    <p>TODO: Figure out how to actually get changelog content.
-                    <p>Changelog content for this version goes here.</p>
-                    <p>Donec et mollis dolor. Praesent et diam eget libero egestas mattis sit amet vitae augue. Nam tincidunt congue enim, ut porta lorem lacinia consectetur. Donec ut libero sed arcu vehicula ultricies a non tortor. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
-                    <p><a href="clicking-here-expands-changelog"><i class="fa fa-plus-square-o"></i> <span {{ l20n("showMore") }}>Show More</span></a></p>
-                  </div>
+              <div class="changelog">
+                <div class="card">
+                  <p>TODO: Figure out how to actually get changelog content.
+                  <p>Changelog content for this version goes here.</p>
+                  <p>Donec et mollis dolor. Praesent et diam eget libero egestas mattis sit amet vitae augue. Nam tincidunt congue enim, ut porta lorem lacinia consectetur. Donec ut libero sed arcu vehicula ultricies a non tortor. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+                  <p><a href="clicking-here-expands-changelog"><i class="fa fa-plus-square-o"></i> <span {{ l20n("showMore") }}>Show More</span></a></p>
                 </div>
               </div>
+            </div>
             {% endfor %}
           </section>
         </div>
@@ -279,49 +279,49 @@
             </thead>
             <tbody>
               {% for file in files %}
-                <tr>
-                  <td><a href="{{ request.route_path('packaging.file', path=file.path) }}">{{ file.filename }}</a>{% if file.size %} ({{ file.size|filesizeformat() }}){% endif %}</td>
-                  <td>
-                    {{ file.sha256_digest }}
-                    <a class="sha256-link" href="clicking-here-copies-sha256">
-                      <i class="fa fa-copy"></i>
-                      <span class="sr-only">Copy SHA256 Checksum</span>
-                    </a>
-                  </td>
-                  <td>
-                    {# TODO: This should ideally be part of an enum somewhere or
-                       otherwise defined somewhere other than a big if else
-                       chain inside of a template
-                    #}
-                    {% if file.packagetype == "bdist_dmg" %}
-                      OSX Disk Image
-                    {% elif file.packagetype == "bdist_dumb" %}
-                      "Dumb" Binary
-                    {% elif file.packagetype == "bdist_egg" %}
-                      Egg
-                    {% elif file.packagetype == "bdist_msi" %}
-                      Windows MSI Installer
-                    {% elif file.packagetype == "bdist_rpm" %}
-                      RPM
-                    {% elif file.packagetype == "bdist_wheel" %}
-                      Wheel
-                    {% elif file.packagetype == "bdist_wininst" %}
-                      Windows Installer
-                    {% elif file.packagetype == "sdist" %}
-                      Source
-                    {% else %}
-                      {{ file.packagetype }}
-                    {% endif %}
-                  </td>
-                  <td>{{ file.upload_time|format_date() }}</td>
-                  <td>
-                    {% if file.python_version != "source" %}
-                      {{ file.python_version }}
-                    {% else %}
-                      &ndash;
-                    {% endif %}
-                  </td>
-                </tr>
+              <tr>
+                <td><a href="{{ request.route_path('packaging.file', path=file.path) }}">{{ file.filename }}</a>{% if file.size %} ({{ file.size|filesizeformat() }}){% endif %}</td>
+                <td>
+                  {{ file.sha256_digest }}
+                  <a class="sha256-link" href="clicking-here-copies-sha256">
+                    <i class="fa fa-copy"></i>
+                    <span class="sr-only">Copy SHA256 Checksum</span>
+                  </a>
+                </td>
+                <td>
+                  {# TODO: This should ideally be part of an enum somewhere or
+                     otherwise defined somewhere other than a big if else
+                     chain inside of a template
+                  #}
+                  {% if file.packagetype == "bdist_dmg" %}
+                    OSX Disk Image
+                  {% elif file.packagetype == "bdist_dumb" %}
+                    "Dumb" Binary
+                  {% elif file.packagetype == "bdist_egg" %}
+                    Egg
+                  {% elif file.packagetype == "bdist_msi" %}
+                    Windows MSI Installer
+                  {% elif file.packagetype == "bdist_rpm" %}
+                    RPM
+                  {% elif file.packagetype == "bdist_wheel" %}
+                    Wheel
+                  {% elif file.packagetype == "bdist_wininst" %}
+                    Windows Installer
+                  {% elif file.packagetype == "sdist" %}
+                    Source
+                  {% else %}
+                    {{ file.packagetype }}
+                  {% endif %}
+                </td>
+                <td>{{ file.upload_time|format_date() }}</td>
+                <td>
+                  {% if file.python_version != "source" %}
+                    {{ file.python_version }}
+                  {% else %}
+                    –
+                  {% endif %}
+                </td>
+              </tr>
               {% endfor %}
             </tbody>
           </table>

--- a/warehouse/templates/search/results.html
+++ b/warehouse/templates/search/results.html
@@ -44,13 +44,13 @@
           <a class="-js-expander-trigger expander-hidden" {{ l20n("filterProjectsByDevStatus") }}>By Development Status</a>
           <div class="expander-content">
             <div class="checkbox-tree">
-              <label><input type="checkbox"/><span>1 - Planning</span></label>
-              <label><input type="checkbox"/><span>2 - Pre-Alpha</span></label>
-              <label><input type="checkbox"/><span>3 - Alpha</span></label>
-              <label><input type="checkbox"/><span>4 - Beta</span></label>
-              <label><input type="checkbox"/><span>5 - Production/Stable</span></label>
-              <label><input type="checkbox"/><span>6 - Mature</span></label>
-              <label><input type="checkbox"/><span>7 - Inactive</span></label>
+              <label><input type="checkbox"><span>1 - Planning</span></label>
+              <label><input type="checkbox"><span>2 - Pre-Alpha</span></label>
+              <label><input type="checkbox"><span>3 - Alpha</span></label>
+              <label><input type="checkbox"><span>4 - Beta</span></label>
+              <label><input type="checkbox"><span>5 - Production/Stable</span></label>
+              <label><input type="checkbox"><span>6 - Mature</span></label>
+              <label><input type="checkbox"><span>7 - Inactive</span></label>
             </div>
           </div>
         </div>
@@ -60,13 +60,13 @@
     <div class="main">
       <section class="split-layout -table">
         {% if term %}
-          <p {{ l20n("numberOfSearchResultsWithTerm", number=page.item_count, term=term) }}>
-            <strong>{{ page.item_count }}</strong> projects match '<em>{{ term }}</em>'.
-          </p>
+        <p {{ l20n("numberOfSearchResultsWithTerm", number=page.item_count, term=term) }}>
+          <strong>{{ page.item_count }}</strong> projects match '<em>{{ term }}</em>'.
+        </p>
         {% else %}
-          <p {{ l20n("numberOfSearchResultsWithoutTerm", number=page.item_count) }}>
-            <strong>{{ page.item_count }}</strong> projects.
-          </p>
+        <p {{ l20n("numberOfSearchResultsWithoutTerm", number=page.item_count) }}>
+          <strong>{{ page.item_count }}</strong> projects.
+        </p>
         {% endif %}
         <p>
           <label for="order" {{ l20n("orderPackagesBy") }}>Order packages by &nbsp;</label>


### PR DESCRIPTION
This PR adds HTML5 linting to the `lint` target in order to enforce the Google HTML standard via https://pypi.python.org/pypi/html-linter (which was recently made Python 3.5 compatible).

This PR also fixes the resulting errors/warnings from the linter.

Fixes #811.