### PR TITLE
Classifier-based search should AND, not OR, in the search criteria

### DIFF
--- a/tests/unit/test_views.py
+++ b/tests/unit/test_views.py
@@ -446,7 +446,8 @@ class TestSearch:
             ),
         ]
         assert es_query.filter.calls == [
-            pretend.call('terms', classifiers=['foo :: bar', 'fiz :: buz'])
+            pretend.call('terms', classifiers=['foo :: bar']),
+            pretend.call('terms', classifiers=['fiz :: buz'])
         ]
 
     @pytest.mark.parametrize("page", [None, 1, 5])

--- a/warehouse/views.py
+++ b/warehouse/views.py
@@ -275,8 +275,9 @@ def search(request):
 
         query = query.sort(sort)
 
-    if request.params.getall("c"):
-        query = query.filter("terms", classifiers=request.params.getall("c"))
+    # Require match to all specified classifiers
+    for classifier in request.params.getall("c"):
+        query = query.filter("terms", classifiers=[classifier])
 
     try:
         page_num = int(request.params.get("page", 1))


### PR DESCRIPTION
Make warehouse search show items that match all specified categories, rather than any of them.

This is how it works for the old pypi (see eg https://pypi.python.org/pypi?:action=browse&c=40&c=256), and presumably this is the intended behavior also for pypi.org

Screenshot before (shows entries matching either of the two classifiers):
![before](https://user-images.githubusercontent.com/35046/30784294-de6ce240-a152-11e7-9069-83cc5c8155f0.png)

Screenshot after (shows only entries matching both of the two classifiers):
![after](https://user-images.githubusercontent.com/35046/30784295-e0797fd0-a152-11e7-9786-6a9df9675124.png)
