### PR TITLE
Provide canonical URL for package detail pages

### DIFF
--- a/warehouse/templates/base.html
+++ b/warehouse/templates/base.html
@@ -31,6 +31,9 @@
 
     <link rel="alternate" type="application/rss+xml" title="RSS: 40 latest updates" href="{{ request.route_path('rss.updates') }}">
     <link rel="alternate" type="application/rss+xml" title="RSS: 40 newest packages" href="{{ request.route_path('rss.packages') }}">
+    {% if self.canonical_url() %}
+    <link rel="canonical" href="{% block canonical_url %}{% endblock %}">
+    {% endif %}
 
     {# TODO: We need a solution to https://github.com/pypa/warehouse/issues/833
      #       before we can progress on this. Currently this breaks html_include

--- a/warehouse/templates/packaging/detail.html
+++ b/warehouse/templates/packaging/detail.html
@@ -60,6 +60,8 @@
 
 {% block title %}{{ release.project.name }}{% endblock %}
 
+{% block canonical_url %}{{ request.route_url('packaging.project', name=release.project.name) }}{% endblock %}
+
 {% block content %}
 <section class="banner">
   <div class="package-header">


### PR DESCRIPTION
...as well as a mechanism to provide it anywhere when required

Fixes #968 

I gave it a thought and according to [this](https://audisto.com/insights/guides/28/#choose-full-urls-over-shortened-urls-for-rel-canonical-29f0d99af867efd897fa2074fcb81bec), absolute URLs should be used in rel=canonical links. There might be an issue, that the canonical URL currently changes whether the webpage is served over http:// or https:// but https://pypi.io/ does the redirect, so I don't think it should be a problem.

I did not accompanied this change with a test, as I'm not sure how to properly test it. My idea is to test that rendered HTML pages with specific package version always have the appropriate rel=canonical link, however I'm not sure where would be the good starting point for this, help is appreciated.