### PR TITLE
HTML includes fail to nothing on errors

### DIFF
--- a/warehouse/static/js/warehouse/utils/html-include.js
+++ b/warehouse/static/js/warehouse/utils/html-include.js
@@ -34,7 +34,10 @@ export default () => {
   // the new fetch() API which returns a Promise.
   elements.forEach((element) => {
     let p = fetch(element.getAttribute("data-html-include"), fetchOptions)
-            .then(response => { return response.text(); })
+            .then(response => {
+              if (response.ok) { return response.text(); }
+              else { return ""; }
+            })
             .then(content => { element.innerHTML = content; });
     promises.push(p);
   });


### PR DESCRIPTION
Instead of rendering the error page into the content, which is basically never what we want, we will just render nothing into the page if there is an error returned.

Fixes #1592