### PR TITLE
Boost name field relevancy

### DIFF
--- a/tests/unit/test_views.py
+++ b/tests/unit/test_views.py
@@ -133,9 +133,10 @@ class TestSearch:
                 "multi_match",
                 query="foo bar",
                 fields=[
-                    "name", "version", "author", "author_email", "maintainer",
-                    "maintainer_email", "home_page", "license", "summary",
-                    "description", "keywords", "platform", "download_url",
+                    "name^2", "version", "author", "author_email",
+                    "maintainer", "maintainer_email", "home_page", "license",
+                    "summary", "description", "keywords", "platform",
+                    "download_url",
                 ],
             ),
         ]
@@ -188,9 +189,10 @@ class TestSearch:
                 "multi_match",
                 query="foo bar",
                 fields=[
-                    "name", "version", "author", "author_email", "maintainer",
-                    "maintainer_email", "home_page", "license", "summary",
-                    "description", "keywords", "platform", "download_url",
+                    "name^2", "version", "author", "author_email",
+                    "maintainer", "maintainer_email", "home_page", "license",
+                    "summary", "description", "keywords", "platform",
+                    "download_url",
                 ],
             ),
         ]

--- a/warehouse/views.py
+++ b/warehouse/views.py
@@ -159,7 +159,7 @@ def search(request):
             "multi_match",
             query=request.params["q"],
             fields=[
-                "name", "version", "author", "author_email", "maintainer",
+                "name^2", "version", "author", "author_email", "maintainer",
                 "maintainer_email", "home_page", "license", "summary",
                 "description", "keywords", "platform", "download_url",
             ],


### PR DESCRIPTION
This PR fixes #1019 by making a match on the `name` field more relevant than any other fields.