### PR TITLE
implement limits on response size for changelog and changelog_since_serial XMLRPC endpoints

### DIFF
--- a/tests/unit/legacy/api/test_xmlrpc.py
+++ b/tests/unit/legacy/api/test_xmlrpc.py
@@ -471,7 +471,7 @@ def test_changelog(db_request, with_ids):
         for _ in range(10):
             entries.append(JournalEntryFactory.create(name=project.name))
 
-    entries = sorted(entries, key=lambda x: x.id)
+    entries = sorted(entries, key=lambda x: x.submitted_date)
 
     since = int(
         entries[int(len(entries) / 2)].submitted_date

--- a/warehouse/legacy/api/xmlrpc.py
+++ b/warehouse/legacy/api/xmlrpc.py
@@ -293,7 +293,7 @@ def changelog_since_serial(request, serial):
         request.db.query(JournalEntry)
                   .filter(JournalEntry.id > serial)
                   .order_by(JournalEntry.id)
-                  .all()
+                  .limit(50000)
     )
 
     return [
@@ -318,8 +318,8 @@ def changelog(request, since, with_ids=False):
     entries = (
         request.db.query(JournalEntry)
                   .filter(JournalEntry.submitted_date > since)
-                  .order_by(JournalEntry.id)
-                  .all()
+                  .order_by(JournalEntry.submitted_date)
+                  .limit(50000)
     )
 
     results = (


### PR DESCRIPTION
This matches behavior introduced to XMLRPC in the pypi-legacy codebase.

I ended up tracking a reoccuring severe memory consumption issue to these methods.

When requested with an argument that is wildly behind of the current serial or date, these methods led to very large responses which were slow and cost us precious memory on the backend servers.