### PR TITLE
Add a "Show Password" Checkbox to the login and register pages

### DIFF
--- a/Gulpfile.babel.js
+++ b/Gulpfile.babel.js
@@ -65,6 +65,7 @@ let webpackConfig = {
 gulp.task("dist:js", () => {
   let files = [
     path.join(staticPrefix, "js", "warehouse", "index.js"),
+    path.join(staticPrefix, "js", "pwmask", "pw-mask-toggle.js"),
   ];
 
   return gulp.src(files)
@@ -76,9 +77,11 @@ gulp.task("dist:js", () => {
                   file.path
                 );
                 // If this is our main application, then we want to call it
-                // just "warehouse", otherwise, we'll use whatever the real
-                // name is.
+                // just "warehouse". If this is the password unmasking code
+                // we'll call it "pwmask"; much easier to type. otherwise, we'll
+                // use whatever the real name is.
                 if (relPath == "warehouse/index.js") { return "warehouse"; }
+                else if (relPath == "pwmask/pw-mask-toggle.js") { return "pwmask"; }
                 else { return path.parse(relPath).name; }
               }))
               .pipe(gulpWebpack(webpackConfig, webpack))

--- a/tests/unit/test_csp.py
+++ b/tests/unit/test_csp.py
@@ -223,7 +223,11 @@ def test_includeme():
                 ],
                 "referrer": ["origin-when-cross-origin"],
                 "reflected-xss": ["block"],
-                "script-src": ["'self'", "www.google-analytics.com"],
+                "script-src": [
+                    "'self'",
+                    "www.google-analytics.com",
+                    "ajax.googleapis.com",
+                ],
                 "style-src": ["'self'", "fonts.googleapis.com"],
             },
         })

--- a/warehouse/csp.py
+++ b/warehouse/csp.py
@@ -88,7 +88,11 @@ def includeme(config):
             ],
             "referrer": ["origin-when-cross-origin"],
             "reflected-xss": ["block"],
-            "script-src": [SELF, "www.google-analytics.com"],
+            "script-src": [
+                SELF,
+                "www.google-analytics.com",
+                "ajax.googleapis.com",
+            ],
             "style-src": [SELF, "fonts.googleapis.com"],
         },
     })

