### PR TITLE
Refactor Read Only Support

### DIFF
--- a/warehouse/db.py
+++ b/warehouse/db.py
@@ -13,6 +13,7 @@
 import functools
 
 import alembic.config
+import psycopg2.extensions
 import sqlalchemy
 import venusian
 import zope.sqlalchemy
@@ -26,6 +27,9 @@ from warehouse.utils.attrs import make_repr
 
 
 __all__ = ["includeme", "metadata", "ModelBase"]
+
+
+DEFAULT_ISOLATION = "SERIALIZABLE"
 
 
 # We'll add a basic predicate that won't do anything except allow marking a
@@ -98,29 +102,69 @@ def _configure_alembic(config):
     return alembic_cfg
 
 
-def _create_session(request):
-    # Create our session
-    session = Session(bind=request.registry["sqlalchemy.engine"])
+def _reset(dbapi_connection, connection_record):
+    # Determine if we need to reset the connection, and if so go ahead and
+    # set it back to our default isolation level.
+    needs_reset = connection_record.info.pop("warehouse.needs_reset", False)
+    if needs_reset:
+        dbapi_connection.set_session(
+            isolation_level=DEFAULT_ISOLATION,
+            readonly=False,
+            deferrable=False,
+        )
 
-    # Set our transaction to read only if the route has been marked as read
-    # only.
-    for predicate in request.matched_route.predicates:
-        if isinstance(predicate, ReadOnlyPredicate) and predicate.val:
-            session.execute(
-                """ SET TRANSACTION
-                    ISOLATION LEVEL SERIALIZABLE READ ONLY DEFERRABLE
-                """
-            )
+
+def _create_engine(url):
+    engine = sqlalchemy.create_engine(url, isolation_level=DEFAULT_ISOLATION)
+    event.listen(engine, "reset", _reset)
+    return engine
+
+
+def _create_session(request):
+    # Create our connection, most likely pulling it from the pool of
+    # connections
+    connection = request.registry["sqlalchemy.engine"].connect()
+    if (connection.connection.get_transaction_status() !=
+            psycopg2.extensions.TRANSACTION_STATUS_IDLE):
+        # Work around a bug where SQLALchemy leaves the initial connection in
+        # a pool inside of a transaction.
+        # TODO: Remove this in the future, brand new connections on a fresh
+        #       instance should not raise an Exception.
+        connection.connection.rollback()
+
+    # Now that we have a connection, we're going to go and set it to the
+    # correct isolation level.
+    if request.read_only:
+        connection.info["warehouse.needs_reset"] = True
+        connection.connection.set_session(
+            isolation_level="SERIALIZABLE",
+            readonly=True,
+            deferrable=True,
+        )
+
+    # Now, create a session from our connection
+    session = Session(bind=connection)
 
     # Register only this particular session with zope.sqlalchemy
     zope.sqlalchemy.register(session, transaction_manager=request.tm)
 
-    # Set a finished callback to close the session at the end of the HTTP
-    # request so that the connection is returned to the pool.
-    request.add_finished_callback(lambda request: request.db.close())
+    # Setup a callback that will ensure that everything is cleaned up at the
+    # end of our connection.
+    @request.add_finished_callback
+    def cleanup(request):
+        session.close()
+        connection.close()
 
     # Return our session now that it's created and registered
     return session
+
+
+def _readonly(request):
+    for predicate in request.matched_route.predicates:
+        if isinstance(predicate, ReadOnlyPredicate) and predicate.val:
+            return True
+
+    return False
 
 
 def includeme(config):
@@ -128,9 +172,8 @@ def includeme(config):
     config.add_directive("alembic_config", _configure_alembic)
 
     # Create our SQLAlchemy Engine.
-    config.registry["sqlalchemy.engine"] = sqlalchemy.create_engine(
+    config.registry["sqlalchemy.engine"] = _create_engine(
         config.registry.settings["database.url"],
-        isolation_level="SERIALIZABLE",
     )
 
     # Register our request.db property
@@ -138,3 +181,7 @@ def includeme(config):
 
     # Add a route predicate to mark a route as read only.
     config.add_route_predicate("read_only", ReadOnlyPredicate)
+
+    # Add a request.read_only property which can be used to determine if a
+    # request is being acted upon as a read-only request or not.
+    config.add_request_method(_readonly, name="read_only", reify=True)


### PR DESCRIPTION
Setup the Read Only transaction so that it will occur *prior* to actually starting the transaction. This is important because ``SERIALIZABLE READ ONLY DEFERRABLE`` relies on this behavior. In addition, we'll use the SQLAlchemy event system to better handle reseting the connection to our default state.