### PR TITLE
Fix link to checksum explanation. Closes #1318

### DIFF
--- a/warehouse/templates/packaging/detail.html
+++ b/warehouse/templates/packaging/detail.html
@@ -293,7 +293,7 @@
                 <tr>
                   <th class="downloads-table__filename">
                     File Name &amp; Checksum
-                    <a href="TODO">
+                    <a href="https://pip.pypa.io/en/stable/reference/pip_install/#hash-checking-mode">
                       <i class="fa fa-question-circle"></i>
                       <span class="sr-only">SHA256 Checksum Help</span>
                     </a>


### PR DESCRIPTION
I've set the link to the pip documentation as @berkerpeksag suggested.