### PR TITLE
Update [pytest] section to [tool:pytest]

### DIFF
--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -3,7 +3,7 @@ coverage
 factory_boy
 freezegun
 pretend
-pytest
+pytest>=3.0.0
 pytest-dbfixtures>=0.9.0
 responses>=0.5.1
 webtest

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 exclude = *.egg,*/interfaces.py,node_modules,.state
 select = E,W,F,N
 
-[pytest]
+[tool:pytest]
 norecursedirs = build dist node_modules *.egg-info .state requirements
 markers =
     unit: Quick running unit tests which test small units of functionality.


### PR DESCRIPTION
This fixes the following warning from the test suite:

```
=============================== pytest-warning summary ===============================
WC1 None [pytest] section in setup.cfg files is deprecated, use [tool:pytest] instead.
```