### PR TITLE
Relax CSP for XML pages

### DIFF
--- a/tests/unit/rss/test_views.py
+++ b/tests/unit/rss/test_views.py
@@ -12,11 +12,23 @@
 
 import datetime
 
+import pretend
+
 from warehouse.rss import views as rss
 from ...common.db.packaging import ProjectFactory, ReleaseFactory
 
 
 def test_rss_updates(db_request):
+    db_request.find_service = pretend.call_recorder(
+        lambda *args, **kwargs: pretend.stub(
+            enabled=False,
+            csp_policy=pretend.stub(),
+            merge=lambda _: None,
+        )
+    )
+
+    db_request.session = pretend.stub()
+
     project1 = ProjectFactory.create()
     project2 = ProjectFactory.create()
 
@@ -34,6 +46,16 @@ def test_rss_updates(db_request):
 
 
 def test_rss_packages(db_request):
+    db_request.find_service = pretend.call_recorder(
+        lambda *args, **kwargs: pretend.stub(
+            enabled=False,
+            csp_policy=pretend.stub(),
+            merge=lambda _: None,
+        )
+    )
+
+    db_request.session = pretend.stub()
+
     project1 = ProjectFactory.create()
     project1.created = datetime.date(2011, 1, 1)
     ReleaseFactory.create(project=project1)

--- a/tests/unit/sitemap/test_views.py
+++ b/tests/unit/sitemap/test_views.py
@@ -19,6 +19,14 @@ from ...common.db.packaging import ProjectFactory
 
 
 def test_sitemap_index(db_request):
+    db_request.find_service = pretend.call_recorder(
+        lambda *args, **kwargs: pretend.stub(
+            enabled=False,
+            csp_policy=pretend.stub(),
+            merge=lambda _: None,
+        )
+    )
+
     project = ProjectFactory.create(name="foobar")
     users = [
         UserFactory.create(username="a"),
@@ -42,6 +50,14 @@ def test_sitemap_index(db_request):
 
 
 def test_sitemap_bucket(db_request):
+    db_request.find_service = pretend.call_recorder(
+        lambda *args, **kwargs: pretend.stub(
+            enabled=False,
+            csp_policy=pretend.stub(),
+            merge=lambda _: None,
+        )
+    )
+
     expected = ["/project/foobar/"]
     expected_iter = iter(expected)
     db_request.route_url = pretend.call_recorder(
@@ -59,6 +75,14 @@ def test_sitemap_bucket(db_request):
 
 
 def test_sitemap_bucket_too_many(monkeypatch, db_request):
+    db_request.find_service = pretend.call_recorder(
+        lambda *args, **kwargs: pretend.stub(
+            enabled=False,
+            csp_policy=pretend.stub(),
+            merge=lambda _: None,
+        )
+    )
+
     db_request.route_url = pretend.call_recorder(lambda *a, **kw: "/")
     db_request.matchdict["bucket"] = "5"
 

--- a/warehouse/rss/views.py
+++ b/warehouse/rss/views.py
@@ -15,6 +15,7 @@ from sqlalchemy.orm import joinedload
 
 from warehouse.cache.origin import origin_cache
 from warehouse.packaging.models import Project, Release
+from warehouse.xml import XML_CSP
 
 
 @view_config(
@@ -30,6 +31,8 @@ from warehouse.packaging.models import Project, Release
 )
 def rss_updates(request):
     request.response.content_type = "text/xml"
+
+    request.find_service(name="csp").merge(XML_CSP)
 
     latest_releases = (
         request.db.query(Release)
@@ -55,6 +58,8 @@ def rss_updates(request):
 )
 def rss_packages(request):
     request.response.content_type = "text/xml"
+
+    request.find_service(name="csp").merge(XML_CSP)
 
     newest_projects = (
         request.db.query(Project)

--- a/warehouse/sitemap/views.py
+++ b/warehouse/sitemap/views.py
@@ -20,6 +20,7 @@ from warehouse.accounts.models import User
 from warehouse.cache.origin import origin_cache
 from warehouse.cache.http import cache_control
 from warehouse.packaging.models import Project
+from warehouse.xml import XML_CSP
 
 
 SITEMAP_MAXSIZE = 50000
@@ -43,6 +44,8 @@ Bucket = collections.namedtuple("Bucket", ["name", "modified"])
 )
 def sitemap_index(request):
     request.response.content_type = "text/xml"
+
+    request.find_service(name="csp").merge(XML_CSP)
 
     # We have > 50,000 URLs on PyPI and a single sitemap file can only support
     # a maximum of 50,000 URLs. We need to split our URLs up into multiple
@@ -98,6 +101,8 @@ def sitemap_index(request):
 )
 def sitemap_bucket(request):
     request.response.content_type = "text/xml"
+
+    request.find_service(name="csp").merge(XML_CSP)
 
     bucket = request.matchdict["bucket"]
 

--- a/warehouse/xml.py
+++ b/warehouse/xml.py
@@ -1,0 +1,1 @@
+XML_CSP = {"style-src": ["'unsafe-inline'"]}


### PR DESCRIPTION
This PR relaxes the CSP on XML pages to allow browsers such as Chrome to inline styles and images.

Before:
<img width="535" alt="screen shot 2016-03-18 at 6 25 17 pm" src="https://cloud.githubusercontent.com/assets/294415/13893667/f0ec9248-ed36-11e5-81f1-07196cd0effb.png">

After:
<img width="582" alt="screen shot 2016-03-18 at 6 24 27 pm" src="https://cloud.githubusercontent.com/assets/294415/13893673/f6879b8a-ed36-11e5-82cb-4a0233578ce3.png">
