### PR TITLE
add support for opengraph tags to warehouse

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,10 @@ saucelabs:
 lint: .state/env/pyvenv.cfg
 	$(BINDIR)/flake8 .
 	$(BINDIR)/doc8 --allow-long-titles README.rst CONTRIBUTING.rst docs/ --ignore-path docs/_build/
-	$(BINDIR)/html_lint.py --disable=optional_tag,names,protocol `find ./warehouse/templates -path ./warehouse/templates/legacy -prune -o -name '*.html' -print`
+	# TODO: Figure out a solution to https://github.com/deezer/template-remover/issues/1
+	#       so we can remove extra_whitespace from below.
+	$(BINDIR)/html_lint.py --disable=optional_tag,names,protocol,extra_whitespace `find ./warehouse/templates -path ./warehouse/templates/legacy -prune -o -name '*.html' -print`
+
 	./node_modules/.bin/eslint 'warehouse/static/js/**'
 
 

--- a/warehouse/templates/base.html
+++ b/warehouse/templates/base.html
@@ -22,6 +22,7 @@
     <meta name="availableLanguages" content="en">
 
     <title>{% block title_base %}{% block title %}{% endblock %}{% if self.title() %} · {% endif %}{{ request.registry.settings['site.name'] }}{% endblock %}</title>
+    <meta name="description" content="{% block description %}The Python Package Index (PyPI) is a repository of software for the Python programming language.{% endblock %}">
 
     <link rel="stylesheet" href="{{ request.static_path('warehouse:static/dist/css/warehouse.css') }}">
     <link rel="stylesheet" href="{{ request.static_path('warehouse:static/dist/css/font-awesome.css') }}">
@@ -34,6 +35,13 @@
     {% if self.canonical_url() %}
     <link rel="canonical" href="{% block canonical_url %}{% endblock %}">
     {% endif %}
+
+    <meta property="og:url" content="{{ request.current_route_url() }}">
+    <meta property="og:site_name" content="PyPI">
+    <meta property="og:type" content="website">
+    <meta property="og:image" content="{{ request.static_url('warehouse:static/dist/images/logo-large.svg') }}">
+    <meta property="og:title" content="{{ self.title()|default('Python Package Index') }}">
+    <meta property="og:description" content="{{ self.description() }}">
 
     <link rel="search" type="application/opensearchdescription+xml" title="PyPI" href="{{ request.route_path('opensearch.xml') }}">
 

--- a/warehouse/templates/packaging/detail.html
+++ b/warehouse/templates/packaging/detail.html
@@ -55,6 +55,8 @@
 
 {% block title %}{{ release.project.name }}{% endblock %}
 
+{% block description %}{{ release.summary }}{% endblock %}
+
 {% block canonical_url %}{{ request.route_url('packaging.project', name=release.project.name) }}{% endblock %}
 
 {% block content %}


### PR DESCRIPTION
These tags are used for Facebook, Slack, Pinterest, and other sites and provide richer metadata when sharing links.

This may resolve #677.