### PR TITLE
Deduplicate getting started info, refer to docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,29 +10,9 @@ You can find more information in the `documentation`_.
 Getting Started
 ---------------
 
-Running a copy of Warehouse locally requires using ``docker`` and
-``docker-compose``. Assuming you have those two items, here are a number of
-commands you can use:
-
-.. code-block:: console
-
-    $ # Start up a local environment
-    $ make serve
-    $ # Start up a local environment in debug mode (pdb enabled)
-    $ make debug
-    $ # Initialize the database and fill it with test data
-    $ make initdb
-    $ # Run the tests
-    $ make tests
-    $ # Build the documentation
-    $ make docs
-    $ # Run the various linters
-    $ make lint
-
-.. note:: reCaptcha is featured in authentication and registration pages. To
-          enable it, pass ``RECAPTCHA_SITE_KEY`` and ``RECAPTCHA_SECRET_KEY``
-          through to ``serve`` and ``debug`` targets.
-
+You can run Warehouse locally using ``docker`` and ``docker-compose``. See
+`Getting started <https://warehouse.readthedocs.io/development/getting-started/>`__
+in the documentation for instructions on how to set it up.
 
 Discussion
 ----------

--- a/docs/development/getting-started.rst
+++ b/docs/development/getting-started.rst
@@ -125,6 +125,10 @@ In a second terminal, separate from the make serve command above, run:
 If you get an error about xz, you may need to install the `xz` utility. This is
 highly likely on Mac OS X and Windows.
 
+.. note:: reCaptcha is featured in authentication and registration pages. To
+          enable it, pass ``RECAPTCHA_SITE_KEY`` and ``RECAPTCHA_SECRET_KEY``
+          through to ``serve`` and ``debug`` targets.
+
 
 Viewing Warehouse in a browser
 ------------------------------
@@ -218,8 +222,8 @@ db     The SQLAlchemy ORM ``Session`` object which has already been configured
 ====== ========================================================================
 
 
-Running tests
-=============
+Running tests and linters
+=========================
 
 .. note:: PostgreSQL 9.4 is required because of pgcrypto extension
 
@@ -240,6 +244,12 @@ If you want to run a specific test, you can use the ``T`` variable:
 .. code-block:: console
 
     $ T=tests/unit/i18n/test_filters.py make tests
+
+You can run linters, programs that check the code, with:
+
+.. code-block:: console
+
+    $ make lint
 
 
 Building documentation


### PR DESCRIPTION
Closes gh-1447

As suggested in that issue, I've made the README refer to the docs, and moved a couple of pieces which weren't duplicated into the docs.