### PR TITLE
Move all package.json devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,21 +3,16 @@
     "node": "5.5.0"
   },
   "dependencies": {
-    "babel-polyfill": "6.7.4",
-    "font-awesome": "4.5.0",
-    "jquery": "2.2.2",
-    "timeago": "1.5.2",
-    "whatwg-fetch": "0.11.0"
-  },
-  "devDependencies": {
     "babel-core": "6.7.4",
     "babel-loader": "6.2.4",
+    "babel-polyfill": "6.7.4",
     "babel-preset-es2015": "6.6.0",
     "babel-preset-es2015-native-modules": "6.6.0",
     "babel-register": "6.7.2",
     "del": "2.2.0",
     "eslint": "2.7.0",
     "exports-loader": "0.6.3",
+    "font-awesome": "4.5.0",
     "gulp": "3.9.1",
     "gulp-batch": "1.0.5",
     "gulp-cssnano": "2.1.1",
@@ -30,11 +25,14 @@
     "gulp-uglify": "1.5.3",
     "gulp-watch": "4.3.5",
     "imports-loader": "0.6.5",
+    "jquery": "2.2.2",
     "node-sass": "3.4.2",
+    "timeago": "1.5.2",
     "uglify-js": "2.6.2",
     "vinyl-named": "1.1.0",
     "webpack": "2.1.0-beta.4",
-    "webpack-stream": "3.1.0"
+    "webpack-stream": "3.1.0",
+    "whatwg-fetch": "0.11.0"
   },
   "eslintConfig": {
     "env": {


### PR DESCRIPTION
Heroku only installs regular dependency in a Node.js application, however we need all of our dependencies to build our static files, so we'll just make them all regular dependencies.