### PR TITLE
Remove double border with sticky banner

### DIFF
--- a/warehouse/static/sass/blocks/_notification-bar.scss
+++ b/warehouse/static/sass/blocks/_notification-bar.scss
@@ -46,9 +46,10 @@
   &--success {
     background-color: $success-color;
   }
+}
 
-  // Remove top border when notification-bars are stacked on top of each other
-  + .notification-bar {
-    border-top: 0;
-  }
+// Remove top border when notification-bars are stacked on top of each other
+.notification-bar + .notification-bar,
+.stick-to-top ~ .notification-bar {
+  border-top: 0;
 }

--- a/warehouse/templates/base.html
+++ b/warehouse/templates/base.html
@@ -64,15 +64,13 @@
 
     <section class="stick-to-top js-stick-to-top">
       {% include "warehouse:templates/includes/warning-banner.html" %}
-
       <!-- Add browser warning. Will show for ie9 and below -->
       <!--[if IE]>
       <div class="notification-bar notification-bar--warning">
         <span class="notification-bar__icon"><i class="fa fa-exclamation-triangle"></i></span>
         <span class="notification-bar__message">You are using an unsupported browser, please upgrade to a newer version.</span>
-      <![endif]-->
       </div>
-
+      <![endif]-->
     </section>
 
     {% block flash_messages %}


### PR DESCRIPTION
## Before

![screenshot from 2017-05-25 08-15-57](https://cloud.githubusercontent.com/assets/3323703/26440168/fc62deca-4122-11e7-82a9-e1380d9c0a60.png)

## After

![screenshot from 2017-05-25 08-15-39](https://cloud.githubusercontent.com/assets/3323703/26440169/fc63934c-4122-11e7-8543-528e6e22bce9.png)

Also fixed up the browser warning code, as there was an orphan `</div>` :)