### PR TITLE
Fix #1163

### DIFF
--- a/warehouse/utils/paginate.py
+++ b/warehouse/utils/paginate.py
@@ -44,9 +44,10 @@ class _ElasticsearchWrapper:
         self.results = self.query[range].execute()
 
         if hasattr(self.results, "suggest"):
-            suggestion = self.results.suggest.name_suggestion[0]
-            if suggestion.options:
-                self.best_guess = suggestion.options[0]
+            if self.results.suggest.name_suggestion:
+                suggestion = self.results.suggest.name_suggestion[0]
+                if suggestion.options:
+                    self.best_guess = suggestion.options[0]
 
         return list(self.results)
 

--- a/warehouse/views.py
+++ b/warehouse/views.py
@@ -182,7 +182,7 @@ def search(request):
         url_maker=paginate_url_factory(request),
     )
 
-    if page_num > page.page_count:
+    if page.page_count and page_num > page.page_count:
         raise HTTPNotFound
 
     available_filters = collections.defaultdict(list)


### PR DESCRIPTION
This PR fixes #1163 by only returning a 404 when there is a `page_count` (e.g., there are results) and the `page_num` exceeds it. When there are no results, it should not 404.

Additionally, when testing this, I discovered that it is possible to raise a 500-level error if the search term is such that it would not generate any "suggestions", for example, just `_`. This PR fixes that bug as well. 