### PR TITLE
Add classifiers to search

### DIFF
--- a/tests/common/db/classifiers.py
+++ b/tests/common/db/classifiers.py
@@ -1,0 +1,28 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import factory
+import factory.fuzzy
+
+from warehouse.classifiers.models import Classifier
+
+from .base import WarehouseFactory
+
+
+class ClassifierFactory(WarehouseFactory):
+    class Meta:
+        model = Classifier
+
+    l2 = factory.fuzzy.FuzzyInteger(0)
+    l3 = factory.fuzzy.FuzzyInteger(0)
+    l4 = factory.fuzzy.FuzzyInteger(0)
+    l5 = factory.fuzzy.FuzzyInteger(0)

--- a/tests/unit/packaging/test_search.py
+++ b/tests/unit/packaging/test_search.py
@@ -39,6 +39,10 @@ def test_build_search():
         keywords="the, keywords, lol",
         platform="any platform",
         created=datetime.datetime(1956, 1, 31),
+        _classifiers=[
+            pretend.stub(classifier='Alpha'),
+            pretend.stub(classifier='Beta'),
+        ],
         uploader=pretend.stub(
             username="some-username",
             name="the-users-name",
@@ -60,5 +64,6 @@ def test_build_search():
     assert obj["keywords"] == "the, keywords, lol"
     assert obj["platform"] == "any platform"
     assert obj["created"] == datetime.datetime(1956, 1, 31)
+    assert obj["classifiers"] == ['Alpha', 'Beta']
     assert obj["uploader_name"] == "the-users-name"
     assert obj["uploader_username"] == "some-username"

--- a/warehouse/packaging/search.py
+++ b/warehouse/packaging/search.py
@@ -40,6 +40,7 @@ class Project(DocType):
     keywords = String(analyzer="snowball")
     platform = String(index="not_analyzed")
     created = Date()
+    classifiers = String(index="not_analyzed", multi=True)
 
     uploader_name = String()
     uploader_username = String()
@@ -65,6 +66,7 @@ class Project(DocType):
         obj["keywords"] = release.keywords
         obj["platform"] = release.platform
         obj["created"] = release.created
+        obj["classifiers"] = [c.classifier for c in release._classifiers]
 
         obj["uploader_name"] = release.uploader.name
         obj["uploader_username"] = release.uploader.username

--- a/warehouse/static/js/main.js
+++ b/warehouse/static/js/main.js
@@ -79,6 +79,11 @@ $(document).ready(function() {
     this.form.submit();
   });
 
+  // Trove classifiers
+  $("#classifiers :checkbox").change(function () {
+    this.form.submit();
+  });
+
   $.timeago.settings.cutoff = 7 * 24 * 60 * 60 * 1000;  // One week
 
   // document.l10n.ready.then(function() {

--- a/warehouse/templates/search/results.html
+++ b/warehouse/templates/search/results.html
@@ -60,24 +60,31 @@
       <aside class="panel-overlay">
         <a class="-js-close-panel"><i class="fa fa-close"></i></a>
         <h2 {{ l20n("filterProjects") }}>Filter Projects</h2>
-        <div class="expander">
-          <a class="-js-expander-trigger expander-hidden" {{ l20n("filterProjectsByDevStatus") }}>By Development Status</a>
-          <div class="expander-content">
-            <div class="checkbox-tree">
-              <label><input type="checkbox"><span>1 - Planning</span></label>
-              <label><input type="checkbox"><span>2 - Pre-Alpha</span></label>
-              <label><input type="checkbox"><span>3 - Alpha</span></label>
-              <label><input type="checkbox"><span>4 - Beta</span></label>
-              <label><input type="checkbox"><span>5 - Production/Stable</span></label>
-              <label><input type="checkbox"><span>6 - Mature</span></label>
-              <label><input type="checkbox"><span>7 - Inactive</span></label>
+        <form id="classifiers">
+        <input id="search" type="hidden" name="q" {{ l20n("search") }} value="{{ term }}">
+        <input type="hidden" name="o" value="{{ order }}">
+
+        {% for top_level, classifiers in available_filters %}
+          <div class="expander">
+            <a class="-js-expander-trigger {{'expander-hidden' if not loop.first }}" {{ l20n("filterProjectsBy{}".format(top_level.replace(' ', ''))) }}>By {{ top_level }}</a>
+            <div class="expander-content">
+              <div class="checkbox-tree">
+              {% for classifier in classifiers %}
+                {% set sub_levels = classifier.split(' :: ') %}
+                {{ ("&nbsp;&nbsp;&nbsp;&nbsp;"*(sub_levels|length))|safe }}
+                <input name="c" type="checkbox" id="{{ classifier }}" value="{{ classifier }}" {{ 'checked' if classifier in applied_filters else '' }}>
+                <label for="{{ classifier }}">{{ sub_levels[-1] }}</label><br>
+              {% endfor %}
+              </div>
             </div>
           </div>
-        </div>
+        {% endfor %}
+        </form>
       </aside>
     </div>
 
     <div class="main">
+      <form action="{{ request.route_path('search') }}">
       <section class="split-layout -table">
         {% if term %}
         <p {{ l20n("numberOfSearchResultsWithTerm", number=page.item_count, term=term) }}>
@@ -91,7 +98,6 @@
           <strong>{{ page.item_count }}</strong> projects.
         </p>
         {% endif %}
-        <form action="{{ request.route_path('search') }}">
           <p>
             <input id="search" type="hidden" name="q" {{ l20n("search") }} value="{{ term }}">
             <label for="order" {{ l20n("orderPackagesBy") }}>Order packages by &nbsp;</label>
@@ -100,21 +106,19 @@
               {{ search_option("Date Last Updated", "-created", "dateLastUpdated") }}
             </select>
           </p>
-        </form>
       </section>
 
       <div class="applied-filters">
+      {% if applied_filters %}
+      {% for filter in applied_filters %}
         <div class="filter">
+          <input type="hidden" name="c" value="{{ filter }}">
           <i class="fa fa-filter"></i>
-          <span>Framework :: TODO</span>
+          <span>{{ filter }}</span>
           <a href="#"><i class="fa fa-close"></i></a>
         </div>
-
-        <div class="filter">
-          <i class="fa fa-filter"></i>
-          <span>Topic :: TODO</span>
-          <a href="#"><i class="fa fa-close"></i></a>
-        </div>
+      {% endfor %}
+      {% endif %}
 
         <a class="-js-add-filter wh-button -small" {{ l20n("addFilter") }} href="#">Add Filter</a>
       </div>
@@ -138,6 +142,7 @@
         {{ page.pager()|safe }}
       </section>
 
+      </form>
     </div>
   </div>
 </section>


### PR DESCRIPTION
This PR addresses the "faceting" part of #702 by adding the PyPI classifiers to the search page.

<img width="618" alt="screen shot 2016-03-22 at 5 19 40 pm" src="https://cloud.githubusercontent.com/assets/294415/13968525/8f62bc8a-f053-11e5-81ba-f7ca720a3e07.png">

A few notes about things I was unsure of:
- Multiple classifiers act as a union (not an intersection). Not sure if this was the original intention.
- Selecting a checkbox for a classifier immediately submits the form. I wasn't sure how the UI should work here without introducing a lot of AJAX complexity, and it didn't feel intuitive to have the user scroll back up to the "Search" button to submit the form.
- A new search from the search bar currently clears the classifiers (and the ordering) thus starting a new search, but this can be easily changed.

Things I am leaving for a future PR (or for @nlhkabu):
- Only way to remove classifiers is unchecking their checkbox. The "X" box on the filter is not wired up.
- Classifiers are just nested/indented with multiple `&nbsp;`s
- #755 is still valid