### PR TITLE
Correct the casing of "GitHub"

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,6 +1,6 @@
 pip-tools>=1.0
 
 # We need a newer version of pyramid_debugtoolbar than what is currently
-# available on PyPI, so we'll install this from Github. This can be switched
+# available on PyPI, so we'll install this from GitHub. This can be switched
 # back when Pylons/pyramid_debugtoolbar#212 is merged and released.
 https://github.com/dstufft/pyramid_debugtoolbar/archive/no-inline.zip#egg=pyramid_debugtoolbar

--- a/warehouse/templates/base.html
+++ b/warehouse/templates/base.html
@@ -108,7 +108,7 @@
             <h3 {{ l20n("contributingToPyPI") }}>Contributing to PyPI</h3>
           </li>
           <li><a {{ l20n("reportABug") }} href="//github.com/pypa/warehouse/issues">Report a Bug</a></li>
-          <li><a {{ l20n("contributeOnGithub") }} href="//github.com/pypa/warehouse">Contribute on Github</a></li>
+          <li><a {{ l20n("contributeOnGitHub") }} href="//github.com/pypa/warehouse">Contribute on GitHub</a></li>
           <li><a {{ l20n("devCredits") }} href="//github.com/pypa/warehouse/graphs/contributors">Development Credits</a></li>
         </ul>
       </div>


### PR DESCRIPTION
Corrected the casing of "GitHub", `Github` -> `GitHub`.