### PR TITLE
Make applied classifiers opened by default

### DIFF
--- a/warehouse/templates/search/results.html
+++ b/warehouse/templates/search/results.html
@@ -103,8 +103,9 @@
         <input id="search" type="hidden" name="q" value="{{ term }}">
         <input type="hidden" name="o" value="{{ order }}">
 
+        {% set applied_filters_str = applied_filters|join(' ') %}
         {% for top_level, classifiers in available_filters %}
-          <div class="accordion accordion--closed">
+          <div class="accordion{{ ' accordion--closed' if top_level not in applied_filters_str else '' }}">
             <a class="accordion__link -js-accordion-trigger">By {{ top_level }}</a>
             <div class="accordion__content">
               <div class="checkbox-tree">


### PR DESCRIPTION
I noticed this while working on #1370. The "By Programming Language" box should not be closed at https://pypi.io/search/?q=&o=&c=Programming+Language+%3A%3A+Ada We need to click again to "By Programming Language" in order to update the filter.