### PR TITLE
WIP: New deprecation feature

### DIFF
--- a/tests/unit/test_routes.py
+++ b/tests/unit/test_routes.py
@@ -105,6 +105,13 @@ def test_routes(warehouse):
             domain=warehouse,
         ),
         pretend.call(
+            "packaging.deprecate",
+            "/project/{name}/deprecate/",
+            factory="warehouse.packaging.models:ProjectFactory",
+            traverse="/{name}",
+            domain=warehouse,
+        ),
+        pretend.call(
             "packaging.release",
             "/project/{name}/{version}/",
             factory="warehouse.packaging.models:ProjectFactory",

--- a/warehouse/migrations/versions/63caa2edd396_create_deprecated_fields.py
+++ b/warehouse/migrations/versions/63caa2edd396_create_deprecated_fields.py
@@ -1,0 +1,53 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+create deprecated fields
+
+Revision ID: 63caa2edd396
+Revises: 3d2b8a42219a
+Create Date: 2016-09-22 10:38:27.188455
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import ENUM
+
+
+revision = '63caa2edd396'
+down_revision = '3d2b8a42219a'
+
+
+def upgrade():
+    enum = ENUM("eol", "insecure", name="deprecated_type", create_type=False)
+    enum.create(op.get_bind(), checkfirst=False)
+    op.add_column(
+        'releases',
+        sa.Column('deprecated_at', sa.DateTime(), nullable=True)
+    )
+    op.add_column(
+        'releases',
+        sa.Column(
+            'deprecated_reason',
+            sa.Enum('eol', 'insecure', name='deprecated_type'),
+            nullable=True
+        )
+    )
+    op.add_column(
+        'releases',
+        sa.Column('deprecated_url', sa.Text(), nullable=True)
+    )
+
+
+def downgrade():
+    op.drop_column('releases', 'deprecated_url')
+    op.drop_column('releases', 'deprecated_reason')
+    op.drop_column('releases', 'deprecated_at')

--- a/warehouse/packaging/forms.py
+++ b/warehouse/packaging/forms.py
@@ -1,0 +1,32 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import wtforms
+import wtforms.fields.html5
+
+from warehouse import forms
+from warehouse.packaging.models import Release
+
+
+class DeprecationForm(forms.Form):
+
+    reason = wtforms.fields.SelectField(
+        choices=Release.DEPRECATED_REASONS
+    )
+    release = wtforms.fields.SelectField()
+
+    url = wtforms.fields.html5.URLField(
+        validators=[
+            wtforms.validators.Optional(),
+            wtforms.validators.URL(),
+        ],
+    )

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -324,6 +324,20 @@ class Release(db.ModelBase):
         viewonly=True,
     )
 
+    deprecated_at = Column(
+        DateTime(timezone=False),
+        nullable=True,
+    )
+    DEPRECATED_REASONS = (
+        ("eol", "End of Life"),
+        ("insecure", "Insecure"),
+    )
+    deprecated_reason = Column(
+        Enum(*[r for r, _ in DEPRECATED_REASONS], name="deprecated_type"),
+        nullable=True,
+    )
+    deprecated_url = Column(Text, nullable=True)
+
     @property
     def urls(self):
         _urls = OrderedDict()

--- a/warehouse/routes.py
+++ b/warehouse/routes.py
@@ -78,6 +78,13 @@ def includeme(config):
         domain=warehouse,
     )
     config.add_route(
+        "packaging.deprecate",
+        "/project/{name}/deprecate/",
+        factory="warehouse.packaging.models:ProjectFactory",
+        traverse="/{name}",
+        domain=warehouse
+    )
+    config.add_route(
         "packaging.release",
         "/project/{name}/{version}/",
         factory="warehouse.packaging.models:ProjectFactory",

--- a/warehouse/static/sass/blocks/_badge.scss
+++ b/warehouse/static/sass/blocks/_badge.scss
@@ -12,4 +12,11 @@
   background-color: $highlight-color;
   padding: 2px 7px;
   border-radius: 3px;
+
+  &--bad {
+    background-color: $danger-color;
+    border: 1px solid darken($danger-color, 7);
+    color: $white;
+  }
+
 }

