### PR TITLE
Add linux_armv6l as a supported wheel type

### DIFF
--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -54,7 +54,7 @@ _allowed_platforms = {
     "any",
     "win32", "win_amd64", "win_ia64",
     "manylinux1_x86_64", "manylinux1_i686",
-    "linux_armv7l",
+    "linux_armv6l", "linux_armv7l",
 }
 # macosx is a little more complicated:
 _macosx_platform_re = re.compile("macosx_10_(\d+)+_(?P<arch>.*)")


### PR DESCRIPTION
https://github.com/pypa/warehouse/issues/2003

armv6 is used by Raspberry Pi 2 and Zero