### PR TITLE
Allow/Disallow legacy types and extensions

### DIFF
--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -870,6 +870,69 @@ class TestFileUpload:
         assert resp.status_code == 400
         assert resp.status == "400 Invalid distribution file."
 
+    def test_upload_fails_with_legacy_type(self, pyramid_config, db_request):
+        pyramid_config.testing_securitypolicy(userid=1)
+
+        user = UserFactory.create()
+        project = ProjectFactory.create()
+        release = ReleaseFactory.create(project=project, version="1.0")
+        RoleFactory.create(user=user, project=project)
+
+        filename = "{}-{}.tar.gz".format(project.name, release.version)
+
+        db_request.POST = MultiDict({
+            "metadata_version": "1.2",
+            "name": project.name,
+            "version": release.version,
+            "filetype": "bdist_dumb",
+            "pyversion": "2.7",
+            "md5_digest": "335c476dc930b959dda9ec82bd65ef19",
+            "content": pretend.stub(
+                filename=filename,
+                file=io.BytesIO(b"A fake file."),
+                type="application/tar",
+            ),
+        })
+
+        with pytest.raises(HTTPBadRequest) as excinfo:
+            legacy.file_upload(db_request)
+
+        resp = excinfo.value
+
+        assert resp.status_code == 400
+        assert resp.status == "400 Unknown type of file."
+
+    def test_upload_fails_with_legacy_ext(self, pyramid_config, db_request):
+        pyramid_config.testing_securitypolicy(userid=1)
+
+        user = UserFactory.create()
+        project = ProjectFactory.create()
+        release = ReleaseFactory.create(project=project, version="1.0")
+        RoleFactory.create(user=user, project=project)
+
+        filename = "{}-{}.tar.bz2".format(project.name, release.version)
+
+        db_request.POST = MultiDict({
+            "metadata_version": "1.2",
+            "name": project.name,
+            "version": release.version,
+            "filetype": "sdist",
+            "md5_digest": "335c476dc930b959dda9ec82bd65ef19",
+            "content": pretend.stub(
+                filename=filename,
+                file=io.BytesIO(b"A fake file."),
+                type="application/tar",
+            ),
+        })
+
+        with pytest.raises(HTTPBadRequest) as excinfo:
+            legacy.file_upload(db_request)
+
+        resp = excinfo.value
+
+        assert resp.status_code == 400
+        assert resp.status == "400 Invalid file extension."
+
     @pytest.mark.parametrize("sig", [b"lol nope"])
     def test_upload_fails_with_invalid_signature(self, pyramid_config,
                                                  db_request, sig):
@@ -1440,6 +1503,96 @@ class TestFileUpload:
                 "10.10.10.30",
             ),
         ]
+
+    def test_upload_succeeds_with_legacy_ext(self, tmpdir, monkeypatch,
+                                             pyramid_config, db_request):
+        monkeypatch.setattr(tempfile, "tempdir", str(tmpdir))
+
+        pyramid_config.testing_securitypolicy(userid=1)
+
+        user = UserFactory.create()
+        project = ProjectFactory.create(allow_legacy_files=True)
+        release = ReleaseFactory.create(project=project, version="1.0")
+        RoleFactory.create(user=user, project=project)
+
+        filename = "{}-{}.tar.bz2".format(project.name, release.version)
+
+        db_request.user = user
+        db_request.client_addr = "10.10.10.30"
+        db_request.POST = MultiDict({
+            "metadata_version": "1.2",
+            "name": project.name,
+            "version": release.version,
+            "filetype": "sdist",
+            "pyversion": "source",
+            "md5_digest": "335c476dc930b959dda9ec82bd65ef19",
+            "content": pretend.stub(
+                filename=filename,
+                file=io.BytesIO(b"A fake file."),
+                type="application/tar",
+            ),
+        })
+
+        def storage_service_store(path, file_path, *, meta):
+            with open(file_path, "rb") as fp:
+                assert fp.read() == b"A fake file."
+
+        storage_service = pretend.stub(store=storage_service_store)
+        db_request.find_service = lambda svc: storage_service
+
+        monkeypatch.setattr(
+            legacy,
+            "_is_valid_dist_file", lambda *a, **kw: True,
+        )
+
+        resp = legacy.file_upload(db_request)
+
+        assert resp.status_code == 200
+
+    def test_upload_succeeds_with_legacy_type(self, tmpdir, monkeypatch,
+                                              pyramid_config, db_request):
+        monkeypatch.setattr(tempfile, "tempdir", str(tmpdir))
+
+        pyramid_config.testing_securitypolicy(userid=1)
+
+        user = UserFactory.create()
+        project = ProjectFactory.create(allow_legacy_files=True)
+        release = ReleaseFactory.create(project=project, version="1.0")
+        RoleFactory.create(user=user, project=project)
+
+        filename = "{}-{}.tar.gz".format(project.name, release.version)
+
+        db_request.user = user
+        db_request.client_addr = "10.10.10.30"
+        db_request.POST = MultiDict({
+            "metadata_version": "1.2",
+            "name": project.name,
+            "version": release.version,
+            "filetype": "bdist_dumb",
+            "pyversion": "3.5",
+            "md5_digest": "335c476dc930b959dda9ec82bd65ef19",
+            "content": pretend.stub(
+                filename=filename,
+                file=io.BytesIO(b"A fake file."),
+                type="application/tar",
+            ),
+        })
+
+        def storage_service_store(path, file_path, *, meta):
+            with open(file_path, "rb") as fp:
+                assert fp.read() == b"A fake file."
+
+        storage_service = pretend.stub(store=storage_service_store)
+        db_request.find_service = lambda svc: storage_service
+
+        monkeypatch.setattr(
+            legacy,
+            "_is_valid_dist_file", lambda *a, **kw: True,
+        )
+
+        resp = legacy.file_upload(db_request)
+
+        assert resp.status_code == 200
 
     @pytest.mark.parametrize("plat", ["linux_x86_64", "linux_x86_64.win32"])
     def test_upload_fails_with_unsupported_wheel_plat(self, monkeypatch,

--- a/warehouse/migrations/versions/3d2b8a42219a_add_a_flag_for_legacy_file_support.py
+++ b/warehouse/migrations/versions/3d2b8a42219a_add_a_flag_for_legacy_file_support.py
@@ -1,0 +1,45 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Add a flag for legacy file support
+
+Revision ID: 3d2b8a42219a
+Revises: 8c8be2c0e69e
+Create Date: 2016-09-02 18:03:06.175231
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "3d2b8a42219a"
+down_revision = "8c8be2c0e69e"
+
+
+def upgrade():
+    op.add_column(
+        "packages",
+        sa.Column("allow_legacy_files", sa.Boolean(), nullable=True),
+    )
+
+    op.execute("UPDATE packages SET allow_legacy_files = 't'")
+
+    op.alter_column(
+        "packages",
+        "allow_legacy_files",
+        nullable=False,
+        server_default=sa.text("false"),
+    )
+
+
+def downgrade():
+    op.drop_column('packages', 'allow_legacy_files')

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -99,6 +99,11 @@ class Project(SitemapMixin, db.ModelBase):
     has_docs = Column(Boolean)
     upload_limit = Column(Integer, nullable=True)
     last_serial = Column(Integer, nullable=False, server_default=sql.text("0"))
+    allow_legacy_files = Column(
+        Boolean,
+        nullable=False,
+        server_default=sql.false(),
+    )
 
     users = orm.relationship(
         User,


### PR DESCRIPTION
PEP 527 deprecates certain file types and extensions from being uploaded. This will implement that, allowing all current projects to continue to upload them and only disallowing it for new projects.