### PR TITLE
Remove redundant 'docker start' command

### DIFF
--- a/docs/development/getting-started.rst
+++ b/docs/development/getting-started.rst
@@ -15,7 +15,6 @@ Quickstart for Developers with Docker experience
 
     $ git clone git@github.com:pypa/warehouse.git
     $ cd warehouse
-    $ docker start
     $ make serve
     $ make initdb
 


### PR DESCRIPTION
It's not needed and incorrect. 'docker start' needs
at least one argument.