### PR TITLE
Reorder trove classifiers on search sidebar

### DIFF
--- a/warehouse/templates/search/results.html
+++ b/warehouse/templates/search/results.html
@@ -61,7 +61,7 @@
         <input type="hidden" name="o" value="{{ order }}">
 
         {% for top_level, classifiers in available_filters %}
-          <div class="accordion {{'accordion--closed' if not loop.first }}">
+          <div class="accordion accordion--closed">
             <a class="accordion__link -js-accordion-trigger">By {{ top_level }}</a>
             <div class="accordion__content">
               <div class="checkbox-tree">

--- a/warehouse/views.py
+++ b/warehouse/views.py
@@ -44,6 +44,17 @@ SEARCH_BOOSTS = {
     "keywords": 5,
     "summary": 5,
 }
+SEARCH_FILTER_ORDER = (
+    "Programming Language",
+    "License",
+    "Framework",
+    "Topic",
+    "Intended Audience",
+    "Environment",
+    "Operating System",
+    "Natural Language",
+    "Development Status",
+)
 
 
 @view_config(context=HTTPException)
@@ -211,11 +222,17 @@ def search(request):
         first, *_ = cls.classifier.split(' :: ')
         available_filters[first].append(cls.classifier)
 
+    def filter_key(item):
+        try:
+            return SEARCH_FILTER_ORDER.index(item)
+        except ValueError:
+            return 100
+
     return {
         "page": page,
         "term": q,
         "order": request.params.get("o", ''),
-        "available_filters": sorted(available_filters.items()),
+        "available_filters": sorted(available_filters.items(), key=filter_key),
         "applied_filters": request.params.getall("c"),
     }
 

--- a/warehouse/views.py
+++ b/warehouse/views.py
@@ -224,9 +224,9 @@ def search(request):
 
     def filter_key(item):
         try:
-            return SEARCH_FILTER_ORDER.index(item)
+            return 0, SEARCH_FILTER_ORDER.index(item[0]), item[0]
         except ValueError:
-            return 100
+            return 1, 0, item[0]
 
     return {
         "page": page,


### PR DESCRIPTION
Perhaps moving order to database would be a better solution in long term, this would do the trick for now.

I have also fixed https://github.com/pypa/warehouse/issues/1298#issuecomment-229862426 in a separate commit.