### PR TITLE
Implement rate limiting of failed logins

### DIFF
--- a/requirements/main.in
+++ b/requirements/main.in
@@ -14,6 +14,7 @@ hiredis
 html5lib
 itsdangerous
 Jinja2>=2.8
+limits
 msgpack-python
 packaging>=15.2
 paginate>=0.5.2

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -69,6 +69,8 @@ jmespath==0.9.0 \
 kombu==4.0.0 \
     --hash=sha256:7fdf5e4a5818c476c95df0af24d79ebcef6a66eca1aa477ae3fcfd98d5c420c0 \
     --hash=sha256:fb855eccbe83d3b97d44ac3f5bb809f97b73938017e383953baf3cb60dbb1ea9
+limits==1.2.0 \
+    --hash=sha256:f8b04e2ead526fdd7382c9a9b9c9817530d1377ad5d8743b021f7c5b4a596a33
 Mako==1.0.6 \
     --hash=sha256:48559ebd872a8e77f92005884b3d88ffae552812cdf17db6768e5c3be5ebbe0d
 MarkupSafe==0.23 \

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -136,6 +136,7 @@ def app_config(database):
             "database.url": database,
             "docs.url": "http://docs.example.com/",
             "download_stats.url": "redis://localhost:0/",
+            "ratelimit.url": "memory://",
             "elasticsearch.url": "https://localhost/warehouse",
             "files.backend": "warehouse.packaging.services.LocalFileStorage",
             "files.url": "http://localhost:7000/",

