### PR TITLE
Optimize reindex

### DIFF
--- a/tests/unit/cli/search/test_reindex.py
+++ b/tests/unit/cli/search/test_reindex.py
@@ -84,6 +84,12 @@ class FakeESIndices:
                 else:
                     raise ValueError("Unknown action: {!r}.".format(action))
 
+    def put_settings(self, index, body):
+        pass
+
+    def forcemerge(self, index):
+        pass
+
 
 class FakeESClient:
 

--- a/tests/unit/cli/search/test_reindex.py
+++ b/tests/unit/cli/search/test_reindex.py
@@ -54,6 +54,9 @@ class FakeESIndices:
         self.indices = {}
         self.aliases = {}
 
+        self.put_settings = pretend.call_recorder(lambda *a, **kw: None)
+        self.forcemerge = pretend.call_recorder(lambda *a, **kw: None)
+
     def create(self, index, body):
         self.indices[index] = body
 
@@ -83,12 +86,6 @@ class FakeESIndices:
                     self.remove_alias(values["alias"], values["index"])
                 else:
                     raise ValueError("Unknown action: {!r}.".format(action))
-
-    def put_settings(self, index, body):
-        pass
-
-    def forcemerge(self, index):
-        pass
 
 
 class FakeESClient:
@@ -152,6 +149,8 @@ class TestReindex:
         assert sess_obj.rollback.calls == [pretend.call()]
         assert sess_obj.close.calls == [pretend.call()]
         assert es_client.indices.indices == {}
+        assert es_client.indices.put_settings.calls == []
+        assert es_client.indices.forcemerge.calls == []
 
     def test_successfully_indexes_and_adds_new(self, monkeypatch, cli):
         sess_obj = pretend.stub(
@@ -204,6 +203,20 @@ class TestReindex:
         assert es_client.indices.aliases == {
             "warehouse": ["warehouse-cbcbcbcbcb"],
         }
+        assert es_client.indices.put_settings.calls == [
+            pretend.call(
+                index='warehouse-cbcbcbcbcb',
+                body={
+                    'index': {
+                        'number_of_replicas': 0,
+                        'refresh_interval': '1s',
+                    },
+                },
+            )
+        ]
+        assert es_client.indices.forcemerge.calls == [
+            pretend.call(index='warehouse-cbcbcbcbcb')
+        ]
 
     def test_successfully_indexes_and_replaces(self, monkeypatch, cli):
         sess_obj = pretend.stub(
@@ -258,3 +271,17 @@ class TestReindex:
         assert es_client.indices.aliases == {
             "warehouse": ["warehouse-cbcbcbcbcb"],
         }
+        assert es_client.indices.put_settings.calls == [
+            pretend.call(
+                index='warehouse-cbcbcbcbcb',
+                body={
+                    'index': {
+                        'number_of_replicas': 0,
+                        'refresh_interval': '1s',
+                    },
+                },
+            )
+        ]
+        assert es_client.indices.forcemerge.calls == [
+            pretend.call(index='warehouse-cbcbcbcbcb')
+        ]

--- a/tests/unit/test_search.py
+++ b/tests/unit/test_search.py
@@ -45,7 +45,7 @@ def test_es(monkeypatch):
         pretend.call(
             number_of_shards=1,
             number_of_replicas=0,
-            refresh_interval="5s",
+            refresh_interval="1s",
         )
     ]
     assert index_obj.search.calls == [pretend.call()]

--- a/tests/unit/test_search.py
+++ b/tests/unit/test_search.py
@@ -42,6 +42,10 @@ def test_es(monkeypatch):
     assert index_cls.calls == [pretend.call("warehouse", using=client)]
     assert index_obj.doc_type.calls == [pretend.call(d) for d in doc_types]
     assert index_obj.settings.calls == [
-        pretend.call(number_of_shards=1, number_of_replicas=0),
+        pretend.call(
+            number_of_shards=1,
+            number_of_replicas=0,
+            refresh_interval="5s",
+        )
     ]
     assert index_obj.search.calls == [pretend.call()]

--- a/warehouse/cli/search/reindex.py
+++ b/warehouse/cli/search/reindex.py
@@ -58,7 +58,7 @@ def reindex(config, **kwargs):
     client = config.registry["elasticsearch.client"]
     db = Session(bind=config.registry["sqlalchemy.engine"])
     number_of_replicas = config.registry.get("elasticsearch.replicas", 0)
-    refresh_interval = config.registry.get("elasticsearch.interval", "5s")
+    refresh_interval = config.registry.get("elasticsearch.interval", "1s")
 
     # We use a randomly named index so that we can do a zero downtime reindex.
     # Essentially we'll use a randomly named index which we will use until all

--- a/warehouse/search.py
+++ b/warehouse/search.py
@@ -29,11 +29,15 @@ def doc_type(cls):
     return cls
 
 
-def get_index(name, doc_types, *, using, shards=1, replicas=0):
+def get_index(name, doc_types, *, using, shards=1, replicas=0, interval="5s"):
     index = Index(name, using=using)
     for doc_type in doc_types:
         index.doc_type(doc_type)
-    index.settings(number_of_shards=shards, number_of_replicas=replicas)
+    index.settings(
+        number_of_shards=shards,
+        number_of_replicas=replicas,
+        refresh_interval=interval,
+    )
     return index
 
 

--- a/warehouse/search.py
+++ b/warehouse/search.py
@@ -62,6 +62,8 @@ def includeme(config):
         [urllib.parse.urlunparse(p[:2] + ("",) * 4)],
         verify_certs=True,
         ca_certs=certifi.where(),
+        timeout=30,
+        retry_on_timeout=True,
     )
     config.registry["elasticsearch.index"] = p.path.strip("/")
     config.registry["elasticsearch.shards"] = int(qs.get("shards", ["1"])[0])

--- a/warehouse/search.py
+++ b/warehouse/search.py
@@ -29,7 +29,7 @@ def doc_type(cls):
     return cls
 
 
-def get_index(name, doc_types, *, using, shards=1, replicas=0, interval="5s"):
+def get_index(name, doc_types, *, using, shards=1, replicas=0, interval="1s"):
     index = Index(name, using=using)
     for doc_type in doc_types:
         index.doc_type(doc_type)


### PR DESCRIPTION
This PR finishes work by @robhudson in #1226 to optimize ES reindexing, as well as prevent the occurrence of the occasional `ReadTimeoutError`.

Closes #1224, closes #1226.