### PR TITLE
Update elasticsearch dsl 5.0.0 to 5.1.0

### DIFF
--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -74,9 +74,9 @@ disposable-email-domains==0.0.6 \
 docutils==0.13.1 \
     --hash=sha256:de454f1015958450b72641165c08afe7023cd7e3944396448f2fb1b0ccba9d77 \
     --hash=sha256:cb3ebcb09242804f84bdbf0b26504077a054da6772c6f4d625f335cc53ebf94d
-elasticsearch-dsl==5.0.0 \
-    --hash=sha256:9ad78dda39e22dcfa16541a447bf7eda57c4766bfed772d86a7b3b6a9e542250 \
-    --hash=sha256:e686337a4094cc0e9241c616090e86b47e96462e43fe9ecc543025a2cfc9ae7d
+elasticsearch-dsl==5.1.0 \
+    --hash=sha256:5d3800d75240e99bbb0b5b16041e88a65cc8f7ddb34b6041d515a2d76df4352b \
+    --hash=sha256:396393f7102a49605a91261d16218b5dd66b991a4a57cea982649cb52e6f25ac
 elasticsearch==5.0.1 \
     --hash=sha256:0454bb57323c10535570042c5cb2246fbdacd286ef4a537cf82e873982a36293 \
     --hash=sha256:bebb51b1bc312f2a305b49a2c0900bbfcbdfd9f23e93ff1fc05f4132f2a3d1ed

--- a/warehouse/search.py
+++ b/warehouse/search.py
@@ -16,7 +16,7 @@ import certifi
 import elasticsearch
 import venusian
 
-from elasticsearch_dsl import Index
+from elasticsearch_dsl import Index, serializer
 
 
 def doc_type(cls):
@@ -64,6 +64,7 @@ def includeme(config):
         ca_certs=certifi.where(),
         timeout=30,
         retry_on_timeout=True,
+        serializer=serializer.serializer,
     )
     config.registry["elasticsearch.index"] = p.path.strip("/")
     config.registry["elasticsearch.shards"] = int(qs.get("shards", ["1"])[0])


### PR DESCRIPTION
Updated to use `elasticsearch-dsl`'s serializer as mentioned [here](https://github.com/elastic/elasticsearch-dsl-py/blob/master/docs/configuration.rst#configuration).

Closes #1653.