### PR TITLE
Add user registration functionality

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,10 +38,10 @@ build:
 	touch .state/docker-build
 
 serve: .state/docker-build
-	docker-compose up
+	RECAPTCHA_SITE_KEY=$(RECAPTCHA_SITE_KEY) RECAPTCHA_SECRET_KEY=$(RECAPTCHA_SECRET_KEY) docker-compose up
 
 debug: .state/docker-build
-	docker-compose run --service-ports web
+	RECAPTCHA_SITE_KEY=$(RECAPTCHA_SITE_KEY) RECAPTCHA_SECRET_KEY=$(RECAPTCHA_SECRET_KEY) docker-compose run --service-ports web
 
 tests:
 	docker-compose run web env -i ENCODING="C.UTF-8" bin/tests --dbfixtures-config tests/dbfixtures.conf $(T) $(TESTARGS)

--- a/README.rst
+++ b/README.rst
@@ -31,6 +31,8 @@ commands you can use:
 
     $ # Start up a local environment
     $ make serve
+    $ # Start up a local environment in debug mode (pdb enabled)
+    $ make debug
     $ # Initialize the database and fill it with test data
     $ make initdb
     $ # Run the tests
@@ -39,6 +41,10 @@ commands you can use:
     $ make docs
     $ # Run the various linters
     $ make lint
+
+.. note:: reCaptcha is featured in authentication and regisration pages. To
+          enable it, pass ``RECAPTCHA_SITE_KEY`` and ``RECAPTCHA_SECRET_KEY``
+          through to ``serve`` and ``debug`` targets.
 
 
 Discussion

--- a/README.rst
+++ b/README.rst
@@ -42,7 +42,7 @@ commands you can use:
     $ # Run the various linters
     $ make lint
 
-.. note:: reCaptcha is featured in authentication and regisration pages. To
+.. note:: reCaptcha is featured in authentication and registration pages. To
           enable it, pass ``RECAPTCHA_SITE_KEY`` and ``RECAPTCHA_SECRET_KEY``
           through to ``serve`` and ``debug`` targets.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,8 @@ app:
     CAMO_KEY: "insecure camo key"
     DOCS_URL: "https://pythonhosted.org/{project}/"
     FILES_BACKEND: "warehouse.packaging.services.LocalFileStorage path=/app/data/packages/"
+    RECAPTCHA_SITE_KEY: "${RECAPTCHA_SITE_KEY}"
+    RECAPTCHA_SECRET_KEY: "${RECAPTCHA_SECRET_KEY}"
 
 web:
   extends:

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,5 +1,4 @@
 pip-tools>=1.0
-responses>=0.5.1
 
 # We need a newer version of pyramid_debugtoolbar than what is currently
 # available on PyPI, so we'll install this from GitHub. This can be switched

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,4 +1,5 @@
 pip-tools>=1.0
+responses>=0.5.1
 
 # We need a newer version of pyramid_debugtoolbar than what is currently
 # available on PyPI, so we'll install this from GitHub. This can be switched

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -4,4 +4,5 @@ freezegun
 pretend
 pytest
 pytest-dbfixtures>=0.9.0
+responses>=0.5.1
 webtest

--- a/tests/unit/accounts/test_forms.py
+++ b/tests/unit/accounts/test_forms.py
@@ -153,8 +153,8 @@ class TestRegistrationForm:
         )
         form = forms.RegistrationForm(
             data={
-                "password": "password",
-                "password_confirm": "password",
+                "password": "MyStr0ng!shPassword",
+                "password_confirm": "MyStr0ng!shPassword",
             },
             user_service=user_service,
             recaptcha_service=pretend.stub(enabled=True),
@@ -257,3 +257,21 @@ class TestRegistrationForm:
         )
         assert not form.validate()
         assert form.username.errors.pop() == "Username exists."
+
+    def test_password_strength(self):
+        cases = (
+            ("foobar", False),
+            ("somethingalittlebetter9", False),
+            ("1aDeCent!1", True),
+        )
+        for pwd, valid in cases:
+            form = forms.RegistrationForm(
+                data={"password": pwd, "password_confirm": pwd},
+                user_service=pretend.stub(),
+                recaptcha_service=pretend.stub(
+                    enabled=False,
+                    verify_response=pretend.call_recorder(lambda _: None),
+                ),
+            )
+            form.validate()
+            assert (len(form.password.errors) == 0) == valid

--- a/tests/unit/accounts/test_forms.py
+++ b/tests/unit/accounts/test_forms.py
@@ -12,89 +12,207 @@
 
 import pretend
 import pytest
+import responses
 import wtforms
 
-from warehouse.accounts.forms import LoginForm
+from warehouse.accounts import forms
+from warehouse import recaptcha
 
 
 class TestLoginForm:
 
     def test_creation(self):
-        login_service = pretend.stub()
-        form = LoginForm(login_service=login_service)
+        user_service = pretend.stub()
+        form = forms.LoginForm(user_service=user_service)
 
-        assert form.login_service is login_service
+        assert form.user_service is user_service
 
     def test_validate_username_with_no_user(self):
