### PR TITLE
Add RSS feeds

### DIFF
--- a/tests/unit/i18n/test_filters.py
+++ b/tests/unit/i18n/test_filters.py
@@ -11,6 +11,7 @@
 # limitations under the License.
 
 import babel.dates
+import email.utils
 import pretend
 
 from warehouse.i18n import filters
@@ -48,3 +49,17 @@ def test_format_datetime(monkeypatch):
 
     kwargs.update({"locale": request.locale})
     assert format_datetime.calls == [pretend.call(*args, **kwargs)]
+
+
+def test_format_rfc822_datetime(monkeypatch):
+    formatted = pretend.stub()
+    formatdate = pretend.call_recorder(lambda *a, **kw: formatted)
+    monkeypatch.setattr(email.utils, "formatdate", formatdate)
+
+    ctx = pretend.stub()
+    timestamp = pretend.stub()
+    args = [pretend.stub(timestamp=lambda: timestamp), pretend.stub()]
+    kwargs = {"foo": pretend.stub()}
+
+    assert filters.format_rfc822_datetime(ctx, *args, **kwargs) is formatted
+    assert formatdate.calls == [pretend.call(timestamp, usegmt=True)]

--- a/tests/unit/i18n/test_init.py
+++ b/tests/unit/i18n/test_init.py
@@ -43,6 +43,8 @@ def test_includeme():
         "jinja2.filters": {
             "format_date": "warehouse.i18n.filters:format_date",
             "format_datetime": "warehouse.i18n.filters:format_datetime",
+            "format_rfc822_datetime":
+                "warehouse.i18n.filters:format_rfc822_datetime",
         },
         "jinja2.globals": {
             "l20n": "warehouse.i18n.l20n:l20n",

--- a/tests/unit/legacy/test_action_routing.py
+++ b/tests/unit/legacy/test_action_routing.py
@@ -58,4 +58,9 @@ def test_includeme():
             action_routing.add_pypi_action_route,
             action_wrap=False,
         ),
+        pretend.call(
+            "add_pypi_action_redirect",
+            action_routing.add_pypi_action_redirect,
+            action_wrap=False,
+        ),
     ]

--- a/tests/unit/rss/__init__.py
+++ b/tests/unit/rss/__init__.py
@@ -1,0 +1,11 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/unit/rss/test_views.py
+++ b/tests/unit/rss/test_views.py
@@ -1,0 +1,51 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import datetime
+
+from warehouse.rss import views as rss
+from ...common.db.packaging import ProjectFactory, ReleaseFactory
+
+
+def test_rss_updates(db_request):
+    project1 = ProjectFactory.create()
+    project2 = ProjectFactory.create()
+
+    release1 = ReleaseFactory.create(project=project1)
+    release1.created = datetime.date(2011, 1, 1)
+    release2 = ReleaseFactory.create(project=project2)
+    release2.created = datetime.date(2012, 1, 1)
+    release3 = ReleaseFactory.create(project=project1)
+    release3.created = datetime.date(2013, 1, 1)
+
+    assert rss.rss_updates(db_request) == {
+        "latest_releases": [release3, release2, release1],
+    }
+    assert db_request.response.content_type == "text/xml"
+
+
+def test_rss_packages(db_request):
+    project1 = ProjectFactory.create()
+    project1.created = datetime.date(2011, 1, 1)
+    ReleaseFactory.create(project=project1)
+
+    project2 = ProjectFactory.create()
+    project2.created = datetime.date(2012, 1, 1)
+
+    project3 = ProjectFactory.create()
+    project3.created = datetime.date(2013, 1, 1)
+    ReleaseFactory.create(project=project3)
+
+    assert rss.rss_packages(db_request) == {
+        "newest_projects": [project3, project1],
+    }
+    assert db_request.response.content_type == "text/xml"

