### PR TITLE
Explicitly create ES index

### DIFF
--- a/tests/unit/cli/search/test_reindex.py
+++ b/tests/unit/cli/search/test_reindex.py
@@ -63,6 +63,7 @@ class FakeESIndices:
         self.put_settings = pretend.call_recorder(lambda *a, **kw: None)
         self.forcemerge = pretend.call_recorder(lambda *a, **kw: None)
         self.delete = pretend.call_recorder(lambda *a, **kw: None)
+        self.create = pretend.call_recorder(lambda *a, **kw: None)
 
     def exists_alias(self, name):
         return name in self.aliases
@@ -184,6 +185,7 @@ class TestReindex:
             registry={
                 "elasticsearch.client": es_client,
                 "elasticsearch.index": "warehouse",
+                "elasticsearch.shards": 42,
                 "sqlalchemy.engine": db_engine,
             },
         )
@@ -201,9 +203,22 @@ class TestReindex:
         assert sess_obj.execute.calls == [
             pretend.call("SET statement_timeout = '600s'"),
         ]
-        assert parallel_bulk .calls == [pretend.call(es_client, docs)]
+        assert parallel_bulk.calls == [pretend.call(es_client, docs)]
         assert sess_obj.rollback.calls == [pretend.call()]
         assert sess_obj.close.calls == [pretend.call()]
+        assert es_client.indices.create.calls == [
+            pretend.call(
+                body={
+                    'settings': {
+                        'number_of_shards': 42,
+                        'number_of_replicas': 0,
+                        'refresh_interval': '-1',
+                    }
+                },
+                wait_for_active_shards=42,
+                index='warehouse-cbcbcbcbcb',
+            )
+        ]
         assert es_client.indices.delete.calls == []
         assert es_client.indices.aliases == {
             "warehouse": ["warehouse-cbcbcbcbcb"],
@@ -252,6 +267,7 @@ class TestReindex:
             registry={
                 "elasticsearch.client": es_client,
                 "elasticsearch.index": "warehouse",
+                "elasticsearch.shards": 42,
                 "sqlalchemy.engine": db_engine,
             },
         )
@@ -272,6 +288,19 @@ class TestReindex:
         assert parallel_bulk.calls == [pretend.call(es_client, docs)]
         assert sess_obj.rollback.calls == [pretend.call()]
         assert sess_obj.close.calls == [pretend.call()]
+        assert es_client.indices.create.calls == [
+            pretend.call(
+                body={
+                    'settings': {
+                        'number_of_shards': 42,
+                        'number_of_replicas': 0,
+                        'refresh_interval': '-1',
+                    }
+                },
+                wait_for_active_shards=42,
+                index='warehouse-cbcbcbcbcb',
+            )
+        ]
         assert es_client.indices.delete.calls == [
             pretend.call('warehouse-aaaaaaaaaa'),
         ]

--- a/warehouse/cli/search/reindex.py
+++ b/warehouse/cli/search/reindex.py
@@ -70,6 +70,7 @@ def reindex(config, **kwargs):
     random_token = binascii.hexlify(os.urandom(5)).decode("ascii")
     new_index_name = "{}-{}".format(index_base, random_token)
     doc_types = config.registry.get("search.doc_types", set())
+    shards = config.registry.get("elasticsearch.shards", 1)
 
     # Create the new index with zero replicas and index refreshes disabled
     # while we are bulk indexing.
@@ -77,10 +78,11 @@ def reindex(config, **kwargs):
         new_index_name,
         doc_types,
         using=client,
-        shards=config.registry.get("elasticsearch.shards", 1),
+        shards=shards,
         replicas=0,
         interval="-1",
     )
+    new_index.create(wait_for_active_shards=shards)
 
     # From this point on, if any error occurs, we want to be able to delete our
     # in progress index.


### PR DESCRIPTION
This fixes #1712 by explicitly creating the new Elasticsearch index when reindexing.

It seems like the behavior has changed since #1473: If we don't explicitly create the index, the default mapping that we get doesn't respect the `keyword` type for properties like `classifier`, which results in them being considered `text` instead, which results in them being tokenized and not matching exactly to their respective values.

To prevent the `index_already_exists_exception` in #1473 from returning, we can now tell `create` to block until all the shards become active. This should prevent the original (hypothesized) race condition between `create`, and `parallel_bulk` attempting to auto-create the index. (It's hard to say whether this really will prevent it as I still haven't been able to reproduce it in dev, but a stale index is better than one that doesn't work at all...) 