### PR TITLE
Remove creation of new index when reindexing

### DIFF
--- a/warehouse/cli/search/reindex.py
+++ b/warehouse/cli/search/reindex.py
@@ -81,7 +81,6 @@ def reindex(config, **kwargs):
         replicas=0,
         interval="-1",
     )
-    new_index.create()
 
     # From this point on, if any error occurs, we want to be able to delete our
     # in progress index.


### PR DESCRIPTION
This PR removes the `new_index.create()` call from the reindexing command. I think the explicit call to create a new index is unnecessary, because [elasticsearch will automatically create an index if it has not been created before](https://www.elastic.co/guide/en/elasticsearch/reference/2.2/docs-index_.html#index-creation). 

Furthermore, it is causing problems when reindexing in production:
- Prior to #1471, this line was producing connection timeout errors nearly every time it was called; 
- Since #1471, the call can return before timing out, which produces a `index_already_exists_exception` instead (but still occasionally times out).

The latter issue leads me to believe that this due to a race condition with the automatic index creation -- since our "temporary" index is given a randomly-generated name every time, I don't see any other way that the index could already exist.

I can't reproduce either exception in local development. However, I have verified that reindexing still creates a new index and runs as expected without this line.
