### PR TITLE
Update donation link to donate.pypi.org

### DIFF
--- a/tests/functional/test_basic.py
+++ b/tests/functional/test_basic.py
@@ -53,6 +53,6 @@ class TestLoginIndicator:
             for a in document.findall(".//nav[@id='user-indicator']/a")
         ]
         assert urls == ["/help/",
-                        "https://donate.pypi.io",
+                        "https://donate.pypi.org",
                         "/account/login/",
                         "/account/register/"]

--- a/warehouse/templates/accounts/macros.html
+++ b/warehouse/templates/accounts/macros.html
@@ -20,7 +20,7 @@
         We're currently working on making the logged in pages on PyPI better.
         If you'd like to see this happen sooner, please consider
         <a href="https://warehouse.readthedocs.io/development/getting-started/">contributing to Warehouse</a>,
-        or <a href="https://donate.pypi.io/">making a donation</a> (or asking
+        or <a href="https://donate.pypi.org/">making a donation</a> (or asking
         your company to make a donation) towards the ongoing development of the Warehouse project.
       </p>
       <p>

--- a/warehouse/templates/base.html
+++ b/warehouse/templates/base.html
@@ -87,7 +87,7 @@
     {% endblock %}
 
     <div class="notification-bar">
-      <span class="notification-bar__message">Help us improve Python packaging - <a href="https://donate.pypi.io">Donate today!</a></span>
+      <span class="notification-bar__message">Help us improve Python packaging - <a href="https://donate.pypi.org">Donate today!</a></span>
     </div>
 
     <header class="site-header">
@@ -178,7 +178,7 @@
         <p>
           Developed and maintained by the Python community, for the Python community.
           <br>
-          <a href="https://donate.pypi.io">Donate Today!</a>
+          <a href="https://donate.pypi.org">Donate Today!</a>
         </p>
         <p>© {{ now()|format_date('yyyy') }} Python Software Foundation. <a href="{{ request.route_path('policy.terms-of-use') }}">Terms of Use</a></p>
       </div>

--- a/warehouse/templates/includes/current-user-indicator.html
+++ b/warehouse/templates/includes/current-user-indicator.html
@@ -37,7 +37,7 @@
           <i class="fa fa-question-circle" aria-hidden="true"></i>
           Get Help
         </a>
-        <a class="dropdown__link" href="https://donate.pypi.io">
+        <a class="dropdown__link" href="https://donate.pypi.org">
           <i class="fa fa-heart" aria-hidden="true"></i>
           Donate
         </a>
@@ -54,7 +54,7 @@
   {% else %}
   <nav id="user-indicator" class="horizontal-menu horizontal-menu--light horizontal-menu--tall">
     <a class="horizontal-menu__link horizontal-menu__link--remove-on-mobile" href="{{ request.route_path('help') }}">Help</a>
-    <a class="horizontal-menu__link horizontal-menu__link--remove-on-mobile" href="https://donate.pypi.io">Donate</a>
+    <a class="horizontal-menu__link horizontal-menu__link--remove-on-mobile" href="https://donate.pypi.org">Donate</a>
     <a class="horizontal-menu__link" href="{{ request.route_path('accounts.login') }}">Login</a>
     <a class="horizontal-menu__link" href="{{ request.route_path('accounts.register') }}">Register</a>
   </nav>


### PR DESCRIPTION
Now that we're not using the .io domain anymore.