### PR TITLE
Return to first tab if hash becomes empty

### DIFF
--- a/warehouse/static/js/main.js
+++ b/warehouse/static/js/main.js
@@ -31,7 +31,7 @@ $(document).ready(function() {
   }
 
   window.onhashchange = function() {
-    setTab(getTab(location.hash));
+    setTab(getTab(location.hash) || getTab(":first"));
   };
 
   // Set the tab if the hash is valid, otherwise show the first tab


### PR DESCRIPTION
This PR fixes an issue with the tabs on the package detail page, where it would not return to the first tab if the hash becomes empty.