--- a/warehouse/static/sass/blocks/_horizontal-section.scss
+++ b/warehouse/static/sass/blocks/_horizontal-section.scss
@@ -30,6 +30,21 @@
     border-top: 1px solid darken($base-grey, 10);
   }
 
+  &--bad {
+    background-color: $danger-color;
+    color: $white;
+  }
+
+  &--highlight {
+    color: darken($highlight-color, 50);
+    background-color: $highlight-color;
+  }
+
+  &--bad a{
+    color: $white;
+    text-decoration: underline;
+  }
+
   &--medium {
     padding: 40px 0;
   }

--- a/warehouse/templates/packaging/deprecate.html
+++ b/warehouse/templates/packaging/deprecate.html
@@ -1,0 +1,112 @@
+{#
+ # Licensed under the Apache License, Version 2.0 (the "License");
+ # you may not use this file except in compliance with the License.
+ # You may obtain a copy of the License at
+ #
+ # http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+-#}
+{% extends "base.html" %}
+
+
+{% block title %}Deprecate{% endblock %}
+
+{% block content %}
+  <section class="horizontal-section horizontal-section--medium">
+    <div class="site-container">
+
+    {% if deprecated_releases %}
+      <h2>Deprecated releases</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>Release</th>
+          <th>Deprecated at</th>
+          <th>Reason</th>
+          <th>URL</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for release in deprecated_releases %}
+        <tr>
+          <td>{{ release.version }}</td>
+          <td>{{ release.deprecated_at }}</td>
+          <td>{{ release.deprecated_reason }}</td>
+          <td><a href="{{ release.deprecated_url }}" rel="nofollow">{{ release.deprecated_url }}</a></td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+    {% endif %}
+
+      <h2>Deprecate a release</h2>
+      <p>
+        Todo: Short explanation what it means to deprecate a release. Why it's useful, and so on..
+      </p>
+      <form method="POST" action="{{ request.current_route_path() }}" >
+    <input name="csrf_token" type="hidden" value="{{ request.session.get_csrf_token() }}">
+
+
+    <div>
+    {% if form.errors.__all__ %}
+    <ul class="errors">
+      {% for error in form.errors.__all__ %}
+      <li>{{ error }}</li>
+      {% endfor %}
+    </ul>
+    {% endif %}
+    </div>
+
+    <div>
+      <div>
+        <label for="reasons">Reason</label>
+      </div>
+      {% if form.reason.errors %}
+      <ul class="errors">
+        {% for error in form.reason.errors %}
+        <li>{{ error }}</li>
+        {% endfor %}
+      </ul>
+      {% endif %}
+      {{ form.reason() }}
+      <p>Todo: Help text describing what EOL and insecure mean.</p>
+    </div>
+
+    <div>
+      <div>
+        <label for="releases">Release</label>
+      </div>
+      {% if form.release.errors %}
+      <ul class="errors">
+        {% for error in form.release.errors %}
+        <li>{{ error }}</li>
+        {% endfor %}
+      </ul>
+      {% endif %}
+      {{ form.release() }}
+    </div>
+
+    <div>
+      <div>
+        <label for="url">URL</label>
+      </div>
+      {% if form.url.errors %}
+      <ul class="errors">
+        {% for error in form.url.errors %}
+        <li>{{ error }}</li>
+        {% endfor %}
+      </ul>
+      {% endif %}
+      {{ form.url() }}
+        <p>Todo: Help text what to fill in here</p>
+      </div>
+    <input type="submit" value="Deprecate">
+  </form>
+  </div>
+  </section>
+{% endblock %}

--- a/warehouse/templates/packaging/detail.html
+++ b/warehouse/templates/packaging/detail.html
@@ -85,6 +85,26 @@
   </div>
 </section>
 
