### PR TITLE
Add proxy settings to Dockerfile and proxy help to FAQ

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,10 @@ FROM python:3.5.1-slim
 
 ENV PYTHONUNBUFFERED 1
 ENV PYTHONPATH /app/
+# Setup proxy configuration
+# ENV http_proxy "http://proxy.foo.com:1234"
+# ENV https_proxy "http://proxy.foo.com:1234"
+# ENV no_proxy "*.foo.com"
 
 # Setup the locales in the Dockerfile
 RUN set -x \

--- a/docs/development/getting-started.rst
+++ b/docs/development/getting-started.rst
@@ -170,6 +170,8 @@ Errors when executing ``make serve``
 * If ``make serve`` hangs after a new build, you should stop any
   running containers and repeat ``make serve``.
 
+* To run Warehouse behind a proxy set the appropriate proxy settings in the
+  ``Dockerfile``.
 
 Building Styles
 ===============


### PR DESCRIPTION
Add additional settings to Dockerfile for proxy config and update the FAQ docs for instructions on running Warehouse behind a proxy.