### PR TITLE
Check licenses in CI and add missing licences

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -93,6 +93,9 @@ matrix:
             - ubuntu-toolchain-r-test
           packages:
             - g++-4.8
+    - script: make licenses BINDIR="$(dirname $(which python))"
+      env:
+        - SUITE=Licenses
 
 after_success: codecov
 

--- a/Makefile
+++ b/Makefile
@@ -121,10 +121,12 @@ lint: .state/env/pyvenv.cfg
 
 	./node_modules/.bin/eslint 'warehouse/static/js/**'
 
-
 docs: .state/env/pyvenv.cfg
 	$(MAKE) -C docs/ doctest SPHINXOPTS="-W" SPHINXBUILD="$(BINDIR)/sphinx-build"
 	$(MAKE) -C docs/ html SPHINXOPTS="-W" SPHINXBUILD="$(BINDIR)/sphinx-build"
+
+licenses: .state/env/pyvenv.cfg
+	bin/licenses
 
 export DEPCHECKER
 deps: .state/env/pyvenv.cfg

--- a/bin/licenses
+++ b/bin/licenses
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+EXIT_CODE=0
+
+# Search all .py files
+for fn in $(find . -type f -name "*.py" ! -path "./.state*" ! -path "./node_modules*"); do
+    # Check for license in first 3 lines (allows for shebang and encoding)
+    if [[ ! "$(head -3 $fn | grep "^# Licensed")" ]]; then
+        echo $fn is missing a license
+        EXIT_CODE=1
+    fi
+done
+
+exit $EXIT_CODE

--- a/tests/unit/cli/search/__init__.py
+++ b/tests/unit/cli/search/__init__.py
@@ -1,0 +1,11 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/unit/test_csp.py
+++ b/tests/unit/test_csp.py
@@ -1,3 +1,15 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import collections
 
 import pretend

--- a/tests/unit/test_http.py
+++ b/tests/unit/test_http.py
@@ -1,3 +1,15 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import threading
 import queue
 

--- a/tests/unit/test_recaptcha.py
+++ b/tests/unit/test_recaptcha.py
@@ -1,3 +1,15 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import socket
 import urllib.parse
 

--- a/warehouse/csp.py
+++ b/warehouse/csp.py
@@ -1,3 +1,15 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import collections
 import copy
 

--- a/warehouse/http.py
+++ b/warehouse/http.py
@@ -1,3 +1,15 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import threading
 import requests
 

--- a/warehouse/migrations/env.py
+++ b/warehouse/migrations/env.py
@@ -1,3 +1,15 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from alembic import context
 from sqlalchemy import create_engine, pool
 

--- a/warehouse/recaptcha.py
+++ b/warehouse/recaptcha.py
@@ -1,3 +1,15 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import collections
 import http
 

--- a/warehouse/xml.py
+++ b/warehouse/xml.py
@@ -1,1 +1,13 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 XML_CSP = {"style-src": ["'unsafe-inline'"]}


### PR DESCRIPTION
I noticed a couple source files were missing licenses. This PR adds those missing licenses, and adds a CI test to ensure all `.py` files have a license notice.

You can see a failing build for c74645b here: https://travis-ci.org/di/warehouse/jobs/163465151