### PR TITLE
Use a hash based file paths on *new* uploads

### DIFF
--- a/requirements/main.in
+++ b/requirements/main.in
@@ -16,6 +16,7 @@ packaging>=15.2
 paginate>=0.5.2
 passlib>=1.6.4
 psycopg2
+pyblake2
 pyramid>=1.7a1
 pyramid_jinja2>=2.5
 pyramid_multiauth

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -85,6 +85,8 @@ PasteDeploy==1.5.2 \
     --hash=sha256:d5858f89a255e6294e63ed46b73613c56e3b9a2d82a42f1df4d06c8421a9e3cb
 psycopg2==2.6.1 \
     --hash=sha256:6acf9abbbe757ef75dc2ecd9d91ba749547941abaffbe69ff2086a9e37d4904c
+pyblake2==0.9.3 \
+    --hash=sha256:626448e1fe1cc01d2197118954bec9f158378577e12686d5b01979f7f0fa2212
 pycparser==2.14 \
     --hash=sha256:7959b4a74abdc27b312fed1c21e6caf9309ce0b29ea86b591fd2e99ecdf27f73
 Pygments==2.1.3 \

--- a/tests/unit/legacy/api/test_pypi.py
+++ b/tests/unit/legacy/api/test_pypi.py
@@ -12,7 +12,6 @@
 
 import hashlib
 import io
-import os.path
 import re
 import tempfile
 import zipfile
@@ -733,12 +732,12 @@ class TestFileUpload:
         assert db_request.find_service.calls == [pretend.call(IFileStorage)]
         assert len(storage_service.store.calls) == 2 if has_signature else 1
         assert storage_service.store.calls[0] == pretend.call(
-            os.path.join(
-                "source",
-                project.name[0],
-                project.name,
+            "/".join([
+                "4e",
+                "6e",
+                "fa4c0ee2bbad071b4f5b5ea68f1aea89fa716e7754eb13e2314d45a5916e",
                 filename,
-            ),
+            ]),
             mock.ANY,
             meta={
                 "project": project.normalized_name,
@@ -750,12 +749,15 @@ class TestFileUpload:
 
         if has_signature:
             assert storage_service.store.calls[1] == pretend.call(
-                os.path.join(
-                    "source",
-                    project.name[0],
-                    project.name,
+                "/".join([
+                    "4e",
+                    "6e",
+                    (
+                        "fa4c0ee2bbad071b4f5b5ea68f1aea89fa716e7754eb13e2314d"
+                        "45a5916e"
+                    ),
                     filename + ".asc",
-                ),
+                ]),
                 mock.ANY,
                 meta={
                     "project": project.normalized_name,
@@ -1352,12 +1354,15 @@ class TestFileUpload:
         assert db_request.find_service.calls == [pretend.call(IFileStorage)]
         assert storage_service.store.calls == [
             pretend.call(
-                os.path.join(
-                    "cp34",
-                    project.name[0],
-                    project.name,
+                "/".join([
+                    "4e",
+                    "6e",
+                    (
+                        "fa4c0ee2bbad071b4f5b5ea68f1aea89fa716e7754eb13e2314d4"
+                        "5a5916e"
+                    ),
                     filename,
-                ),
+                ]),
                 mock.ANY,
                 meta={
                     "project": project.normalized_name,

--- a/tests/unit/packaging/test_services.py
+++ b/tests/unit/packaging/test_services.py
@@ -297,3 +297,23 @@ class TestS3FileStorage:
                 ExtraArgs={"Metadata": {"foo": "bar"}},
             ),
         ]
+
+    def test_hashed_path_with_prefix(self):
+        s3key = pretend.stub(get=lambda: {"Body": io.BytesIO(b"my contents")})
+        bucket = pretend.stub(Object=pretend.call_recorder(lambda path: s3key))
+        storage = S3FileStorage(bucket, prefix="packages/")
+
+        file_object = storage.get("ab/file.txt")
+
+        assert file_object.read() == b"my contents"
+        assert bucket.Object.calls == [pretend.call("packages/ab/file.txt")]
+
+    def test_hashed_path_without_prefix(self):
+        s3key = pretend.stub(get=lambda: {"Body": io.BytesIO(b"my contents")})
+        bucket = pretend.stub(Object=pretend.call_recorder(lambda path: s3key))
+        storage = S3FileStorage(bucket)
+
+        file_object = storage.get("ab/file.txt")
+
+        assert file_object.read() == b"my contents"
+        assert bucket.Object.calls == [pretend.call("ab/file.txt")]

--- a/warehouse/migrations/versions/0977b97fce94_add_file_blake2_256_digest.py
+++ b/warehouse/migrations/versions/0977b97fce94_add_file_blake2_256_digest.py
@@ -1,0 +1,44 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Add File.blake2_256_digest
+
+Revision ID: 0977b97fce94
+Revises: f46672a776f1
+Create Date: 2016-04-18 20:40:22.101245
+"""
+
+import citext
+import sqlalchemy as sa
+
+from alembic import op
+
+
+revision = "0977b97fce94"
+down_revision = "f46672a776f1"
+
+
+def upgrade():
+    op.add_column(
+        "release_files",
+        sa.Column("blake2_256_digest", citext.CIText(), nullable=True),
+    )
+    op.create_unique_constraint(None, "release_files", ["blake2_256_digest"])
+    op.create_check_constraint(
+        None,
+        "release_files",
+        "sha256_digest ~* '^[A-F0-9]{64}$'",
+    )
+
+
+def downgrade():
+    raise RuntimeError("Cannot Go Backwards In Time.")

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -350,6 +350,7 @@ class File(db.Model):
         ),
 
         CheckConstraint("sha256_digest ~* '^[A-F0-9]{64}$'"),
+        CheckConstraint("blake2_256_digest ~* '^[A-F0-9]{64}$'"),
 
         Index("release_files_name_idx", "name"),
         Index("release_files_name_version_idx", "name", "version"),
@@ -373,6 +374,7 @@ class File(db.Model):
     has_signature = Column(Boolean)
     md5_digest = Column(Text, unique=True)
     sha256_digest = Column(CIText, unique=True, nullable=False)
+    blake2_256_digest = Column(CIText, unique=True, nullable=True)
     downloads = Column(Integer, server_default=sql.text("0"))
     upload_time = Column(DateTime(timezone=False), server_default=func.now())
 


### PR DESCRIPTION
Instead of using a file path like ``{pyver}/{name[0]}/{name}/{filename}``, we will instead use one that looks like ``{hash[:2]}/{hash[2:4]}/{hash[4:]}{filename}``, where `hash` is the blake2b(digest_size=32) hex digest (lowercased) of the actual file contents. This will ensure that the contents referred to by a specific file URL cannot change without also changing the URL.

This also adds ``File.blake2_256_digest`` to hold this new hash.