### PR TITLE
Remove README.rst service status badges

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,20 +1,6 @@
 Warehouse
 =========
 
-.. image:: https://readthedocs.org/projects/warehouse/badge/?version=latest
-    :target: https://warehouse.readthedocs.io/
-    :alt: Latest Docs
-
-.. image:: https://travis-ci.org/pypa/warehouse.svg?branch=master
-    :target: https://travis-ci.org/pypa/warehouse
-
-.. image:: http://codecov.io/github/pypa/warehouse/coverage.svg?branch=master
-    :target: http://codecov.io/github/pypa/warehouse?branch=master
-
-.. image:: https://requires.io/github/pypa/warehouse/requirements.svg?branch=master
-     :target: https://requires.io/github/pypa/warehouse/requirements/?branch=master
-     :alt: Requirements Status
-
 Warehouse is a next generation Python Package Repository designed to replace
 the legacy code base that currently powers `PyPI <https://pypi.python.org/>`_
 (whose source code `lives on Github <https://github.com/pypa/pypi-legacy/>`_).


### PR DESCRIPTION
These badges are not super useful, they're either always green or always yellow depending on which badge it is. They're not really conveying any useful information so we'll just get rid of them.