### PR TITLE
Automatically run migrations during Heroku's "Release" Phase

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
-web bin/start-web python -m twisted web -n -p tcp:port=$PORT --wsgi warehouse.wsgi.application
+release: bin/release
+web: bin/start-web python -m twisted web -n -p tcp:port=$PORT --wsgi warehouse.wsgi.application
 worker: bin/start-worker celery -A warehouse worker -B -S redbeat.RedBeatScheduler -l info

--- a/bin/release
+++ b/bin/release
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Fail fast and fail hard.
+set -eo pipefail
+
+# Migrate our database to the latest revision.
+python -m warehouse db upgrade head

--- a/bin/release
+++ b/bin/release
@@ -3,5 +3,11 @@
 # Fail fast and fail hard.
 set -eo pipefail
 
+# Setup our Redis settings
+source bin/redis-tls
+
 # Migrate our database to the latest revision.
 python -m warehouse db upgrade head
+
+# Make sure that our Fastly configuration is deployed
+bin/fastly-config

--- a/bin/start-web
+++ b/bin/start-web
@@ -6,9 +6,6 @@ set -eo pipefail
 # Setup our Redis settings
 source bin/redis-tls
 
-# Make sure that our Fastly configuration is deployed
-bin/fastly-config
-
 # Configure Google Cloud
 bin/configure-gcloud
 

--- a/docs/development/database-migrations.rst
+++ b/docs/development/database-migrations.rst
@@ -9,3 +9,13 @@ and adding tables). To autogenerate migrations::
 Then migrate and test your migration::
 
     $ docker-compose run web python -m warehouse db upgrade head
+
+Migrations are automatically ran as part of the deployment process, but prior
+to the old version of Warehouse from being shut down. This means that each
+migration *must* be compatible with the current ``master`` branch of Warehouse.
+
+This makes it more difficult to making breaking changes, since you must phase
+them in over time (for example, to rename a column you must add the column in
+one migration + start writing to that column/reading from both, then you must
+make a migration that backfills all of the data, then switch the code to stop
+using the old column all together, then finally you can remove the old column).

--- a/tests/unit/cli/test_db.py
+++ b/tests/unit/cli/test_db.py
@@ -30,11 +30,24 @@ def test_branches_command(monkeypatch, cli, pyramid_config):
     alembic_branches = pretend.call_recorder(lambda config: None)
     monkeypatch.setattr(alembic.command, "branches", alembic_branches)
 
-    alembic_config = pretend.stub()
+    alembic_config = pretend.stub(attributes={})
     pyramid_config.alembic_config = lambda: alembic_config
+
+    connection = pretend.stub(
+        __enter__=lambda: connection,
+        __exit__=lambda *a, **k: None,
+        execute=pretend.call_recorder(lambda sql: None),
+    )
+    engine = pretend.stub(begin=lambda: connection)
+    pyramid_config.registry["sqlalchemy.engine"] = engine
 
     result = cli.invoke(branches, obj=pyramid_config)
     assert result.exit_code == 0
+    assert alembic_config.attributes == {"connection": connection}
+    assert connection.execute.calls == [
+        pretend.call("SELECT pg_advisory_lock(hashtext('alembic'))"),
+        pretend.call("SELECT pg_advisory_unlock(hashtext('alembic'))"),
+    ]
     assert alembic_branches.calls == [pretend.call(alembic_config)]
 
 
@@ -42,11 +55,24 @@ def test_current_command(monkeypatch, cli, pyramid_config):
     alembic_current = pretend.call_recorder(lambda config: None)
     monkeypatch.setattr(alembic.command, "current", alembic_current)
 
-    alembic_config = pretend.stub()
+    alembic_config = pretend.stub(attributes={})
     pyramid_config.alembic_config = lambda: alembic_config
+
+    connection = pretend.stub(
+        __enter__=lambda: connection,
+        __exit__=lambda *a, **k: None,
+        execute=pretend.call_recorder(lambda sql: None),
+    )
+    engine = pretend.stub(begin=lambda: connection)
+    pyramid_config.registry["sqlalchemy.engine"] = engine
 
     result = cli.invoke(current, obj=pyramid_config)
     assert result.exit_code == 0
+    assert alembic_config.attributes == {"connection": connection}
+    assert connection.execute.calls == [
+        pretend.call("SELECT pg_advisory_lock(hashtext('alembic'))"),
+        pretend.call("SELECT pg_advisory_unlock(hashtext('alembic'))"),
+    ]
     assert alembic_current.calls == [pretend.call(alembic_config)]
 
 
