### PR TITLE
Use a less aggressive transaction isolation by default

### DIFF
--- a/tests/unit/test_db.py
+++ b/tests/unit/test_db.py
@@ -213,6 +213,11 @@ def test_readonly(predicates, expected):
     assert _readonly(request) == expected
 
 
+def test_readonly_predicate():
+    assert db.ReadOnlyPredicate(False, None)(pretend.stub(), pretend.stub())
+    assert db.ReadOnlyPredicate(True, None)(pretend.stub(), pretend.stub())
+
+
 def test_includeme(monkeypatch):
     class FakeRegistry(dict):
         settings = {"database.url": pretend.stub()}

--- a/tests/unit/test_routes.py
+++ b/tests/unit/test_routes.py
@@ -52,26 +52,20 @@ def test_routes():
     includeme(config)
 
     assert config.add_route.calls == [
-        pretend.call('index', '/', read_only=True),
-        pretend.call("robots.txt", "/robots.txt", read_only=True),
-        pretend.call("index.sitemap.xml", "/sitemap.xml", read_only=True),
-        pretend.call(
-            "bucket.sitemap.xml",
-            "/{bucket}.sitemap.xml",
-            read_only=True,
-        ),
+        pretend.call('index', '/'),
+        pretend.call("robots.txt", "/robots.txt"),
+        pretend.call("index.sitemap.xml", "/sitemap.xml"),
+        pretend.call("bucket.sitemap.xml", "/{bucket}.sitemap.xml"),
         pretend.call(
             "includes.current-user-indicator",
             "/_includes/current-user-indicator/",
-            read_only=True,
         ),
-        pretend.call("search", "/search/", read_only=True),
+        pretend.call("search", "/search/"),
         pretend.call(
             "accounts.profile",
             "/user/{username}/",
             factory="warehouse.accounts.models:UserFactory",
             traverse="/{username}",
-            read_only=True,
         ),
         pretend.call("accounts.login", "/account/login/"),
         pretend.call("accounts.logout", "/account/logout/"),
@@ -81,19 +75,17 @@ def test_routes():
             "/project/{name}/",
             factory="warehouse.packaging.models:ProjectFactory",
             traverse="/{name}",
-            read_only=True,
         ),
         pretend.call(
             "packaging.release",
             "/project/{name}/{version}/",
             factory="warehouse.packaging.models:ProjectFactory",
             traverse="/{name}/{version}",
-            read_only=True,
         ),
-        pretend.call("packaging.file", "/packages/{path:.*}", read_only=True),
-        pretend.call("rss.updates", "/rss/updates.xml", read_only=True),
-        pretend.call("rss.packages", "/rss/packages.xml", read_only=True),
-        pretend.call("legacy.api.simple.index", "/simple/", read_only=True),
+        pretend.call("packaging.file", "/packages/{path:.*}"),
+        pretend.call("rss.updates", "/rss/updates.xml"),
+        pretend.call("rss.packages", "/rss/packages.xml"),
+        pretend.call("legacy.api.simple.index", "/simple/"),
         pretend.call(
             "legacy.api.simple.detail",
             "/simple/{name}/",
@@ -141,6 +133,5 @@ def test_routes():
             "pypi",
             pattern="/pypi",
             header="Content-Type:text/xml",
-            read_only=True,
         ),
     ]

--- a/warehouse/db.py
+++ b/warehouse/db.py
@@ -29,7 +29,7 @@ from warehouse.utils.attrs import make_repr
 __all__ = ["includeme", "metadata", "ModelBase"]
 
 
-DEFAULT_ISOLATION = "SERIALIZABLE"
+DEFAULT_ISOLATION = "READ COMMITTED"
 
 
 # We'll add a basic predicate that won't do anything except allow marking a

--- a/warehouse/routes.py
+++ b/warehouse/routes.py
@@ -13,24 +13,19 @@
 
 def includeme(config):
     # Basic global routes
-    config.add_route("index", "/", read_only=True)
-    config.add_route("robots.txt", "/robots.txt", read_only=True)
-    config.add_route("index.sitemap.xml", "/sitemap.xml", read_only=True)
-    config.add_route(
-        "bucket.sitemap.xml",
-        "/{bucket}.sitemap.xml",
-        read_only=True,
-    )
+    config.add_route("index", "/")
+    config.add_route("robots.txt", "/robots.txt")
+    config.add_route("index.sitemap.xml", "/sitemap.xml")
+    config.add_route("bucket.sitemap.xml", "/{bucket}.sitemap.xml")
 
     # HTML Snippets for including into other pages.
     config.add_route(
         "includes.current-user-indicator",
         "/_includes/current-user-indicator/",
-        read_only=True,
     )
 
     # Search Routes
-    config.add_route("search", "/search/", read_only=True)
+    config.add_route("search", "/search/")
 
     # Accounts
     config.add_route(
@@ -38,7 +33,6 @@ def includeme(config):
         "/user/{username}/",
         factory="warehouse.accounts.models:UserFactory",
         traverse="/{username}",
-        read_only=True,
     )
     config.add_route("accounts.login", "/account/login/")
     config.add_route("accounts.logout", "/account/logout/")
@@ -50,23 +44,21 @@ def includeme(config):
         "/project/{name}/",
         factory="warehouse.packaging.models:ProjectFactory",
         traverse="/{name}",
-        read_only=True,
     )
     config.add_route(
         "packaging.release",
         "/project/{name}/{version}/",
         factory="warehouse.packaging.models:ProjectFactory",
         traverse="/{name}/{version}",
-        read_only=True,
     )
-    config.add_route("packaging.file", "/packages/{path:.*}", read_only=True)
+    config.add_route("packaging.file", "/packages/{path:.*}")
 
     # RSS
-    config.add_route("rss.updates", "/rss/updates.xml", read_only=True)
-    config.add_route("rss.packages", "/rss/packages.xml", read_only=True)
+    config.add_route("rss.updates", "/rss/updates.xml")
+    config.add_route("rss.packages", "/rss/packages.xml")
 
     # Legacy URLs
-    config.add_route("legacy.api.simple.index", "/simple/", read_only=True)
+    config.add_route("legacy.api.simple.index", "/simple/")
     config.add_route(
         "legacy.api.simple.detail",
         "/simple/{name}/",
@@ -104,7 +96,6 @@ def includeme(config):
         "pypi",
         pattern="/pypi",
         header="Content-Type:text/xml",
-        read_only=True,
     )
 
     # Legacy Documentation


### PR DESCRIPTION
Most of Warehouse doesn't *really* to have serializable transactions, there is really only ~3 views that need that level of isolation (and they are also highly cacheable views). Instead we'll use a much less aggressive default isolation (``READ COMMITTED``) and only use ``SERIALIZABLE READ ONLY DEFERRABLE`` on the three views that need it.