### PR TITLE
Humanize dates < 1 week only, fixes #959

### DIFF
--- a/warehouse/static/js/main.js
+++ b/warehouse/static/js/main.js
@@ -68,6 +68,8 @@ $(document).ready(function() {
     positionWarning();
   });
 
+  $.timeago.settings.cutoff = 7 * 24 * 60 * 60 * 1000;  // One week
+
   // document.l10n.ready.then(function() {
   //   // Format all of the time.relative tags to display relative time.
   //   $(".-js-relative-time").timeago();

--- a/warehouse/templates/packaging/detail.html
+++ b/warehouse/templates/packaging/detail.html
@@ -108,7 +108,7 @@
         {% endfor %}
       </nav>
       <p class="author">
-        <span {{ l20n("releasedAgoBy", when=release.created|format_date(), by=release.uploader.name|default(release.uploader.username, true)) }}>Uploaded <time class="-js-relative-time" datetime="{{ release.created|format_datetime('yyyy-MM-ddTHH:mm:ss') }}">{{ release.created|format_datetime() }}</time> by <a href="{{ request.route_path('accounts.profile', username=release.uploader.username) }}">{{ release.uploader.name|default(release.uploader.username, true) }}</a></span>
+        <span {{ l20n("releasedAgoBy", when=release.created|format_date(), by=release.uploader.name|default(release.uploader.username, true)) }}>Uploaded <time class="-js-relative-time" datetime="{{ release.created|format_datetime('yyyy-MM-ddTHH:mm:ss') }}">{{ release.created|format_date() }}</time> by <a href="{{ request.route_path('accounts.profile', username=release.uploader.username) }}">{{ release.uploader.name|default(release.uploader.username, true) }}</a></span>
         <a href="{{ request.route_path('accounts.profile', username=release.uploader.username) }}"><img src="{{ gravatar(release.uploader.email, size=40) }}" class="avatar" height="40" width="40" alt="{{ release.uploader.name|default(release.uploader.username, true) }}"></a>
       </p>
     </div>
@@ -210,7 +210,7 @@
                 <p><a href="{{ request.route_path('packaging.release', name=release.project.name, version=hrelease.version) }}">{{ hrelease.version }}</a></p>
                 {% endif %}
 
-                <p class="version-date"><time class="-js-relative-time" datetime="{{ hrelease.created|format_datetime('yyyy-MM-ddTHH:mm:ss') }}">{{ hrelease.created|format_datetime()}}</time></span>
+                <p class="version-date"><time class="-js-relative-time" datetime="{{ hrelease.created|format_datetime('yyyy-MM-ddTHH:mm:ss') }}">{{ hrelease.created|format_date()}}</time></span>
               </div>
 
               <div class="graphic">


### PR DESCRIPTION
This fixes #959 by humanizing dates up to 1 week old only.

(There were no packages in the dev DB with release dates < 1 week, so I modified the cutoff to be 4 months for these screenshots)

Before:
<img width="175" alt="screen shot 2016-02-08 at 8 17 29 pm" src="https://cloud.githubusercontent.com/assets/294415/12905130/a04facf6-cea2-11e5-9714-46d11daae482.png">

After:
<img width="190" alt="screen shot 2016-02-08 at 8 20 54 pm" src="https://cloud.githubusercontent.com/assets/294415/12905140/bba18b14-cea2-11e5-8f38-e607671987c8.png">
