### PR TITLE
Test and fix missing titles. Fixes #784

### DIFF
--- a/tests/functional/pages/index.py
+++ b/tests/functional/pages/index.py
@@ -18,4 +18,5 @@ class IndexPage(PageObject):
     path = "/"
 
     def is_browser_on_page(self):
-        return self.browser.title == "Warehouse"
+        return self.browser.title == \
+            "PyPI - the Python Package Index · Warehouse"

--- a/tests/functional/test_templates.py
+++ b/tests/functional/test_templates.py
@@ -1,0 +1,53 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import warehouse
+from jinja2 import Environment, FileSystemLoader
+
+
+def test_templates_for_empty_titles():
+    """
+        Test if all HTML templates have defined the title block. See
+        https://github.com/pypa/warehouse/issues/784
+    """
+    dir_name = os.path.join(os.path.dirname(warehouse.__file__), 'templates')
+
+    env = Environment(
+        loader=FileSystemLoader(dir_name),
+        extensions=[],
+        cache_size=0,
+    )
+
+    env.filters.update({
+        "format_date": "warehouse.i18n.filters:format_date",
+        "format_datetime": "warehouse.i18n.filters:format_datetime",
+        "format_rfc822_datetime":
+            "warehouse.i18n.filters:format_rfc822_datetime",
+        "format_tags": "warehouse.filters:format_tags",
+        "json": "warehouse.filters:tojson",
+        "readme": "warehouse.filters:readme",
+        "shorten_number": "warehouse.filters:shorten_number",
+        "urlparse": "warehouse.filters:urlparse",
+    })
+
+    for dir_, _, files in os.walk(dir_name):
+        if dir_.find("/includes") > -1 or \
+           dir_.find("/legacy") > -1:
+            continue
+
+        for file_name in files:
+            if file_name.endswith(".html"):
+                rel_dir = os.path.relpath(dir_, dir_name)
+                rel_file = os.path.join(rel_dir, file_name)
+                template = env.get_template(rel_file)
+                assert 'title' in template.blocks

--- a/warehouse/templates/accounts/register.html
+++ b/warehouse/templates/accounts/register.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 
+{% block title %}Register{% endblock %}
+
 {%- from "warehouse:templates/includes/input-recaptcha.html" import recaptcha_html, recaptcha_src %}
 
 {% block content %}

--- a/warehouse/templates/index.html
+++ b/warehouse/templates/index.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 
+{% block title %}PyPI - the Python Package Index{% endblock %}
 
 {% macro project_snippet(release) -%}
 

--- a/warehouse/templates/pages/help.html
+++ b/warehouse/templates/pages/help.html
@@ -13,6 +13,8 @@
 -#}
 {% extends "base.html" %}
 
+{% block title %}Help{% endblock %}
+
 {% block content %}
   <section class="horizontal-section">
     <div class="narrow-container">

--- a/warehouse/templates/pages/legal.html
+++ b/warehouse/templates/pages/legal.html
@@ -12,3 +12,4 @@
  # limitations under the License.
 -#}
 {% extends "base.html" %}
+{% block title %}Legal statements{% endblock %}

--- a/warehouse/templates/pages/security.html
+++ b/warehouse/templates/pages/security.html
@@ -12,3 +12,4 @@
  # limitations under the License.
 -#}
 {% extends "base.html" %}
+{% block title %}Security{% endblock %}

--- a/warehouse/templates/pages/sponsors.html
+++ b/warehouse/templates/pages/sponsors.html
@@ -12,6 +12,6 @@
  # limitations under the License.
 -#}
 {% extends "base.html" %}
-
+{% block title %}Sponsors{% endblock %}
 
 {# Note: The actual sponsors page for PyPI is defined in pypi-theme #}

--- a/warehouse/templates/search/results.html
+++ b/warehouse/templates/search/results.html
@@ -13,6 +13,7 @@
 -#}
 {% extends "base.html" %}
 
+{% block title %}Search results{% endblock %}
 
 {% macro project_snippet(item) -%}
 


### PR DESCRIPTION
Here is a quick test for #784 and fixes to a number of templates. Notes:

* `pages/legal.html`, `pages/security.html` and `pages/sponsors.html` are missing titles at the moment but are essentially empty. 
* assert will stop at the first failure.

On legacy PyPI the legal link points to http://www.python.org/about/legal. If we have the text I can add it to this template or modify the code to redirect to the same URL. 

Do we want to copy the text from https://pypi.python.org/security for `security.html` ? 

`sponsors.html` contains the following comment
```
{# Note: The actual sponsors page for PyPI is defined in pypi-theme #}
```

Please advise how to proceed with this PR. 

Regards,
@MrSenko

