### PR TITLE
Add description_content_type field to Release

### DIFF
--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -298,6 +298,33 @@ class TestValidation:
         with pytest.raises(ValidationError):
             legacy._validate_rfc822_email_field(form, field)
 
+    @pytest.mark.parametrize(
+        "data",
+        [
+            "text/plain; charset=UTF-8",
+            "text/x-rst; charset=UTF-8",
+            "text/markdown; charset=UTF-8; variant=CommonMark",
+            "text/markdown",
+        ],
+    )
+    def test_validate_description_content_type_valid(self, data):
+        form, field = pretend.stub(), pretend.stub(data=data)
+        legacy._validate_description_content_type(form, field)
+
+    @pytest.mark.parametrize(
+        "data",
+        [
+            "invalid_type/plain",
+            "text/invalid_subtype",
+            "text/plain; charset=invalid_charset",
+            "text/markdown; charset=UTF-8; variant=invalid_variant",
+        ],
+    )
+    def test_validate_description_content_type_invalid(self, data):
+        form, field = pretend.stub(), pretend.stub(data=data)
+        with pytest.raises(ValidationError):
+            legacy._validate_description_content_type(form, field)
+
 
 def test_construct_dependencies():
     types = {

--- a/warehouse/admin/templates/admin/projects/release_detail.html
+++ b/warehouse/admin/templates/admin/projects/release_detail.html
@@ -80,12 +80,10 @@
           <td>Description</td>
           <td><code>{{ release.description }}</code></td>
         </tr>
-        {#
         <tr>
           <td>Description-Content-Type</td>
           <td><code>{{ release.description_content_type }}</code></td>
         </tr>
-        #}
         <tr>
           <td>Keywords</td>
           <td><code>{{ release.keywords }}</code></td>

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -327,7 +327,7 @@ class MetadataForm(forms.Form):
                 # Note: This isn't really Metadata 2.0, however bdist_wheel
                 #       claims it is producing a Metadata 2.0 metadata when in
                 #       reality it's more like 1.2 with some extensions.
-                ["1.0", "1.1", "1.2", "2.0"],
+                ["1.0", "1.1", "1.2", "2.0", "2.1"],
                 message="Unknown Metadata Version",
             ),
         ],

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -17,6 +17,7 @@ import os.path
 import re
 import tempfile
 import zipfile
+from cgi import parse_header
 
 from cgi import FieldStorage
 from itertools import chain
@@ -134,6 +135,13 @@ _project_name_re = re.compile(
 _legacy_specifier_re = re.compile(
     r"^(?P<name>\S+)(?: \((?P<specifier>\S+)\))?$"
 )
+
+
+_valid_description_content_types = {
+    'text/plain',
+    'text/x-rst',
+    'text/markdown',
+}
 
 
 def _exc_with_message(exc, message):
@@ -274,6 +282,25 @@ def _validate_rfc822_email_field(form, field):
         email_validator(form, type('field', (), {'data': address}))
 
 
+def _validate_description_content_type(form, field):
+    def _raise(message):
+        raise wtforms.validators.ValidationError(
+            f"Invalid description content type: {message}"
+        )
+
+    content_type, parameters = parse_header(field.data)
+    if content_type not in _valid_description_content_types:
+        _raise("type/subtype is not valid")
+
+    charset = parameters.get('charset')
+    if charset and charset != 'UTF-8':
+        _raise("charset is not valid")
+
+    variant = parameters.get('variant')
+    if content_type == 'text/markdown' and variant and variant != 'CommonMark':
+        _raise("variant is not valid")
+
+
 def _construct_dependencies(form, types):
     for name, kind in types.items():
         for item in getattr(form, name).data:
@@ -352,6 +379,13 @@ class MetadataForm(forms.Form):
     author = wtforms.StringField(
         description="Author",
         validators=[wtforms.validators.Optional()],
+    )
+    description_content_type = wtforms.StringField(
+        description="Description-Content-Type",
+        validators=[
+            wtforms.validators.Optional(),
+            _validate_description_content_type,
+        ],
     )
     author_email = wtforms.StringField(
         description="Author-email",
@@ -890,9 +924,9 @@ def file_upload(request):
                     # This is a list of all the fields in the form that we
                     # should pull off and insert into our new release.
                     "version",
-                    "summary", "description", "license",
-                    "author", "author_email",
-                    "maintainer", "maintainer_email",
+                    "summary", "description", "description_content_type",
+                    "license",
+                    "author", "author_email", "maintainer", "maintainer_email",
                     "keywords", "platform",
                     "home_page", "download_url",
                     "requires_python",

--- a/warehouse/migrations/versions/5dda74213989_add_description_content_type_field.py
+++ b/warehouse/migrations/versions/5dda74213989_add_description_content_type_field.py
@@ -1,0 +1,36 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+add description-content-type field
+
+Revision ID: 5dda74213989
+Revises: 2730e54f8717
+Create Date: 2017-09-08 21:15:55.822175
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '5dda74213989'
+down_revision = '2730e54f8717'
+
+
+def upgrade():
+    op.add_column(
+        "releases",
+        sa.Column("description_content_type", sa.Text(), nullable=True)
+    )
+
+
+def downgrade():
+    op.drop_column("releases", "description_content_type")

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -275,6 +275,7 @@ class Release(db.ModelBase):
     home_page = Column(Text)
     license = Column(Text)
     summary = Column(Text)
+    description_content_type = Column(Text)
     keywords = Column(Text)
     platform = Column(Text)
     download_url = Column(Text)


### PR DESCRIPTION
This PR adds the `description_content_type` field to the `Release` model and captures it on upload.