### PR TITLE
Add ability for admins to set the upload limit on projects

### DIFF
--- a/warehouse/admin/routes.py
+++ b/warehouse/admin/routes.py
@@ -57,6 +57,13 @@ def includeme(config):
         traverse="/{project_name}",
         domain=warehouse,
     )
+    config.add_route(
+        "admin.project.set_upload_limit",
+        "/admin/projects/{project_name}/set_upload_limit/",
+        factory="warehouse.packaging.models:ProjectFactory",
+        traverse="/{project_name}",
+        domain=warehouse,
+    )
 
     # Journal related Admin pages
     config.add_route(

--- a/warehouse/admin/templates/admin/projects/detail.html
+++ b/warehouse/admin/templates/admin/projects/detail.html
@@ -46,6 +46,18 @@
         <div class="box box-primary">
           <div class="box-body box-profile">
             <h3 class="project-name text-center">{{ project.name }}</h3>
+            <div class="box-body box-attributes">
+              <table class="table table-hover">
+                <tr>
+                  <th>Attribute</th>
+                  <th>Value</th>
+                </tr>
+                <tr>
+                  <td>Upload limit</td>
+                  <td>{{ project.upload_limit }}</td>
+                </tr>
+              </table>
+            </div>
             <div class="box-body box-maintainers">
               <table class="table table-hover">
                 <tr>
@@ -108,6 +120,7 @@
         </div>
       </div>
   </div>
+  <!-- Blacklist form -->
   <div class="box box-secondary collapsed-box">
     <div class="box-header with-border">
       <h3 class="box-title">Blacklist Project</h3>
@@ -122,6 +135,32 @@
         <div class="form-group col-sm-12">
           <label for="blacklistedComment">Comment</label>
           <textarea name="comment" class="form-control" id="blacklistedComment" rows="3" placeholder="Enter comment ..."></textarea>
+        </div>
+      </div>
+
+      <div class="box-footer">
+        <div class="pull-right">
+          <button type="submit" class="btn btn-primary">Submit</button>
+        </div>
+      </div>
+    </form>
+  </div>
+
+  <!-- Upload limit form -->
+  <div class="box box-secondary collapsed-box">
+    <div class="box-header with-border">
+      <h3 class="box-title">Set upload limit</h3>
+      <div class="box-tools">
+        <button class="btn btn-box-tool" data-widget="collapse" data-toggle="tooltip" title="Expand"><i class="fa fa-plus"></i></button>
+      </div>
+    </div>
+
+    <form method="POST" action="{{ request.route_path('admin.project.set_upload_limit', project_name=project.normalized_name) }}">
+      <input name="csrf_token" type="hidden" value="{{ request.session.get_csrf_token() }}">
+      <div class="box-body">
+        <div class="form-group col-sm-12">
+          <label for="uploadLimit">Upload limit (in bytes)</label>
+          <input type="text" name="upload_limit" class="form-control" id="uploadLimit" rows="3" value="{{ project.upload_limit | default('', True)}}">
         </div>
       </div>
 

--- a/warehouse/admin/views/projects.py
+++ b/warehouse/admin/views/projects.py
@@ -214,17 +214,22 @@ def journals_list(project, request):
 def set_upload_limit(project, request):
     upload_limit = request.POST.get("upload_limit", "")
 
+    # Update the project's upload limit.
     # If the upload limit is an empty string or othrwise falsy, just set the
     # limit to None, indicating the default limit.
     if not upload_limit:
-        upload_limit = None
-
-    # Update the project's upload limit.
-    project.upload_limit = int(upload_limit)
+        project.upload_limit = None
+    else:
+        try:
+            project.upload_limit = int(upload_limit)
+        except ValueError:
+            raise HTTPBadRequest(
+                f"Invalid value for upload_limit: {upload_limit}, "
+                f"must be integer or empty string.")
 
     request.session.flash(
         f"Successfully set the upload limit on {project.name!r} to "
-        f"{upload_limit!r}",
+        f"{project.upload_limit!r}",
         queue="success",
     )
 

--- a/warehouse/admin/views/projects.py
+++ b/warehouse/admin/views/projects.py
@@ -19,7 +19,7 @@ from pyramid.httpexceptions import (
     HTTPSeeOther,
 )
 from pyramid.view import view_config
-from sqlalchemy import func, or_
+from sqlalchemy import or_
 
 from warehouse.accounts.models import User
 from warehouse.packaging.models import Project, Release, Role, JournalEntry


### PR DESCRIPTION
@dstufft this is a quick implementation to make it easier for you and @ewdurbin to field upload limit size requests until #2017 is done.

I couldn't get the one test I wrote to work, I'm pretty unfamiliar with testing pyramid apps, so a little help there would be awesome. I did test this feature manually locally and it appears to work.

Stacktrace from test output:

```python
_________________________________________________________________________________________________ TestProjectSetLimit.test_sets_integer_limit _________________________________________________________________________________________________

self = <tests.unit.admin.views.test_projects.TestProjectSetLimit object at 0x7f85b27ee828>, db_request = <pyramid.testing.DummyRequest object at 0x7f85b27f89e8>

    def test_sets_integer_limit(self, db_request):
        project = ProjectFactory.create()

        db_request.user = UserFactory.create()
        db_request.current_route_path = lambda: "/admin/projects/",
        db_request.session = pretend.stub(
            flash=pretend.call_recorder(lambda *a, **kw: None),
        )
        db_request.matchdict["project_name"] = project.normalized_name
        db_request.POST["upload_limit"] = "12345"

>       views.set_upload_limit(project, db_request)

tests/unit/admin/views/test_projects.py:360:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
warehouse/admin/views/projects.py:233: in set_upload_limit
    'admin.project.detail', project_name=project.normalized_name))
/usr/local/lib/python3.6/site-packages/pyramid/url.py:312: in route_path
    return self.route_url(route_name, *elements, **kw)
/usr/local/lib/python3.6/site-packages/pyramid/url.py:261: in route_url
    mapper = reg.getUtility(IRoutesMapper)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <Registry global>, provided = <InterfaceClass pyramid.interfaces.IRoutesMapper>, name = ''

    def getUtility(self, provided, name=u''):
        utility = self.utilities.lookup((), provided, name)
        if utility is None:
>           raise ComponentLookupError(provided, name)
E           zope.interface.interfaces.ComponentLookupError: (<InterfaceClass pyramid.interfaces.IRoutesMapper>, '')

/usr/local/lib/python3.6/site-packages/zope/interface/registry.py:286: ComponentLookupError
```