### PR TITLE
DEPCHECKER: dependency updates check fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,11 +23,11 @@ from pip.req import parse_requirements
 
 left, right = sys.argv[1:3]
 left_reqs = {
-    d.name
+    d.name.lower()
 	for d in parse_requirements(left, session=object())
 }
 right_reqs = {
-    d.name
+    d.name.lower()
 	for d in parse_requirements(right, session=object())
 }
 


### PR DESCRIPTION
```
echo "$DEPCHECKER" | python - /tmp/tmp.IOedXGIvzf/deploy.txt requirements/deploy.txt

- automat
- twisted
+ Automat
+ Twisted
```

@dstufft : I think this is not an intended behavior, Ideally they are not different. Hence comparing names converted to lower.
Note: This is not the fix that we were talking here PR #1857 