### PR TITLE
Add a tooltip library (and add it to pip install button)

### DIFF
--- a/warehouse/static/js/warehouse/index.js
+++ b/warehouse/static/js/warehouse/index.js
@@ -34,9 +34,9 @@ docReady(formUtils.submitTriggers);
 
 // Copy handler for the pip command on package detail page
 docReady(() => {
-  let clipboard = new Clipboard(".copy-pip-command");
-  clipboard.on('success', (e) => {
-    e.trigger.setAttribute('aria-label', 'Copied!');
+  let clipboard = new Clipboard(".-js-copy-pip-command");
+  clipboard.on("success", (e) => {
+    e.trigger.setAttribute("aria-label", "Copied!");
     e.clearSelection();
   });
 });

--- a/warehouse/static/js/warehouse/index.js
+++ b/warehouse/static/js/warehouse/index.js
@@ -37,7 +37,6 @@ docReady(() => {
   let clipboard = new Clipboard(".copy-pip-command");
   clipboard.on('success', (e) => {
     e.trigger.setAttribute('aria-label', 'Copied!');
-    e.trigger.setAttribute('aria-label', 'Copy to clipboard');
     e.clearSelection();
   });
 });

--- a/warehouse/static/js/warehouse/index.js
+++ b/warehouse/static/js/warehouse/index.js
@@ -34,5 +34,10 @@ docReady(formUtils.submitTriggers);
 
 // Copy handler for the pip command on package detail page
 docReady(() => {
-  new Clipboard(".copy-pip-command");
+  let clipboard = new Clipboard(".copy-pip-command");
+  clipboard.on('success', (e) => {
+    e.trigger.setAttribute('aria-label', 'Copied!');
+    e.trigger.setAttribute('aria-label', 'Copy to clipboard');
+    e.clearSelection();
+  });
 });

--- a/warehouse/static/sass/components/_tooltip.scss
+++ b/warehouse/static/sass/components/_tooltip.scss
@@ -1,1 +1,199 @@
-// TODO: Tooltips styling
+// The following is derived from https://github.com/primer/tooltips
+// The MIT License (MIT)
+// Copyright (c) 2016 GitHub Inc.
+
+$tooltip-max-width: 250px !default;
+$tooltip-background-color: rgba(0, 0, 0, 0.8) !default;
+$tooltip-text-color: #fff !default;
+$tooltip-delay: 0.4s !default;
+$tooltip-duration: 0.1s !default;
+
+.tooltipped {
+  position: relative;
+}
+
+// This is the tooltip bubble
+.tooltipped::after {
+  position: absolute;
+  z-index: 1000000;
+  display: none;
+  padding: 5px 8px;
+  font-size: 11px/1.5;
+  -webkit-font-smoothing: subpixel-antialiased;
+  color: $tooltip-text-color;
+  text-align: center;
+  text-decoration: none;
+  text-shadow: none;
+  text-transform: none;
+  letter-spacing: normal;
+  word-wrap: break-word;
+  white-space: pre;
+  pointer-events: none;
+  content: attr(aria-label);
+  background: $tooltip-background-color;
+  border-radius: 3px;
+  opacity: 0;
+}
+
+// This is the tooltip arrow
+.tooltipped::before {
+  position: absolute;
+  z-index: 1000001;
+  display: none;
+  width: 0;
+  height: 0;
+  color: $tooltip-background-color;
+  pointer-events: none;
+  content: "";
+  border: 5px solid transparent;
+  opacity: 0;
+}
+
+// delay animation for tooltip
+@keyframes tooltip-appear {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+// This will indicate when we'll activate the tooltip
+.tooltipped:hover,
+.tooltipped:active,
+.tooltipped:focus {
+  &::before,
+  &::after {
+    display: inline-block;
+    text-decoration: none;
+    animation-name: tooltip-appear;
+    animation-duration: $tooltip-duration;
+    animation-fill-mode: forwards;
+    animation-timing-function: ease-in;
+    animation-delay: $tooltip-delay;
+  }
+}
+
+.tooltipped-no-delay:hover,
+.tooltipped-no-delay:active,
+.tooltipped-no-delay:focus {
+  &::before,
+  &::after {
+    opacity: 1;
+    animation: none;
+  }
+}
+
+.tooltipped-multiline:hover,
+.tooltipped-multiline:active,
+.tooltipped-multiline:focus {
+  &::after {
+    display: table-cell;
+  }
+}
+
+// Tooltipped south
+.tooltipped-s,
+.tooltipped-se,
+.tooltipped-sw {
+  &::after {
+    top: 100%;
+    right: 50%;
+    margin-top: 5px;
+  }
+
+  &::before {
+    top: auto;
+    right: 50%;
+    bottom: -5px;
+    margin-right: -5px;
+    border-bottom-color: $tooltip-background-color;
+  }
+}
+
+.tooltipped-se {
+  &::after {
+    right: auto;
+    left: 50%;
+    margin-left: -15px;
+  }
+}
+
+.tooltipped-sw::after {
+  margin-right: -15px;
+}
+
+// Tooltips above the object
+.tooltipped-n,
+.tooltipped-ne,
+.tooltipped-nw {
+  &::after {
+    right: 50%;
+    bottom: 100%;
+    margin-bottom: 5px;
+  }
+
+  &::before {
+    top: -5px;
+    right: 50%;
+    bottom: auto;
+    margin-right: -5px;
+    border-top-color: $tooltip-background-color;
+  }
+}
+
+.tooltipped-ne {
+  &::after {
+    right: auto;
+    left: 50%;
+    margin-left: -15px;
+  }
+}
+
+.tooltipped-nw::after {
+  margin-right: -15px;
+}
+
+// Move the tooltip body to the center of the object.
+.tooltipped-s::after,
+.tooltipped-n::after {
+  transform: translateX(50%);
+}
+
+// Tooltipped to the left
+.tooltipped-w {
+  &::after {
+    right: 100%;
+    bottom: 50%;
+    margin-right: 5px;
+    transform: translateY(50%);
+  }
+
+  &::before {
+    top: 50%;
+    bottom: 50%;
+    left: -5px;
+    margin-top: -5px;
+    border-left-color: $tooltip-background-color;
+  }
+}
+
+// tooltipped to the right
+.tooltipped-e {
+  &::after {
+    bottom: 50%;
+    left: 100%;
+    margin-left: 5px;
+    transform: translateY(50%);
+  }
+
+  &::before {
+    top: 50%;
+    right: -5px;
+    bottom: 50%;
+    margin-top: -5px;
+    border-right-color: $tooltip-background-color;
+  }
+}

--- a/warehouse/static/sass/warehouse.scss
+++ b/warehouse/static/sass/warehouse.scss
@@ -96,6 +96,7 @@
 @import "components/statistics-bar";
 @import "components/vertical-tabs";
 @import "components/wh-buttons";
+@import "components/tooltip";
 
 
 // TRUMPS LAYER

--- a/warehouse/static/sass/warehouse.scss
+++ b/warehouse/static/sass/warehouse.scss
@@ -94,9 +94,9 @@
 @import "components/site-header"; // refactor
 @import "components/sponsor-footer";
 @import "components/statistics-bar";
+@import "components/tooltip";
 @import "components/vertical-tabs";
 @import "components/wh-buttons";
-@import "components/tooltip";
 
 
 // TRUMPS LAYER

--- a/warehouse/templates/packaging/detail.html
+++ b/warehouse/templates/packaging/detail.html
@@ -71,7 +71,7 @@
 
     <p class="pip-instructions">
       <span id="pip-command">pip install {{ release.project.normalized_name }}</span>
-      <a href="#" class="copy-pip-command" data-clipboard-target="#pip-command">
+      <a href="#" class="copy-pip-command tooltipped tooltipped-s" data-clipboard-target="#pip-command" aria-label="Copy to clipboard">
         <i class="fa fa-copy"></i>
         <span class="sr-only">Copy PIP instructions<span>
       </a>

--- a/warehouse/templates/packaging/detail.html
+++ b/warehouse/templates/packaging/detail.html
@@ -71,7 +71,7 @@
 
     <p class="pip-instructions">
       <span id="pip-command">pip install {{ release.project.normalized_name }}</span>
-      <a href="#" class="copy-pip-command tooltipped tooltipped-s" data-clipboard-target="#pip-command" aria-label="Copy to clipboard">
+      <a href="#" class="-js-copy-pip-command tooltipped tooltipped-s" data-clipboard-target="#pip-command" aria-label="Copy to clipboard">
         <i class="fa fa-copy"></i>
         <span class="sr-only">Copy PIP instructions<span>
       </a>


### PR DESCRIPTION
#818 and #819

This is based on github's implementation and is distributed with MIT license.

![phone](https://cloud.githubusercontent.com/assets/3261985/15797834/fb00f62c-29d9-11e6-85fd-157084719654.gif)

The one little snafu is that after copying, if the user hover off of the button and then back on the button, it says "Copied" - it should say "Copy to clipboard". Haven't found a good solution to that yet.

Next up will be integrating copy to clipboard to sha sums.