### PR TITLE
Change projects to packages

### DIFF
--- a/warehouse/templates/base.html
+++ b/warehouse/templates/base.html
@@ -53,7 +53,7 @@
 
             <form class="search-form -primary" action="{{ request.route_path('search') }}">
               <label for="search" class="sr-only">Search PyPI</label>
-              <input id="search" class="search" type="text" name="q" {{ l20n("search") }} placeholder="Search Projects" value="{{ term }}">
+              <input id="search" class="search" type="text" name="q" {{ l20n("search") }} placeholder="Search Packages" value="{{ term }}">
               <input class="wh-button -dark" type="submit" {{ l20n("search") }} value="Search">
             </form>
           </div>
@@ -68,7 +68,7 @@
     <section class="mobile-search">
       <form class="search-form -fullwidth" action="{{ request.route_path('search') }}">
         <label for="mobile-search" class="sr-only">Search PyPI</label>
-        <input id="mobile-search" class="search" type="text" name="q" {{ l20n("search") }} placeholder="Search Projects">
+        <input id="mobile-search" class="search" type="text" name="q" {{ l20n("search") }} placeholder="Search Packages">
         <button class="wh-button -dark" type="submit">
           <i class="icon fa fa-search"></i>
           <span class="text" {{ l20n("search") }}>Search</span>

--- a/warehouse/templates/index.html
+++ b/warehouse/templates/index.html
@@ -37,20 +37,20 @@
 
     <form class="search-form -large -fullwidth" action="{{ request.route_path('search') }}">
       <label for="search" class="sr-only">Search PyPI</label>
-      <input id="search" class="search large-input" type="text" name="q" {{ l20n("search") }} placeholder="Search Projects" autofocus>
+      <input id="search" class="search large-input" type="text" name="q" {{ l20n("search") }} placeholder="Search Packages" autofocus>
       <button class="wh-button -large -dark" type="submit">
         <i class="icon fa fa-search"></i>
         <span class="text" {{ l20n("search") }}>Search</span>
       </button>
     </form>
 
-    <p class="browse" {{ l20n("orBrowse") }}>Or <a href="{{ request.route_path('search') }}">browse projects</a>.</p>
+    <p class="browse" {{ l20n("orBrowse") }}>Or <a href="{{ request.route_path('search') }}">browse packages</a>.</p>
   </div>
 </section>
 
 <section class="horizontal-section -grey -thin -statistics">
   <div class="statistics-bar">
-    <p class="statistic" {{ l20n("numberOfProjects", number=num_projects) }}>{{ num_projects }} Projects</p>
+    <p class="statistic" {{ l20n("numberOfProjects", number=num_projects) }}>{{ num_projects }} Packages</p>
     <p class="statistic" {{ l20n("numberOfReleases", number=num_releases) }}>{{ num_releases }} Releases</p>
     <p class="statistic" {{ l20n("numberOfFiles", number=num_files) }}>{{ num_files }} Files</p>
     <p class="statistic" {{ l20n("numberOfUsers", number=num_users) }}>{{ num_users }} Users</p>
@@ -74,8 +74,8 @@
   <div class="site-container">
     <div class="half-column">
       <div class="heading-wsubtitle">
-        <h2 class="heading" {{ l20n("topProjectsTitle") }}>Top Projects</h2>
-        <p class="subtitle" {{ l20n("topProjectsSubTitle") }}>Top projects as downloaded by the community</p>
+        <h2 class="heading" {{ l20n("topProjectsTitle") }}>Top Packages</h2>
+        <p class="subtitle" {{ l20n("topProjectsSubTitle") }}>Top packages as downloaded by the community</p>
       </div>
       <div class="package-list">
         {% for release in top_projects %}
@@ -87,7 +87,7 @@
     <div class="half-column">
       <div class="heading-wsubtitle">
         <h2 class="heading" {{ l20n("newReleasesTitle") }}>New Releases</h2>
-        <p class="subtitle" {{ l20n("newReleasesSubTitle") }}>Hot off the press: the newest projects to be released to PyPI</p>
+        <p class="subtitle" {{ l20n("newReleasesSubTitle") }}>Hot off the press: the newest packages to be released to PyPI</p>
       </div>
       <div class="package-list">
         {% for release in latest_releases %}

