### PR TITLE
Use HTML5 autofocus attribute instead of javascript

### DIFF
--- a/warehouse/static/js/main.js
+++ b/warehouse/static/js/main.js
@@ -78,18 +78,4 @@ $(document).ready(function() {
   // });
   $(".-js-relative-time").timeago();  // Add back to document.l10n.ready
 
-  // Add focus to search bar.  Only do this above 750px, so we avoid
-  // prompting the keyboard on mobile (which can get in the way).
-
-  function focusSearch(){
-    var screenWidth = $(window).width();
-    if (screenWidth > 750) {
-      $('#search').focus();
-    }
-  }
-
-  focusSearch();
-
-
-
 });

--- a/warehouse/templates/index.html
+++ b/warehouse/templates/index.html
@@ -36,7 +36,7 @@
 
     <form class="search-form -large -fullwidth" action="{{ request.route_path('search') }}">
       <label for="search" class="sr-only">Search PyPI</label>
-      <input id="search" class="search large-input" type="text" name="q" {{ l20n("search") }} placeholder="Search Projects">
+      <input id="search" class="search large-input" type="text" name="q" {{ l20n("search") }} placeholder="Search Projects" autofocus>
       <button class="wh-button -large -dark" type="submit">
         <i class="icon fa fa-search"></i>
         <span class="text" {{ l20n("search") }}>Search</span>


### PR DESCRIPTION
The original issue (#854) wanted this to not happen on mobile devices (or more specifically, devices with a soft keyboard) to prevent the soft keyboard from opening and covering up a significant part of the page. This was using an imperfect detection method of using the width of the screen to determine if something had a soft keyboard or not.

Using javascript for this appears to be a bit prone to issues, however there is an ``autofocus`` attribute in HTML5 that can be used for this exact purpose, which we are already using on legacy PyPI without any complaints (to my knowledge). In my limited testing, the ``autofocus`` attribute seems to not bring up a soft keyboard on a mobile device (Mobile Safari on iOS 9.2.1) so I think we can just unconditionally set this attribute and let the UserAgent decide how to handle it.

This may mean that people with an old enough browser don't get autofocus support, but that seems reasonable to me.

/cc @nlhkabu 

Fixes #983 