-        login_service = pretend.stub(
+        user_service = pretend.stub(
             find_userid=pretend.call_recorder(lambda userid: None),
         )
-        form = LoginForm(login_service=login_service)
+        form = forms.LoginForm(user_service=user_service)
         field = pretend.stub(data="my_username")
 
         with pytest.raises(wtforms.validators.ValidationError):
             form.validate_username(field)
 
-        assert login_service.find_userid.calls == [pretend.call("my_username")]
+        assert user_service.find_userid.calls == [pretend.call("my_username")]
 
     def test_validate_username_with_user(self):
-        login_service = pretend.stub(
+        user_service = pretend.stub(
             find_userid=pretend.call_recorder(lambda userid: 1),
         )
-        form = LoginForm(login_service=login_service)
+        form = forms.LoginForm(user_service=user_service)
         field = pretend.stub(data="my_username")
 
         form.validate_username(field)
 
-        assert login_service.find_userid.calls == [pretend.call("my_username")]
+        assert user_service.find_userid.calls == [pretend.call("my_username")]
 
     def test_validate_password_no_user(self):
-        login_service = pretend.stub(
+        user_service = pretend.stub(
             find_userid=pretend.call_recorder(lambda userid: None),
         )
-        form = LoginForm(
+        form = forms.LoginForm(
             data={"username": "my_username"},
-            login_service=login_service,
+            user_service=user_service,
         )
         field = pretend.stub(data="password")
 
         form.validate_password(field)
 
-        assert login_service.find_userid.calls == [pretend.call("my_username")]
+        assert user_service.find_userid.calls == [pretend.call("my_username")]
 
     def test_validate_password_ok(self):
-        login_service = pretend.stub(
+        user_service = pretend.stub(
             find_userid=pretend.call_recorder(lambda userid: 1),
             check_password=pretend.call_recorder(
                 lambda userid, password: True
             ),
         )
-        form = LoginForm(
+        form = forms.LoginForm(
             data={"username": "my_username"},
-            login_service=login_service,
+            user_service=user_service,
         )
         field = pretend.stub(data="pw")
 
         form.validate_password(field)
 
-        assert login_service.find_userid.calls == [pretend.call("my_username")]
-        assert login_service.check_password.calls == [pretend.call(1, "pw")]
+        assert user_service.find_userid.calls == [pretend.call("my_username")]
+        assert user_service.check_password.calls == [pretend.call(1, "pw")]
 
     def test_validate_password_notok(self, db_session):
-        login_service = pretend.stub(
+        user_service = pretend.stub(
             find_userid=pretend.call_recorder(lambda userid: 1),
             check_password=pretend.call_recorder(
                 lambda userid, password: False
             ),
         )
-        form = LoginForm(
+        form = forms.LoginForm(
             data={"username": "my_username"},
-            login_service=login_service,
+            user_service=user_service,
         )
         field = pretend.stub(data="pw")
 
         with pytest.raises(wtforms.validators.ValidationError):
             form.validate_password(field)
 
-        assert login_service.find_userid.calls == [pretend.call("my_username")]
-        assert login_service.check_password.calls == [pretend.call(1, "pw")]
+        assert user_service.find_userid.calls == [pretend.call("my_username")]
+        assert user_service.check_password.calls == [pretend.call(1, "pw")]
+
+
+class TestRegistrationForm:
+    def test_create(self):
+        user_service = pretend.stub()
+        recaptcha_service = pretend.stub()
+
+        form = forms.RegistrationForm(
+            data={}, user_service=user_service,
+            recaptcha_service=recaptcha_service
+        )
+        assert form.user_service is user_service
+        assert form.recaptcha_service is recaptcha_service
+
+    def test_password_confirm_required_error(self):
+        form = forms.RegistrationForm(
+            data={"password_confirm": ""},
+            user_service=pretend.stub(
+                find_by_email=pretend.call_recorder(lambda _: pretend.stub()),
+            ),
+            recaptcha_service=pretend.stub(),
+        )
+        
+        assert not form.validate()
+        assert form.password_confirm.errors.pop() == "This field is required."
+
+    def test_passwords_mismatch_error(self):
+        user_service = pretend.stub(
+            find_by_email=pretend.call_recorder(lambda _: pretend.stub()),
+        )
+        form = forms.RegistrationForm(
+            data={
+                "password": "password",
+                "password_confirm": "mismatch",
+            },
+            user_service=user_service,
+            recaptcha_service=pretend.stub(),
+        )
+
+        assert not form.validate()
+        assert form.password_confirm.errors.pop() == "Passwords must match."
+
+    def test_passwords_match_success(self):
+        user_service = pretend.stub(
+            find_by_email=pretend.call_recorder(lambda _: pretend.stub()),
+        )
+        form = forms.RegistrationForm(
+            data={
+                "password": "password",
+                "password_confirm": "password",
+            },
+            user_service=user_service,
+            recaptcha_service=pretend.stub(),
+        )
+
+        form.validate()
+        assert len(form.password.errors) == 0
+        assert len(form.password_confirm.errors) == 0
+
+    def test_email_required_error(self):
+        form = forms.RegistrationForm(
+            data={"email": ""},
+            user_service=pretend.stub(
+                find_by_email=pretend.call_recorder(lambda _: pretend.stub()),
+            ),
+            recaptcha_service=pretend.stub(),
+        )
+
+        assert not form.validate()
+        assert form.email.errors.pop() == "This field is required."
+
+    def test_invalid_email_error(self):
+        form = forms.RegistrationForm(
+            data={"email": "bad"},
+            user_service=pretend.stub(
+                find_by_email=pretend.call_recorder(lambda _: None),
+            ),
+            recaptcha_service=pretend.stub(),
+        )
+
+        assert not form.validate()
+        assert form.email.errors.pop() == "Invalid email address."
+
+    def test_email_exists_error(self):
+        form = forms.RegistrationForm(
+            data={"email": "foo@bar.com"},
+            user_service=pretend.stub(
+                find_by_email=pretend.call_recorder(lambda _: pretend.stub()),
+            ),
+            recaptcha_service=pretend.stub(),
+        )
+
+        assert not form.validate()
+        assert form.email.errors.pop() == "Email already exists."
+
+    def test_recaptcha_required_error(self):
+        form = forms.RegistrationForm(
+            data={"g_recaptcha_response": ""},
+            user_service=pretend.stub(),
+            recaptcha_service=pretend.stub(),
+        )
+        assert not form.validate()
+        assert form.g_recaptcha_response.errors.pop() \
+            == "This field is required."
+
+    def test_recaptcha_error(self):
+        form = forms.RegistrationForm(
+            data={"g_recaptcha_response": "asd"},
+            user_service=pretend.stub(),
+            recaptcha_service=pretend.stub(
+                verify_response=pretend.raiser(recaptcha.RecaptchaError),
+            ),
+        )
+        assert not form.validate()
+        assert form.g_recaptcha_response.errors.pop() \
+            == "Recaptcha error."

--- a/tests/unit/accounts/test_forms.py
+++ b/tests/unit/accounts/test_forms.py
@@ -117,7 +117,9 @@ class TestRegistrationForm:
         form = forms.RegistrationForm(
             data={"password_confirm": ""},
             user_service=pretend.stub(
-                find_userid_by_email=pretend.call_recorder(lambda _: pretend.stub()),
+                find_userid_by_email=pretend.call_recorder(
+                    lambda _: pretend.stub()
+                ),
             ),
             recaptcha_service=pretend.stub(enabled=True),
         )
@@ -127,7 +129,9 @@ class TestRegistrationForm:
 
     def test_passwords_mismatch_error(self):
         user_service = pretend.stub(
-            find_userid_by_email=pretend.call_recorder(lambda _: pretend.stub()),
+            find_userid_by_email=pretend.call_recorder(
+                lambda _: pretend.stub()
+            ),
         )
         form = forms.RegistrationForm(
             data={
@@ -143,7 +147,9 @@ class TestRegistrationForm:
 
     def test_passwords_match_success(self):
         user_service = pretend.stub(
-            find_userid_by_email=pretend.call_recorder(lambda _: pretend.stub()),
+            find_userid_by_email=pretend.call_recorder(
+                lambda _: pretend.stub()
+            ),
         )
         form = forms.RegistrationForm(
             data={
@@ -162,7 +168,9 @@ class TestRegistrationForm:
         form = forms.RegistrationForm(
             data={"email": ""},
             user_service=pretend.stub(
-                find_userid_by_email=pretend.call_recorder(lambda _: pretend.stub()),
+                find_userid_by_email=pretend.call_recorder(
+                    lambda _: pretend.stub()
+                ),
             ),
             recaptcha_service=pretend.stub(enabled=True),
         )
@@ -186,7 +194,9 @@ class TestRegistrationForm:
         form = forms.RegistrationForm(
             data={"email": "foo@bar.com"},
             user_service=pretend.stub(
-                find_userid_by_email=pretend.call_recorder(lambda _: pretend.stub()),
+                find_userid_by_email=pretend.call_recorder(
+                    lambda _: pretend.stub()
+                ),
             ),
             recaptcha_service=pretend.stub(enabled=True),
         )

--- a/tests/unit/accounts/test_forms.py
+++ b/tests/unit/accounts/test_forms.py
@@ -117,7 +117,7 @@ class TestRegistrationForm:
         form = forms.RegistrationForm(
             data={"password_confirm": ""},
             user_service=pretend.stub(
-                find_by_email=pretend.call_recorder(lambda _: pretend.stub()),
+                find_userid_by_email=pretend.call_recorder(lambda _: pretend.stub()),
             ),
             recaptcha_service=pretend.stub(enabled=True),
         )
@@ -127,7 +127,7 @@ class TestRegistrationForm:
 
     def test_passwords_mismatch_error(self):
         user_service = pretend.stub(
-            find_by_email=pretend.call_recorder(lambda _: pretend.stub()),
+            find_userid_by_email=pretend.call_recorder(lambda _: pretend.stub()),
         )
         form = forms.RegistrationForm(
             data={
@@ -143,7 +143,7 @@ class TestRegistrationForm:
 
     def test_passwords_match_success(self):
         user_service = pretend.stub(
-            find_by_email=pretend.call_recorder(lambda _: pretend.stub()),
+            find_userid_by_email=pretend.call_recorder(lambda _: pretend.stub()),
         )
         form = forms.RegistrationForm(
             data={
@@ -162,7 +162,7 @@ class TestRegistrationForm:
         form = forms.RegistrationForm(
             data={"email": ""},
             user_service=pretend.stub(
-                find_by_email=pretend.call_recorder(lambda _: pretend.stub()),
+                find_userid_by_email=pretend.call_recorder(lambda _: pretend.stub()),
             ),
             recaptcha_service=pretend.stub(enabled=True),
         )
@@ -174,7 +174,7 @@ class TestRegistrationForm:
         form = forms.RegistrationForm(
             data={"email": "bad"},
             user_service=pretend.stub(
-                find_by_email=pretend.call_recorder(lambda _: None),
+                find_userid_by_email=pretend.call_recorder(lambda _: None),
             ),
             recaptcha_service=pretend.stub(enabled=True),
         )
@@ -186,7 +186,7 @@ class TestRegistrationForm:
         form = forms.RegistrationForm(
             data={"email": "foo@bar.com"},
             user_service=pretend.stub(
-                find_by_email=pretend.call_recorder(lambda _: pretend.stub()),
+                find_userid_by_email=pretend.call_recorder(lambda _: pretend.stub()),
             ),
             recaptcha_service=pretend.stub(enabled=True),
         )
@@ -233,3 +233,17 @@ class TestRegistrationForm:
         assert not form.validate()
         assert form.g_recaptcha_response.errors.pop() \
             == "Recaptcha error."
+
+    def test_username_exists(self):
+        form = forms.RegistrationForm(
+            data={"username": "foo"},
+            user_service=pretend.stub(
+                find_userid=pretend.call_recorder(lambda name: 1),
+            ),
+            recaptcha_service=pretend.stub(
+                enabled=False,
+                verify_response=pretend.call_recorder(lambda _: None),
+            ),
+        )
+        assert not form.validate()
+        assert form.username.errors.pop() == "Username exists."

--- a/tests/unit/accounts/test_services.py
+++ b/tests/unit/accounts/test_services.py
@@ -116,7 +116,6 @@ class TestDatabaseUserService:
         user_from_db = service.get_user(new_user.id)
         assert user_from_db.username == user.username
         assert user_from_db.name == user.name
-        assert user_from_db.password == user.password
         assert user_from_db.email == email
 
     def test_update_user(self, db_session):

--- a/tests/unit/accounts/test_services.py
+++ b/tests/unit/accounts/test_services.py
@@ -138,6 +138,23 @@ class TestDatabaseUserService:
         assert user.emails[0].verified
         assert not user.emails[1].verified
 
+    def test_create_login_success(self, db_session):
+        service = services.DatabaseUserService(db_session)
+        user = service.create_user(
+            "test_user", "test_name", "test_password", "test_email")
+
+        assert user.id is not None
+        # now make sure that we can log in as that user
+        assert service.check_password(user.id, "test_password")
+
+    def test_create_login_error(self, db_session):
+        service = services.DatabaseUserService(db_session)
+        user = service.create_user(
+            "test_user", "test_name", "test_password", "test_email")
+
+        assert user.id is not None
+        assert not service.check_password(user.id, "bad_password")
+
 
 def test_database_login_factory(monkeypatch):
     service_obj = pretend.stub()

--- a/tests/unit/accounts/test_services.py
+++ b/tests/unit/accounts/test_services.py
@@ -137,6 +137,20 @@ class TestDatabaseUserService:
         assert user.emails[0].verified
         assert not user.emails[1].verified
 
+    def test_find_by_email(self, db_session):
+        service = services.DatabaseUserService(db_session)
+        user = UserFactory.create()
+        EmailFactory.create(user=user, primary=True, verified=False)
+        
+        found_userid = service.find_userid_by_email(user.emails[0].email)
+        db_session.flush()
+
+        assert user.id == found_userid
+
+    def test_find_by_email_not_found(self, db_session):
+        service = services.DatabaseUserService(db_session)
+        assert service.find_userid_by_email("something") is None
+
     def test_create_login_success(self, db_session):
         service = services.DatabaseUserService(db_session)
         user = service.create_user(

--- a/tests/unit/accounts/test_services.py
+++ b/tests/unit/accounts/test_services.py
@@ -141,7 +141,7 @@ class TestDatabaseUserService:
         service = services.DatabaseUserService(db_session)
         user = UserFactory.create()
         EmailFactory.create(user=user, primary=True, verified=False)
-        
+
         found_userid = service.find_userid_by_email(user.emails[0].email)
         db_session.flush()
 

--- a/tests/unit/accounts/test_views.py
+++ b/tests/unit/accounts/test_views.py
@@ -254,7 +254,8 @@ class TestRegister:
         pyramid_request.find_service = pretend.call_recorder(
             lambda *args, **kwargs: pretend.stub(
                 enabled=False,
-                add_to_csp_policy=pretend.call_recorder(lambda: None),
+                csp_policy=pretend.stub(),
+                merge=lambda _: None,
             )
         )
         result = views.register(pyramid_request, _form_class=form)
@@ -269,7 +270,8 @@ class TestRegister:
         pyramid_request.method = "POST"
         pyramid_request.find_service = pretend.call_recorder(
             lambda *args, **kwargs: pretend.stub(
-                add_to_csp_policy=pretend.call_recorder(lambda: None),
+                csp_policy={},
+                merge=lambda _: {},
                 enabled=False,
                 verify_response=pretend.call_recorder(lambda _: None),
                 find_userid=pretend.call_recorder(lambda _: None),
@@ -279,6 +281,7 @@ class TestRegister:
                 ),
             )
         )
+        pyramid_request.route_path = pretend.call_recorder(lambda name: "/")
         pyramid_request.POST.update({
             "username": "username_value",
             "password": "password_value",

--- a/tests/unit/accounts/test_views.py
+++ b/tests/unit/accounts/test_views.py
@@ -56,12 +56,12 @@ class TestLogin:
 
     @pytest.mark.parametrize("next_url", [None, "/foo/bar/", "/wat/"])
     def test_get_returns_form(self, pyramid_request, next_url):
-        login_service = pretend.stub()
+        user_service = pretend.stub()
         pyramid_request.find_service = pretend.call_recorder(
-            lambda iface, context: login_service
+            lambda iface, context: user_service
         )
         form_obj = pretend.stub()
-        form_class = pretend.call_recorder(lambda d, login_service: form_obj)
+        form_class = pretend.call_recorder(lambda d, user_service: form_obj)
 
         if next_url is not None:
             pyramid_request.GET["next"] = next_url
@@ -76,20 +76,20 @@ class TestLogin:
             pretend.call(IUserService, context=None),
         ]
         assert form_class.calls == [
-            pretend.call(pyramid_request.POST, login_service=login_service),
+            pretend.call(pyramid_request.POST, user_service=user_service),
         ]
 
     @pytest.mark.parametrize("next_url", [None, "/foo/bar/", "/wat/"])
     def test_post_invalid_returns_form(self, pyramid_request, next_url):
-        login_service = pretend.stub()
+        user_service = pretend.stub()
         pyramid_request.find_service = pretend.call_recorder(
-            lambda iface, context: login_service
+            lambda iface, context: user_service
         )
         pyramid_request.method = "POST"
         if next_url is not None:
             pyramid_request.POST["next"] = next_url
         form_obj = pretend.stub(validate=pretend.call_recorder(lambda: False))
-        form_class = pretend.call_recorder(lambda d, login_service: form_obj)
+        form_class = pretend.call_recorder(lambda d, user_service: form_obj)
 
         result = views.login(pyramid_request, _form_class=form_class)
 
@@ -101,7 +101,7 @@ class TestLogin:
             pretend.call(IUserService, context=None),
         ]
         assert form_class.calls == [
-            pretend.call(pyramid_request.POST, login_service=login_service),
+            pretend.call(pyramid_request.POST, user_service=user_service),
         ]
         assert form_obj.validate.calls == [pretend.call()]
 
@@ -115,11 +115,11 @@ class TestLogin:
 
         new_session = {}
 
-        login_service = pretend.stub(
+        user_service = pretend.stub(
             find_userid=pretend.call_recorder(lambda username: 1),
         )
         pyramid_request.find_service = pretend.call_recorder(
-            lambda iface, context: login_service
+            lambda iface, context: user_service
         )
         pyramid_request.method = "POST"
         pyramid_request.session = pretend.stub(
@@ -138,7 +138,7 @@ class TestLogin:
             validate=pretend.call_recorder(lambda: True),
             username=pretend.stub(data="theuser"),
         )
-        form_class = pretend.call_recorder(lambda d, login_service: form_obj)
+        form_class = pretend.call_recorder(lambda d, user_service: form_obj)
 
         result = views.login(pyramid_request, _form_class=form_class)
 
@@ -148,11 +148,11 @@ class TestLogin:
         assert result.headers["foo"] == "bar"
 
         assert form_class.calls == [
-            pretend.call(pyramid_request.POST, login_service=login_service),
+            pretend.call(pyramid_request.POST, user_service=user_service),
         ]
         assert form_obj.validate.calls == [pretend.call()]
 
-        assert login_service.find_userid.calls == [pretend.call("theuser")]
+        assert user_service.find_userid.calls == [pretend.call("theuser")]
 
         if with_user:
             assert new_session == {}
@@ -177,11 +177,11 @@ class TestLogin:
     )
     def test_post_validate_no_redirects(self, pyramid_request,
                                         expected_next_url, observed_next_url):
-        login_service = pretend.stub(
+        user_service = pretend.stub(
             find_userid=pretend.call_recorder(lambda username: 1),
         )
         pyramid_request.find_service = pretend.call_recorder(
-            lambda iface, context: login_service
+            lambda iface, context: user_service
         )
         pyramid_request.method = "POST"
         pyramid_request.POST["next"] = expected_next_url
@@ -190,7 +190,7 @@ class TestLogin:
             validate=pretend.call_recorder(lambda: True),
             username=pretend.stub(data="theuser"),
         )
-        form_class = pretend.call_recorder(lambda d, login_service: form_obj)
+        form_class = pretend.call_recorder(lambda d, user_service: form_obj)
 
         result = views.login(pyramid_request, _form_class=form_class)
 

--- a/tests/unit/accounts/test_views.py
+++ b/tests/unit/accounts/test_views.py
@@ -260,6 +260,11 @@ class TestRegister:
         result = views.register(pyramid_request, _form_class=form)
         assert result["form"] is form_inst
 
+    def test_redirect_authenticated_user(self):
+        result = views.register(pretend.stub(authenticated_userid=1))
+        assert isinstance(result, HTTPSeeOther)
+        assert result.headers["Location"] == "/"
+
     def test_register_redirect(self, pyramid_request):
         pyramid_request.method = "POST"
         pyramid_request.find_service = pretend.call_recorder(
@@ -284,3 +289,4 @@ class TestRegister:
 
         result = views.register(pyramid_request)
         assert isinstance(result, HTTPSeeOther)
+        assert result.headers["Location"] == "/"

--- a/tests/unit/accounts/test_views.py
+++ b/tests/unit/accounts/test_views.py
@@ -284,8 +284,8 @@ class TestRegister:
         pyramid_request.route_path = pretend.call_recorder(lambda name: "/")
         pyramid_request.POST.update({
             "username": "username_value",
-            "password": "password_value",
-            "password_confirm": "password_value",
+            "password": "MyStr0ng!shP455w0rd",
+            "password_confirm": "MyStr0ng!shP455w0rd",
             "email": "foo@bar.com",
             "full_name": "full_name",
         })

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -326,6 +326,7 @@ def test_configure(monkeypatch, settings, environment, other_settings):
             pretend.call(".redirects"),
             pretend.call(".routes"),
             pretend.call(".csp"),
+            pretend.call(".recaptcha"),
             pretend.call(".raven"),
         ] + [
             pretend.call(x) for x in [

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -325,9 +325,10 @@ def test_configure(monkeypatch, settings, environment, other_settings):
             pretend.call(".packaging"),
             pretend.call(".redirects"),
             pretend.call(".routes"),
+            pretend.call(".raven"),
             pretend.call(".csp"),
             pretend.call(".recaptcha"),
-            pretend.call(".raven"),
+            pretend.call(".http"),
         ] + [
             pretend.call(x) for x in [
                 configurator_settings.get("warehouse.theme"),
@@ -352,6 +353,11 @@ def test_configure(monkeypatch, settings, environment, other_settings):
             "tm.manager_hook": mock.ANY,
             "tm.activate_hook": config.activate_hook,
             "tm.annotate_user": False,
+        }),
+        pretend.call({
+            "http": {
+                "verify": "/etc/ssl/certs/",
+            },
         }),
     ]
     add_settings_dict = configurator_obj.add_settings.calls[1].args[0]

--- a/tests/unit/test_csp.py
+++ b/tests/unit/test_csp.py
@@ -169,7 +169,6 @@ class TestCSPPolicy:
         }
 
 
-
 def test_includeme():
     config = pretend.stub(
         register_service_factory=pretend.call_recorder(
@@ -223,8 +222,8 @@ class TestFactory:
             },
         }
         request = pretend.stub(
-            registry = pretend.stub(
-                settings = settings
+            registry=pretend.stub(
+                settings=settings
             )
         )
         result = csp.csp_factory(None, request)
@@ -239,8 +238,8 @@ class TestFactory:
 
     def test_default(self):
         request = pretend.stub(
-            registry = pretend.stub(
-                settings = {}
+            registry=pretend.stub(
+                settings={}
             )
         )
         result = csp.csp_factory(None, request)

--- a/tests/unit/test_http.py
+++ b/tests/unit/test_http.py
@@ -1,0 +1,67 @@
+import threading
+import queue
+
+import pretend
+
+import warehouse.http
+
+
+class TestSession:
+    def test_create(self):
+        config = {
+            "verify": "foo",
+        }
+        factory = warehouse.http.ThreadLocalSessionFactory(config)
+        session_a, session_b = factory(None), factory(None)
+        assert session_a is session_b
+        assert session_a.verify == session_b.verify == config["verify"]
+
+    def test_threads(self):
+        def _test_factory(fifo, start):
+            start.wait()
+            factory = warehouse.http.ThreadLocalSessionFactory()
+            # the actual session instance is stuck into the queue here as to
+            # maintain a reference so it's not gc'd (which can result in id
+            # reuse)
+            fifo.put((threading.get_ident(), factory(pretend.stub())))
+
+        start = threading.Event()
+
+        fifo = queue.Queue()
+        threads = [
+            threading.Thread(target=_test_factory, args=(fifo, start))
+            for _ in range(10)
+        ]
+
+        for thread in threads:
+            thread.start()
+
+        start.set()
+
+        for thread in threads:
+            thread.join()
+
+        # data pushed into the queue is (threadid, session).
+        # this basically proves that the session object id is different per
+        # thread
+        results = [fifo.get() for _ in range(len(threads))]
+        idents, objects = zip(*results)
+        assert len(set(idents)) == len(threads)
+        assert len(set(id(obj) for obj in objects)) == len(threads)
+
+
+def test_includeme():
+    config = pretend.stub(
+        registry=pretend.stub(
+            settings={},
+        ),
+        add_request_method=pretend.call_recorder(
+            lambda *args, **kwargs: None
+        ),
+    )
+    warehouse.http.includeme(config)
+
+    assert len(config.add_request_method.calls) == 1
+    call = config.add_request_method.calls[0]
+    assert isinstance(call.args[0], warehouse.http.ThreadLocalSessionFactory)
+    assert call.kwargs == {"name": "http", "reify": True}

--- a/tests/unit/test_http.py
+++ b/tests/unit/test_http.py
@@ -11,6 +11,7 @@ _REQUEST = pretend.stub(
     )
 )
 
+
 class TestSession:
     def test_create(self):
         config = {

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -13,6 +13,7 @@
 import json
 import logging
 import logging.config
+import threading
 import uuid
 
 from unittest import mock
@@ -49,6 +50,7 @@ class TestStructlogFormatter:
             "logger": "another.logger",
             "level": "INFO",
             "event": "the message",
+            "thread": threading.get_ident(),
         }
 
 

--- a/tests/unit/test_recaptcha.py
+++ b/tests/unit/test_recaptcha.py
@@ -206,7 +206,7 @@ class TestCSPPolicy:
                 "https://www.google.com/recaptcha/",
                 "https://www.gstatic.com/recaptcha/",
             ],
-            "frame-src": ["https://www.google.com/recaptcha/",],
+            "frame-src": ["https://www.google.com/recaptcha/"],
             "style-src": ["'unsafe-inline'"],
         }
 

--- a/tests/unit/test_recaptcha.py
+++ b/tests/unit/test_recaptcha.py
@@ -222,14 +222,6 @@ class TestCSPPolicy:
             "style-src": ["'unsafe-inline'"],
         }
 
-    def test_policy_when_disabled(self):
-        settings = {}
-        request = pretend.stub(
-            registry=pretend.stub(settings=settings)
-        )
-        serv = recaptcha.Service(request)
-        assert serv.csp_policy == {}
-
 
 def test_service_factory():
     serv = recaptcha.service_factory(None, _REQUEST)

--- a/tests/unit/test_recaptcha.py
+++ b/tests/unit/test_recaptcha.py
@@ -1,4 +1,3 @@
-import collections
 import socket
 import urllib.parse
 from os import environ

--- a/tests/unit/test_recaptcha.py
+++ b/tests/unit/test_recaptcha.py
@@ -1,0 +1,165 @@
+from os import environ
+
+import pytest
+import pretend
+import responses
+
+from warehouse import recaptcha
+
+
+_SETTINGS = {
+    "recaptcha": {
+        "site_key": "site_key_value",
+        "secret_key": "secret_key_value",
+    },
+}
+_REQUEST = pretend.stub(
+    registry=pretend.stub(
+        settings=_SETTINGS,
+    ),
+)
+
+
+class TestVerifyResponse:
+    @responses.activate
+    def test_unexpected_data_error(self):
+        responses.add(
+            responses.POST,
+            recaptcha.VERIFY_URL,
+            body="something awful",
+        )
+        serv = recaptcha.Service(_REQUEST)
+        
+        with pytest.raises(recaptcha.UnknownError) as err:
+            res = serv.verify_response("meaningless")
+            assert str(err) == \
+                "Unexpected data in response body: something awful"
+    
+    @responses.activate
+    def test_missing_success_key_error(self):
+        responses.add(
+            responses.POST,
+            recaptcha.VERIFY_URL,
+            json={},
+        )
+        serv = recaptcha.Service(_REQUEST)
+
+        with pytest.raises(recaptcha.UnknownError) as err:
+            res = serv.verify_response("meaningless")
+            assert str(err) == "Missing 'success' key in response: {}"
+
+    @responses.activate
+    def test_error_map_error(self):
+        for key, exc_tp in recaptcha.ERROR_CODE_MAP.items():
+            responses.add(
+                responses.POST,
+                recaptcha.VERIFY_URL,
+                json={
+                    "success": False,
+                    "challenge_ts": 0,
+                    "hostname": "hotname_value",
+                    "error_codes": [key]
+                }
+            )
+
+            serv = recaptcha.Service(_REQUEST)
+            with pytest.raises(exc_tp):
+                res = serv.verify_response("meaningless")
+
+            responses.reset()
+
+    @responses.activate
+    def test_error_map_unknown_error(self):
+        responses.add(
+            responses.POST,
+            recaptcha.VERIFY_URL,
+            json={
+                "success": False,
+                "challenge_ts": 0,
+                "hostname": "hostname_value",
+                "error_codes": ["slartibartfast"],
+            },
+        )
+
+        serv = recaptcha.Service(_REQUEST)
+        with pytest.raises(recaptcha.UnknownError) as err:
+            res = serv.verify_response("meaningless")
+            assert str(err) == "Unhandled error code: slartibartfast"
+
+    @responses.activate
+    def test_challenge_response_missing_timestamp_success(self):
+        responses.add(
+            responses.POST,
+            recaptcha.VERIFY_URL,
+            json={
+                "success": True,
+                "hostname": "hostname_value",
+            },
+        )
+
+        serv = recaptcha.Service(_REQUEST)
+        res = serv.verify_response("meaningless")
+        
+        assert isinstance(res, recaptcha.ChallengeResponse)
+        assert res.challenge_ts is None
+        assert res.hostname == "hostname_value"
+
+    @responses.activate
+    def test_challenge_response_missing_hostname_success(self):
+        responses.add(
+            responses.POST,
+            recaptcha.VERIFY_URL,
+            json={
+                "success": True,
+                "challenge_ts": 0,
+            },
+        )
+
+        serv = recaptcha.Service(_REQUEST)
+        res = serv.verify_response("meaningless")
+
+        assert isinstance(res, recaptcha.ChallengeResponse)
+        assert res.hostname is None
+        assert res.challenge_ts == 0
+
+    @responses.activate
+    def test_challenge_response_successs(self):
+        responses.add(
+            responses.POST,
+            recaptcha.VERIFY_URL,
+            json={
+                "success": True,
+                "hostname": "hostname_value",
+                "challenge_ts": 0,
+            },
+        )
+
+        serv = recaptcha.Service(_REQUEST)
+        res = serv.verify_response("meaningless")
+
+        assert isinstance(res, recaptcha.ChallengeResponse)
+        assert res.hostname == "hostname_value"
+        assert res.challenge_ts == 0
+
+
+def test_includeme():
+    config = pretend.stub(
+        register_service_factory=pretend.call_recorder(
+            lambda fact, name: None
+        ),
+        add_settings=pretend.call_recorder(lambda settings: None),
+    )
+    recaptcha.includeme(config)
+    
+    assert config.register_service_factory.calls == [
+        pretend.call(recaptcha.service_factory, name="recaptcha"),
+    ]
+
+    assert config.add_settings.calls == [
+        pretend.call({
+            "recaptcha": {
+                "site_key": environ.get("RECAPTCHA_SITE_KEY", ""),
+                "secret_key": environ.get("RECAPTCHA_SECRET_KEY", ""),
+            },
+        }),
+    ]

--- a/tests/unit/test_recaptcha.py
+++ b/tests/unit/test_recaptcha.py
@@ -202,7 +202,9 @@ class TestVerifyResponse:
 
 class TestCSPPolicy:
     def test_csp_policy(self):
+        scheme = 'https'
         request = pretend.stub(
+            scheme=scheme,
             registry=pretend.stub(settings={
                 "recaptcha": {
                     "site_key": "foo",
@@ -213,9 +215,8 @@ class TestCSPPolicy:
         serv = recaptcha.Service(request)
         assert serv.csp_policy == {
             "script-src": [
-                "https://www.google.com/recaptcha/",
-                "https://www.gstatic.com/recaptcha/",
-                "'unsafe-inline'",
+                "%s://www.google.com/recaptcha/" % scheme,
+                "%s://www.gstatic.com/recaptcha/" % scheme,
             ],
             "frame-src": ["https://www.google.com/recaptcha/"],
             "style-src": ["'unsafe-inline'"],

--- a/tests/unit/test_recaptcha.py
+++ b/tests/unit/test_recaptcha.py
@@ -207,6 +207,7 @@ class TestCSPPolicy:
             "script-src": [
                 "https://www.google.com/recaptcha/",
                 "https://www.gstatic.com/recaptcha/",
+                "'unsafe-inline'",
             ],
             "frame-src": ["https://www.google.com/recaptcha/"],
             "style-src": ["'unsafe-inline'"],

--- a/tests/unit/test_recaptcha.py
+++ b/tests/unit/test_recaptcha.py
@@ -29,12 +29,12 @@ class TestVerifyResponse:
             body="something awful",
         )
         serv = recaptcha.Service(_REQUEST)
-        
+
         with pytest.raises(recaptcha.UnknownError) as err:
-            res = serv.verify_response("meaningless")
+            serv.verify_response("meaningless")
             assert str(err) == \
                 "Unexpected data in response body: something awful"
-    
+
     @responses.activate
     def test_missing_success_key_error(self):
         responses.add(
@@ -45,7 +45,7 @@ class TestVerifyResponse:
         serv = recaptcha.Service(_REQUEST)
 
         with pytest.raises(recaptcha.UnknownError) as err:
-            res = serv.verify_response("meaningless")
+            serv.verify_response("meaningless")
             assert str(err) == "Missing 'success' key in response: {}"
 
     @responses.activate
@@ -64,7 +64,7 @@ class TestVerifyResponse:
 
             serv = recaptcha.Service(_REQUEST)
             with pytest.raises(exc_tp):
-                res = serv.verify_response("meaningless")
+                serv.verify_response("meaningless")
 
             responses.reset()
 
@@ -83,7 +83,7 @@ class TestVerifyResponse:
 
         serv = recaptcha.Service(_REQUEST)
         with pytest.raises(recaptcha.UnknownError) as err:
-            res = serv.verify_response("meaningless")
+            serv.verify_response("meaningless")
             assert str(err) == "Unhandled error code: slartibartfast"
 
     @responses.activate
@@ -99,7 +99,7 @@ class TestVerifyResponse:
 
         serv = recaptcha.Service(_REQUEST)
         res = serv.verify_response("meaningless")
-        
+
         assert isinstance(res, recaptcha.ChallengeResponse)
         assert res.challenge_ts is None
         assert res.hostname == "hostname_value"
@@ -150,7 +150,7 @@ def test_includeme():
         add_settings=pretend.call_recorder(lambda settings: None),
     )
     recaptcha.includeme(config)
-    
+
     assert config.register_service_factory.calls == [
         pretend.call(recaptcha.service_factory, name="recaptcha"),
     ]
@@ -158,8 +158,8 @@ def test_includeme():
     assert config.add_settings.calls == [
         pretend.call({
             "recaptcha": {
-                "site_key": environ.get("RECAPTCHA_SITE_KEY", ""),
-                "secret_key": environ.get("RECAPTCHA_SECRET_KEY", ""),
+                "site_key": environ.get("RECAPTCHA_SITE_KEY"),
+                "secret_key": environ.get("RECAPTCHA_SECRET_KEY"),
             },
         }),
     ]

--- a/tests/unit/test_recaptcha.py
+++ b/tests/unit/test_recaptcha.py
@@ -1,4 +1,5 @@
 import collections
+import socket
 import urllib.parse
 from os import environ
 
@@ -190,6 +191,14 @@ class TestVerifyResponse:
         assert isinstance(res, recaptcha.ChallengeResponse)
         assert res.hostname == "hostname_value"
         assert res.challenge_ts == 0
+
+    @responses.activate
+    def test_unexpected_error(self):
+        serv = recaptcha.Service(_REQUEST)
+        serv.request.http.post = pretend.raiser(socket.error)
+
+        with pytest.raises(recaptcha.UnexpectedError):
+            serv.verify_response("meaningless")
 
 
 class TestCSPPolicy:

--- a/tests/unit/test_routes.py
+++ b/tests/unit/test_routes.py
@@ -75,6 +75,7 @@ def test_routes():
         ),
         pretend.call("accounts.login", "/account/login/"),
         pretend.call("accounts.logout", "/account/logout/"),
+        pretend.call("accounts.register", "/account/register/"),
         pretend.call(
             "packaging.project",
             "/project/{name}/",

--- a/warehouse/accounts/forms.py
+++ b/warehouse/accounts/forms.py
@@ -11,12 +11,12 @@
 # limitations under the License.
 
 import wtforms
+import wtforms.fields.html5
 
-from warehouse import forms
+from warehouse import forms, recaptcha
 
 
-class LoginForm(forms.Form):
-
+class CredentialsMixin:
     username = wtforms.StringField(
         validators=[
             wtforms.validators.DataRequired(),
@@ -30,19 +30,67 @@ class LoginForm(forms.Form):
         ],
     )
 
-    def __init__(self, *args, login_service, **kwargs):
+    def __init__(self, *args, user_service, **kwargs):
         super().__init__(*args, **kwargs)
+        self.user_service = user_service
 
-        self.login_service = login_service
+
+class RegistrationForm(CredentialsMixin, forms.Form):
+    password_confirm = wtforms.PasswordField(
+        validators=[
+            wtforms.validators.DataRequired(),
+            wtforms.validators.EqualTo(
+                "password", "Passwords must match."
+            ),
+        ],
+    )
+
+    full_name = wtforms.StringField()
+
+    email = wtforms.fields.html5.EmailField(
+        validators=[
+            wtforms.validators.DataRequired(),
+            wtforms.validators.Email(),
+        ],
+    )
+
+    g_recaptcha_response = wtforms.StringField()
+
+    def __init__(self, *args, recaptcha_service, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.recaptcha_service = recaptcha_service
 
     def validate_username(self, field):
-        userid = self.login_service.find_userid(field.data)
+        if self.user_service.find_userid(field.data) is not None:
+            raise wtforms.validators.ValidationError(
+                "Username exists.")
+
+    def validate_email(self, field):
+        if self.user_service.find_by_email(field.data) is not None:
+            raise wtforms.validators.ValidationError("Email exists.")
+
+    def validate_g_recaptcha_response(self, field):
+        # do required data validation here due to enabled flag being required
+        if self.recaptcha_service.enabled and len(field.data) <= 0:
+            raise wtforms.validators.ValidationError("This field is required.")
+
+        try:
+            self.recaptcha_service.verify_response(field.data)
+        except recaptcha.RecaptchaError:
+            # TODO: log error
+            # don't want to provide the user with any detail
+            raise wtforms.validators.ValidationError("Recaptcha error.")
+
+
+class LoginForm(CredentialsMixin, forms.Form):
+    def validate_username(self, field):
+        userid = self.user_service.find_userid(field.data)
 
         if userid is None:
             raise wtforms.validators.ValidationError("Invalid user.")
 
     def validate_password(self, field):
-        userid = self.login_service.find_userid(self.username.data)
+        userid = self.user_service.find_userid(self.username.data)
         if userid is not None:
-            if not self.login_service.check_password(userid, field.data):
+            if not self.user_service.check_password(userid, field.data):
                 raise wtforms.validators.ValidationError("Invalid password.")

--- a/warehouse/accounts/forms.py
+++ b/warehouse/accounts/forms.py
@@ -71,8 +71,8 @@ class RegistrationForm(CredentialsMixin, forms.Form):
 
     def validate_g_recaptcha_response(self, field):
         # do required data validation here due to enabled flag being required
-        if self.recaptcha_service.enabled and len(field.data) <= 0:
-            raise wtforms.validators.ValidationError("This field is required.")
+        if self.recaptcha_service.enabled and not field.data:
+            raise wtforms.validators.ValidationError("Recaptcha error.")
 
         try:
             self.recaptcha_service.verify_response(field.data)

--- a/warehouse/accounts/forms.py
+++ b/warehouse/accounts/forms.py
@@ -66,7 +66,7 @@ class RegistrationForm(CredentialsMixin, forms.Form):
                 "Username exists.")
 
     def validate_email(self, field):
-        if self.user_service.find_by_email(field.data) is not None:
+        if self.user_service.find_userid_by_email(field.data) is not None:
             raise wtforms.validators.ValidationError("Email exists.")
 
     def validate_g_recaptcha_response(self, field):

--- a/warehouse/accounts/forms.py
+++ b/warehouse/accounts/forms.py
@@ -99,8 +99,8 @@ class RegistrationForm(CredentialsMixin, forms.Form):
     def validate_password(self, field):
         if not PWD_RE.match(field.data):
             raise wtforms.validators.ValidationError(
-                "Password must contain 1+ upper case letter, 1+ lower case "
-                "letter, 1+ number, 1+ special character and be at least "
+                "Password must contain an upper case letter, a lower case "
+                "letter, a number, a special character and be at least "
                 "%d characters in length" % PWD_MIN_LEN
             )
 

--- a/warehouse/accounts/forms.py
+++ b/warehouse/accounts/forms.py
@@ -73,7 +73,6 @@ class RegistrationForm(CredentialsMixin, forms.Form):
         # do required data validation here due to enabled flag being required
         if self.recaptcha_service.enabled and not field.data:
             raise wtforms.validators.ValidationError("Recaptcha error.")
-
         try:
             self.recaptcha_service.verify_response(field.data)
         except recaptcha.RecaptchaError:

--- a/warehouse/accounts/services.py
+++ b/warehouse/accounts/services.py
@@ -91,9 +91,10 @@ class DatabaseUserService:
 
     def create_user(self, username, name, password, email,
                     is_active=False, is_staff=False, is_superuser=False):
+
         user = User(username=username,
                     name=name,
-                    password=password,
+                    password=self.hasher.encrypt(password),
                     is_active=is_active,
                     is_staff=is_staff,
                     is_superuser=is_superuser)

--- a/warehouse/accounts/services.py
+++ b/warehouse/accounts/services.py
@@ -56,6 +56,19 @@ class DatabaseUserService:
 
         return user.id
 
+    @functools.lru_cache()
+    def find_by_email(self, email):
+        try:
+            user_id = (
+                self.db.query(Email.user_id)
+                    .filter(Email.email == email)
+                    .one()
+            )
+        except NoResultFound:
+            return
+
+        return user_id
+
     def check_password(self, userid, password):
         user = self.get_user(userid)
         if user is None:
@@ -89,6 +102,8 @@ class DatabaseUserService:
         email_object = Email(email=email, user=user,
                              primary=True, verified=False)
         self.db.add(email_object)
+        # flush the db now so user.id is available
+        self.db.flush()
         return user
 
     def update_user(self, user_id, **changes):

--- a/warehouse/accounts/services.py
+++ b/warehouse/accounts/services.py
@@ -59,6 +59,7 @@ class DatabaseUserService:
     @functools.lru_cache()
     def find_by_email(self, email):
         try:
+            # flake8: noqa
             user_id = (
                 self.db.query(Email.user_id)
                     .filter(Email.email == email)

--- a/warehouse/accounts/services.py
+++ b/warehouse/accounts/services.py
@@ -57,14 +57,14 @@ class DatabaseUserService:
         return user.id
 
     @functools.lru_cache()
-    def find_by_email(self, email):
+    def find_userid_by_email(self, email):
         try:
             # flake8: noqa
             user_id = (
                 self.db.query(Email.user_id)
                     .filter(Email.email == email)
                     .one()
-            )
+            )[0]
         except NoResultFound:
             return
 

--- a/warehouse/accounts/views.py
+++ b/warehouse/accounts/views.py
@@ -177,6 +177,9 @@ def logout(request, redirect_field_name=REDIRECT_FIELD_NAME):
     decorator=[csrf_protect("accounts.register"), uses_session],
 )
 def register(request, _form_class=forms.RegistrationForm):
+    if request.authenticated_userid is not None:
+        return HTTPSeeOther("/")
+
     user_service = request.find_service(IUserService, context=None)
     recaptcha_service = request.find_service(name="recaptcha")
     recaptcha_service.add_to_csp_policy()

--- a/warehouse/accounts/views.py
+++ b/warehouse/accounts/views.py
@@ -84,11 +84,10 @@ def login(request, redirect_field_name=REDIRECT_FIELD_NAME,
                 not is_safe_url(url=redirect_to, host=request.host)):
             redirect_to = "/"
 
+        headers = _login_user(request, userid)
         # Now that we're logged in we'll want to redirect the user to either
         # where they were trying to go originally, or to the default view.
-        return HTTPSeeOther(
-            redirect_to,
-            headers=dict(_login_user(request, userid)))
+        return HTTPSeeOther(redirect_to, headers=dict(headers))
 
     return {
         "form": form,

--- a/warehouse/config.py
+++ b/warehouse/config.py
@@ -300,7 +300,11 @@ def configure(settings=None):
     # Register all our URL routes for Warehouse.
     config.include(".routes")
 
+    # Register Content-Security-Policy service
     config.include(".csp")
+
+    # Register recaptcha service
+    config.include(".recaptcha")
 
     # Block non HTTPS requests for the legacy ?:action= routes when they are
     # sent via POST.

--- a/warehouse/config.py
+++ b/warehouse/config.py
@@ -300,12 +300,6 @@ def configure(settings=None):
     # Register all our URL routes for Warehouse.
     config.include(".routes")
 
-    # Register Content-Security-Policy service
-    config.include(".csp")
-
-    # Register recaptcha service
-    config.include(".recaptcha")
-
     # Block non HTTPS requests for the legacy ?:action= routes when they are
     # sent via POST.
     config.add_tween("warehouse.config.require_https_tween_factory")
@@ -356,6 +350,19 @@ def configure(settings=None):
     # We want Raven to be the last things we add here so that it's the outer
     # most WSGI middleware.
     config.include(".raven")
+
+    # Register Content-Security-Policy service
+    config.include(".csp")
+
+    # Register recaptcha service
+    config.include(".recaptcha")
+
+    config.add_settings({
+        "http": {
+            "verify": "/etc/ssl/certs/",
+        },
+    })
+    config.include(".http")
 
     # Add our theme if one was configured
     if config.get_settings().get("warehouse.theme"):

--- a/warehouse/csp.py
+++ b/warehouse/csp.py
@@ -32,13 +32,15 @@ def content_security_policy_tween_factory(handler, registry):
 
 
 def csp_factory(_, request):
-    return copy.deepcopy(request.registry.settings.get("csp", {}))
+    return collections.defaultdict(
+        list, request.registry.settings.get("csp", {})
+    )
 
 
 def includeme(config):
     config.register_service_factory(csp_factory, name="csp")
     # Enable a Content Security Policy
-    config.add_settings({
+    config.add_settings(collections.defaultdict(list, {
         "csp": {
             "connect-src": ["'self'"],
             "default-src": ["'none'"],
@@ -55,5 +57,5 @@ def includeme(config):
             "script-src": ["'self'"],
             "style-src": ["'self'", "fonts.googleapis.com"],
         },
-    })
+    }))
     config.add_tween("warehouse.csp.content_security_policy_tween_factory")

--- a/warehouse/csp.py
+++ b/warehouse/csp.py
@@ -1,5 +1,4 @@
 import collections
-import copy
 
 
 def _serialize(policy):

--- a/warehouse/http.py
+++ b/warehouse/http.py
@@ -2,16 +2,15 @@ import threading
 import requests
 
 
-_local = threading.local()
-
 
 class ThreadLocalSessionFactory:
     def __init__(self, config=None):
         self.config = config
+        self._local = threading.local()
 
     def __call__(self, request):
         try:
-            session = _local.session
+            session = self._local.session
             request.log.debug("reusing existing session")
             return session
         except AttributeError:
@@ -23,7 +22,7 @@ class ThreadLocalSessionFactory:
                     assert hasattr(session, attr)
                     setattr(session, attr, val)
 
-            _local.session = session
+            self._local.session = session
             return session
 
 

--- a/warehouse/http.py
+++ b/warehouse/http.py
@@ -1,4 +1,3 @@
-import logging
 import threading
 import requests
 

--- a/warehouse/http.py
+++ b/warehouse/http.py
@@ -1,0 +1,27 @@
+import threading
+import requests
+
+
+class ThreadLocalSessionFactory(threading.local):
+    def __init__(self, config=None):
+        self.config = config
+
+    def __call__(self, request):
+        try:
+            return self.session
+        except AttributeError:
+            self.session = requests.Session()
+
+            if self.config is not None:
+                for attr, val in self.config.items():
+                    assert hasattr(self.session, attr)
+                    setattr(self.session, attr, val)
+
+            return self.session
+
+
+def includeme(config):
+    config.add_request_method(
+        ThreadLocalSessionFactory(config.registry.settings.get("http")),
+        name="http", reify=True
+    )

--- a/warehouse/http.py
+++ b/warehouse/http.py
@@ -2,7 +2,6 @@ import threading
 import requests
 
 
-
 class ThreadLocalSessionFactory:
     def __init__(self, config=None):
         self.config = config

--- a/warehouse/logging.py
+++ b/warehouse/logging.py
@@ -11,6 +11,7 @@
 # limitations under the License.
 
 import logging.config
+import threading
 import uuid
 
 import structlog
@@ -35,6 +36,7 @@ class StructlogFormatter(logging.Formatter):
                 "logger": record.name,
                 "level": record.levelname,
                 "event": record.msg,
+                "thread": threading.get_ident(),
             }
             record.msg = RENDERER(None, None, event_dict)
 

--- a/warehouse/recaptcha.py
+++ b/warehouse/recaptcha.py
@@ -35,10 +35,7 @@ class Service:
     @property
     def enabled(self):
         settings = self.request.registry.settings.get("recaptcha", {})
-        return (
-            settings.get("site_key") is not None and
-            settings.get("secret_key") is not None
-        )
+        return settings.get("site_key") and settings.get("secret_key")
 
     def verify_response(self, response, remote_ip=None):
         if not self.enabled:
@@ -61,7 +58,7 @@ class Service:
             VERIFY_URL, urlencode(payload),
             headers={"Content-Type":
                 "application/x-www-form-urlencoded; charset=utf-8"},
-            verify=False,
+            verify="/etc/ssl/certs/",
         )
         try:
             data = resp.json()

--- a/warehouse/recaptcha.py
+++ b/warehouse/recaptcha.py
@@ -33,9 +33,10 @@ class Service:
 
     @property
     def csp_policy(self):
-        if not self.enabled:
-            return {}
-
+        # the use of request.scheme should ever only be for dev. problem is
+        # that we use "//" in the script tags, so the request scheme is used.
+        # because the csp has to match the script src scheme, it also has to
+        # be dynamic.
         return {
             "script-src": [
                 "%s://www.google.com/recaptcha/" % self.request.scheme,

--- a/warehouse/recaptcha.py
+++ b/warehouse/recaptcha.py
@@ -1,0 +1,137 @@
+import collections
+import http
+from os import environ
+from urllib.parse import urlencode
+
+import requests
+
+
+VERIFY_URL = "https://www.google.com/recaptcha/api/siteverify"
+
+
+class RecaptchaError(ValueError): pass
+class MissingInputSecretError(RecaptchaError): pass
+class InvalidInputSecretError(RecaptchaError): pass
+class MissingInputResponseError(RecaptchaError): pass
+class InvalidInputResponseError(RecaptchaError): pass
+class UnknownError(RecaptchaError): pass
+
+ERROR_CODE_MAP = {
+    "missing-input-secret": MissingInputSecretError,
+    "invalid-input-secret": InvalidInputSecretError,
+    "missing-input-response": MissingInputResponseError,
+    "invalid-input-response": InvalidInputResponseError,
+}
+
+ChallengeResponse = collections.namedtuple(
+    "ChallengeResponse", ("challenge_ts", "hostname")
+)
+
+
+class Service:
+    def __init__(self, request):
+        self.request = request
+
+    @property
+    def enabled(self):
+        settings = self.request.registry.settings.get("recaptcha", {})
+        return (
+            settings.get("site_key") is not None and
+            settings.get("secret_key") is not None
+        )
+
+    def verify_response(self, response, remote_ip=None):
+        if not self.enabled:
+            # TODO: logging
+            return
+
+        settings = self.request.registry.settings["recaptcha"]
+
+        payload = {
+            "secret": settings["secret_key"],
+            "response": response,
+        }
+        if remote_ip is not None:
+            payload["remoteip"] = remote_ip
+
+        # TODO: maybe add a session service? there doesn't seem to be anything
+        # calling out to external services atm though
+        # TODO: turn verify back on once the certs are fixed
+        resp = requests.post(
+            VERIFY_URL, urlencode(payload),
+            headers={"Content-Type":
+                "application/x-www-form-urlencoded; charset=utf-8"},
+            verify=False,
+        )
+        try:
+            data = resp.json()
+        except ValueError:
+            raise UnknownError(
+                "Unexpected data in response body: %s" % resp.content
+            )
+
+        try:
+            success = data["success"]
+        except KeyError:
+            raise UnknownError(
+                "Missing 'success' key in response: %s" % data
+            )
+
+        if resp.status_code != http.HTTPStatus.OK or not data["success"]:
+            try:
+                error_codes = data["error_codes"]
+            except KeyError:
+                raise UnknownError(
+                    "Response missing 'error-codes' key: %s" % data
+                )
+            try:
+                exc_tp = ERROR_CODE_MAP[error_codes[0]]
+            except KeyError:
+                raise UnknownError(
+                    "Unhandled error code: %s" % error_codes[0]
+                )
+            raise exc_tp
+
+        # challenge_ts = timestamp of the challenge load
+        # (ISO format yyyy-MM-dd'T'HH:mm:ssZZ)
+        # TODO: maybe run some validation against the hostname and timestamp?
+        # TODO: log if either field is empty.. it shouldn't cause a failure,
+        # but it likely means that google has changed their response structure
+        return ChallengeResponse(
+            data.get("challenge_ts"), 
+            data.get("hostname"),
+        )
+
+    def add_to_csp_policy(self):
+        if not self.enabled:
+            # TODO: logging
+            return
+
+        csp_service = self.request.find_service(name="csp")
+        csp_service["script-src"].extend([
+            "https://www.google.com/recaptcha/",
+            "https://www.gstatic.com/recaptcha/",
+        ])
+        csp_service["frame-src"].append(
+            "https://www.google.com/recaptcha/",
+        )
+        csp_service["style-src"].append("'unsafe-inline'")
+
+
+def service_factory(handler, request):
+    return Service(request)
+
+
+def includeme(config):
+    # yeah yeah, binding to a concrete implementation rather than an
+    # interface. in a perfect world, this will never be offloaded to another
+    # service. however, if it is, then we'll deal with the refactor then
+    config.register_service_factory(service_factory, name="recaptcha")
+
+    # key-less recaptcha config will work on localhost, but not prod
+    config.add_settings({
+        "recaptcha": {
+            "site_key": environ.get("RECAPTCHA_SITE_KEY"),
+            "secret_key": environ.get("RECAPTCHA_SECRET_KEY"),
+        },
+    })

--- a/warehouse/recaptcha.py
+++ b/warehouse/recaptcha.py
@@ -40,6 +40,7 @@ class Service:
             "script-src": [
                 "https://www.google.com/recaptcha/",
                 "https://www.gstatic.com/recaptcha/",
+                "'unsafe-inline'",
             ],
             "frame-src": [
                 "https://www.google.com/recaptcha/",
@@ -57,7 +58,7 @@ class Service:
 
     def verify_response(self, response, remote_ip=None):
         if not self.enabled:
-            # TODO: logging
+            # TODO: debug logging
             return
 
         settings = self.request.registry.settings["recaptcha"]

--- a/warehouse/recaptcha.py
+++ b/warehouse/recaptcha.py
@@ -9,6 +9,7 @@ import requests
 VERIFY_URL = "https://www.google.com/recaptcha/api/siteverify"
 
 
+# flake8: noqa
 class RecaptchaError(ValueError): pass
 class MissingInputSecretError(RecaptchaError): pass
 class InvalidInputSecretError(RecaptchaError): pass

--- a/warehouse/recaptcha.py
+++ b/warehouse/recaptcha.py
@@ -38,12 +38,11 @@ class Service:
 
         return {
             "script-src": [
-                "https://www.google.com/recaptcha/",
-                "https://www.gstatic.com/recaptcha/",
-                "'unsafe-inline'",
+                "%s://www.google.com/recaptcha/" % self.request.scheme,
+                "%s://www.gstatic.com/recaptcha/" % self.request.scheme,
             ],
             "frame-src": [
-                "https://www.google.com/recaptcha/",
+                "%s://www.google.com/recaptcha/" % self.request.scheme,
             ],
             "style-src": [
                 "'unsafe-inline'",

--- a/warehouse/recaptcha.py
+++ b/warehouse/recaptcha.py
@@ -71,10 +71,13 @@ class Service:
             payload["remoteip"] = remote_ip
 
         try:
+            # TODO: the timeout is hardcoded for now. it would be nice to do
+            # something a little more generalized in the future.
             resp = self.request.http.post(
                 VERIFY_URL, urlencode(payload),
                 headers={"Content-Type":
                     "application/x-www-form-urlencoded; charset=utf-8"},
+                timeout=10
             )
         except Exception as err:
             raise UnexpectedError(str(err))

--- a/warehouse/recaptcha.py
+++ b/warehouse/recaptcha.py
@@ -70,11 +70,15 @@ class Service:
         if remote_ip is not None:
             payload["remoteip"] = remote_ip
 
-        resp = self.request.http.post(
-            VERIFY_URL, urlencode(payload),
-            headers={"Content-Type":
-                "application/x-www-form-urlencoded; charset=utf-8"},
-        )
+        try:
+            resp = self.request.http.post(
+                VERIFY_URL, urlencode(payload),
+                headers={"Content-Type":
+                    "application/x-www-form-urlencoded; charset=utf-8"},
+            )
+        except Exception as err:
+            raise UnexpectedError(str(err))
+
         try:
             data = resp.json()
         except ValueError:

--- a/warehouse/routes.py
+++ b/warehouse/routes.py
@@ -42,6 +42,7 @@ def includeme(config):
     )
     config.add_route("accounts.login", "/account/login/")
     config.add_route("accounts.logout", "/account/logout/")
+    config.add_route("accounts.register", "/account/register/")
 
     # Packaging
     config.add_route(

--- a/warehouse/static/js/recaptcha.js
+++ b/warehouse/static/js/recaptcha.js
@@ -1,0 +1,5 @@
+function renderCaptcha() {
+    var config = new Object();
+    config.sitekey = $("script#recaptcha-js").data("site-key");
+    grecaptcha.render($("#recaptcha-container")[0], config);
+}

--- a/warehouse/templates/accounts/login.html
+++ b/warehouse/templates/accounts/login.html
@@ -18,24 +18,7 @@
     </ul>
     {% endif %}
 
-    {% if form.username.errors %}
-    <ul class="errors">
-      {% for error in form.username.errors %}
-      <li>{{ error }}</li>
-      {% endfor %}
-    </ul>
-    {% endif %}
-    {{ form.username(placeholder="Username") }}
-
-    {% if form.password.errors %}
-    <ul class="errors">
-      {% for error in form.password.errors %}
-      <li>{{ error }}</li>
-      {% endfor %}
-    </ul>
-    {% endif %}
-    {{ form.password(placeholder="Password") }}
-
+    {% include "warehouse:templates/includes/input-credentials.html" %}
     <input type="submit" value="Login">
   </form>
 {% endblock %}

--- a/warehouse/templates/accounts/register.html
+++ b/warehouse/templates/accounts/register.html
@@ -1,5 +1,9 @@
 {% extends "base.html" %}
-{%- from "warehouse:templates/includes/input-recaptcha.html" import recaptcha_src, recaptcha_html with context %}
+{%- from "warehouse:templates/includes/input-recaptcha.html" import recaptcha_src, recaptcha_html, recaptcha_callback with context %}
+
+{% block topload %}
+ {{ recaptcha_callback() }}
+{% endblock %}
 
 {% block content %}
   <form method="POST" action="{{ request.current_route_path() }}">

--- a/warehouse/templates/accounts/register.html
+++ b/warehouse/templates/accounts/register.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{%- from "warehouse:templates/includes/input-recaptcha.html" import recaptcha_src, recaptcha_html with context %}
 
 {% block content %}
   <form method="POST" action="{{ request.current_route_path() }}">
@@ -33,8 +34,11 @@
     {% endif %}
     {{ form.email(placeholder="Email") }}
 
-    {% include "warehouse:templates/includes/input-recaptcha.html" %}
-
+    {{ recaptcha_html() }}
     <input type="submit" value="Register">
   </form>
+{% endblock %}
+
+{% block bottomload %}
+  {{ recaptcha_src() }}
 {% endblock %}

--- a/warehouse/templates/accounts/register.html
+++ b/warehouse/templates/accounts/register.html
@@ -1,0 +1,40 @@
+{% extends "base.html" %}
+
+{% block content %}
+  <form method="POST" action="{{ request.current_route_path() }}">
+    <input name="csrf_token" type="hidden" value="{{ request.session.get_scoped_csrf_token('accounts.register') }}">
+
+    {% include "warehouse:templates/includes/input-credentials.html" %}
+
+    {% if form.password_confirm.errors %}
+    <ul class="errors">
+      {% for error in form.password_confirm.errors %}
+      <li>{{ error }}</li>
+      {% endfor %}
+    </ul>
+    {% endif %}
+    {{ form.password_confirm(placeholder="Confirm password") }}
+
+    {% if form.full_name.errors %}
+    <ul class="errors">
+      {% for error in form.full_name.errors %}
+      <li>{{ error }}</li>
+      {% endfor %}
+    </ul>
+    {% endif %}
+    {{ form.full_name(placeholder="Full name") }}
+
+    {% if form.email.errors %}
+    <ul class="errors">
+      {% for error in form.email.errors %}
+      <li>{{ error }}</li>
+      {% endfor %}
+    </ul>
+    {% endif %}
+    {{ form.email(placeholder="Email") }}
+
+    {% include "warehouse:templates/includes/input-recaptcha.html" %}
+
+    <input type="submit" value="Register">
+  </form>
+{% endblock %}

--- a/warehouse/templates/base.html
+++ b/warehouse/templates/base.html
@@ -40,7 +40,7 @@
      #       before we can progress on this. Currently this breaks html_include
      #}
     {# <script defer src="{{ request.static_path('warehouse:static/dist/components/l20n/dist/compat/web/l20n.js') }}"></script> #}
-    {% block top_script %}{% endblock %}
+    {% block topload %}{% endblock %}
   </head>
 
   <body>
@@ -132,6 +132,7 @@
     <script src="{{ request.static_path('warehouse:static/dist/components/jquery-timeago/jquery.timeago.js') }}"></script>
     <script src="{{ request.static_path('warehouse:static/dist/js/plugins.js') }}"></script>
     <script src="{{ request.static_path('warehouse:static/dist/js/main.js') }}"></script>
+    {% block bottomload %}{% endblock %}
   </body>
 
 </html>

--- a/warehouse/templates/base.html
+++ b/warehouse/templates/base.html
@@ -40,6 +40,7 @@
      #       before we can progress on this. Currently this breaks html_include
      #}
     {# <script defer src="{{ request.static_path('warehouse:static/dist/components/l20n/dist/compat/web/l20n.js') }}"></script> #}
+    {% block top_script %}{% endblock %}
   </head>
 
   <body>

--- a/warehouse/templates/includes/current-user-indicator.html
+++ b/warehouse/templates/includes/current-user-indicator.html
@@ -7,7 +7,7 @@
 {% else %}
   <nav class="horizontal-menu -light -tall">
     <a class="link" {{ l20n("signin") }} href="{{ request.route_path('accounts.login') }}">Sign In</a>
-    <a class="link" {{ l20n("register") }} href="TODO">Register</a>
+    <a class="link" {{ l20n("register") }} href="{{ request.route_path('accounts.register') }}">Register</a>
     <a class="link" {{ l20n("help") }} href="TODO">Help</a>
   </nav>
 {% endif %}

--- a/warehouse/templates/includes/input-credentials.html
+++ b/warehouse/templates/includes/input-credentials.html
@@ -1,0 +1,17 @@
+{% if form.username.errors %}
+<ul class="errors">
+  {% for error in form.username.errors %}
+  <li>{{ error }}</li>
+  {% endfor %}
+</ul>
+{% endif %}
+{{ form.username(placeholder="Username") }}
+
+{% if form.password.errors %}
+<ul class="errors">
+  {% for error in form.password.errors %}
+  <li>{{ error }}</li>
+  {% endfor %}
+</ul>
+{% endif %}
+{{ form.password(placeholder="Password") }}

--- a/warehouse/templates/includes/input-recaptcha.html
+++ b/warehouse/templates/includes/input-recaptcha.html
@@ -1,0 +1,12 @@
+{% if request.find_service(name="recaptcha").enabled %}
+  {% block top_script %}<script src='https://www.google.com/recaptcha/api.js'></script>{% endblock %}
+
+  <div class="g-recaptcha" data-sitekey="{{ request.registry.settings["recaptcha"]["site_key"] }}"></div>
+  {% if form.g_recaptcha_response.errors %}
+  <ul class="errors">
+    {% for error in form.g_recaptcha_response.errors %}
+    <li>{{ error }}</li>
+    {% endfor %}
+  </ul>
+  {% endif %}
+{% endif %}

--- a/warehouse/templates/includes/input-recaptcha.html
+++ b/warehouse/templates/includes/input-recaptcha.html
@@ -1,5 +1,7 @@
 {% if request.find_service(name="recaptcha").enabled %}
-  {% block top_script %}<script src='https://www.google.com/recaptcha/api.js'></script>{% endblock %}
+  {% block top_script %}
+  <script src="www.google.com/recaptcha/api.js"></script>
+  {% endblock %}
 
   <div class="g-recaptcha" data-sitekey="{{ request.registry.settings["recaptcha"]["site_key"] }}"></div>
   {% if form.g_recaptcha_response.errors %}

--- a/warehouse/templates/includes/input-recaptcha.html
+++ b/warehouse/templates/includes/input-recaptcha.html
@@ -1,6 +1,6 @@
 {% if request.find_service(name="recaptcha").enabled %}
   {% block top_script %}
-  <script src="www.google.com/recaptcha/api.js"></script>
+  <script src="https://www.google.com/recaptcha/api.js"></script>
   {% endblock %}
 
   <div class="g-recaptcha" data-sitekey="{{ request.registry.settings["recaptcha"]["site_key"] }}"></div>

--- a/warehouse/templates/includes/input-recaptcha.html
+++ b/warehouse/templates/includes/input-recaptcha.html
@@ -1,29 +1,28 @@
+{% macro recaptcha_callback() -%}
+  <script src="{{ request.static_path('warehouse:static/dist/js/recaptcha.js') }}"></script>
+{%- endmacro %}
+
 {% macro recaptcha_html() -%}
   {% if request.find_service(name="recaptcha").enabled %}
-    <div id="recaptcha-container" class="g-recaptcha"></div>
-    {% if form.g_recaptcha_response.errors %}
-    <ul class="errors">
-      {% for error in form.g_recaptcha_response.errors %}
-      <li>{{ error }}</li>
-      {% endfor %}
-    </ul>
-    {% endif %}
+  <div id="recaptcha-container"></div>
+  {% if form.g_recaptcha_response.errors %}
+  <ul class="errors">
+    {% for error in form.g_recaptcha_response.errors %}
+    <li>{{ error }}</li>
+    {% endfor %}
+  </ul>
+  {% endif %}
   {% endif %}
 {%- endmacro %}
 
 {% macro recaptcha_src() -%}
   {% if request.find_service(name="recaptcha").enabled %}
-    <script type="text/javascript">
-      var config = new Object();
-      config.sitekey = "{{ request.registry.settings["recaptcha"]["site_key"] }}";
-
-      var onloadCallback = function() {
-        grecaptcha.render(
-            document.getElementById("recaptcha-container"),
-            config
-        );
-      };
+    <script
+      id="recaptcha-js"
+      src="//www.google.com/recaptcha/api.js?onload=renderCaptcha&render=explicit"
+      data-site-key="{{ request.registry.settings["recaptcha"]["site_key"] }}"
+      async
+      defer>
     </script>
-    <script src="https://www.google.com/recaptcha/api.js?onload=onloadCallback&render=explicit" async defer></script>
   {% endif %}
 {%- endmacro %}

--- a/warehouse/templates/includes/input-recaptcha.html
+++ b/warehouse/templates/includes/input-recaptcha.html
@@ -1,14 +1,29 @@
-{% if request.find_service(name="recaptcha").enabled %}
-  {% block top_script %}
-  <script src="https://www.google.com/recaptcha/api.js"></script>
-  {% endblock %}
-
-  <div class="g-recaptcha" data-sitekey="{{ request.registry.settings["recaptcha"]["site_key"] }}"></div>
-  {% if form.g_recaptcha_response.errors %}
-  <ul class="errors">
-    {% for error in form.g_recaptcha_response.errors %}
-    <li>{{ error }}</li>
-    {% endfor %}
-  </ul>
+{% macro recaptcha_html() -%}
+  {% if request.find_service(name="recaptcha").enabled %}
+    <div id="recaptcha-container" class="g-recaptcha"></div>
+    {% if form.g_recaptcha_response.errors %}
+    <ul class="errors">
+      {% for error in form.g_recaptcha_response.errors %}
+      <li>{{ error }}</li>
+      {% endfor %}
+    </ul>
+    {% endif %}
   {% endif %}
-{% endif %}
+{%- endmacro %}
+
+{% macro recaptcha_src() -%}
+  {% if request.find_service(name="recaptcha").enabled %}
+    <script type="text/javascript">
+      var config = new Object();
+      config.sitekey = "{{ request.registry.settings["recaptcha"]["site_key"] }}";
+
+      var onloadCallback = function() {
+        grecaptcha.render(
+            document.getElementById("recaptcha-container"),
+            config
+        );
+      };
+    </script>
+    <script src="https://www.google.com/recaptcha/api.js?onload=onloadCallback&render=explicit" async defer></script>
+  {% endif %}
+{%- endmacro %}


### PR DESCRIPTION
New items:
- Recaptcha service (conditionally functional, dependent on env vars)
- forms.RegistrationForm
- Reusable recaptcha template

Also added the responses lib as a dependency for mocking recaptcha tests

Features:
- [x] reCaptcha service
- [x] Reusable reCapatcha template
- [x] ``forms.RegistrationForm``
- [x] ``views.register``

Review items:
- [x] Address SSL verification issue
- [x] Expose reCaptcha keys through make targets and docker-compose
- [x] Move from base ``requests.post`` to a thread local session implementation
- [x] Handle timeouts & other lower level socket errors in recaptcha.py
- [x] Security review on session handling in registration handler
- [x] Bottom load recaptcha scripts
- [x] Create a threadlocal requests session 
- [x] Configure sane timeouts for ``requests.Session`` instance