### PR TITLE
Omit the uploader information from the UI

### DIFF
--- a/warehouse/packaging/views.py
+++ b/warehouse/packaging/views.py
@@ -12,7 +12,6 @@
 
 from pyramid.httpexceptions import HTTPMovedPermanently, HTTPNotFound
 from pyramid.view import view_config
-from sqlalchemy.orm import joinedload
 from sqlalchemy.orm.exc import NoResultFound
 
 from warehouse.accounts.models import User
@@ -40,7 +39,6 @@ def project_detail(project, request):
     try:
         release = (
             request.db.query(Release)
-                      .options(joinedload(Release.uploader))
                       .filter(Release.project == project)
                       .order_by(Release._pypi_ordering.desc())
                       .limit(1)

--- a/warehouse/static/sass/blocks/_package-links.scss
+++ b/warehouse/static/sass/blocks/_package-links.scss
@@ -1,15 +1,11 @@
 /*
   A horizontal bar on the package detail page that includes the main links
-  for each page, as well as author information.
+  for each page.
 
   <div class="package-links">
     <nav class="horizontal-menu package-links__horizontal-menu">
       // package links
     </nav>
-    <p class="package-links__author">
-      <span class="package-links__author-info"></span>
-      <a><img class="package-links__author-avatar"></a>
-    </p>
   </div>
 */
 
@@ -28,32 +24,6 @@
 
     @media only screen and (max-width: $large-desktop){
        display: block;
-    }
-  }
-
-  &__author {
-    text-align: right;
-    display: table-cell;
-    font-size: $base-font-size * 0.9;
-    font-style: italic;
-
-    @media only screen and (max-width: $large-desktop){
-      display: block;
-      text-align: left;
-    }
-  }
-
-  &__author-info {
-    display: inline-block;
-    padding: 10px 0;
-    line-height: 20px;
-  }
-
-  &__author-avatar {
-    margin-left: 10px;
-
-    @media only screen and (max-width: $large-desktop){
-       display: none;
     }
   }
 }

--- a/warehouse/templates/index.html
+++ b/warehouse/templates/index.html
@@ -3,15 +3,10 @@
 {% block title %}PyPI - the Python Package Index{% endblock %}
 
 {% macro project_snippet(release) -%}
-
-{% set version = release.version %}
-{% set uploader_username = release.uploader.username %}
-{% set uploader_name = release.uploader.name|default(uploader_username, true) %}
-
 <div class="package-snippet">
   <h3 class="package-snippet__title"><a href="{{ request.route_path('packaging.project', name=release.project.normalized_name) }}">{{ release.project.name }}</a></h3>
-  <p class="package-snippet__meta" {{ l20n("packageSnippetMeta", version=version, user=uploader_name) }}>
-    <span class="package-snippet__version">{{ version }}</span> uploaded by <a href="{{ request.route_path('accounts.profile', username=uploader_username) }}">{{ uploader_name }}</a>
+  <p class="package-snippet__meta" {{ l20n("packageSnippetMeta", version=release.version) }}>
+    <span class="package-snippet__version">{{ release.version }}</span>
   </p>
   <p class="package-snippet__description">{{ release.summary }}</p>
 </div>

--- a/warehouse/templates/packaging/detail.html
+++ b/warehouse/templates/packaging/detail.html
@@ -43,15 +43,10 @@
 
 
 {% macro project_snippet(release) -%}
-
-{% set version = release.version %}
-{% set uploader_username = release.uploader.username %}
-{% set uploader_name = release.uploader.name|default(uploader_username, true) %}
-
 <div class="package-snippet">
   <h3 class="package-snippet__title"><a href="{{ request.route_path('packaging.project', name=release.project.normalized_name) }}">{{ release.project.name }}</a></h3>
-  <p class="package-snippet__meta" {{ l20n("packageSnippetMeta", version=version, user=uploader_name) }}>
-    <span class="package-snippet__version">{{ version }}</span> uploaded by <a href="{{ request.route_path('accounts.profile', username=uploader_username) }}">{{ uploader_name }}</a>
+  <p class="package-snippet__meta" {{ l20n("packageSnippetMeta", version=release.version) }}>
+    <span class="package-snippet__version">{{ release.version }}</span>
   </p>
   <p class="package-snippet__description">{{ release.summary }}</p>
 </div>
@@ -106,10 +101,6 @@
         {% endif %}
         {% endfor %}
       </nav>
-      <p class="package-links__author">
-        <span class="package-links__author-info" {{ l20n("releasedAgoBy", when=release.created|format_date(), by=release.uploader.name|default(release.uploader.username, true)) }}>Uploaded <time class="-js-relative-time" datetime="{{ release.created|format_datetime('yyyy-MM-ddTHH:mm:ssZ') }}">{{ release.created|format_date() }}</time> by <a href="{{ request.route_path('accounts.profile', username=release.uploader.username) }}">{{ release.uploader.name|default(release.uploader.username, true) }}</a></span>
-        <a href="{{ request.route_path('accounts.profile', username=release.uploader.username) }}" class="package-links__author-avatar"><img src="{{ gravatar(release.uploader.email, size=40) }}" class="avatar" height="40" width="40" alt="{{ release.uploader.name|default(release.uploader.username, true) }}"></a>
-      </p>
     </div>
   </div>
 </section>

--- a/warehouse/views.py
+++ b/warehouse/views.py
@@ -117,16 +117,14 @@ def index(request):
     )
     top_projects = (
         request.db.query(release_a)
-               .options(joinedload(release_a.project),
-                        joinedload(release_a.uploader))
+               .options(joinedload(release_a.project))
                .order_by(func.array_idx(project_names, release_a.name))
                .all()
     )
 
     latest_releases = (
         request.db.query(Release)
-                  .options(joinedload(Release.project),
-                           joinedload(Release.uploader))
+                  .options(joinedload(Release.project))
                   .order_by(Release.created.desc())
                   .limit(5)
                   .all()


### PR DESCRIPTION
This is inspired partially by #1060, and it removes the "uploaded by" information from everywhere in the UI. I think we should maybe not remove it from everywhere, but we should instead remove it from everywhere it is surfaced *now* and instead add it in as part of the "Version History & Changelog" view so people can get a list of the history of the releases of the project, when they were releases, and by whom they were released.

This might need a bit of tweaking still, the top bar looks like this now:

<img width="1222" alt="screen-shot-2016-06-12-21-58-06" src="https://cloud.githubusercontent.com/assets/145979/15995406/cacf5154-30e8-11e6-8f27-7799359e3747.png">

However, I'm not sure that the ``Uploaded <on>`` thing actually makes sense still, is that information that important to have always available? Should we just rely on the "Version History & Changelog" page for this and give the project links more room to flow over to the right in? In any case, if we keep it there it's currently in a ``<p class="author">`` and that should probably be changed to something else since it doesn't expose the author anymore.

I don't know if this is the right thing to do or not, so I'll leave this for @nlhkabu to either merge, reject, or ask for further refinement.