### PR TITLE
Add search result ordering

### DIFF
--- a/tests/unit/cli/search/test_reindex.py
+++ b/tests/unit/cli/search/test_reindex.py
@@ -38,6 +38,7 @@ def test_project_docs(db_session):
             "_id": p.normalized_name,
             "_type": "project",
             "_source": {
+                "created": p.created,
                 "name": p.name,
                 "normalized_name": p.normalized_name,
                 "version": [r.version for r in prs],

--- a/tests/unit/packaging/test_search.py
+++ b/tests/unit/packaging/test_search.py
@@ -10,6 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import datetime
 import pretend
 
 from warehouse.packaging import search
@@ -37,6 +38,7 @@ def test_build_search():
         download_url="https://example.com/foobar/downloads/",
         keywords="the, keywords, lol",
         platform="any platform",
+        created=datetime.datetime(1956, 1, 31),
         uploader=pretend.stub(
             username="some-username",
             name="the-users-name",
@@ -57,5 +59,6 @@ def test_build_search():
     assert obj["download_url"] == "https://example.com/foobar/downloads/"
     assert obj["keywords"] == "the, keywords, lol"
     assert obj["platform"] == "any platform"
+    assert obj["created"] == datetime.datetime(1956, 1, 31)
     assert obj["uploader_name"] == "the-users-name"
     assert obj["uploader_username"] == "some-username"

--- a/warehouse/packaging/search.py
+++ b/warehouse/packaging/search.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from elasticsearch_dsl import DocType, String, analyzer, MetaField
+from elasticsearch_dsl import DocType, String, analyzer, MetaField, Date
 
 from warehouse.search import doc_type
 
@@ -39,6 +39,7 @@ class Project(DocType):
     download_url = String(index="not_analyzed")
     keywords = String(analyzer="snowball")
     platform = String(index="not_analyzed")
+    created = Date()
 
     uploader_name = String()
     uploader_username = String()
@@ -63,6 +64,7 @@ class Project(DocType):
         obj["download_url"] = release.download_url
         obj["keywords"] = release.keywords
         obj["platform"] = release.platform
+        obj["created"] = release.created
 
         obj["uploader_name"] = release.uploader.name
         obj["uploader_username"] = release.uploader.username

--- a/warehouse/static/js/main.js
+++ b/warehouse/static/js/main.js
@@ -70,6 +70,11 @@ $(document).ready(function() {
     positionWarning();
   });
 
+  // Search ordering
+  $('#order').on("change", function(event) {
+    this.form.submit();
+  });
+
   $.timeago.settings.cutoff = 7 * 24 * 60 * 60 * 1000;  // One week
 
   // document.l10n.ready.then(function() {

--- a/warehouse/templates/base.html
+++ b/warehouse/templates/base.html
@@ -57,7 +57,7 @@
 
             <form class="search-form -primary" action="{{ request.route_path('search') }}">
               <label for="search" class="sr-only">Search PyPI</label>
-              <input id="search" class="search" type="text" name="q" {{ l20n("search") }} placeholder="Search Projects">
+              <input id="search" class="search" type="text" name="q" {{ l20n("search") }} placeholder="Search Projects" value="{{ term }}">
               <input class="wh-button -dark" type="submit" {{ l20n("search") }} value="Search">
             </form>
           </div>

--- a/warehouse/templates/search/results.html
+++ b/warehouse/templates/search/results.html
@@ -47,6 +47,10 @@
 {%- endmacro %}
 
 
+{% macro search_option(text, value, l20n_id) -%}
+<option {{ l20n(l20n_id) }} value="{{ value }}" {{ 'selected' if value == order else ''}}>{{ text }}</option>
+{%- endmacro %}
+
 {% block content %}
 <section class="horizontal-section -medium">
   <div class="left-sidebar">
@@ -86,13 +90,16 @@
           <strong>{{ page.item_count }}</strong> projects.
         </p>
         {% endif %}
-        <p>
-          <label for="order" {{ l20n("orderPackagesBy") }}>Order packages by &nbsp;</label>
-          <select id="order">
-            <option {{ l20n("relevance") }}>Relevance</option>
-            <option {{ l20n("dateLastUpdated") }}>Date Last Updated</option>
-          </select>
-        </p>
+        <form action="{{ request.route_path('search') }}">
+          <p>
+            <input id="search" type="hidden" name="q" {{ l20n("search") }} value="{{ term }}">
+            <label for="order" {{ l20n("orderPackagesBy") }}>Order packages by &nbsp;</label>
+            <select id="order" name="o">
+              {{ search_option("Relevance", "", "relevance") }}
+              {{ search_option("Date Last Updated", "-created", "dateLastUpdated") }}
+            </select>
+          </p>
+        </form>
       </section>
 
       <div class="applied-filters">

--- a/warehouse/templates/search/results.html
+++ b/warehouse/templates/search/results.html
@@ -17,6 +17,7 @@
 {% macro project_snippet(item) -%}
 
 {% set version = item.version[0] %}
+{% set created = item.created %}
 {% set uploader_username = item.uploader_username %}
 {% set uploader_name = item.uploader_name|default(uploader_username, true) %}
 
@@ -24,7 +25,7 @@
   <h3 class="title"><a href="{{ request.route_path('packaging.project', name=item.normalized_name) }}">{{ item.name }}</a></h3>
 
   <p class="meta" {{ l20n("packageSnippetMeta", version=version, user=uploader_name) }}>
-    <span class="version">{{ version }}</span> uploaded by <a href="{{ request.route_path('accounts.profile', username=uploader_username) }}">{{ uploader_name }}</a>
+    <span class="version">{{ version }}</span> uploaded by <a href="{{ request.route_path('accounts.profile', username=uploader_username) }}">{{ uploader_name }}</a> on {{ created|format_date() }}
   </p>
 
   <p class="description">{{ item.summary }}</p>

--- a/warehouse/views.py
+++ b/warehouse/views.py
@@ -171,13 +171,20 @@ def search(request):
     else:
         query = request.es.query()
 
+    if request.params.get("o"):
+        query = query.sort(request.params["o"])
+
     page = ElasticsearchPage(
         query,
         page=int(request.params.get("page", 1)),
         url_maker=paginate_url_factory(request),
     )
 
-    return {"page": page, "term": request.params.get("q")}
+    return {
+        "page": page,
+        "term": request.params.get("q"),
+        "order": request.params.get("o"),
+    }
 
 
 @view_config(


### PR DESCRIPTION
This PR addresses the "sorting" part of #702 by making the "Order packages by" options functional. Search results can now be sorted by the date of the latest release.

@nlhkabu This also makes two small UI changes.

First, it adds the release creation date (a.k.a. "upload" date) to each individual search result, to make it clear how the results are being ordered:

Before:
<img width="349" alt="screen shot 2016-03-04 at 1 53 24 pm" src="https://cloud.githubusercontent.com/assets/294415/13537039/f245b79a-e210-11e5-8029-af965eeae663.png">

After:
<img width="379" alt="screen shot 2016-03-04 at 1 52 51 pm" src="https://cloud.githubusercontent.com/assets/294415/13537041/f7d6c730-e210-11e5-9d35-896eab1beb21.png">

Second, it also adds the current search term to the search field, which I think improves usability when doing multiple searches (you don't have to retype the entire term again):

Before:
<img width="613" alt="screen shot 2016-03-04 at 1 59 21 pm" src="https://cloud.githubusercontent.com/assets/294415/13537149/844f1460-e211-11e5-8d79-854538694a8f.png">

After:
<img width="621" alt="screen shot 2016-03-04 at 1 59 06 pm" src="https://cloud.githubusercontent.com/assets/294415/13537154/8ac9026a-e211-11e5-9772-8528548f158d.png">
