### PR TITLE
Set original tooltip text when hover out

### DIFF
--- a/warehouse/static/js/warehouse/index.js
+++ b/warehouse/static/js/warehouse/index.js
@@ -39,4 +39,22 @@ docReady(() => {
     e.trigger.setAttribute("aria-label", "Copied!");
     e.clearSelection();
   });
+
+  // Get all elements with class "tooltipped" and bind to focousout and
+  // mouseout events. Change the "aria-label" to "original-label" attribute
+  // value.
+  let setOriginalLabel = (element) => {
+    element.setAttribute("aria-label", element.getAttribute("original-label"))
+  };
+  let tooltippedElems = Array.from(document.querySelectorAll(".tooltipped"));
+  tooltippedElems.forEach((element) => {
+    element.addEventListener("focousout",
+      setOriginalLabel.bind(undefined, element),
+      false
+    );
+    element.addEventListener("mouseout",
+      setOriginalLabel.bind(undefined, element),
+      false
+    );
+  });
 });

--- a/warehouse/templates/packaging/detail.html
+++ b/warehouse/templates/packaging/detail.html
@@ -71,7 +71,7 @@
 
     <p class="pip-instructions">
       <span id="pip-command">pip install {{ release.project.normalized_name }}</span>
-      <a class="-js-copy-pip-command tooltipped tooltipped-s" data-clipboard-target="#pip-command" aria-label="Copy to clipboard">
+      <a class="-js-copy-pip-command tooltipped tooltipped-s" data-clipboard-target="#pip-command" aria-label="Copy to clipboard" original-label="Copy to clipboard">
         <i class="fa fa-copy"></i>
         <span class="sr-only">Copy PIP instructions<span>
       </a>


### PR DESCRIPTION
Fix for #1234 

Tested on desktop Chrome stable and Firefox. `setAttribute` does not work in Safari.

![phone](https://cloud.githubusercontent.com/assets/3261985/15836138/47e4169e-2be8-11e6-9651-50831b92e1ee.gif)