### PR TITLE
Remove modernizr

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -6,7 +6,6 @@ var cssnano = require("gulp-cssnano"),
     imageminOptipng = require("imagemin-optipng"),
     install = require("gulp-install"),
     mainBowerFiles = require("main-bower-files"),
-    modernizr = require("gulp-modernizr"),
     path = require("path"),
     rename = require("gulp-rename"),
     revAll = require("gulp-rev-all"),
@@ -103,12 +102,6 @@ gulp.task("dist:js", function() {
              .pipe(gulp.dest(dstPaths.js));
 });
 
-gulp.task("dist:modernizr", function() {
-  return gulp.src(path.join(dstPaths.js, "**", "*.js"))
-             .pipe(modernizr({ options : ["setClasses"] }))
-             .pipe(uglify({ preserveComments: "license" }))
-             .pipe(gulp.dest(dstPaths.components));
-});
 
 gulp.task("dist:manifest", function() {
   var revision = new revAll({ fileNameManifest: "manifest.json" });
@@ -124,7 +117,6 @@ gulp.task("dist", function(cb) {
   return gulpSequence(
     "clean",
     ["dist:components", "dist:css", "dist:images", "dist:js"],
-    "dist:modernizr",
     "dist:manifest"
   )(cb);
 });

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "gulp-cssnano": "^2.1.0",
     "gulp-imagemin": "^2.4.0",
     "gulp-install": "^0.6.0",
-    "gulp-modernizr": "^1.0.0-alpha",
     "gulp-rename": "^1.2.2",
     "gulp-rev-all": "^0.8.22",
     "gulp-sass": "^2.1.0",

--- a/warehouse/templates/base.html
+++ b/warehouse/templates/base.html
@@ -12,10 +12,10 @@
  # limitations under the License.
 -#}
 <!DOCTYPE html>
-<!--[if lt IE 7]>      <html class="no-js lt-ie9 lt-ie8 lt-ie7" lang="en"> <![endif]-->
-<!--[if IE 7]>         <html class="no-js lt-ie9 lt-ie8" lang="en"> <![endif]-->
-<!--[if IE 8]>         <html class="no-js lt-ie9" lang="en"> <![endif]-->
-<!--[if gt IE 8]><!--> <html class="no-js" lang="en"> <!--<![endif]-->
+<!--[if lt IE 7]>      <html class="lt-ie9 lt-ie8 lt-ie7" lang="en"> <![endif]-->
+<!--[if IE 7]>         <html class="lt-ie9 lt-ie8" lang="en"> <![endif]-->
+<!--[if IE 8]>         <html class="lt-ie9" lang="en"> <![endif]-->
+<!--[if gt IE 8]><!--> <html lang="en"> <!--<![endif]-->
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -35,7 +35,6 @@
     <link rel="alternate" type="application/rss+xml" title="RSS: 40 latest updates" href="{{ request.route_path('rss.updates') }}">
     <link rel="alternate" type="application/rss+xml" title="RSS: 40 newest packages" href="{{ request.route_path('rss.packages') }}">
 
-    <script src="{{ request.static_path('warehouse:static/dist/components/modernizr.js') }}"></script>
     {# TODO: We need a solution to https://github.com/pypa/warehouse/issues/833
      #       before we can progress on this. Currently this breaks html_include
      #}


### PR DESCRIPTION
Our new browser support policy no longer requires the use of modernizr, so we'll remove it to improve page load.