### PR TITLE
Add test coverage for utils.http

### DIFF
--- a/tests/unit/utils/test_http.py
+++ b/tests/unit/utils/test_http.py
@@ -93,3 +93,9 @@ class TestIsValidURI:
     def test_plain_schemes(self):
         assert is_valid_uri("ftp://example.com/", require_scheme=True,
                             allowed_schemes=[])
+
+    def test_scheme_not_required(self):
+        assert is_valid_uri("//example.com", require_scheme=False)
+
+    def test_authority_not_required(self):
+        assert is_valid_uri("http://", require_authority=False)


### PR DESCRIPTION
This brings total test coverage back up to 100%.

Seems like it has been at 98% for `warehouse/utils/http.py` for a while now, and at 99% overall. Not sure when it changed, but I guess codecov has been rounding up?