### PR TITLE
Correctly get the service factory when origin purging

### DIFF
--- a/warehouse/cache/origin/__init__.py
+++ b/warehouse/cache/origin/__init__.py
@@ -41,7 +41,7 @@ def execute_purge(config, session):
     purges = session.info.pop("warehouse.cache.origin.purges", set())
 
     try:
-        cacher_factory = config.find_service_factory(IOriginCache)
+        cacher_factory = config.find_service_factory(IOriginCache).factory
     except ValueError:
         return
 


### PR DESCRIPTION
Changes to the pyramid_services library has caused ``find_service_factory`` to return a ``ServiceInfo`` object instead of the factory itself. We've adjusted the call to handle this change and refactored a test so that it will catch a change like this in the future.