### PR TITLE
Add bold yellow highlight to links

### DIFF
--- a/warehouse/static/sass/base/_typography.scss
+++ b/warehouse/static/sass/base/_typography.scss
@@ -103,6 +103,8 @@ a {
     color: darken($brand-color, 10);
     text-decoration: underline;
   }
+
+  @include link-focus
 }
 
 @include selection {

--- a/warehouse/static/sass/blocks/_footer.scss
+++ b/warehouse/static/sass/blocks/_footer.scss
@@ -76,10 +76,11 @@
         color: $footer-faded-color;
         text-decoration: none;
 
-        &:focus,
         &:hover {
           color: transparentize($white, 0);
         }
+
+        @include link-focus
       }
 
       h3 {
@@ -106,6 +107,8 @@
     a {
       color: transparentize($white, 0.5);
       text-decoration: underline;
+
+      @include link-focus
     }
   }
 }

--- a/warehouse/static/sass/blocks/_homepage-banner.scss
+++ b/warehouse/static/sass/blocks/_homepage-banner.scss
@@ -53,6 +53,8 @@
       &:hover {
         text-decoration-color: $white;
       }
+
+      @include link-focus
     }
   }
 }

--- a/warehouse/static/sass/blocks/_horizontal-menu.scss
+++ b/warehouse/static/sass/blocks/_horizontal-menu.scss
@@ -50,6 +50,8 @@
       &:hover {
         text-decoration-color: $transparent-white;
       }
+
+      @include link-focus
     }
   }
 

--- a/warehouse/static/sass/blocks/_notification-bar.scss
+++ b/warehouse/static/sass/blocks/_notification-bar.scss
@@ -50,6 +50,8 @@
     a {
       color: $white;
       text-decoration: underline;
+
+      @include link-focus
     }
   }
 

--- a/warehouse/static/sass/blocks/_package-header.scss
+++ b/warehouse/static/sass/blocks/_package-header.scss
@@ -45,6 +45,8 @@
     &:hover {
       text-decoration-color: $white;
     }
+
+    @include link-focus
   }
 
   &__left {

--- a/warehouse/static/sass/tools/_design-utilities.scss
+++ b/warehouse/static/sass/tools/_design-utilities.scss
@@ -17,3 +17,11 @@
   box-shadow: 1px 1px 2px 1px rgba(0,0,0,0.05);
   background-color: $white;
 }
+
+@mixin link-focus {
+  &:focus {
+    background-color: $highlight-color;
+    color: $black;
+    outline: 2px solid $highlight-color;
+  }
+}


### PR DESCRIPTION
This highlight allows users to more easily navigate the page, especially users with mobility or visual impairments who might be using a keyboard and not a mouse.

It's similar to the highlight used by [GOV.UK](https://www.gov.uk/), which is a site that's had a lot of user research go into it and cares deeply about accessibility.

Contributes to #2127.

## Screenshots

![screenshot from 2017-08-07 22-29-16](https://user-images.githubusercontent.com/121219/29046559-edc14032-7bbf-11e7-81bb-825bc0e2610e.png)

![screenshot from 2017-08-07 22-29-42](https://user-images.githubusercontent.com/121219/29046562-f1d635b0-7bbf-11e7-8bc4-df8d80170cb6.png)
