### PR TITLE
Prevent search pagination deeper than 10,000 items

### DIFF
--- a/tests/unit/utils/test_paginate.py
+++ b/tests/unit/utils/test_paginate.py
@@ -94,6 +94,18 @@ class TestElasticsearchWrapper:
         assert wrapper[1:3] == [2, 3]
         assert len(wrapper) == 6
 
+    def test_slice_start_clamps_to_max(self):
+        wrapper = paginate._ElasticsearchWrapper(FakeQuery([1, 2, 3, 4, 5, 6]))
+        wrapper.max_results = 5
+        assert wrapper[6:10] == []
+        assert len(wrapper) == 5
+
+    def test_slice_end_clamps_to_max(self):
+        wrapper = paginate._ElasticsearchWrapper(FakeQuery([1, 2, 3, 4, 5, 6]))
+        wrapper.max_results = 5
+        assert wrapper[1:10] == [2, 3, 4, 5]
+        assert len(wrapper) == 5
+
     def test_second_slice_fails(self):
         wrapper = paginate._ElasticsearchWrapper(FakeQuery([1, 2, 3, 4, 5, 6]))
         wrapper[1:3]

--- a/warehouse/utils/paginate.py
+++ b/warehouse/utils/paginate.py
@@ -15,12 +15,30 @@ from paginate import Page
 
 class _ElasticsearchWrapper:
 
+    max_results = 10000
+
     def __init__(self, query):
         self.query = query
         self.results = None
         self.best_guess = None
 
     def __getitem__(self, range):
+        # If we're asking for a range that extends past our maximum results,
+        # then we need to clamp the start of our slice to our maximum results
+        # size, and make sure that the end of our slice >= to that to ensure a
+        # consistent slice.
+        if range.start > self.max_results:
+            range = slice(
+                self.max_results,
+                max(range.stop, self.max_results),
+                range.step,
+            )
+
+        # If we're being asked for a range that extends past our maximum result
+        # then we'll clamp it to the maximum result size and stop there.
+        if range.stop > self.max_results:
+            range = slice(range.start, self.max_results, range.step)
+
         if self.results is not None:
             raise RuntimeError("Cannot reslice after having already sliced.")
         self.results = self.query[range].execute()
@@ -35,7 +53,7 @@ class _ElasticsearchWrapper:
     def __len__(self):
         if self.results is None:
             raise RuntimeError("Cannot get length until a slice.")
-        return self.results.hits.total
+        return min(self.results.hits.total, self.max_results)
 
 
 def ElasticsearchPage(*args, **kwargs):  # noqa

--- a/warehouse/views.py
+++ b/warehouse/views.py
@@ -11,7 +11,7 @@
 # limitations under the License.
 
 from pyramid.httpexceptions import (
-    HTTPException, HTTPSeeOther, HTTPMovedPermanently,
+    HTTPException, HTTPSeeOther, HTTPMovedPermanently, HTTPNotFound,
 )
 from pyramid.view import (
     notfound_view_config, forbidden_view_config, view_config,
@@ -173,11 +173,15 @@ def search(request):
     if request.params.get("o"):
         query = query.sort(request.params["o"])
 
+    page_num = int(request.params.get("page", 1))
     page = ElasticsearchPage(
         query,
-        page=int(request.params.get("page", 1)),
+        page=page_num,
         url_maker=paginate_url_factory(request),
     )
+
+    if page_num > page.page_count:
+        raise HTTPNotFound
 
     return {
         "page": page,


### PR DESCRIPTION
Elasticsearch (and distributed search engines in general) get a pathological behavior when attempting to paginate too deeply into their result set. Since it's unlikely that anyone is going to need a result past the 500th page, we'll just limit the total number of items that we can return to 10,000.

In addition, we'll make any attempt to view a page past the end of the result set for a search query result in a 404 error.

Fixes #1076