### PR TITLE
Trove classifiers API endpoint

### DIFF
--- a/tests/unit/legacy/api/test_pypi.py
+++ b/tests/unit/legacy/api/test_pypi.py
@@ -72,13 +72,16 @@ def test_forbidden_legacy():
 
 
 def test_list_classifiers(pyramid_request):
-    request = pretend.stub(
+    pyramid_request = pretend.stub(
         db=pretend.stub(
-            query=pretend.call_recorder(lambda q: None),
+            query=pretend.stub(
+                order_by=pretend.stub(
+                    all=lambda: 'abc'
+                )
+            ),
         ),
     )
     resp = pypi.list_classifiers(pyramid_request)
 
     assert resp.status_code == 200
-    # assert request.db.execute.calls == [pretend.call("SELECT 1")]
     # assert resp.status == "410 DOAP is no longer supported."

--- a/tests/unit/legacy/api/test_pypi.py
+++ b/tests/unit/legacy/api/test_pypi.py
@@ -17,6 +17,8 @@ from pyramid.httpexceptions import HTTPBadRequest
 
 from warehouse.legacy.api import pypi
 
+from ....common.db.classifiers import ClassifierFactory
+
 
 def test_exc_with_message():
     exc = pypi._exc_with_message(HTTPBadRequest, "My Test Message.")
@@ -69,8 +71,14 @@ def test_forbidden_legacy():
     assert resp is exc
 
 
-def test_doap(pyramid_request):
+def test_list_classifiers(pyramid_request):
+    request = pretend.stub(
+        db=pretend.stub(
+            query=pretend.call_recorder(lambda q: None),
+        ),
+    )
     resp = pypi.list_classifiers(pyramid_request)
 
     assert resp.status_code == 200
+    # assert request.db.execute.calls == [pretend.call("SELECT 1")]
     # assert resp.status == "410 DOAP is no longer supported."

--- a/tests/unit/legacy/api/test_pypi.py
+++ b/tests/unit/legacy/api/test_pypi.py
@@ -67,3 +67,10 @@ def test_forbidden_legacy():
     exc, request = pretend.stub(), pretend.stub()
     resp = pypi.forbidden_legacy(exc, request)
     assert resp is exc
+
+
+def test_doap(pyramid_request):
+    resp = pypi.list_classifiers(pyramid_request)
+
+    assert resp.status_code == 200
+    # assert resp.status == "410 DOAP is no longer supported."

--- a/tests/unit/legacy/api/test_pypi.py
+++ b/tests/unit/legacy/api/test_pypi.py
@@ -72,9 +72,9 @@ def test_forbidden_legacy():
 
 
 def test_list_classifiers(db_request):
-    classifier1 = ClassifierFactory.create(classifier="foo :: bar")
-    classifier2 = ClassifierFactory.create(classifier="foo :: baz")
-    classifier3 = ClassifierFactory.create(classifier="fiz :: buz")
+    ClassifierFactory.create(classifier="foo :: bar")
+    ClassifierFactory.create(classifier="foo :: baz")
+    ClassifierFactory.create(classifier="fiz :: buz")
 
     resp = pypi.list_classifiers(db_request)
 

--- a/tests/unit/legacy/api/test_pypi.py
+++ b/tests/unit/legacy/api/test_pypi.py
@@ -71,17 +71,12 @@ def test_forbidden_legacy():
     assert resp is exc
 
 
-def test_list_classifiers(pyramid_request):
-    pyramid_request = pretend.stub(
-        db=pretend.stub(
-            query=pretend.stub(
-                order_by=pretend.stub(
-                    all=lambda: 'abc'
-                )
-            ),
-        ),
-    )
-    resp = pypi.list_classifiers(pyramid_request)
+def test_list_classifiers(db_request):
+    classifier1 = ClassifierFactory.create(classifier="foo :: bar")
+    classifier2 = ClassifierFactory.create(classifier="foo :: baz")
+    classifier3 = ClassifierFactory.create(classifier="fiz :: buz")
+
+    resp = pypi.list_classifiers(db_request)
 
     assert resp.status_code == 200
-    # assert resp.status == "410 DOAP is no longer supported."
+    assert resp.text == "fiz :: buz\nfoo :: bar\nfoo :: baz"

--- a/tests/unit/test_routes.py
+++ b/tests/unit/test_routes.py
@@ -187,6 +187,11 @@ def test_routes(warehouse):
             domain=warehouse,
         ),
         pretend.call("legacy.api.pypi.doap", "doap", domain=warehouse),
