### PR TITLE
Only support ZIP_STORED and ZIP_DEFLATED zip files

### DIFF
--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -401,6 +401,27 @@ class TestFileValidation:
 
         assert legacy._is_valid_dist_file(f, "sdist")
 
+    def test_zipfile_supported_compression(self, tmpdir):
+        f = str(tmpdir.join("test.zip"))
+
+        with zipfile.ZipFile(f, "w") as zfp:
+            zfp.writestr("PKG-INFO", b"this is the package info")
+            zfp.writestr("1.txt", b"1", zipfile.ZIP_STORED)
+            zfp.writestr("2.txt", b"2", zipfile.ZIP_DEFLATED)
+
+        assert legacy._is_valid_dist_file(f, "")
+
+    @pytest.mark.parametrize("method", [zipfile.ZIP_BZIP2, zipfile.ZIP_LZMA])
+    def test_zipfile_unsupported_compression(self, tmpdir, method):
+        f = str(tmpdir.join("test.zip"))
+
+        with zipfile.ZipFile(f, "w") as zfp:
+            zfp.writestr("1.txt", b"1", zipfile.ZIP_STORED)
+            zfp.writestr("2.txt", b"2", zipfile.ZIP_DEFLATED)
+            zfp.writestr("3.txt", b"3", method)
+
+        assert not legacy._is_valid_dist_file(f, "")
+
     def test_egg_no_pkg_info(self, tmpdir):
         f = str(tmpdir.join("test.egg"))
 

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -486,6 +486,15 @@ def _is_valid_dist_file(filename, filetype):
     a valid distribution file.
     """
 
+    # If our file is a zipfile, then ensure that it's members are only
+    # compressed with supported compression methods.
+    if zipfile.is_zipfile(filename):
+        with zipfile.ZipFile(filename) as zfp:
+            for zinfo in zfp.infolist():
+                if zinfo.compress_type not in {zipfile.ZIP_STORED,
+                                               zipfile.ZIP_DEFLATED}:
+                    return False
+
     if filename.endswith(".exe"):
         # The only valid filetype for a .exe file is "bdist_wininst".
         if filetype != "bdist_wininst":


### PR DESCRIPTION
Zip files support compressing individual members with different compression methods, and each of those methods have different Python version requirements as well as C library requirements. To keep the possible requirements down, we will only support ``ZIP_STORED``, which has no compression and ``ZIP_DEFLATED`` which depends on the near universally available, zlib library.