### PR TITLE
Select latest releases for display on profile pages

### DIFF
--- a/warehouse/accounts/views.py
+++ b/warehouse/accounts/views.py
@@ -46,7 +46,7 @@ def profile(user, request):
                   .join(Project)
                   .distinct(Project.name)
                   .filter(Project.users.contains(user))
-                  .order_by(Project.name)
+                  .order_by(Project.name, Release._pypi_ordering.desc())
                   .all()
     )
 


### PR DESCRIPTION
I noticed when viewing my own profile that the date shown as the latest release was in fact the date of the first release.

The release that's pulled out of the database is unlikely to actually be the latest release because we were only sorting based on the project name, so presumably it'll pull the first result it finds in the database, most likely the first.