--- a/tests/unit/test_redirects.py
+++ b/tests/unit/test_redirects.py
@@ -34,21 +34,28 @@ def test_add_redirect(monkeypatch):
     monkeypatch.setattr(redirects, "redirect_view_factory", rview_factory)
 
     config = pretend.stub(
-        add_route=pretend.call_recorder(lambda name, route: None),
+        add_route=pretend.call_recorder(lambda name, route, **kw: None),
         add_view=pretend.call_recorder(lambda view, route_name: None),
     )
 
     source = "/the/{thing}/"
     target = "/other/{thing}/"
     redirect = pretend.stub()
+    kwargs = {
+        'redirect': redirect,
+    }
 
-    redirects.add_redirect(config, source, target, redirect=redirect)
+    redirects.add_redirect(config, source, target, **kwargs)
 
     assert config.add_route.calls == [
-        pretend.call("warehouse.redirects." + source, source),
+        pretend.call(
+            "warehouse.redirects." + source + str(kwargs), source, **kwargs
+        ),
     ]
     assert config.add_view.calls == [
-        pretend.call(rview, route_name="warehouse.redirects." + source),
+        pretend.call(
+            rview, route_name="warehouse.redirects." + source + str(kwargs)
+        ),
     ]
     assert rview_factory.calls == [pretend.call(target, redirect=redirect)]
 

--- a/tests/unit/test_routes.py
+++ b/tests/unit/test_routes.py
@@ -40,6 +40,11 @@ def test_routes():
 
         @staticmethod
         @pretend.call_recorder
+        def add_pypi_action_redirect(action, target, **kwargs):
+            pass
+
+        @staticmethod
+        @pretend.call_recorder
         def add_xmlrpc_endpoint(endpoint, pattern, header, read_only=False):
             pass
 
@@ -85,6 +90,8 @@ def test_routes():
             read_only=True,
         ),
         pretend.call("packaging.file", "/packages/{path:.*}", read_only=True),
+        pretend.call("rss.updates", "/rss/updates.xml", read_only=True),
+        pretend.call("rss.packages", "/rss/packages.xml", read_only=True),
         pretend.call("legacy.api.simple.index", "/simple/", read_only=True),
         pretend.call(
             "legacy.api.simple.detail",
@@ -121,6 +128,11 @@ def test_routes():
         pretend.call("legacy.api.pypi.submit_pkg_info", "submit_pkg_info"),
         pretend.call("legacy.api.pypi.doc_upload", "doc_upload"),
         pretend.call("legacy.api.pypi.doap", "doap"),
+    ]
+
+    assert config.add_pypi_action_redirect.calls == [
+        pretend.call("rss", "/rss/updates.xml"),
+        pretend.call("packages_rss", "/rss/packages.xml"),
     ]
 
     assert config.add_xmlrpc_endpoint.calls == [

--- a/warehouse/i18n/__init__.py
+++ b/warehouse/i18n/__init__.py
@@ -31,6 +31,10 @@ def includeme(config):
         "format_datetime",
         "warehouse.i18n.filters:format_datetime",
     )
+    filters.setdefault(
+        "format_rfc822_datetime",
+        "warehouse.i18n.filters:format_rfc822_datetime",
+    )
 
     # Register our utility functions with Jinja2
     jglobals = config.get_settings().setdefault("jinja2.globals", {})

--- a/warehouse/i18n/filters.py
+++ b/warehouse/i18n/filters.py
@@ -11,6 +11,7 @@
 # limitations under the License.
 
 import babel.dates
+import email.utils
 import jinja2
 
 from pyramid.threadlocal import get_current_request
@@ -28,3 +29,8 @@ def format_datetime(ctx, *args, **kwargs):
     request = ctx.get("request") or get_current_request()
     kwargs.setdefault("locale", request.locale)
     return babel.dates.format_datetime(*args, **kwargs)
+
+
+@jinja2.contextfilter
+def format_rfc822_datetime(ctx, dt, *args, **kwargs):
+    return email.utils.formatdate(dt.timestamp(), usegmt=True)

--- a/warehouse/legacy/action_routing.py
+++ b/warehouse/legacy/action_routing.py
@@ -28,9 +28,25 @@ def add_pypi_action_route(config, name, action, **kwargs):
     )
 
 
