### PR TITLE
truncate long package description text

### DIFF
--- a/warehouse/static/sass/blocks/_package-snippet.scss
+++ b/warehouse/static/sass/blocks/_package-snippet.scss
@@ -46,5 +46,8 @@
     clear: both;
     font-size: 1rem;
     font-style: italic;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 }


### PR DESCRIPTION
discussed here: #827 

i think using a single line description everywhere makes card heights more consistent and visually pleasing.
also other repositories (like [rubygems](https://rubygems.org/search?utf8=%E2%9C%93&query=test) or [metacpan](https://metacpan.org/search?q=test)) are okay with ellipses. and this solution plays nicely with responsive design.

result:
![image](https://cloud.githubusercontent.com/assets/4911300/16862119/e3c368dc-4a68-11e6-9baf-33863af0ebea.png)