### PR TITLE
Use correct requirements for ES dependencies

### DIFF
--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -13,8 +13,8 @@ cffi==1.5.2
 click==6.3
 contextlib2==0.5.1
 docutils==0.12
-elasticsearch-dsl==2.0.0
-elasticsearch==2.3.0
+elasticsearch-dsl<2.0.0
+elasticsearch>=1.0.0,<2.0.0
 hiredis==0.2.0
 html5lib==0.9999999
 itsdangerous==0.24


### PR DESCRIPTION
We are using Elasticsearch 1.7 (https://github.com/pypa/warehouse/blob/master/docker-compose.yml#L11) but the versions of `elasticsearch` and `elasticsearch-dsl` packages which correspond to version 2.x.

(See https://github.com/elastic/elasticsearch-py#compatibility and https://github.com/elastic/elasticsearch-dsl-py#compatibility)

This PR pins the requirements to be compatible with Elasticsearch 1.7.