### PR TITLE
Wrap "expected" xmlrpc errors to prevent logging

### DIFF
--- a/tests/unit/legacy/api/test_xmlrpc.py
+++ b/tests/unit/legacy/api/test_xmlrpc.py
@@ -31,12 +31,18 @@ from ....common.db.packaging import (
 class TestSearch:
 
     def test_fails_with_invalid_operator(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(xmlrpc.XMLRPCWrappedError) as exc:
             xmlrpc.search(pretend.stub(), {}, "lol nope")
 
+        assert exc.value.faultString == \
+            "ValueError: Invalid operator, must be one of 'and' or 'or'."
+
     def test_fails_if_spec_not_mapping(self):
-        with pytest.raises(TypeError):
+        with pytest.raises(xmlrpc.XMLRPCWrappedError) as exc:
             xmlrpc.search(pretend.stub(), "a string")
+
+        assert exc.value.faultString == \
+            "TypeError: Invalid spec, must be a mapping/dictionary."
 
     def test_default_search_operator(self):
         class FakeQuery:


### PR DESCRIPTION
There are two kinds of exceptions that may occur in an XMLRPC view, ones that are the fault of bad logic in the view, and ones that are the fault of the remote client calling the view with the wrong inputs.

For the first of these, we want to raise the normal exceptions and have pyramid_rpc log the fact they occurred. However, we don't want this to happen with the other kind since we're only using them as a way to signal to the end user they need to change something.

To handle this, we've created a subclass of xmlrpc.server.Fault which will wrap a real exception and automatically translate this to an xmlrpc error. This will avoid hitting the branch in pyramid_rpc that causes this exception to get logged but will still signal an error back to the end user.