@@ -54,11 +80,24 @@ def test_downgrade_command(monkeypatch, cli, pyramid_config):
     alembic_downgrade = pretend.call_recorder(lambda config, revision: None)
     monkeypatch.setattr(alembic.command, "downgrade", alembic_downgrade)
 
-    alembic_config = pretend.stub()
+    alembic_config = pretend.stub(attributes={})
     pyramid_config.alembic_config = lambda: alembic_config
+
+    connection = pretend.stub(
+        __enter__=lambda: connection,
+        __exit__=lambda *a, **k: None,
+        execute=pretend.call_recorder(lambda sql: None),
+    )
+    engine = pretend.stub(begin=lambda: connection)
+    pyramid_config.registry["sqlalchemy.engine"] = engine
 
     result = cli.invoke(downgrade, ["--", "-1"], obj=pyramid_config)
     assert result.exit_code == 0
+    assert alembic_config.attributes == {"connection": connection}
+    assert connection.execute.calls == [
+        pretend.call("SELECT pg_advisory_lock(hashtext('alembic'))"),
+        pretend.call("SELECT pg_advisory_unlock(hashtext('alembic'))"),
+    ]
     assert alembic_downgrade.calls == [pretend.call(alembic_config, "-1")]
 
 
@@ -76,11 +115,24 @@ def test_heads_command(monkeypatch, cli, pyramid_config, args, ekwargs):
     )
     monkeypatch.setattr(alembic.command, "heads", alembic_heads)
 
-    alembic_config = pretend.stub()
+    alembic_config = pretend.stub(attributes={})
     pyramid_config.alembic_config = lambda: alembic_config
+
+    connection = pretend.stub(
+        __enter__=lambda: connection,
+        __exit__=lambda *a, **k: None,
+        execute=pretend.call_recorder(lambda sql: None),
+    )
+    engine = pretend.stub(begin=lambda: connection)
+    pyramid_config.registry["sqlalchemy.engine"] = engine
 
     result = cli.invoke(heads, args, obj=pyramid_config)
     assert result.exit_code == 0
+    assert alembic_config.attributes == {"connection": connection}
+    assert connection.execute.calls == [
+        pretend.call("SELECT pg_advisory_lock(hashtext('alembic'))"),
+        pretend.call("SELECT pg_advisory_unlock(hashtext('alembic'))"),
+    ]
     assert alembic_heads.calls == [pretend.call(alembic_config, **ekwargs)]
 
 
@@ -88,11 +140,24 @@ def test_history_command(monkeypatch, cli, pyramid_config):
     alembic_history = pretend.call_recorder(lambda config, range: None)
     monkeypatch.setattr(alembic.command, "history", alembic_history)
 
-    alembic_config = pretend.stub()
+    alembic_config = pretend.stub(attributes={})
     pyramid_config.alembic_config = lambda: alembic_config
+
+    connection = pretend.stub(
+        __enter__=lambda: connection,
+        __exit__=lambda *a, **k: None,
+        execute=pretend.call_recorder(lambda sql: None),
+    )
+    engine = pretend.stub(begin=lambda: connection)
+    pyramid_config.registry["sqlalchemy.engine"] = engine
 
     result = cli.invoke(history, ["foo:bar"], obj=pyramid_config)
     assert result.exit_code == 0
+    assert alembic_config.attributes == {"connection": connection}
+    assert connection.execute.calls == [
+        pretend.call("SELECT pg_advisory_lock(hashtext('alembic'))"),
+        pretend.call("SELECT pg_advisory_unlock(hashtext('alembic'))"),
+    ]
     assert alembic_history.calls == [pretend.call(alembic_config, "foo:bar")]
 
 
@@ -123,11 +188,24 @@ def test_merge_command(monkeypatch, cli, pyramid_config, args, eargs, ekwargs):
     )
     monkeypatch.setattr(alembic.command, "merge", alembic_merge)
 
-    alembic_config = pretend.stub()
+    alembic_config = pretend.stub(attributes={})
     pyramid_config.alembic_config = lambda: alembic_config
+
+    connection = pretend.stub(
+        __enter__=lambda: connection,
+        __exit__=lambda *a, **k: None,
+        execute=pretend.call_recorder(lambda sql: None),
+    )
+    engine = pretend.stub(begin=lambda: connection)
+    pyramid_config.registry["sqlalchemy.engine"] = engine
 
     result = cli.invoke(merge, args, obj=pyramid_config)
     assert result.exit_code == 0
+    assert alembic_config.attributes == {"connection": connection}
+    assert connection.execute.calls == [
+        pretend.call("SELECT pg_advisory_lock(hashtext('alembic'))"),
+        pretend.call("SELECT pg_advisory_unlock(hashtext('alembic'))"),
+    ]
     assert alembic_merge.calls == [
         pretend.call(alembic_config, *eargs, **ekwargs),
     ]
