### PR TITLE
Don't strip query string on /search?foo=bar

### DIFF
--- a/vcl/main.vcl
+++ b/vcl/main.vcl
@@ -45,7 +45,7 @@ sub vcl_recv {
     #   * /account/logout/
     #   * /account/register/
     #   * /pypi
-    if (req.url !~ "^/(search/|account/(login|logout|register)/|pypi)") {
+    if (req.url.path !~ "^/(search(/|$)|account/(login|logout|register)/|pypi)") {
         set req.url = req.url.path;
     }
 


### PR DESCRIPTION
Fixes #1488