### PR TITLE
Add intermediate containers

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,3 @@
 .git/*
-
+node_modules
 dev/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,38 +23,42 @@ RUN set -x \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-# Copy the directory into the Dockerfile
-COPY . /app/
-
-# Set our work directory to our app directory
-WORKDIR /app/
-
-# Uncomment the below line and add the appropriate private index for the
-# pypi-theme package.
-# ENV PIP_EXTRA_INDEX_URL ...
-
-# Install Warehouse
 RUN set -x \
     && apt-get update \
     && apt-get install inotify-tools wget bzip2 gcc g++ make libpq-dev libjpeg-dev libffi-dev --no-install-recommends -y \
-    && rm -rf node_modules \
     && wget https://saucelabs.com/downloads/sc-4.3.14-linux.tar.gz -O /tmp/sc.tar.gz \
     && tar zxvf /tmp/sc.tar.gz --strip 1 -C /usr/ \
-    && chmod 755 /usr/bin/sc \
+    && chmod 755 /usr/bin/sc
+
+COPY package.json /tmp/package.json
+
+# Install NPM dependencies
+RUN set -x \
     && npm install -g phantomjs-prebuilt gulp-cli \
+    && cd /tmp \
     && npm install \
+    && mkdir /app \
+    && cp -a /tmp/node_modules /app/
+
+COPY requirements /tmp/requirements
+
+# Install Python dependencies
+RUN set -x \
     && pip install -U pip setuptools \
-    && pip install -r requirements/dev.txt \
-                   -r requirements/tests.txt \
-    && pip install -r requirements/deploy.txt \
-                   -r requirements/main.txt \
+    && pip install -r /tmp/requirements/dev.txt \
+                   -r /tmp/requirements/tests.txt \
+    && pip install -r /tmp/requirements/deploy.txt \
+                   -r /tmp/requirements/main.txt \
     # Uncomment the below line if you're working on the PyPI theme, this is a
     # private repository due to the fact that other people's IP is contained
     # in it.
     # && pip install -c requirements/main.txt -r requirements/theme.txt \
     && find /usr/local -type f -name '*.pyc' -name '*.pyo' -delete \
-    && rm -rf ~/.cache/ \
-    && apt-get purge bzip2 gcc g++ make libpq-dev libffi-dev -y \
-    && apt-get autoremove -y \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    && rm -rf ~/.cache/
+
+# Copy the directory into the container
+COPY . /app/
+
+# Uncomment the below line and add the appropriate private index for the
+# pypi-theme package.
+# ENV PIP_EXTRA_INDEX_URL ...


### PR DESCRIPTION
Changes to the working directory can force a rebuild of the containers after the `COPY . /app/` step. At the moment, this includes downloading a fair amount of dependencies, none of which need to happen after copying the Warehouse source into the container.

This PR moves the installation of these dependencies into a series of intermediate containers before finally performing the `COPY . /app/` step.

Fixes #1221.