### PR TITLE
Add node_modules as data volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ app:
   build: .
   volumes:
     - .:/app/
+    - /app/node_modules
   environment:
     WAREHOUSE_ENV: development
     WAREHOUSE_TOKEN: insecuretoken


### PR DESCRIPTION
This was removed in #937 but still seems to be necessary. Without it, `warehouse_static_1` fails because `node_modules` is an empty directory:

```
static_1        | [19:24:54] Local gulp not found in /app
static_1        | [19:24:54] Try running: npm install gulp
warehouse_static_1 exited with code 1
```

See http://stackoverflow.com/a/32785014 for more explanation.