### PR TITLE
Only show bullet if title is non-empty

### DIFF
--- a/warehouse/templates/base.html
+++ b/warehouse/templates/base.html
@@ -24,7 +24,7 @@
     <meta name="defaultLanguage" content="en">
     <meta name="availableLanguages" content="en">
 
-    <title>{% block title_base %}{% block title %}{% endblock %} · {{ request.registry.settings['site.name'] }}{% endblock %}</title>
+    <title>{% block title_base %}{% block title %}{% endblock %}{% if self.title() %} · {% endif %}{{ request.registry.settings['site.name'] }}{% endblock %}</title>
 
     <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Source+Sans+Pro:400,400italic,600,600italic,700,700italic|Source+Code+Pro:500">
     <link rel="stylesheet" href="{{ request.static_path('warehouse:static/dist/components/font-awesome/css/font-awesome.css') }}">


### PR DESCRIPTION
Fixes #966 by only showing the bullet if the title is non-empty.