### PR TITLE
Remove codecov and use --fail-under to enforce coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ cache:
 
 install:
   - 'rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm install $TRAVIS_NODE_VERSION'
-  - pip install -U pip setuptools wheel codecov
+  - pip install -U pip setuptools wheel
   - pip install -r requirements/main.txt -r requirements/deploy.txt -r requirements/docs.txt -r requirements/lint.txt -r requirements/tests.txt
   - npm install
 
@@ -95,8 +95,6 @@ matrix:
     - script: make licenses BINDIR="$(dirname $(which python))"
       env:
         - SUITE=Licenses
-
-after_success: codecov
 
 branches:
   only:

--- a/bin/tests
+++ b/bin/tests
@@ -35,5 +35,5 @@ fi
 
 # Actually run our tests.
 python -m coverage run -m pytest --strict $@
-python -m coverage report -m
+python -m coverage report -m --fail-under=100 || echo "Must Have 100% Coverage"
 python -m coverage html

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,9 +1,0 @@
-coverage:
-  status:
-    project:
-      default:
-        target: 100
-    patch: false
-    changes: false
-
-comment: off


### PR DESCRIPTION
While I like the codecov service, it's ability to actually report a status to GitHub has been incredibly inconsistent. I regularly have to force merge a PR because codecov has not yet reported a status.

Since we only have one job that can cover the entire code base, and we can just easily mandate 100% coverage (instead of needing to do the harder, 100% diff coverage) we'll just remove codecov and switch to letting coverage.py handle enforcing our 100% coverage rule.