### PR TITLE
Automatically generate a coverage html report

### DIFF
--- a/bin/tests
+++ b/bin/tests
@@ -36,3 +36,4 @@ fi
 # Actually run our tests.
 python -m coverage run -m pytest --strict $@
 python -m coverage report -m
+python -m coverage html

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,7 @@ app:
     - ./docs:/app/docs:z
     - ./warehouse:/app/warehouse:z
     - ./tests:/app/tests:z
+    - ./htmlcov:/app/htmlcov:z
   environment:
     WAREHOUSE_ENV: development
     WAREHOUSE_TOKEN: insecuretoken


### PR DESCRIPTION
Creates a coverage html report with each test run and mounts it at `./htmlcov`. 