--- a/warehouse/templates/packaging/detail.html
+++ b/warehouse/templates/packaging/detail.html
@@ -122,7 +122,7 @@
       <div class="vertical-tabs">
         <div class="sidebar-section">
           <h3 {{ l20n("projectNavigation") }}>Navigation</h3>
-            <a class="-js-vertical-tab vertical-tab is-active" href="#description" {{ l20n("projectDescription") }}>Project Description</a>
+            <a class="-js-vertical-tab vertical-tab is-active" href="#description" {{ l20n("projectDescription") }}>Package Description</a>
             <a class="-js-vertical-tab vertical-tab" href="#dependencies" {{ l20n("projectDependencies") }}>Dependencies</a>
             <a class="-js-vertical-tab vertical-tab" href="#history" {{ l20n("projectHistory") }}>Version History &amp; Changelog</a>
             <a class="-js-vertical-tab vertical-tab" href="#statistics" {{ l20n("projectDownloadStats") }}>Download Statistics</a>
@@ -174,7 +174,7 @@
         <div id="dependencies" class="js-vertical-tab-content vertical-tab-content">
           <h2 {{ l20n("numberProjectDependencies", number="TODO") }}>Dependencies (TODO)</h2>
           <p {{ l20n("projectDependenciesInfo", name=release.project.name) }}>
-            To run <em>{{ release.project.name }}</em>, you will need to have the following projects installed:
+            To run <em>{{ release.project.name }}</em>, you will need to have the following packages installed:
           </p>
 
           <div class="package-list">
@@ -185,7 +185,7 @@
 
           <h2 class="no-top-padding" {{ l20n("numberProjectReverseDependencies", number="TODO") }}>Reverse Dependencies (TODO)</h2>
           <p {{ l20n("projectReverseDependenciesInfo", name=release.project.name) }}>
-            The following projects rely on <em>{{ release.project.name }}</em>:
+            The following packages rely on <em>{{ release.project.name }}</em>:
           </p>
 
           <div class="package-list">

--- a/warehouse/templates/search/results.html
+++ b/warehouse/templates/search/results.html
@@ -57,7 +57,7 @@
       <div class="dark-overlay"></div>
       <aside class="panel-overlay">
         <a class="-js-close-panel"><i class="fa fa-close"></i></a>
-        <h2 class="no-top-padding" {{ l20n("filterProjects") }}>Filter Projects</h2>
+        <h2 class="no-top-padding" {{ l20n("filterProjects") }}>Filter Packages</h2>
         <form id="classifiers">
         <input id="search" type="hidden" name="q" {{ l20n("search") }} value="{{ term }}">
         <input type="hidden" name="o" value="{{ order }}">
@@ -86,14 +86,14 @@
       <section class="split-layout -table">
         {% if term %}
         <p {{ l20n("numberOfSearchResultsWithTerm", number=page.item_count, term=term) }}>
-          <strong>{{ page.item_count }}</strong> projects match '<em>{{ term }}</em>'.
+          <strong>{{ page.item_count }}</strong> packages match '<em>{{ term }}</em>'.
           {% if page.collection.best_guess and page.collection.best_guess.freq > page.item_count %}
             {{ suggestion_link(page.collection.best_guess) }}
           {% endif %}
         </p>
         {% else %}
         <p {{ l20n("numberOfSearchResultsWithoutTerm", number=page.item_count) }}>
-          <strong>{{ page.item_count }}</strong> projects.
+          <strong>{{ page.item_count }}</strong> packages.
         </p>
         {% endif %}
           <p>


### PR DESCRIPTION
Fix for issue : #1250 

Change has been done in the below pages. (please use localhost)

1) http://localhost/  (Index page)

![index_page](https://cloud.githubusercontent.com/assets/10979862/15925600/6f0b0b64-2e55-11e6-9de5-cfa8e7523a2c.gif)





2) http://localhost/search/?q=sphinx (Search result page)

![search_page](https://cloud.githubusercontent.com/assets/10979862/15925634/909b7822-2e55-11e6-8bfe-d0cc728fba55.gif)





3) http://localhost/project/Sphinx/#description  (Package description page)

![package_description](https://cloud.githubusercontent.com/assets/10979862/15925697/dcca2630-2e55-11e6-9341-44e8cc3879aa.gif)


@nlhkabu @dstufft  So far I found above pages need a change from "Projects" to "Packages" and I'm still finding if there are any other pages. Please verify the changes I've done. 
