### PR TITLE
Add padding to large-logo

### DIFF
--- a/warehouse/static/sass/components/_about-pypi.scss
+++ b/warehouse/static/sass/components/_about-pypi.scss
@@ -9,8 +9,8 @@
     text-align: left;
 
     @media only screen and (max-width: 550px){
-       display: block;
-       width: 100%;
+      display: block;
+      width: 100%;
     }
 
     @media only screen and (max-width: 550px){
@@ -20,6 +20,7 @@
 
   .large-logo {
     text-align: right;
+    padding-right: 50px;
 
     @media only screen and (max-width: 550px){
       display: none;
@@ -31,7 +32,7 @@
       margin: -15px 50px 0 0;
 
       @media only screen and (max-width: 800px){
-         margin-right: 20px;
+        margin-right: 20px;
       }
     }
   }


### PR DESCRIPTION
This fixes #977 by adding padding to the `.large-logo` class. The 50px margin was being ignored due to the `display: table-cell` on the element.

From https://developer.mozilla.org/en-US/docs/Web/CSS/margin: 
> Applies to: all elements, except elements with table display types other than table-caption, table and inline-table.

Before (in Chrome version 50.0.2655.0):
<img width="355" alt="screen shot 2016-02-22 at 11 11 08 am" src="https://cloud.githubusercontent.com/assets/294415/13224416/7c1e0300-d956-11e5-8356-7b12c2fa6b9d.png">

After:
<img width="440" alt="screen shot 2016-02-22 at 11 12 30 am" src="https://cloud.githubusercontent.com/assets/294415/13224421/81f5d64a-d956-11e5-8a7d-a1417ac97b16.png">

@nlhkabu, I'm curious what this looks like in whatever browser you were using which was showing a margin.