+        pretend.call(
+            "legacy.api.pypi.list_classifiers",
+            "list_classifiers",
+            domain=warehouse,
+        ),
     ]
 
     assert config.add_pypi_action_redirect.calls == [

--- a/warehouse/legacy/api/pypi.py
+++ b/warehouse/legacy/api/pypi.py
@@ -72,3 +72,8 @@ def forbidden_legacy(exc, request):
     # the default forbidden handler we have which does redirects to the login
     # view, which we do not want on this API.
     return exc
+
+
+@view_config(route_name="legacy.api.pypi.list_classifiers")
+def list_classifiers(request):
+    return _exc_with_message(HTTPGone, "This works.")

--- a/warehouse/legacy/api/pypi.py
+++ b/warehouse/legacy/api/pypi.py
@@ -11,7 +11,10 @@
 # limitations under the License.
 
 from pyramid.httpexceptions import HTTPGone
+from pyramid.response import Response
 from pyramid.view import forbidden_view_config, view_config
+
+from warehouse.classifiers.models import Classifier
 
 
 def _exc_with_message(exc, message):
@@ -76,4 +79,13 @@ def forbidden_legacy(exc, request):
 
 @view_config(route_name="legacy.api.pypi.list_classifiers")
 def list_classifiers(request):
-    return _exc_with_message(HTTPGone, "This works.")
+    classifiers = (
+        request.db.query(Classifier.classifier)
+                  .order_by(Classifier.classifier)
+                  .all()
+    )
+
+    return Response(
+        text='\n'.join(c[0] for c in classifiers),
+        content_type='text/plain; charset=utf-8'
+    )

--- a/warehouse/legacy/api/pypi.py
+++ b/warehouse/legacy/api/pypi.py
@@ -81,8 +81,8 @@ def forbidden_legacy(exc, request):
 def list_classifiers(request):
     classifiers = (
         request.db.query(Classifier.classifier)
-                  .order_by(Classifier.classifier)
-                  .all()
+               .order_by(Classifier.classifier)
+               .all()
     )
 
     return Response(

--- a/warehouse/routes.py
+++ b/warehouse/routes.py
@@ -145,6 +145,11 @@ def includeme(config):
         "doap",
         domain=warehouse,
     )
+    config.add_pypi_action_route(
+        "legacy.api.pypi.list_classifiers",
+        "list_classifiers",
+        domain=warehouse,
+    )
 
     # Legacy XMLRPC
     config.add_xmlrpc_endpoint(


### PR DESCRIPTION
#1241 

WIP - @dstufft - I can't get the test to work. Any hints? :)

```
    def test_list_classifiers(pyramid_request):
        pyramid_request = pretend.stub(
            db=pretend.stub(
                query=pretend.stub(
                    order_by=pretend.stub(
                        all=lambda: 'abc'
                    )
                ),
            ),
        )
>       resp = pypi.list_classifiers(pyramid_request)

tests/unit/legacy/api/test_pypi.py:84:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

    @view_config(route_name="legacy.api.pypi.list_classifiers")
    def list_classifiers(request):
        classifiers = (
>           request.db.query(Classifier.classifier)
                      .order_by(Classifier.classifier)
                      .all()
        )
E       TypeError: 'stub' object is not callable

warehouse/legacy/api/pypi.py:83: TypeError
```