### PR TITLE
Move version number (Closes #1337)

### DIFF
--- a/warehouse/static/sass/blocks/_package-snippet.scss
+++ b/warehouse/static/sass/blocks/_package-snippet.scss
@@ -40,6 +40,7 @@
 
   &__version {
     font-weight: $bold-font-weight;
+    float: right;
   }
 
   &__description {

--- a/warehouse/static/sass/blocks/_package-snippet.scss
+++ b/warehouse/static/sass/blocks/_package-snippet.scss
@@ -15,7 +15,7 @@
 .package-snippet {
   @include card;
   padding: ($spacing-unit / 2) 20px ($spacing-unit / 2) 75px;
-  margin: 10px 0 20px;
+  margin: 5px 0 15px;
   // Use png fallback
   background: $white url('../images/white-cube.png') no-repeat 0 50%;
   // Or svg if the browser supports it

--- a/warehouse/static/sass/blocks/_package-snippet.scss
+++ b/warehouse/static/sass/blocks/_package-snippet.scss
@@ -41,6 +41,9 @@
   &__version {
     font-weight: $bold-font-weight;
     float: right;
+    &::before {
+      content: "v";
+    }
   }
 
   &__description {

--- a/warehouse/static/sass/blocks/_package-snippet.scss
+++ b/warehouse/static/sass/blocks/_package-snippet.scss
@@ -41,9 +41,6 @@
   &__version {
     font-weight: $bold-font-weight;
     float: right;
-    &::before {
-      content: "v";
-    }
   }
 
   &__description {

--- a/warehouse/templates/index.html
+++ b/warehouse/templates/index.html
@@ -4,10 +4,10 @@
 
 {% macro project_snippet(release) -%}
 <div class="package-snippet">
-  <h3 class="package-snippet__title"><a href="{{ request.route_path('packaging.project', name=release.project.normalized_name) }}">{{ release.project.name }}</a></h3>
-  <p class="package-snippet__meta">
+  <h3 class="package-snippet__title">
+    <a href="{{ request.route_path('packaging.project', name=release.project.normalized_name) }}">{{ release.project.name }}</a>
     <span class="package-snippet__version">{{ release.version }}</span>
-  </p>
+  </h3>
   <p class="package-snippet__description">{{ release.summary }}</p>
 </div>
 {%- endmacro %}


### PR DESCRIPTION
I moved the version number from below the title to be inline with it as described in #1337.

I took a few *creative liberties* beyond what's strictly described in the issue:
- The version number is floated to the right. I couldn't decide if it would be better to have the version number maintain the same distance from the right as the indentation level on the left, but the text overflows past this level, so I positioned the version number as in the screenshot below.
- The version number is prefixed with a `v`

if either is a problem I'll happily take it out.

The result:
![](http://i.imgur.com/4q5Sqxp.png)

I haven't yet played with the margins yet, but I'll do that now.