--- a/warehouse/static/js/pwmask/pw-mask-toggle.js
+++ b/warehouse/static/js/pwmask/pw-mask-toggle.js
@@ -1,0 +1,131 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This code is based upon freely redistributable example code published by
+ * Geoffrey Crofte on codepen.io. Below is the license included with his code.
+ *
+ * ***************************************************************************
+ * Copyright (c) 2017 by Geoffrey Crofte (http://codepen.io/CreativeJuiz/pen/cvyEi)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * ***************************************************************************
+ */
+
+
+/*****************************************************************************
+ *****************************************************************************
+ *                                                                           *
+ *   **NOTE**NOTE**NOTE**NOTE**NOTE**NOTE**NOTE**NOTE**NOTE**NOTE**NOTE**    *
+ *                                                                           *
+ *   The following code **requires** jQuery!                                 *
+ *                                                                           *
+ *   We normally don't use jQuery to avoid the overhead of "GET"ting the     *
+ *   the code on every page load.  However, in this case only two pages      *
+ *   are impacted and normally used only once per session. Thus, impact      *
+ *   on application performance is minimal to none.                          *
+ *                                                                           *
+ *   **NOTE**NOTE**NOTE**NOTE**NOTE**NOTE**NOTE**NOTE**NOTE**NOTE**NOTE**    *
+ *                                                                           *
+ *****************************************************************************
+ */
+
+
+/*****************************************************************************
+ * This event handler is invoked when the submit button in the login.html and
+ * register.html page is clicked. The purpose is to remove the "Show password"
+ * checkbox element, thus prevent polluting the POST request with the current
+ * value of the checkbox.
+ */
+
+window.jQuery(".-js-pw-m-sbt").on("submit", function () {
+  window.jQuery("#-js-pw-m-lbl").remove();
+  return true;
+});
+
+
+/*****************************************************************************
+ * This code is invoked when the "Show password" checkbox is clicked
+ * thus changing it value from "On" to "Off". It toggles the "password*"
+ * input element type attribute from "password" to "text" and vice-versa.
+ *
+ * This checkbox is identified by the CSS seleector "-js-pw-m-fld".
+ */
+
+window.jQuery(".-js-pw-m-cbx").on("change", function(){
+  var element = document.querySelectorAll(".-js-pw-m-fld");
+  for (var elem of element) {
+    if(window.jQuery(elem).attr("type") === "password")
+      changeType(window.jQuery(elem), "text");
+    else
+      changeType(window.jQuery(elem), "password");
+  }
+  return false;
+});
+
+
+/* 
+ * Loosely based on a function from : https://gist.github.com/3559343
+ * Thank you bminer!
+ *
+ * Function Name:
+ *     changeType(x, type)
+ *
+ * Parameters:
+ *     x    => The "password" input element to be manipulated.
+ *     type => A string that is assigned to the x.type attribute.
+ *
+ * NOTE:
+ *   The only values accepted for the *type* parameter are "text"
+ *   and "password".  All other values are silently ignored.
+ */
+
+function changeType(x, type) {
+  if(type !== "text" && type !== "password")
+    return true; // Ignore unknown "type". Yes, I'm a bit paranoid. ;-)
+
+  if(x.attr("type") === type)
+    return true; // Attribute already set to "type". Nothing to do.
+
+  try {       // Modify the password element "type" attribute
+    return x.attr("type", type); // Stupid IE security will not allow this
+  } catch(e) {
+    // Try re-creating the input element (yep... this sucks)
+    // Clone the existing element
+    var tmp = x.clone(true, true);
+
+    // Now set the element type to whatever value was passed to us
+    // in the :type: parameter. We can get away with this because
+    // this copy of the element is not in the DOM ... yet.
+    tmp.attr("type", type);
+
+    // Replace the existing input element with our shiny new one (*Surprise IE* :-)
+    x.replaceWith(tmp);
+    return true;
+  }
+}

--- a/warehouse/static/sass/blocks/_form-group.scss
+++ b/warehouse/static/sass/blocks/_form-group.scss
@@ -31,6 +31,12 @@
     margin-bottom: 7px;
   }
 
