### PR TITLE
Use a 302 redirect instead of a 307 redirect

### DIFF
--- a/tests/unit/legacy/test_views.py
+++ b/tests/unit/legacy/test_views.py
@@ -13,7 +13,7 @@
 import pretend
 import pytest
 
-from pyramid.httpexceptions import HTTPTemporaryRedirect, HTTPNotFound
+from pyramid.httpexceptions import HTTPFound, HTTPNotFound
 
 from warehouse.legacy.views import file_redirect
 
@@ -73,7 +73,7 @@ class TestFileRedirect:
 
         resp = file_redirect(db_request)
 
-        assert isinstance(resp, HTTPTemporaryRedirect)
+        assert isinstance(resp, HTTPFound)
         assert resp.headers["Location"] == \
             "/packages/ab/ab/thisisahash/" + expected_filename
         assert route_path.calls == [

--- a/warehouse/legacy/views.py
+++ b/warehouse/legacy/views.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pyramid.httpexceptions import HTTPTemporaryRedirect, HTTPNotFound
+from pyramid.httpexceptions import HTTPFound, HTTPNotFound
 from pyramid.view import view_config
 from sqlalchemy.orm.exc import NoResultFound
 
@@ -65,7 +65,7 @@ def file_redirect(request):
     # 404.
     if signature:
         if file_.has_signature:
-            return HTTPTemporaryRedirect(
+            return HTTPFound(
                 request.route_path("packaging.file", path=file_.pgp_path)
             )
         else:
@@ -73,6 +73,4 @@ def file_redirect(request):
 
     # Finally if we've gotten here, then we want to just return a redirect to
     # the actual file.
-    return HTTPTemporaryRedirect(
-        request.route_path("packaging.file", path=file_.path)
-    )
+    return HTTPFound(request.route_path("packaging.file", path=file_.path))


### PR DESCRIPTION
Not all of our downstreams currently understand a 307 redirect, so we'll instead use a 302 which is more common but slightly semantically vague.