### PR TITLE
make package description container conditional

### DIFF
--- a/warehouse/templates/packaging/detail.html
+++ b/warehouse/templates/packaging/detail.html
@@ -66,7 +66,9 @@
       <h1 class="package-header__name">
         {{ release.project.name }} {{ release.version }}
       </h1>
-      <p class="package-header__description">{% if release.summary %}{{ release.summary }}{% endif %}</p>
+      {% if release.summary %}
+        <p class="package-header__description">{{ release.summary }}</p>
+      {% endif %}
 
       {% if files %}
       <p class="package-header__pip-instructions">


### PR DESCRIPTION
Remove empy `p` when there is no description.

## Before

![screenshot from 2017-05-26 09-39-09](https://cloud.githubusercontent.com/assets/3323703/26487448/73121250-41f7-11e7-92bc-7487bd675ecc.png)

## After

![screenshot from 2017-05-26 09-38-59](https://cloud.githubusercontent.com/assets/3323703/26487447/730e7f64-41f7-11e7-8e17-cb4c43dd184b.png)