--- a/tests/unit/accounts/test_core.py
+++ b/tests/unit/accounts/test_core.py
@@ -154,7 +154,7 @@ def test_includeme(monkeypatch):
 
     config = pretend.stub(
         register_service_factory=pretend.call_recorder(
-            lambda factory, iface: None
+            lambda factory, iface, name=None: None
         ),
         add_request_method=pretend.call_recorder(lambda f, name, reify: None),
         set_authentication_policy=pretend.call_recorder(lambda p: None),

--- a/tests/unit/accounts/test_forms.py
+++ b/tests/unit/accounts/test_forms.py
@@ -15,6 +15,7 @@ import pytest
 import wtforms
 
 from warehouse.accounts import forms
+from warehouse.accounts.interfaces import TooManyFailedLogins
 from warehouse import recaptcha
 
 
@@ -87,6 +88,27 @@ class TestLoginForm:
             check_password=pretend.call_recorder(
                 lambda userid, password: False
             ),
+        )
+        form = forms.LoginForm(
+            data={"username": "my_username"},
+            user_service=user_service,
+        )
+        field = pretend.stub(data="pw")
+
+        with pytest.raises(wtforms.validators.ValidationError):
+            form.validate_password(field)
+
+        assert user_service.find_userid.calls == [pretend.call("my_username")]
+        assert user_service.check_password.calls == [pretend.call(1, "pw")]
+
+    def test_validate_password_too_many_failed(self):
+        @pretend.call_recorder
+        def check_password(userid, password):
+            raise TooManyFailedLogins(resets_in=None)
+
+        user_service = pretend.stub(
+            find_userid=pretend.call_recorder(lambda userid: 1),
+            check_password=check_password,
         )
         form = forms.LoginForm(
             data={"username": "my_username"},

--- a/tests/unit/accounts/test_services.py
+++ b/tests/unit/accounts/test_services.py
@@ -13,11 +13,13 @@
 import uuid
 
 import pretend
+import pytest
 
 from zope.interface.verify import verifyClass
 
 from warehouse.accounts import services
-from warehouse.accounts.interfaces import IUserService
+from warehouse.accounts.interfaces import IUserService, TooManyFailedLogins
+from warehouse.rate_limiting.interfaces import IRateLimiter
 
 from ...common.db.accounts import UserFactory, EmailFactory
 
@@ -65,9 +67,41 @@ class TestDatabaseUserService:
         service = services.DatabaseUserService(db_session)
         assert service.find_userid(user.username) == user.id
 
+    def test_check_password_global_rate_limited(self):
+        resets = pretend.stub()
+        limiter = pretend.stub(test=lambda: False, resets_in=lambda: resets)
+        service = services.DatabaseUserService(
+            pretend.stub(),
+            ratelimiters={"global": limiter},
+        )
+
+        with pytest.raises(TooManyFailedLogins) as excinfo:
+            service.check_password(uuid.uuid4(), None)
+
+        assert excinfo.value.resets_in is resets
+
     def test_check_password_nonexistant_user(self, db_session):
         service = services.DatabaseUserService(db_session)
         assert not service.check_password(uuid.uuid4(), None)
+
+    def test_check_password_user_rate_limited(self, db_session):
+        user = UserFactory.create()
+        resets = pretend.stub()
+        limiter = pretend.stub(
+            test=pretend.call_recorder(lambda uid: False),
+            resets_in=pretend.call_recorder(lambda uid: resets),
+        )
+        service = services.DatabaseUserService(
+            db_session,
+            ratelimiters={"user": limiter},
+        )
+
+        with pytest.raises(TooManyFailedLogins) as excinfo:
+            service.check_password(user.id, None)
+
+        assert excinfo.value.resets_in is resets
+        assert limiter.test.calls == [pretend.call(user.id)]
+        assert limiter.resets_in.calls == [pretend.call(user.id)]
 
     def test_check_password_invalid(self, db_session):
         user = UserFactory.create()
@@ -178,11 +212,37 @@ class TestDatabaseUserService:
 
 def test_database_login_factory(monkeypatch):
     service_obj = pretend.stub()
-    service_cls = pretend.call_recorder(lambda session: service_obj)
+    service_cls = pretend.call_recorder(
+        lambda session, ratelimiters: service_obj,
+    )
     monkeypatch.setattr(services, "DatabaseUserService", service_cls)
 
+    global_ratelimiter = pretend.stub()
+    user_ratelimiter = pretend.stub()
+
+    def find_service(iface, name, context):
+        assert iface is IRateLimiter
+        assert context is None
+        assert name in {"global.login", "user.login"}
+
+        return ({
+            "global.login": global_ratelimiter,
+            "user.login": user_ratelimiter
+        }).get(name)
+
     context = pretend.stub()
-    request = pretend.stub(db=pretend.stub())
+    request = pretend.stub(
+        db=pretend.stub(),
+        find_service=find_service,
+    )
 
     assert services.database_login_factory(context, request) is service_obj
-    assert service_cls.calls == [pretend.call(request.db)]
+    assert service_cls.calls == [
+        pretend.call(
+            request.db,
+            ratelimiters={
+                "global": global_ratelimiter,
+                "user": user_ratelimiter,
+            },
+        ),
+    ]

--- a/tests/unit/accounts/test_views.py
+++ b/tests/unit/accounts/test_views.py
@@ -20,9 +20,23 @@ import pytest
 from pyramid.httpexceptions import HTTPMovedPermanently, HTTPSeeOther
 
 from warehouse.accounts import views
-from warehouse.accounts.interfaces import IUserService
+from warehouse.accounts.interfaces import IUserService, TooManyFailedLogins
 
 from ...common.db.accounts import UserFactory
+
+
+class TestFailedLoginView:
+    exc = TooManyFailedLogins(resets_in=datetime.timedelta(seconds=600))
+    request = pretend.stub()
+
+    resp = views.failed_logins(exc, request)
+
+    assert resp.status == "429 Too Many Failed Login Attempts"
+    assert resp.detail == (
+        "There have been too many unsuccessful login attempts. Please try "
+        "again later."
+    )
+    assert dict(resp.headers).get("Retry-After") == "600"
 
 
 class TestUserProfile:

--- a/tests/unit/rate_limiting/__init__.py
+++ b/tests/unit/rate_limiting/__init__.py
@@ -1,0 +1,11 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/unit/rate_limiting/test_core.py
+++ b/tests/unit/rate_limiting/test_core.py
@@ -1,0 +1,137 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import datetime
+
+import pretend
+
+from limits import storage
+
+from warehouse import rate_limiting
+from warehouse.rate_limiting import RateLimiter, DummyRateLimiter, RateLimit
+
+
+class TestRateLimiter:
+
+    def test_basic(self):
+        limiter = RateLimiter(
+            storage.MemoryStorage(),
+            "1 per minute",
+            identifiers=["foo"],
+        )
+
+        assert limiter.test("foo")
+        assert limiter.test("bar")
+
+        while limiter.hit("bar"):
+            pass
+
+        assert limiter.test("foo")
+        assert not limiter.test("bar")
+
+    def test_namespacing(self):
+        storage_ = storage.MemoryStorage()
+        limiter1 = RateLimiter(storage_, "1 per minute", identifiers=["foo"])
+        limiter2 = RateLimiter(storage_, "1 per minute")
+
+        assert limiter1.test("bar")
+        assert limiter2.test("bar")
+
+        while limiter1.hit("bar"):
+            pass
+
+        assert limiter2.test("bar")
+        assert not limiter1.test("bar")
+
+    def test_results_in(self):
+        limiter = RateLimiter(storage.MemoryStorage(), "1 per minute")
+
+        assert limiter.resets_in("foo") is None
+
+        while limiter.hit("foo"):
+            pass
+
+        assert limiter.resets_in("foo") > datetime.timedelta(seconds=0)
+        assert limiter.resets_in("foo") < datetime.timedelta(seconds=60)
+
+    def test_results_in_expired(self):
+        limiter = RateLimiter(
+            storage.MemoryStorage(),
+            "1 per minute; 1 per hour; 1 per day",
+        )
+
+        current = datetime.datetime.now(tz=datetime.timezone.utc)
+        stats = iter([
+            (0, 0),
+            ((current + datetime.timedelta(seconds=60)).timestamp(), 0),
+            ((current + datetime.timedelta(seconds=5)).timestamp(), 0),
+        ])
+
+        limiter._window = pretend.stub(
+            get_window_stats=lambda l, *a: next(stats),
+        )
+
+        resets_in = limiter.resets_in("foo")
+
+        assert resets_in > datetime.timedelta(seconds=0)
+        assert resets_in <= datetime.timedelta(seconds=5)
+
+
+class TestDummyRateLimiter:
+
+    def test_basic(self):
+        limiter = DummyRateLimiter()
+
+        assert limiter.test()
+        assert limiter.hit()
+        assert limiter.resets_in() is None
+
+
+class TestRateLimit:
+
+    def test_basic(self):
+        limiter_obj = pretend.stub()
+        limiter_class = pretend.call_recorder(lambda *a, **kw: limiter_obj)
+
+        context = pretend.stub()
+        request = pretend.stub(
+            registry={"ratelimiter.storage": pretend.stub()},
+        )
+
+        result = RateLimit(
+            "1 per 5 minutes",
+            identifiers=["foo"],
+            limiter_class=limiter_class,
+        )(context, request)
+
+        assert result is limiter_obj
+        assert limiter_class.calls == [
+            pretend.call(
+                request.registry["ratelimiter.storage"],
+                limit="1 per 5 minutes",
+                identifiers=["foo"],
+            ),
+        ]
+
+
+def test_includeme():
+    registry = {}
+    config = pretend.stub(
+        registry=pretend.stub(
+            settings={"ratelimit.url": "memory://"},
+            __setitem__=registry.__setitem__,
+        ),
+    )
+
+    rate_limiting.includeme(config)
+
+    assert isinstance(registry["ratelimiter.storage"], storage.MemoryStorage)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -320,6 +320,7 @@ def test_configure(monkeypatch, settings, environment, other_settings):
             pretend.call(".domain"),
             pretend.call(".i18n"),
             pretend.call(".db"),
+            pretend.call(".rate_limiting"),
             pretend.call(".search"),
             pretend.call(".aws"),
             pretend.call(".celery"),

--- a/warehouse/accounts/__init__.py
+++ b/warehouse/accounts/__init__.py
@@ -20,6 +20,8 @@ from warehouse.accounts.services import database_login_factory
 from warehouse.accounts.auth_policy import (
     BasicAuthAuthenticationPolicy, SessionAuthenticationPolicy,
 )
+from warehouse.rate_limiting import RateLimit, IRateLimiter
+
 
 REDIRECT_FIELD_NAME = 'next'
 
@@ -71,3 +73,16 @@ def includeme(config):
 
     # Add a request method which will allow people to access the user object.
     config.add_request_method(_user, name="user", reify=True)
+
+    # Register the rate limits that we're going to be using for our login
+    # attempts
+    config.register_service_factory(
+        RateLimit("10 per 5 minutes"),
+        IRateLimiter,
+        name="user.login",
+    )
+    config.register_service_factory(
+        RateLimit("1000 per 5 minutes"),
+        IRateLimiter,
+        name="global.login",
+    )

--- a/warehouse/accounts/interfaces.py
+++ b/warehouse/accounts/interfaces.py
@@ -13,6 +13,14 @@
 from zope.interface import Interface
 
 
+class TooManyFailedLogins(Exception):
+
+    def __init__(self, *args, resets_in, **kwargs):
+        self.resets_in = resets_in
+
+        return super().__init__(*args, **kwargs)
+
+
 class IUserService(Interface):
 
     def get_user(userid):

--- a/warehouse/accounts/services.py
+++ b/warehouse/accounts/services.py
@@ -10,22 +10,33 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import collections
 import datetime
 import functools
+import logging
 
 from passlib.context import CryptContext
 from sqlalchemy.orm.exc import NoResultFound
 from zope.interface import implementer
 
-from warehouse.accounts.interfaces import IUserService
+from warehouse.accounts.interfaces import IUserService, TooManyFailedLogins
 from warehouse.accounts.models import Email, User
+from warehouse.rate_limiting import IRateLimiter, DummyRateLimiter
+
+
+logger = logging.getLogger(__name__)
 
 
 @implementer(IUserService)
 class DatabaseUserService:
 
-    def __init__(self, session):
+    def __init__(self, session, ratelimiters=None):
+        if ratelimiters is None:
+            ratelimiters = {}
+        ratelimiters = collections.defaultdict(DummyRateLimiter, ratelimiters)
+
         self.db = session
+        self.ratelimiters = ratelimiters
         self.hasher = CryptContext(
             schemes=[
                 "argon2",
@@ -78,24 +89,49 @@ class DatabaseUserService:
         return user_id
 
     def check_password(self, userid, password):
+        # The very first thing we want to do is check to see if we've hit our
+        # global rate limit or not, assuming that we've been configured with a
+        # global rate limiter anyways.
+        if not self.ratelimiters["global"].test():
+            logger.warning("Global failed login threshold reached.")
+            raise TooManyFailedLogins(
+                resets_in=self.ratelimiters["global"].resets_in(),
+            )
+
         user = self.get_user(userid)
-        if user is None:
-            return False
+        if user is not None:
+            # Now, check to make sure that we haven't hitten a rate limit on a
+            # per user basis.
+            if not self.ratelimiters["user"].test(user.id):
+                raise TooManyFailedLogins(
+                    resets_in=self.ratelimiters["user"].resets_in(user.id),
+                )
 
-        # Actually check our hash, optionally getting a new hash for it if
-        # we should upgrade our saved hashed.
-        ok, new_hash = self.hasher.verify_and_update(password, user.password)
+            # Actually check our hash, optionally getting a new hash for it if
+            # we should upgrade our saved hashed.
+            ok, new_hash = self.hasher.verify_and_update(
+                password,
+                user.password,
+            )
 
-        # Check if the password itself was OK or not.
-        if not ok:
-            return False
+            # First, check to see if the password that we were given was OK.
+            if ok:
+                # Then, if the password was OK check to see if we've been given
+                # a new password hash from the hasher, if so we'll want to save
+                # that hash.
+                if new_hash:
+                    user.password = new_hash
 
-        # If we've gotten a new password hash from the hasher, then we'll want
-        # to save that hash.
-        if new_hash:
-            user.password = new_hash
+                return True
 
-        return True
+        # If we've gotten here, then we'll want to record a failed login in our
+        # rate limiting before returning False to indicate a failed password
+        # verification.
+        if user is not None:
+            self.ratelimiters["user"].hit(user.id)
+        self.ratelimiters["global"].hit()
+
+        return False
 
     def create_user(self, username, name, password, email,
                     is_active=False, is_staff=False, is_superuser=False):
@@ -128,4 +164,18 @@ class DatabaseUserService:
 
 
 def database_login_factory(context, request):
-    return DatabaseUserService(request.db)
+    return DatabaseUserService(
+        request.db,
+        ratelimiters={
+            "global": request.find_service(
+                IRateLimiter,
+                name="global.login",
+                context=None,
+            ),
+            "user": request.find_service(
+                IRateLimiter,
+                name="user.login",
+                context=None,
+            ),
+        },
+    )

--- a/warehouse/accounts/views.py
+++ b/warehouse/accounts/views.py
@@ -13,20 +13,41 @@
 import datetime
 
 from pyblake2 import blake2b
-from pyramid.httpexceptions import HTTPMovedPermanently, HTTPSeeOther
+from pyramid.httpexceptions import (
+    HTTPMovedPermanently, HTTPSeeOther, HTTPTooManyRequests,
+)
 from pyramid.security import remember, forget
 from pyramid.view import view_config
 from sqlalchemy.orm import joinedload
 
 from warehouse.accounts import REDIRECT_FIELD_NAME
 from warehouse.accounts import forms
-from warehouse.accounts.interfaces import IUserService
+from warehouse.accounts.interfaces import IUserService, TooManyFailedLogins
 from warehouse.cache.origin import origin_cache
 from warehouse.packaging.models import Project, Release
 from warehouse.utils.http import is_safe_url
 
 
 USER_ID_INSECURE_COOKIE = "user_id__insecure"
+
+
+@view_config(context=TooManyFailedLogins)
+def failed_logins(exc, request):
+    resp = HTTPTooManyRequests(
+        "There have been too many unsuccessful login attempts. Please try "
+        "again later.",
+        retry_after=exc.resets_in.total_seconds(),
+    )
+
+    # TODO: This is kind of gross, but we need it for as long as the legacy
+    #       upload API exists and is supported. Once we get rid of that we can
+    #       get rid of this as well.
+    resp.status = "{} {}".format(
+        resp.status_code,
+        "Too Many Failed Login Attempts",
+    )
+
+    return resp
 
 
 @view_config(

--- a/warehouse/config.py
+++ b/warehouse/config.py
@@ -136,6 +136,7 @@ def configure(settings=None):
     maybe_set(settings, "sentry.transport", "SENTRY_TRANSPORT")
     maybe_set(settings, "sessions.url", "REDIS_URL")
     maybe_set(settings, "download_stats.url", "REDIS_URL")
+    maybe_set(settings, "ratelimit.url", "REDIS_URL")
     maybe_set(settings, "recaptcha.site_key", "RECAPTCHA_SITE_KEY")
     maybe_set(settings, "recaptcha.secret_key", "RECAPTCHA_SECRET_KEY")
     maybe_set(settings, "sessions.secret", "SESSION_SECRET")
@@ -296,6 +297,9 @@ def configure(settings=None):
 
     # Register the configuration for the PostgreSQL database.
     config.include(".db")
+
+    # Register support for our rate limiting mechanisms
+    config.include(".rate_limiting")
 
     config.include(".search")
 

--- a/warehouse/rate_limiting/__init__.py
+++ b/warehouse/rate_limiting/__init__.py
@@ -1,0 +1,112 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from datetime import datetime, timezone
+
+from first import first
+from limits import parse_many
+from limits.strategies import MovingWindowRateLimiter
+from limits.storage import storage_from_string
+from zope.interface import implementer
+
+from warehouse.rate_limiting.interfaces import IRateLimiter
+
+
+@implementer(IRateLimiter)
+class RateLimiter:
+
+    def __init__(self, storage, limit, identifiers=None):
+        if identifiers is None:
+            identifiers = []
+
+        self._window = MovingWindowRateLimiter(storage)
+        self._limits = parse_many(limit)
+        self._identifiers = identifiers
+
+    def _get_identifiers(self, identifiers):
+        return [str(i) for i in list(self._identifiers) + list(identifiers)]
+
+    def test(self, *identifiers):
+        return all([
+            self._window.test(limit, *self._get_identifiers(identifiers))
+            for limit in self._limits
+        ])
+
+    def hit(self, *identifiers):
+        return all([
+            self._window.hit(limit, *self._get_identifiers(identifiers))
+            for limit in self._limits
+        ])
+
+    def resets_in(self, *identifiers):
+        resets = []
+        for limit in self._limits:
+            resets_at, remaining = self._window.get_window_stats(
+                limit,
+                *self._get_identifiers(identifiers),
+            )
+
+            # If this limit has any remaining limits left, then we will skip it
+            # since it doesn't need reset.
+            if remaining > 0:
+                continue
+
+            current = datetime.now(tz=timezone.utc)
+            reset = datetime.fromtimestamp(resets_at, tz=timezone.utc)
+
+            # If our current datetime is either greater than or equal to when
+            # the limit resets, then we will skipp it since it has either
+            # already reset, or it is resetting now.
+            if current >= reset:
+                continue
+
+            # Add a timedelta that represents how long until this limit resets.
+            resets.append(reset - current)
+
+        # If we have any resets, then we'll go through and find whichever one
+        # is going to reset soonest and use that as our hint for when this
+        # limit might be available again.
+        return first(sorted(resets))
+
+
+@implementer(IRateLimiter)
+class DummyRateLimiter:
+
+    def test(self, *identifiers):
+        return True
+
+    def hit(self, *identifiers):
+        return True
+
+    def resets_in(self, *identifiers):
+        return None
+
+
+class RateLimit:
+
+    def __init__(self, limit, identifiers=None, limiter_class=RateLimiter):
+        self.limit = limit
+        self.identifiers = identifiers
+        self.limiter_class = limiter_class
+
+    def __call__(self, context, request):
+        return self.limiter_class(
+            request.registry["ratelimiter.storage"],
+            limit=self.limit,
+            identifiers=self.identifiers,
+        )
+
+
+def includeme(config):
+    config.registry["ratelimiter.storage"] = storage_from_string(
+        config.registry.settings["ratelimit.url"],
+    )

--- a/warehouse/rate_limiting/interfaces.py
+++ b/warehouse/rate_limiting/interfaces.py
@@ -1,0 +1,36 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from zope.interface import Interface
+
+
+class IRateLimiter(Interface):
+
+    def test(*identifiers):
+        """
+        Checks if the rate limit identified by the identifiers has been
+        reached, returning a boolean to indicate whether or not to allow the
+        action.
+        """
+
+    def hit(*identifiers):
+        """
+        Registers a hit for the rate limit identified by the identifiers. This
+        will return a boolean to indicate whether or not to allow the action
+        for which a hit has been registered.
+        """
+
+    def resets_in(*identifiers):
+        """
+        Returns a timedelta indicating how long until the rate limit identified
+        by identifiers will reset.
+        """


### PR DESCRIPTION
This implements a rate limiting scheme for failed logins. It uses the limits of 10 failed login attempts every 5 minutes per user, and 1000 failed login attempts globally (across all users and IPs etc).

This should protect against targeted attacks against a single user (limiting them to effectively 1 per 30 seconds) and mass attacks across all users (limiting to 1.6 attempts per second, but spread out so you can only do a maximum of 10 per user per 5 minutes, allowing you to only test a maximum of 100 users, 10 attempts each in a 5 minute period).

Fixes #707