### PR TITLE
Remove IE conditional html classes

### DIFF
--- a/warehouse/templates/base.html
+++ b/warehouse/templates/base.html
@@ -12,10 +12,7 @@
  # limitations under the License.
 -#}
 <!DOCTYPE html>
-<!--[if lt IE 7]>      <html class="lt-ie9 lt-ie8 lt-ie7" lang="en"> <![endif]-->
-<!--[if IE 7]>         <html class="lt-ie9 lt-ie8" lang="en"> <![endif]-->
-<!--[if IE 8]>         <html class="lt-ie9" lang="en"> <![endif]-->
-<!--[if gt IE 8]><!--> <html lang="en"> <!--<![endif]-->
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">


### PR DESCRIPTION
We don't support any of the Internet Explorer versions that these conditionals were checking for, making them pointless.