### PR TITLE
Ditch the term 'packages' where we can

### DIFF
--- a/warehouse/templates/accounts/profile.html
+++ b/warehouse/templates/accounts/profile.html
@@ -22,7 +22,7 @@
     </div>
 
     <div class="left-layout__main">
-      <h2>Packages</h2>
+      <h2>Projects</h2>
       <div class="package-list">
         {% for release in projects %}
         <div class="package-snippet">

--- a/warehouse/templates/search/results.html
+++ b/warehouse/templates/search/results.html
@@ -100,7 +100,7 @@
         </div>
           <div>
             <input id="search" type="hidden" name="q" value="{{ term }}">
-            <label for="order">Order packages by &nbsp;</label>
+            <label for="order">Order by &nbsp;</label>
             <select class="-js-form-submit-trigger" name="o">
               {{ search_option("Relevance", "") }}
               {{ search_option("Date Last Updated", "-created") }}
@@ -135,7 +135,7 @@
         {% else %}
           <div class="callout-block">
             <p>
-              There were no packages matching '<em>{{term}}</em>'.
+              There were no results for '<em>{{term}}</em>'.
               {% if page.collection.best_guess %}
                 {{ suggestion_link(page.collection.best_guess) }}
               {% endif %}


### PR DESCRIPTION
This doesn't remove every word "package" from the site, but the ones that it leaves are either places where we're purposely disambiguating the term to explain the difference *OR* it's places where the ambiguity is purposeful.

Fixes #1270