@@ -167,11 +245,24 @@ def test_revision_command(monkeypatch, cli, pyramid_config, args, ekwargs):
     )
     monkeypatch.setattr(alembic.command, "revision", alembic_revision)
 
-    alembic_config = pretend.stub()
+    alembic_config = pretend.stub(attributes={})
     pyramid_config.alembic_config = lambda: alembic_config
+
+    connection = pretend.stub(
+        __enter__=lambda: connection,
+        __exit__=lambda *a, **k: None,
+        execute=pretend.call_recorder(lambda sql: None),
+    )
+    engine = pretend.stub(begin=lambda: connection)
+    pyramid_config.registry["sqlalchemy.engine"] = engine
 
     result = cli.invoke(revision, args, obj=pyramid_config)
     assert result.exit_code == 0
+    assert alembic_config.attributes == {"connection": connection}
+    assert connection.execute.calls == [
+        pretend.call("SELECT pg_advisory_lock(hashtext('alembic'))"),
+        pretend.call("SELECT pg_advisory_unlock(hashtext('alembic'))"),
+    ]
     assert alembic_revision.calls == [pretend.call(alembic_config, **ekwargs)]
 
 
@@ -179,11 +270,24 @@ def test_show_command(monkeypatch, cli, pyramid_config):
     alembic_show = pretend.call_recorder(lambda config, revision: None)
     monkeypatch.setattr(alembic.command, "show", alembic_show)
 
-    alembic_config = pretend.stub()
+    alembic_config = pretend.stub(attributes={})
     pyramid_config.alembic_config = lambda: alembic_config
+
+    connection = pretend.stub(
+        __enter__=lambda: connection,
+        __exit__=lambda *a, **k: None,
+        execute=pretend.call_recorder(lambda sql: None),
+    )
+    engine = pretend.stub(begin=lambda: connection)
+    pyramid_config.registry["sqlalchemy.engine"] = engine
 
     result = cli.invoke(show, ["foo"], obj=pyramid_config)
     assert result.exit_code == 0
+    assert alembic_config.attributes == {"connection": connection}
+    assert connection.execute.calls == [
+        pretend.call("SELECT pg_advisory_lock(hashtext('alembic'))"),
+        pretend.call("SELECT pg_advisory_unlock(hashtext('alembic'))"),
+    ]
     assert alembic_show.calls == [pretend.call(alembic_config, "foo")]
 
 
@@ -191,11 +295,24 @@ def test_stamp_command(monkeypatch, cli, pyramid_config):
     alembic_stamp = pretend.call_recorder(lambda config, revision: None)
     monkeypatch.setattr(alembic.command, "stamp", alembic_stamp)
 
-    alembic_config = pretend.stub()
+    alembic_config = pretend.stub(attributes={})
     pyramid_config.alembic_config = lambda: alembic_config
+
+    connection = pretend.stub(
+        __enter__=lambda: connection,
+        __exit__=lambda *a, **k: None,
+        execute=pretend.call_recorder(lambda sql: None),
+    )
+    engine = pretend.stub(begin=lambda: connection)
+    pyramid_config.registry["sqlalchemy.engine"] = engine
 
     result = cli.invoke(stamp, ["foo"], obj=pyramid_config)
     assert result.exit_code == 0
+    assert alembic_config.attributes == {"connection": connection}
+    assert connection.execute.calls == [
+        pretend.call("SELECT pg_advisory_lock(hashtext('alembic'))"),
+        pretend.call("SELECT pg_advisory_unlock(hashtext('alembic'))"),
+    ]
     assert alembic_stamp.calls == [pretend.call(alembic_config, "foo")]
 
 
@@ -203,9 +320,22 @@ def test_upgrade_command(monkeypatch, cli, pyramid_config):
     alembic_upgrade = pretend.call_recorder(lambda config, revision: None)
     monkeypatch.setattr(alembic.command, "upgrade", alembic_upgrade)
 
-    alembic_config = pretend.stub()
+    alembic_config = pretend.stub(attributes={})
     pyramid_config.alembic_config = lambda: alembic_config
+
+    connection = pretend.stub(
+        __enter__=lambda: connection,
+        __exit__=lambda *a, **k: None,
+        execute=pretend.call_recorder(lambda sql: None),
+    )
+    engine = pretend.stub(begin=lambda: connection)
+    pyramid_config.registry["sqlalchemy.engine"] = engine
 
     result = cli.invoke(upgrade, ["foo"], obj=pyramid_config)
     assert result.exit_code == 0