+{% if release.deprecated_reason == "insecure" %}
+<section class="horizontal-section horizontal-section--bad horizontal-section--thin">
+  <div class="site-container">
+    This release is insecure and should'nt be used.
+    {% if release.deprecated_url %}
+    <a href="{{ release.deprecated_url }}">Read more about the vulnerabilities</a>.
+    {% endif %}
+  </div>
+</section>
+{% elif release.deprecated_reason == "eol" %}
+<section class="horizontal-section horizontal-section--highlight horizontal-section--thin">
+  <div class="site-container">
+    This release is deprecated, please consider upgrading.
+    {% if release.deprecated_url %}
+    <a href="{{ release.deprecated_url }}">Read more here</a>.
+    {% endif %}
+  </div>
+</section>
+{% endif %}
+
 <section class="package-status">
   <div class="site-container">
     {% if release.version != all_releases[0].version %}
@@ -249,7 +269,11 @@
                 {% else %}
                 <p class="release__version"><a href="{{ request.route_path('packaging.release', name=release.project.name, version=hrelease.version) }}">{{ hrelease.version }}</a></p>
                 {% endif %}
-
+                {% if hrelease.deprecated_reason == "insecure" %}
+                  <span class="badge -bad">Insecure</span>
+                {% elif hrelease.deprecated_reason == "eol" %}
+                  <span class="badge">EOL</span>
+                {% endif %}
                 <p class="release__version-date"><time class="-js-relative-time" datetime="{{ hrelease.created|format_datetime('yyyy-MM-ddTHH:mm:ss') }}">{{ hrelease.created|format_date()}}</time></span>
               </div>
 


### PR DESCRIPTION
This PR is a continuation of https://github.com/pypa/warehouse/pull/910. #798 is also related.

The basic idea is that package maintainers can deprecate a release as insecure or EOL and provide a URL to a CVE or a blog post for further information. 

After the discussion in #910, I've settled for the more generic _deprecation_ instead of just marking a release as insecure.
## Views/Routes

This PR adds a new view `deprecate` under `packaging/views.py`. To use it, the user has to be authenticated and to be a Project maintainer.

There's also a new route `packaging.deprecate`, accessible under `/project/{name}/deprecate/`
## Database

Adds 3 new columns in the releases table, including a migration.
- `deprecated_at`, Datetime, nullable.
- `deprecated_reason`, enum("eol", "insecure"), nullable.
- `deprecated_url`, Text, nullable.
## Template Changes

There's a new template `packaging/deprecate.html` for the `deprecate` view.

Additionally, there are changes in `packaging/detail.html`:
- Adds a visible banner if the selected release is EOL (yellow), or insecure (red)
- Adds badges in the _Version History_ tab.

I couldn't find any form styling options, so the form looks pretty abysmal. Right now the form is just wrapped in `div`s to get proper form blocks. I thought that there's probably a bigger plan for forms in general, so I've decided to not include any stylings here.
## Design

There are some minor changes:
- Adds a `--bad` option to badges (to display insecure releases)
- Adds a `--highlight` and `--bad` option to horizontal sections (to display a banner for the selected release).
## Screenshots
### Deprecate view

![screen shot 2016-09-26 at 17 18 31](https://cloud.githubusercontent.com/assets/2930472/18840088/b5db985c-840d-11e6-952c-8722b5d86dd5.png)
### Release history with insecure and EOL release

![screen shot 2016-09-26 at 10 17 12](https://cloud.githubusercontent.com/assets/2930472/18838735/c8e2795c-8408-11e6-92e1-77bdcc85ae54.png)
### Deprecated release selected

![screen shot 2016-09-26 at 11 36 22](https://cloud.githubusercontent.com/assets/2930472/18838740/ccd44ebe-8408-11e6-9a1e-803289a648b5.png)
### Insecure release selected

![screen shot 2016-09-26 at 11 36 44](https://cloud.githubusercontent.com/assets/2930472/18838795/f8d99690-8408-11e6-9492-41b4a427b0b1.png)
## Discussion/Todo

There are still some things to left to do/discuss here.

Currently, the only _deprecation_ options are insecure and EOL. Maybe add a third, unmaintained?

The deprecation form is full of placeholder texts once we have consensus on the options, this needs to be added.

Where to place the link? The package detail view would be an ideal fit, but from what I know is heavily cached. Is there some kind of session detection mechanism in place that makes it possible to use uncached views of the page?

API? Should this be added to the legacy JSON API views, or is there a new API planned?

Accessibility: Add a warning icon?
