### PR TITLE
Don't use a CA bundle with 1024 bit roots

### DIFF
--- a/tests/unit/test_aws.py
+++ b/tests/unit/test_aws.py
@@ -18,13 +18,6 @@ import pytest
 from warehouse import aws
 
 
-class TestBoto3Session:
-    def test_boto3_session_client_overrides_verify(self):
-        session = aws._Boto3Session()
-        client = session.client(service_name="s3", verify="LOL")
-        assert client._endpoint.verify == "LOL"
-
-
 @pytest.mark.parametrize("region", [None, "us-west-2"])
 def test_aws_session_factory(monkeypatch, region):
     boto_session_obj = pretend.stub()

--- a/tests/unit/test_aws.py
+++ b/tests/unit/test_aws.py
@@ -11,7 +11,6 @@
 # limitations under the License.
 
 import boto3
-import certifi
 import pretend
 import pytest
 

--- a/tests/unit/test_aws.py
+++ b/tests/unit/test_aws.py
@@ -10,6 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import boto3
 import certifi
 import pretend
 import pytest
@@ -18,12 +19,6 @@ from warehouse import aws
 
 
 class TestBoto3Session:
-
-    def test_boto3_session_client_defaults_old_certifi(self):
-        session = aws._Boto3Session()
-        client = session.client(service_name="s3")
-        assert client._endpoint.verify == certifi.old_where()
-
     def test_boto3_session_client_overrides_verify(self):
         session = aws._Boto3Session()
         client = session.client(service_name="s3", verify="LOL")
@@ -34,7 +29,7 @@ class TestBoto3Session:
 def test_aws_session_factory(monkeypatch, region):
     boto_session_obj = pretend.stub()
     boto_session_cls = pretend.call_recorder(lambda **kw: boto_session_obj)
-    monkeypatch.setattr(aws, "_Boto3Session", boto_session_cls)
+    monkeypatch.setattr(boto3.session, "Session", boto_session_cls)
 
     request = pretend.stub(
         registry=pretend.stub(

--- a/warehouse/aws.py
+++ b/warehouse/aws.py
@@ -11,20 +11,6 @@
 # limitations under the License.
 
 import boto3.session
-import certifi
-
-
-class _Boto3Session(boto3.session.Session):
-
-    def client(self, *args, **kwargs):
-        # We have certifi installed, which causes botocore to use the newer
-        # CA Bundle which does not have the 1024 bit roots that Amazon requires
-        # so instead we'll override this so that it uses the old bundle when
-        # talking to Amazon.
-        if kwargs.get("verify") is None:
-            kwargs["verify"] = certifi.old_where()
-
-        return super().client(*args, **kwargs)
 
 
 def aws_session_factory(context, request):
@@ -34,7 +20,7 @@ def aws_session_factory(context, request):
     if request.registry.settings.get("aws.region") is not None:
         kwargs["region_name"] = request.registry.settings["aws.region"]
 
-    return _Boto3Session(
+    return boto3.session.Session(
         aws_access_key_id=request.registry.settings["aws.key_id"],
         aws_secret_access_key=request.registry.settings["aws.secret_key"],
         **kwargs


### PR DESCRIPTION
The fix for this was backported to 1.0.1, including on Ubuntu, so I suspect this code is not needed anymore.