### PR TITLE
Switch from pypi.io to pypi.org

### DIFF
--- a/vcl/main.vcl
+++ b/vcl/main.vcl
@@ -95,10 +95,10 @@ sub vcl_recv {
         }
     }
 
-    # Redirect www.pypi.io and warehouse.python.org to pypi.io, this is
-    # purposely done *after* the HTTPS checks.
-    if (std.tolower(req.http.host) ~ "^(www.pypi.io|warehouse.python.org)$") {
-        set req.http.Location = "https://pypi.io" req.url;
+    # Redirect pypi.io, www.pypi.io, and warehouse.python.org to pypi.io, this
+    # is purposely done *after* the HTTPS checks.
+    if (std.tolower(req.http.host) ~ "^(www.pypi.org|(www.)?pypi.io|warehouse.python.org)$") {
+        set req.http.Location = "https://pypi.org" req.url;
         error 750 "Redirect to Primary Domain";
     }
     # Redirect warehouse-staging.python.org to test.pypi.io.


### PR DESCRIPTION
Support pypi.org instead of pypi.io, in particular:

* Redirect www.pypi.io and pypi.io to pypi.org.
* ~~Redirect GET/HEAD requests to upload.pypi.io to upload.pypi.org.~~
* ~~Rewrite the HOST header for all other requests to upload.pypi.io to upload.pypi.org.~~
* ~~Redirect test.pypi.io to test.pypi.org.~~

This will ensure that we switch over to the new domain everywhere except allowing uploads to upload.pypi.io still since we have a released version of Twine that is using that domain by default. A new version of twine should switch to upload.pypi.org but it's not urgent.

This cannot be merged until DNS propagates and we have our TLS certificates configured.