### PR TITLE
Latest release is non-prerelease if possible

### DIFF
--- a/requirements/main.in
+++ b/requirements/main.in
@@ -9,6 +9,7 @@ click
 disposable-email-domains
 elasticsearch>=5.0.0,<6.0.0
 elasticsearch_dsl>=5.0.0,<6.0.0
+first
 hiredis
 html5lib
 itsdangerous

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -51,6 +51,9 @@ elasticsearch-dsl==5.0.0 \
 elasticsearch==5.0.1 \
     --hash=sha256:0454bb57323c10535570042c5cb2246fbdacd286ef4a537cf82e873982a36293 \
     --hash=sha256:bebb51b1bc312f2a305b49a2c0900bbfcbdfd9f23e93ff1fc05f4132f2a3d1ed
+first==2.0.1 \
+    --hash=sha256:3bb3de3582cb27071cfb514f00ed784dc444b7f96dc21e140de65fe00585c95e \
+    --hash=sha256:41d5b64e70507d0c3ca742d68010a76060eea8a3d863e9b5130ab11a4a91aa0e
 hiredis==0.2.0 \
     --hash=sha256:ca958e13128e49674aa4a96f02746f5de5973f39b57297b84d59fd44d314d5b5
 html5lib==0.9999999 \

--- a/tests/unit/cli/search/test_reindex.py
+++ b/tests/unit/cli/search/test_reindex.py
@@ -15,6 +15,8 @@ import os
 import packaging.version
 import pretend
 
+from first import first
+
 import warehouse.cli.search.reindex
 
 from warehouse.cli.search.reindex import reindex, _project_docs
@@ -42,6 +44,10 @@ def test_project_docs(db_session):
                 "name": p.name,
                 "normalized_name": p.normalized_name,
                 "version": [r.version for r in prs],
+                "latest_version": first(
+                    prs,
+                    key=lambda r: not r.is_prerelease,
+                ).version,
             },
         }
         for p, prs in sorted(releases.items(), key=lambda x: x[0].name.lower())

--- a/tests/unit/packaging/test_search.py
+++ b/tests/unit/packaging/test_search.py
@@ -22,10 +22,11 @@ def test_build_search():
             name="Foobar",
             normalized_name="foobar",
             releases=[
-                pretend.stub(version="1.0"),
-                pretend.stub(version="2.0"),
-                pretend.stub(version="3.0"),
-                pretend.stub(version="4.0"),
+                pretend.stub(version="1.0", is_prerelease=False),
+                pretend.stub(version="2.0", is_prerelease=False),
+                pretend.stub(version="3.0", is_prerelease=False),
+                pretend.stub(version="4.0", is_prerelease=False),
+                pretend.stub(version="5.0.dev0", is_prerelease=True),
             ],
         ),
         summary="This is my summary",
@@ -45,7 +46,8 @@ def test_build_search():
 
     assert obj.meta.id == "foobar"
     assert obj["name"] == "Foobar"
-    assert obj["version"] == ["1.0", "2.0", "3.0", "4.0"]
+    assert obj["version"] == ["5.0.dev0", "4.0", "3.0", "2.0", "1.0"]
+    assert obj["latest_version"] == "4.0"
     assert obj["summary"] == "This is my summary"
     assert obj["description"] == "This is my description"
     assert obj["author"] == "Jane Author"

--- a/warehouse/cli/search/reindex.py
+++ b/warehouse/cli/search/reindex.py
@@ -38,7 +38,7 @@ def _project_docs(db):
                    (joinedload(Release.project)
                     .load_only("normalized_name", "name")
                     .joinedload(Project.releases)
-                    .load_only("version")),
+                    .load_only("version", "is_prerelease")),
                    joinedload(Release._classifiers).load_only("classifier"))
           .distinct(Release.name)
           .order_by(Release.name, Release._pypi_ordering.desc())