+def add_pypi_action_redirect(config, action, target, **kwargs):
+    custom_predicates = kwargs.pop("custom_predicates", [])
+    custom_predicates += [pypi_action(action)]
+
+    config.add_redirect(
+        "/pypi", target,
+        custom_predicates=custom_predicates,
+        **kwargs
+    )
+
+
 def includeme(config):
     config.add_directive(
         "add_pypi_action_route",
         add_pypi_action_route,
+        action_wrap=False,
+    )
+    config.add_directive(
+        "add_pypi_action_redirect",
+        add_pypi_action_redirect,
         action_wrap=False,
     )

--- a/warehouse/redirects.py
+++ b/warehouse/redirects.py
@@ -13,16 +13,16 @@
 from pyramid.httpexceptions import HTTPMovedPermanently
 
 
-def redirect_view_factory(target, redirect=HTTPMovedPermanently):
+def redirect_view_factory(target, redirect=HTTPMovedPermanently, **kw):
     def redirect_view(request):
         return redirect(target.format(_request=request, **request.matchdict))
     return redirect_view
 
 
 def add_redirect(config, source, target, **kw):
-    route_name = "warehouse.redirects." + source
+    route_name = "warehouse.redirects." + source + str(kw)
 
-    config.add_route(route_name, source)
+    config.add_route(route_name, source, **kw)
     config.add_view(redirect_view_factory(target, **kw), route_name=route_name)
 
 

--- a/warehouse/routes.py
+++ b/warehouse/routes.py
@@ -60,6 +60,10 @@ def includeme(config):
     )
     config.add_route("packaging.file", "/packages/{path:.*}", read_only=True)
 
+    # RSS
+    config.add_route("rss.updates", "/rss/updates.xml", read_only=True)
+    config.add_route("rss.packages", "/rss/packages.xml", read_only=True)
+
     # Legacy URLs
     config.add_route("legacy.api.simple.index", "/simple/", read_only=True)
     config.add_route(
@@ -111,3 +115,7 @@ def includeme(config):
         "/pypi/{name}/{version}/",
         "/project/{name}/{version}/",
     )
+
+    # Legacy Action Redirects
+    config.add_pypi_action_redirect("rss", "/rss/updates.xml")
+    config.add_pypi_action_redirect("packages_rss", "/rss/packages.xml")

--- a/warehouse/rss/__init__.py
+++ b/warehouse/rss/__init__.py
@@ -1,0 +1,11 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/warehouse/rss/views.py
+++ b/warehouse/rss/views.py
@@ -1,0 +1,68 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pyramid.view import view_config
+from sqlalchemy.orm import joinedload
+
+from warehouse.cache.origin import origin_cache
+from warehouse.packaging.models import Project, Release
+
+
+@view_config(
+    route_name="rss.updates",
+    renderer="rss/updates.xml",
+    decorator=[
+        origin_cache(
+            1 * 24 * 60 * 60,                         # 1 day
+            stale_while_revalidate=1 * 24 * 60 * 60,  # 1 day
+            stale_if_error=5 * 24 * 60 * 60,          # 5 days
+        ),
+    ],
+)
+def rss_updates(request):
+    request.response.content_type = "text/xml"
+
+    latest_releases = (
+        request.db.query(Release)
+                  .options(joinedload(Release.project))
+                  .order_by(Release.created.desc())
+                  .limit(40)
+                  .all()
+    )
+
+    return {"latest_releases": latest_releases}
+
+
+@view_config(
+    route_name="rss.packages",
+    renderer="rss/packages.xml",
+    decorator=[
+        origin_cache(
+            1 * 24 * 60 * 60,                         # 1 day
+            stale_while_revalidate=1 * 24 * 60 * 60,  # 1 day
+            stale_if_error=5 * 24 * 60 * 60,          # 5 days
+        ),
+    ],
+)
+def rss_packages(request):
+    request.response.content_type = "text/xml"
+
+    newest_projects = (
+        request.db.query(Project)
+                  .options(joinedload(Project.releases))
+                  .order_by(Project.created.desc())
+                  .filter(Project.releases.any())
+                  .limit(40)
+                  .all()
+    )
+
+    return {"newest_projects": newest_projects}

