### PR TITLE
Remove search field autofocus

### DIFF
--- a/warehouse/static/js/main.js
+++ b/warehouse/static/js/main.js
@@ -78,18 +78,4 @@ $(document).ready(function() {
   // });
   $(".-js-relative-time").timeago();  // Add back to document.l10n.ready
 
-  // Add focus to search bar.  Only do this above 750px, so we avoid
-  // prompting the keyboard on mobile (which can get in the way).
-
-  function focusSearch(){
-    var screenWidth = $(window).width();
-    if (screenWidth > 750) {
-      $('#search').focus();
-    }
-  }
-
-  focusSearch();
-
-
-
 });


### PR DESCRIPTION
Autofocusing fields gives bad user experience on mobile and tablet devices with soft keyboard.

Please ref #854 for discussion.