+    assert alembic_config.attributes == {"connection": connection}
+    assert connection.execute.calls == [
+        pretend.call("SELECT pg_advisory_lock(hashtext('alembic'))"),
+        pretend.call("SELECT pg_advisory_unlock(hashtext('alembic'))"),
+    ]
     assert alembic_upgrade.calls == [pretend.call(alembic_config, "foo")]

--- a/vcl/main.vcl
+++ b/vcl/main.vcl
@@ -1,3 +1,10 @@
+# Note: It is VERY important to ensure that any changes to VCL will work
+#       properly with both the current version of ``master`` and the version in
+#       the pull request that adds any new changes. This is because the
+#       configuration will be applied automatically as part of the deployment
+#       process, but while the previous version of the code is still up and
+#       running. Thus backwards incompatible changes must be broken up over
+#       multiple pull requests in order to phase them in over multiple deploys.
 
 sub vcl_recv {
 

--- a/warehouse/cli/db/branches.py
+++ b/warehouse/cli/db/branches.py
@@ -13,7 +13,7 @@
 import alembic.command
 import click
 
-from warehouse.cli.db import db
+from warehouse.cli.db import db, alembic_lock
 
 
 @db.command()
@@ -22,4 +22,6 @@ def branches(config, **kwargs):
     """
     Show current branch points.
     """
-    alembic.command.branches(config.alembic_config(), **kwargs)
+    with alembic_lock(config.registry["sqlalchemy.engine"],
+                      config.alembic_config()) as alembic_config:
+        alembic.command.branches(alembic_config, **kwargs)

--- a/warehouse/cli/db/current.py
+++ b/warehouse/cli/db/current.py
@@ -13,7 +13,7 @@
 import alembic.command
 import click
 
-from warehouse.cli.db import db
+from warehouse.cli.db import db, alembic_lock
 
 
 @db.command()
@@ -22,4 +22,6 @@ def current(config, **kwargs):
     """
     Display the current revision for a database.
     """
-    alembic.command.current(config.alembic_config(), **kwargs)
+    with alembic_lock(config.registry["sqlalchemy.engine"],
+                      config.alembic_config()) as alembic_config:
+        alembic.command.current(alembic_config, **kwargs)

--- a/warehouse/cli/db/downgrade.py
+++ b/warehouse/cli/db/downgrade.py
@@ -13,7 +13,7 @@
 import alembic.command
 import click
 
-from warehouse.cli.db import db
+from warehouse.cli.db import db, alembic_lock
 
 
 @db.command()
@@ -23,4 +23,6 @@ def downgrade(config, revision, **kwargs):
     """
     Revert to a previous version.
     """
-    alembic.command.downgrade(config.alembic_config(), revision, **kwargs)
+    with alembic_lock(config.registry["sqlalchemy.engine"],
+                      config.alembic_config()) as alembic_config:
+        alembic.command.downgrade(alembic_config, revision, **kwargs)

--- a/warehouse/cli/db/heads.py
+++ b/warehouse/cli/db/heads.py
@@ -13,7 +13,7 @@
 import alembic.command
 import click
 
-from warehouse.cli.db import db
+from warehouse.cli.db import db, alembic_lock
 
 
 @db.command()
@@ -27,4 +27,6 @@ def heads(config, **kwargs):
     """
     Show current available heads.
     """
-    alembic.command.heads(config.alembic_config(), **kwargs)
+    with alembic_lock(config.registry["sqlalchemy.engine"],
+                      config.alembic_config()) as alembic_config:
+        alembic.command.heads(alembic_config, **kwargs)

--- a/warehouse/cli/db/history.py
+++ b/warehouse/cli/db/history.py
@@ -13,7 +13,7 @@
 import alembic.command
 import click
 
-from warehouse.cli.db import db
+from warehouse.cli.db import db, alembic_lock
 
 
 @db.command()
@@ -23,4 +23,6 @@ def history(config, revision_range, **kwargs):
     """
     List changeset scripts in chronological order.
     """
-    alembic.command.history(config.alembic_config(), revision_range, **kwargs)
+    with alembic_lock(config.registry["sqlalchemy.engine"],
+                      config.alembic_config()) as alembic_config:
+        alembic.command.history(alembic_config, revision_range, **kwargs)

--- a/warehouse/cli/db/merge.py
+++ b/warehouse/cli/db/merge.py
@@ -13,7 +13,7 @@
 import alembic.command
 import click
 
-from warehouse.cli.db import db
+from warehouse.cli.db import db, alembic_lock
 
 
 @db.command()
@@ -36,4 +36,6 @@ def merge(config, revisions, **kwargs):
     Takes one or more revisions or "heads" for all heads and merges them into
     a single revision.
     """
-    alembic.command.merge(config.alembic_config(), revisions, **kwargs)
+    with alembic_lock(config.registry["sqlalchemy.engine"],
+                      config.alembic_config()) as alembic_config:
+        alembic.command.merge(alembic_config, revisions, **kwargs)

--- a/warehouse/cli/db/revision.py
+++ b/warehouse/cli/db/revision.py
@@ -13,7 +13,7 @@
 import alembic.command
 import click
 
-from warehouse.cli.db import db
+from warehouse.cli.db import db, alembic_lock
 
 
 @db.command()
@@ -52,4 +52,6 @@ def revision(config, **kwargs):
     """
     Create a new revision file.
     """
-    alembic.command.revision(config.alembic_config(), **kwargs)
+    with alembic_lock(config.registry["sqlalchemy.engine"],
+                      config.alembic_config()) as alembic_config:
+        alembic.command.revision(alembic_config, **kwargs)

--- a/warehouse/cli/db/show.py
+++ b/warehouse/cli/db/show.py
@@ -13,7 +13,7 @@
 import alembic.command
 import click
 
-from warehouse.cli.db import db
+from warehouse.cli.db import db, alembic_lock
 
 
 @db.command()
@@ -23,4 +23,6 @@ def show(config, revision, **kwargs):
     """
     Show the revision(s) denoted by the given symbol.
     """
-    alembic.command.show(config.alembic_config(), revision, **kwargs)
+    with alembic_lock(config.registry["sqlalchemy.engine"],
+                      config.alembic_config()) as alembic_config:
+        alembic.command.show(alembic_config, revision, **kwargs)

--- a/warehouse/cli/db/stamp.py
+++ b/warehouse/cli/db/stamp.py
@@ -13,7 +13,7 @@
 import alembic.command
 import click
 
-from warehouse.cli.db import db
+from warehouse.cli.db import db, alembic_lock
 
 
 @db.command()
@@ -23,4 +23,6 @@ def stamp(config, revision, **kwargs):
     """
     Stamp the revision table with the given revision.
     """
-    alembic.command.stamp(config.alembic_config(), revision, **kwargs)
+    with alembic_lock(config.registry["sqlalchemy.engine"],
+                      config.alembic_config()) as alembic_config:
+        alembic.command.stamp(alembic_config, revision, **kwargs)

--- a/warehouse/cli/db/upgrade.py
+++ b/warehouse/cli/db/upgrade.py
@@ -13,7 +13,7 @@
 import alembic.command
 import click
 
-from warehouse.cli.db import db
+from warehouse.cli.db import db, alembic_lock
 
 
 @db.command()
@@ -23,4 +23,6 @@ def upgrade(config, revision, **kwargs):
     """
     Upgrade database.
     """
-    alembic.command.upgrade(config.alembic_config(), revision, **kwargs)
+    with alembic_lock(config.registry["sqlalchemy.engine"],
+                      config.alembic_config()) as alembic_config:
+        alembic.command.upgrade(alembic_config, revision, **kwargs)

--- a/warehouse/migrations/script.py.mako
+++ b/warehouse/migrations/script.py.mako
@@ -24,6 +24,15 @@ ${imports if imports else ""}
 revision = ${repr(up_revision)}
 down_revision = ${repr(down_revision)}
 
+# Note: It is VERY important to ensure that a migration does not lock for a
+#       long period of time and to ensure that each individual migration does
+#       not break compatibility with the *previous* version of the code base.
+#       This is because the migrations will be ran automatically as part of the
+#       deployment process, but while the previous version of the code is still
+#       up and running. Thus backwards incompatible changes must be broken up
+#       over multiple migrations inside of multiple pull requests in order to
+#       phase them in over multiple deploys.
+
 def upgrade():
     ${upgrades if upgrades else "pass"}
 


### PR DESCRIPTION
This change ensures that only one alembic command can be run at any one time (and they will queue up behind the currently running command waiting to acquire the lock). This means that two independently run migration commands won't have one of them failing to commit the transaction.

In addition this uses the Heroku [Release Phase](https://devcenter.heroku.com/articles/release-phase) to run the database migrations and deploy the Fastly configuration automatically when a new release is created. That new release won't deploy until after the release command has been run (and if it unsuccessful, the deploy will fail).

This will prevent the Fastly config from slowing down start up as well.

One important caveat here is that obviously with an already running website both the Fastly and the DB migrations will have to not break compatibility with the currently running code unless we're fine with getting errors during that window.

Fixes #661 