--- a/warehouse/templates/base.html
+++ b/warehouse/templates/base.html
@@ -32,6 +32,9 @@
 
     <link rel="icon" href="{{ request.static_path('warehouse:static/dist/images/favicon.ico') }}" type="image/x-icon">
 
+    <link rel="alternate" type="application/rss+xml" title="RSS: 40 latest updates" href="{{ request.route_path('rss.updates') }}">
+    <link rel="alternate" type="application/rss+xml" title="RSS: 40 newest packages" href="{{ request.route_path('rss.packages') }}">
+
     <script src="{{ request.static_path('warehouse:static/dist/components/modernizr.js') }}"></script>
     {# TODO: We need a solution to https://github.com/pypa/warehouse/issues/833
      #       before we can progress on this. Currently this breaks html_include

--- a/warehouse/templates/rss/base.xml
+++ b/warehouse/templates/rss/base.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE rss PUBLIC "-//Netscape Communications//DTD RSS 0.91//EN" "http://my.netscape.com/publish/formats/rss-0.91.dtd">
+<rss version="0.91">
+ <channel>
+  <title>{% block title %}{% endblock %}</title>
+  <link>{{ request.route_url('index') }}</link>
+  <description>{% block description %}{% endblock %}</description>
+  <language>en</language>
+  {% block items %}{% endblock %}
+  </channel>
+</rss>

--- a/warehouse/templates/rss/packages.xml
+++ b/warehouse/templates/rss/packages.xml
@@ -1,0 +1,14 @@
+{% extends "base.xml" %}
+{% block title %}PyPI Newest Packages{% endblock %}
+{% block description %}Newest packages registered at the Python Package Index{% endblock %}
+{% block items %}
+  {% for project in newest_projects %}
+  <item>
+    <title>{{ project.normalized_name }} added to PyPI</title>
+    <link>{{ request.route_url('packaging.project', name=project.normalized_name) }}</link>
+    <guid>{{ request.route_url('packaging.project', name=project.normalized_name) }}</guid>
+    <description>{{ project.releases[0].summary }}</description>
+    <pubDate>{{ project.created|format_rfc822_datetime() }}</pubDate>
+  </item>
+  {% endfor %}
+{% endblock %}

--- a/warehouse/templates/rss/updates.xml
+++ b/warehouse/templates/rss/updates.xml
@@ -1,0 +1,13 @@
+{% extends "base.xml" %}
+{% block title %}PyPI Recent Updates{% endblock %}
+{% block description %}Recent updates to the Python Package Index{% endblock %}
+{% block items %}
+  {% for release in latest_releases %}
+  <item>
+    <title>{{ release.project.normalized_name }} {{ release.version }}</title>
+    <link>{{ request.route_url('packaging.release', name=release.project.normalized_name, version=release.version) }}</link>
+    <description>{{ release.summary }}</description>
+    <pubDate>{{ release.project.created|format_rfc822_datetime() }}</pubDate>
+  </item>
+  {% endfor %}
+{% endblock %}


### PR DESCRIPTION
This fixes #794 and fixes #390 by adding duplicates of PyPI's two RSS feeds:

* https://pypi.python.org/pypi?:action=rss
* https://pypi.python.org/pypi?:action=packages_rss

It also adds redirects from the old feed URLs to the new ones.

_Note_: If you look at these feeds in a browser such as Chrome, the XML will probably look a little more like garbage than you're used to. This is because our Content Security Policy is not allowing the browser to inline JS or CSS, but it still rewrites the HTML expecting the styles and scripts to be there. You'll see an error in the console such as:

```
Refused to apply inline style because it violates the following Content Security
Policy directive: "style-src 'self' fonts.googleapis.com". Either the
'unsafe-inline' keyword, a hash
('sha256-nx7T2vM3FG2GqDCK5NErQR6tT6iOS/rBjaBaUvmACC0='), or a nonce
('nonce-...') is required to enable inline execution.
```