### PR TITLE
Remove max-warnings from sass-lint command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ lint: .state/env/pyvenv.cfg
 	$(BINDIR)/html_lint.py --printfilename --disable=optional_tag,names,protocol,extra_whitespace `find ./warehouse/templates -path ./warehouse/templates/legacy -prune -o -name '*.html' -print`
 
 	./node_modules/.bin/eslint 'warehouse/static/js/**'
-	./node_modules/.bin/sass-lint --verbose --max-warnings 98
+	./node_modules/.bin/sass-lint --verbose
 
 docs: .state/env/pyvenv.cfg
 	$(MAKE) -C docs/ doctest SPHINXOPTS="-W" SPHINXBUILD="$(BINDIR)/sphinx-build"


### PR DESCRIPTION
No longer necessary after #2307 was merged.