### PR TITLE
Get gulp-modernizr to remove the no-js classes from the HTML element

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -105,7 +105,7 @@ gulp.task("dist:js", function() {
 
 gulp.task("dist:modernizr", function() {
   return gulp.src(path.join(dstPaths.js, "**", "*.js"))
-             .pipe(modernizr())
+             .pipe(modernizr({ options : ["setClasses"] }))
              .pipe(uglify({ preserveComments: "license" }))
              .pipe(gulp.dest(dstPaths.components));
 });

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "gulp-cssnano": "^2.1.0",
     "gulp-imagemin": "^2.4.0",
     "gulp-install": "^0.6.0",
-    "gulp-modernizr": "0.0.0",
+    "gulp-modernizr": "^1.0.0-alpha",
     "gulp-rename": "^1.2.2",
     "gulp-rev-all": "^0.8.22",
     "gulp-sass": "^2.1.0",


### PR DESCRIPTION
Fixes #774