### PR TITLE
update colors of warning badge

### DIFF
--- a/warehouse/static/sass/blocks/_status-badge.scss
+++ b/warehouse/static/sass/blocks/_status-badge.scss
@@ -59,11 +59,10 @@
   }
 
   &--warn {
-    color: $black;
     background-color: $warn-color;
 
     &:hover {
-      color: $black;
+      color: $white;
     }
 
     &:before {

--- a/warehouse/static/sass/settings/_colours.scss
+++ b/warehouse/static/sass/settings/_colours.scss
@@ -3,7 +3,7 @@
 $brand-color:           #006dad;
 $highlight-color:       #ffd343;
 $success-color:         #169428;
-$warn-color:            #ffd343;
+$warn-color:            #f05d22;
 $danger-color:          #f41f1f;
 $brand-color-soft:      lighten($brand-color, 45);
 


### PR DESCRIPTION
Use orange for increased contrast

## Before

![screenshot from 2017-05-26 08-15-53](https://cloud.githubusercontent.com/assets/3323703/26485091/74254e5a-41ed-11e7-8c24-0dd00c2b9e12.png)

## After

![screenshot from 2017-05-26 08-26-43](https://cloud.githubusercontent.com/assets/3323703/26485090/741f1ff8-41ed-11e7-980f-6b8a3393d729.png)