### PR TITLE
Remove the CSP Report URI support

### DIFF
--- a/tests/unit/test_csp.py
+++ b/tests/unit/test_csp.py
@@ -175,12 +175,7 @@ def test_includeme():
             lambda fact, name: None),
         add_settings=pretend.call_recorder(lambda settings: None),
         add_tween=pretend.call_recorder(lambda tween: None),
-        registry=pretend.stub(
-            settings={
-                "camo.url": "camo.url.value",
-                "csp.report_uri": "csp.report_uri.value",
-            }
-        ),
+        registry=pretend.stub(settings={"camo.url": "camo.url.value"}),
     )
     csp.includeme(config)
 
@@ -206,7 +201,6 @@ def test_includeme():
                 ],
                 "referrer": ["origin-when-cross-origin"],
                 "reflected-xss": ["block"],
-                "report-uri": ["csp.report_uri.value"],
                 "script-src": ["'self'"],
                 "style-src": ["'self'", "fonts.googleapis.com"],
             },

--- a/warehouse/config.py
+++ b/warehouse/config.py
@@ -142,7 +142,6 @@ def configure(settings=None):
     maybe_set(settings, "aws.region", "AWS_REGION")
     maybe_set(settings, "celery.broker_url", "AMQP_URL")
     maybe_set(settings, "celery.result_url", "REDIS_URL")
-    maybe_set(settings, "csp.report_uri", "CSP_REPORT_URI")
     maybe_set(settings, "database.url", "DATABASE_URL")
     maybe_set(settings, "elasticsearch.url", "ELASTICSEARCH_URL")
     maybe_set(settings, "sentry.dsn", "SENTRY_DSN")

--- a/warehouse/csp.py
+++ b/warehouse/csp.py
@@ -63,7 +63,6 @@ def includeme(config):
             ],
             "referrer": ["origin-when-cross-origin"],
             "reflected-xss": ["block"],
-            "report-uri": [config.registry.settings.get("csp.report_uri")],
             "script-src": ["'self'"],
             "style-src": ["'self'", "fonts.googleapis.com"],
         },


### PR DESCRIPTION
After having this running, it appears these are almost 100% caused by people's addons, making it a bunch of noise with no actionable feedback. We'll just drop this since it doesn't seem valuable.