### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -12,4 +12,4 @@ Examples of contributions include:
 
 Extensive contribution guidelines are available in the repository at
 ``docs/development/index.rst`` or
-`online <https://warehouse.readthedocs.org/development/>`_.
+`online <https://warehouse.readthedocs.io/development/>`_.

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@ Warehouse
 =========
 
 .. image:: https://readthedocs.org/projects/warehouse/badge/?version=latest
-    :target: https://warehouse.readthedocs.org/
+    :target: https://warehouse.readthedocs.io/
     :alt: Latest Docs
 
 .. image:: https://travis-ci.org/pypa/warehouse.svg?branch=master
@@ -57,7 +57,7 @@ You can also join ``#pypa`` or ``#pypa-dev`` on Freenode to ask questions or
 get involved.
 
 
-.. _`documentation`: https://warehouse.readthedocs.org/
+.. _`documentation`: https://warehouse.readthedocs.io/
 .. _`issue tracker`: https://github.com/pypa/warehouse/issues
 
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.