### PR TITLE
Disable autocorrect in the username field, issue #1198

### DIFF
--- a/warehouse/templates/includes/input-credentials.html
+++ b/warehouse/templates/includes/input-credentials.html
@@ -5,7 +5,7 @@
   {% endfor %}
 </ul>
 {% endif %}
-{{ form.username(placeholder="Username") }}
+{{ form.username(placeholder="Username", autocorrect="off", autocapitalize="off", spellcheck="false") }}
 
 {% if form.password.errors %}
 <ul class="errors">


### PR DESCRIPTION
Prevents a device from autocorrecting the username.

Fixes #1198 