### PR TITLE
Remove href from pip copy button

### DIFF
--- a/warehouse/static/sass/components/_package-header.scss
+++ b/warehouse/static/sass/components/_package-header.scss
@@ -49,6 +49,7 @@
     a {
       line-height: 30px;
       float: left;
+      cursor: pointer;
       padding: 10px 15px;
       background-color: rgba(0,0,0,.15);
       border-right: 1px dotted rgba(255,255,255, 0.4);

--- a/warehouse/templates/packaging/detail.html
+++ b/warehouse/templates/packaging/detail.html
@@ -71,7 +71,7 @@
 
     <p class="pip-instructions">
       <span id="pip-command">pip install {{ release.project.normalized_name }}</span>
-      <a href="#" class="-js-copy-pip-command tooltipped tooltipped-s" data-clipboard-target="#pip-command" aria-label="Copy to clipboard">
+      <a class="-js-copy-pip-command tooltipped tooltipped-s" data-clipboard-target="#pip-command" aria-label="Copy to clipboard">
         <i class="fa fa-copy"></i>
         <span class="sr-only">Copy PIP instructions<span>
       </a>


### PR DESCRIPTION
Fixes #1232.

The sass change is required to not affect the UI otherwise the browser will show the default cursor.