--- a/warehouse/migrations/versions/e7b09b5c089d_add_pep440_is_prerelease.py
+++ b/warehouse/migrations/versions/e7b09b5c089d_add_pep440_is_prerelease.py
@@ -1,0 +1,39 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Add pep440_is_prerelease
+
+Revision ID: e7b09b5c089d
+Revises: be4cf6b58557
+Create Date: 2016-12-03 15:04:40.251609
+"""
+
+from alembic import op
+
+
+revision = "e7b09b5c089d"
+down_revision = "be4cf6b58557"
+
+
+def upgrade():
+    op.execute("""
+        CREATE FUNCTION pep440_is_prerelease(text) returns boolean as $$
+                SELECT lower($1) ~* '(a|b|rc|dev|alpha|beta|c|pre|preview)'
+            $$
+            LANGUAGE SQL
+            IMMUTABLE
+            RETURNS NULL ON NULL INPUT;
+    """)
+
+
+def downgrade():
+    op.execute("DROP FUNCTION pep440_is_prerelease")

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -230,6 +230,7 @@ class Release(db.ModelBase):
         primary_key=True,
     )
     version = Column(Text, primary_key=True)
+    is_prerelease = orm.column_property(func.pep440_is_prerelease(version))
     author = Column(Text)
     author_email = Column(Text)
     maintainer = Column(Text)

--- a/warehouse/packaging/views.py
+++ b/warehouse/packaging/views.py
@@ -10,6 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from first import first
 from pyramid.httpexceptions import HTTPMovedPermanently, HTTPNotFound
 from pyramid.view import view_config
 from sqlalchemy.orm.exc import NoResultFound
@@ -40,7 +41,9 @@ def project_detail(project, request):
         release = (
             request.db.query(Release)
                       .filter(Release.project == project)
-                      .order_by(Release._pypi_ordering.desc())
+                      .order_by(
+                            Release.is_prerelease.nullslast(),
+                            Release._pypi_ordering.desc())
                       .limit(1)
                       .one()
         )
@@ -74,9 +77,20 @@ def release_detail(release, request):
     all_releases = (
         request.db.query(Release)
                   .filter(Release.project == project)
-                  .with_entities(Release.version, Release.created)
+                  .with_entities(
+                        Release.version,
+                        Release.is_prerelease,
+                        Release.created)
                   .order_by(Release._pypi_ordering.desc())
                   .all()
+    )
+
+    # Get the latest non-prerelease version of this Project, or the latest
+    # of any version if there are no non-prerelease versions.
+    latest_release = first(
+        all_releases,
+        key=lambda r: not r.is_prerelease,
+        default=all_releases[0],
     )
 
     # Get all of the maintainers for this project.
@@ -107,6 +121,7 @@ def release_detail(release, request):
         "project": project,
         "release": release,
         "files": release.files.all(),
+        "latest_release": latest_release,
         "all_releases": all_releases,
         "maintainers": maintainers,
         "license": license,

--- a/warehouse/templates/packaging/detail.html
+++ b/warehouse/templates/packaging/detail.html
@@ -87,8 +87,8 @@
 
 <section class="package-status">
   <div class="site-container">
-    {% if release.version != all_releases[0].version %}
-    <a class="status-badge status-badge--bad" href="{{ request.route_path('packaging.release', name=release.project.name, version=all_releases[0].version) }}">Newer version available ({{ all_releases[0].version }})</a>
+    {% if release.version != latest_release.version %}
+    <a class="status-badge status-badge--bad" href="{{ request.route_path('packaging.release', name=release.project.name, version=latest_release.version) }}">Newer version available ({{ latest_release.version }})</a>
     {% else %}
     <a class="status-badge status-badge--good" href="{{ request.route_path('packaging.release', name=release.project.name, version=release.version) }}">Latest Version</a>
     {% endif %}

--- a/warehouse/templates/search/results.html
+++ b/warehouse/templates/search/results.html
@@ -17,12 +17,10 @@
 
 {% macro project_snippet(item) -%}
 
-{% set version = item.version[0] %}
-
 <div class="package-snippet">
   <h3 class="package-snippet__title"><a href="{{ request.route_path('packaging.project', name=item.normalized_name) }}">{{ item.name }}</a></h3>
   <p class="package-snippet__meta">
-    <span class="package-snippet__version">{{ version }}</span>
+    <span class="package-snippet__version">{{ item.latest_version }}</span>
   </p>
   <p class="package-snippet__description">{{ item.summary }}</p>
 </div>


### PR DESCRIPTION
Use the PEP 440 mechanism for determining what the "latest" release is. Select the newest non-prerelease as the latest release, unless there are only prereleases, in which case select the newest release.

Fixes #1503