### PR TITLE
Add missing licenses to HTML files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ docs: .state/env/pyvenv.cfg
 	$(MAKE) -C docs/ doctest SPHINXOPTS="-W" SPHINXBUILD="$(BINDIR)/sphinx-build"
 	$(MAKE) -C docs/ html SPHINXOPTS="-W" SPHINXBUILD="$(BINDIR)/sphinx-build"
 
-licenses: .state/env/pyvenv.cfg
+licenses:
 	bin/licenses
 
 export DEPCHECKER

--- a/bin/licenses
+++ b/bin/licenses
@@ -3,9 +3,9 @@
 EXIT_CODE=0
 
 # Search all .py files
-for fn in $(find . -type f -name "*.py" ! -path "./.state*" ! -path "./node_modules*"); do
+for fn in $(find . -type f \( -name "*.py" -o -name "*.html" \) ! -path "./.state*" ! -path "./node_modules*" ! -path "./htmlcov*" ! -path "./warehouse/static*"); do
     # Check for license in first 3 lines (allows for shebang and encoding)
-    if [[ ! "$(head -3 $fn | grep "^# Licensed")" ]]; then
+    if [[ ! "$(head -3 $fn | grep "^ *# Licensed")" ]]; then
         echo $fn is missing a license
         EXIT_CODE=1
     fi

--- a/warehouse/templates/accounts/login.html
+++ b/warehouse/templates/accounts/login.html
@@ -1,3 +1,16 @@
+{#
+ # Licensed under the Apache License, Version 2.0 (the "License");
+ # you may not use this file except in compliance with the License.
+ # You may obtain a copy of the License at
+ #
+ # http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+-#}
 {% extends "base.html" %}
 
 {% import "accounts/macros.html" as macros %}

--- a/warehouse/templates/accounts/logout.html
+++ b/warehouse/templates/accounts/logout.html
@@ -1,3 +1,16 @@
+{#
+ # Licensed under the Apache License, Version 2.0 (the "License");
+ # you may not use this file except in compliance with the License.
+ # You may obtain a copy of the License at
+ #
+ # http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+-#}
 {% extends "base.html" %}
 
 {% block title %}Sign out{% endblock %}

--- a/warehouse/templates/accounts/macros.html
+++ b/warehouse/templates/accounts/macros.html
@@ -1,3 +1,16 @@
+{#
+ # Licensed under the Apache License, Version 2.0 (the "License");
+ # you may not use this file except in compliance with the License.
+ # You may obtain a copy of the License at
+ #
+ # http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+-#}
 {% macro legacy_pypi_message(action) -%}
   {% set current_title = "Sign in" if action == "login_form" else "Register" %}
   <section class="horizontal-section">

--- a/warehouse/templates/accounts/profile.html
+++ b/warehouse/templates/accounts/profile.html
@@ -1,3 +1,16 @@
+{#
+ # Licensed under the Apache License, Version 2.0 (the "License");
+ # you may not use this file except in compliance with the License.
+ # You may obtain a copy of the License at
+ #
+ # http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+-#}
 {% extends "base.html" %}
 
 {% block title %}{{ user.username }}{% endblock %}

--- a/warehouse/templates/accounts/register.html
+++ b/warehouse/templates/accounts/register.html
@@ -1,3 +1,16 @@
+{#
+ # Licensed under the Apache License, Version 2.0 (the "License");
+ # you may not use this file except in compliance with the License.
+ # You may obtain a copy of the License at
+ #
+ # http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+-#}
 {% extends "base.html" %}
 
 {% import "accounts/macros.html" as macros %}

--- a/warehouse/templates/includes/current-user-indicator.html
+++ b/warehouse/templates/includes/current-user-indicator.html
@@ -1,3 +1,16 @@
+{#
+ # Licensed under the Apache License, Version 2.0 (the "License");
+ # you may not use this file except in compliance with the License.
+ # You may obtain a copy of the License at
+ #
+ # http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+-#}
 <nav id="user-indicator" class="horizontal-menu horizontal-menu--light horizontal-menu--tall">
 
   {% if request.user %}

--- a/warehouse/templates/includes/input-credentials.html
+++ b/warehouse/templates/includes/input-credentials.html
@@ -1,3 +1,16 @@
+{#
+ # Licensed under the Apache License, Version 2.0 (the "License");
+ # you may not use this file except in compliance with the License.
+ # You may obtain a copy of the License at
+ #
+ # http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+-#}
 {% if form.username.errors %}
 <ul class="errors">
   {% for error in form.username.errors %}

--- a/warehouse/templates/includes/input-recaptcha.html
+++ b/warehouse/templates/includes/input-recaptcha.html
@@ -1,3 +1,16 @@
+{#
+ # Licensed under the Apache License, Version 2.0 (the "License");
+ # you may not use this file except in compliance with the License.
+ # You may obtain a copy of the License at
+ #
+ # http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+-#}
 {% macro recaptcha_html(request, form) -%}
   {% if request.find_service(name="recaptcha").enabled %}
   {% if form.g_recaptcha_response.errors %}

--- a/warehouse/templates/index.html
+++ b/warehouse/templates/index.html
@@ -1,3 +1,16 @@
+{#
+ # Licensed under the Apache License, Version 2.0 (the "License");
+ # you may not use this file except in compliance with the License.
+ # You may obtain a copy of the License at
+ #
+ # http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+-#}
 {% extends "base.html" %}
 
 {% block title %}PyPI - the Python Package Index{% endblock %}

--- a/warehouse/templates/legacy/api/simple/detail.html
+++ b/warehouse/templates/legacy/api/simple/detail.html
@@ -1,3 +1,16 @@
+{#
+ # Licensed under the Apache License, Version 2.0 (the "License");
+ # you may not use this file except in compliance with the License.
+ # You may obtain a copy of the License at
+ #
+ # http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+-#}
 <html>
   <head>
     <title>Links for {{ project.name }}</title>

--- a/warehouse/templates/legacy/api/simple/index.html
+++ b/warehouse/templates/legacy/api/simple/index.html
@@ -1,3 +1,16 @@
+{#
+ # Licensed under the Apache License, Version 2.0 (the "License");
+ # you may not use this file except in compliance with the License.
+ # You may obtain a copy of the License at
+ #
+ # http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+-#}
 <html>
   <head>
     <title>Simple Index</title>


### PR DESCRIPTION
Extending #1466 to check our `.html` files as well, and adding missing licenses.