### PR TITLE
Update outdated information about external libraries

### DIFF
--- a/docs/development/frontend.rst
+++ b/docs/development/frontend.rst
@@ -6,7 +6,7 @@ CSS handled by SCSS. It uses gulp to process these files and prepare them for
 serving.
 
 All of the static files are located in ``warehouse/static/`` and external
-libraries are found in ``bower.json``.
+libraries are found in ``package.json``.
 
 
 Building


### PR DESCRIPTION
They are now in package.json instead of bower.json.