+  &__show-pw {
+    font-weight: $base-font-weight;
+    font-size: $base-font-size;
+    margin-left: 147px;
+  }
+
   &__input {
     display: block;
     width: 350px;

--- a/warehouse/templates/accounts/login.html
+++ b/warehouse/templates/accounts/login.html
@@ -48,8 +48,8 @@
         </div>
 
         <div class="form-group">
-          <label for="password" class="form-group__label">Password</label>
-          {{ form.password(placeholder="Your Password", required="required", class_="form-group__input") }}
+          <label for="password" class="form-group__label">Password<span id="-js-pw-m-lbl" class="form-group__show-pw"><input type="checkbox" id="unmaskpw" class="-js-pw-m-cbx" name="unmaskpw" value=""> Show password</span></label>
+          {{ form.password(placeholder="Your Password", required="required", class_="form-group__input -js-pw-m-fld") }}
           {% if form.password.errors %}
           <ul class="form-errors">
             {% for error in form.password.errors %}
@@ -59,8 +59,21 @@
           {% endif %}
         </div>
 
-        <input type="submit" value="Login" class="button button--highlight">
+        <input type="submit" value="Login" class="button button--highlight -js-pw-m-sbt">
       </form>
     </div>
   </section>
+
+{% endblock %}
+
+{% block extra_js %}
+{#
+ # The pwmask JS requires jQuery to execute. However, we must guarantee pwmask does execute
+ # until after the HTML parser has completed to assure all elements manipulated by pwmask
+ # to to toggle the password attribute have been identified and added to the DOM tree.
+ # Thus, jQuery is loaded/execited immediately mode while pwmask is loaded async and execution
+ # is deferred until after the parser has completed it's task.
+-#}
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+  <script async defer src="{{ request.static_path('warehouse:static/dist/js/pwmask.js') }}"></script>
 {% endblock %}

--- a/warehouse/templates/accounts/register.html
+++ b/warehouse/templates/accounts/register.html
@@ -47,7 +47,7 @@
         </div>
 
         <div class="form-group">
-          <label for="full_name" class="form-group__label">Email Address</label>
+          <label for="email" class="form-group__label">Email Address</label>
           {{ form.email(placeholder="Your email address", required="required", class_="form-group__input") }}
           {% if form.email.errors %}
           <ul class="form-errors">
@@ -71,8 +71,8 @@
         </div>
 
         <div class="form-group">
-          <label for="password" class="form-group__label">Password</label>
-          {{ form.password(placeholder="Select a password", required="required", class_="form-group__input") }}
+          <label for="password" class="form-group__label">Password<span id="-js-pw-m-lbl" class="form-group__show-pw"><input type="checkbox" id="unmaskpw" class="-js-pw-m-cbx" name="unmaskpw" value=""> Show password</span></label>
+          {{ form.password(placeholder="Select a password", required="required", class_="form-group__input -js-pw-m-fld") }}
           <p class="form-group__help-text">
             Choose a strong password that contains letters (uppercase and lowercase), numbers and special characters. Avoid common words or repetition.
           </p>
@@ -86,7 +86,7 @@
         </div>
 
         <div class="form-group">
-          {{ form.password_confirm(placeholder="Confirm password", required="required", class_="form-group__input") }}
+          {{ form.password_confirm(placeholder="Confirm password", required="required", class_="form-group__input -js-pw-m-fld") }}
           {% if form.password_confirm.errors %}
           <ul class="form-errors">
             {% for error in form.password_confirm.errors %}
@@ -100,12 +100,22 @@
           {{ recaptcha_html(request, form) }}
         </div>
 
-        <input type="submit" value="Create Account" class="button button--highlight">
+        <input type="submit" value="Create Account" class="button button--highlight -js-pw-m-sbt">
       </form>
     </div>
   </section>
+
 {% endblock %}
 
 {% block extra_js %}
+{#
+ # The pwmask JS requires jQuery to execute. However, we must guarantee pwmask does execute
+ # until after the HTML parser has completed to assure all elements manipulated by pwmask
+ # to to toggle the password attribute have been identified and added to the DOM tree.
+ # Thus, jQuery is loaded/execited immediately mode while pwmask is loaded async and execution
+ # is deferred until after the parser has completed it's task.
+-#}
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+  <script async defer src="{{ request.static_path('warehouse:static/dist/js/pwmask.js') }}"></script>
   {{ recaptcha_src(request) }}
 {% endblock %}


### PR DESCRIPTION
Show password input (checkbox) #1984

This pull request updates/supersedes my pull request of June 9, 2017.

Details of changes follow.

NOTE: All "-js-pw-m-*" CSS selectors referenced are
for use by the password reveal JS event handler
code.

.../tests/unit:
test_csp.py:
Updated script-src assert statement spec to include "ajax.googleapis.com".

.../warehouse/templates/account:
login.html, register.html:
Added "-js-pw-m-fld" CSS selector to form.password
class_ string for PW reveal/hide toggle.
Added label and checkbox elements for triggering
password reveal function. Checkbox element
identified by "-js-pw-m-cbx" CSS selector for
cleanup form on submit.
Added "-js-pw-m-sbt" selector to form submit
button used by JS event handler to trigger
form cleanup on submit.
Added "extra_js" block to insert "jQuery" and
"pwmask" script tags for password reveal JS code.
In register.html, "for=" attribute for the email input
was incorrect. Changed from "full_name" to "email".

.../warehouse/static/sass/blocks/_form-group.scss:
Added &__show-pw selector for positioning the show_pw checkbox and text.

.../warehouse/static/js:
pwmask/pw-mask-toggle.js
JS containing event handlers for password
reveal/hide toggle and submit cleanup.

.../warehouse:
csp.py:
Added "ajax.googleapis.com" script-src policy
statement to allow loading jquery.min.js in
login.html and register.html.

.../Gulpfile.babel.js:
Added path.join statement for "pw-mask-toggle.js"
to files list in gulp.task("dist:js", ...) function.
Added "else if (relPath..." statement for naming
minified JS code for password reveal toggling.