### PR TITLE
Remove note related to Docker Machine

### DIFF
--- a/docs/development/getting-started.rst
+++ b/docs/development/getting-started.rst
@@ -136,12 +136,6 @@ Viewing Warehouse in a browser
 
 Web container is listening on port 80. It's accessible at ``http://localhost:80/``.
 
-.. note::
-
-    On Mac OS and Windows, the warehouse application might be accessible at
-    ``https://<docker-ip>:80/` you can get information about the docker
-    container with ``docker-machine env``
-
 
 What did we just do and what is happening behind the scenes?
 ------------------------------------------------------------


### PR DESCRIPTION
Removed a note about using `docker-machine env` to determine the ip address. That's no longer possible using Docker for Mac/Windows.