### PR TITLE
Fixes project tabs screen resize problem

### DIFF
--- a/warehouse/static/js/warehouse/index.js
+++ b/warehouse/static/js/warehouse/index.js
@@ -42,10 +42,9 @@ docReady(() => {
 docReady(()=> {
   const headingBtn = document.querySelector(".-js-vertical-tab-content");
   if (headingBtn) {
-    const mobileBtn = document.querySelector(".-js-vertical-tab-mobile-heading");
-    const styleProps = getComputedStyle(mobileBtn, null);
-    projectTabs(styleProps.getPropertyValue("display") === "block");
+    projectTabs();
   }
+  window.addEventListener("resize", projectTabs, false);
 });
 
 // toggle search panel behavior

--- a/warehouse/static/js/warehouse/utils/project-tabs.js
+++ b/warehouse/static/js/warehouse/utils/project-tabs.js
@@ -1,4 +1,7 @@
-export default (inMobileState) => {
+export default () => {
+  const mobileBtn = document.querySelector(".-js-vertical-tab-mobile-heading");
+  const styleProps = getComputedStyle(mobileBtn, null);
+  const inMobileState = (styleProps.getPropertyValue("display") === "block");
   const btnClassName = inMobileState ? ".-js-vertical-tab-mobile-heading" : ".-js-vertical-tab";
   const activeClass = "vertical-tabs__tab--is-active";
   const getBtnByHref = (id) => document.querySelector(`${btnClassName}[href="#${id}"]`);
@@ -34,4 +37,5 @@ export default (inMobileState) => {
     var btn = getBtnByHref(location.hash.replace("#", ""));
     toggleTab(btn);
   }, false);
+
 };


### PR DESCRIPTION
This PR is designed to address #2052 

These changes move evaluation of `inMobileState` to the `projectTabs` function itself. They also call `projectTabs()` on window resize.

These changes do not includes tests as it does appear as though there are js-specific tests. I took a look at https://warehouse.readthedocs.io/development/submitting-patches but did not see anything about front-end testing. I've tested these changes manually in Firefox 52.0.3 and Chrome 57.0.2987.133 on Ubuntu GNOME 16.04. Please let me know if there is some additional testing I can do.