### PR TITLE
UI improvements to the admin interface for setting project upload limits

### DIFF
--- a/warehouse/admin/templates/admin/projects/detail.html
+++ b/warehouse/admin/templates/admin/projects/detail.html
@@ -54,7 +54,13 @@
                 </tr>
                 <tr>
                   <td>Upload limit</td>
-                  <td>{{ project.upload_limit }}</td>
+                  <td>
+                    {% if project.upload_limit %}
+                      {{ project.upload_limit / ONE_MB }} MB ({{ "{:,.0f}".format(project.upload_limit) }} bytes)
+                    {% else %}
+                      Default ({{ MAX_FILESIZE / ONE_MB }} MB)
+                    {% endif %}
+                  </td>
                 </tr>
               </table>
             </div>
@@ -159,8 +165,13 @@
       <input name="csrf_token" type="hidden" value="{{ request.session.get_csrf_token() }}">
       <div class="box-body">
         <div class="form-group col-sm-12">
-          <label for="uploadLimit">Upload limit (in bytes)</label>
-          <input type="text" name="upload_limit" class="form-control" id="uploadLimit" rows="3" value="{{ project.upload_limit | default('', True)}}">
+          <label for="uploadLimit">Upload limit (in Megabytes)</label>
+          {% if project.upload_limit %}
+            {% set upload_limit_value = project.upload_limit / ONE_MB %}
+          {% else %}
+            {% set upload_limit_value = '' %}
+          {% endif %}
+          <input type="number" name="upload_limit" class="form-control" id="uploadLimit" min="{{ MAX_FILESIZE / ONE_MB }}" value="{{ upload_limit_value }}">
         </div>
       </div>
 

--- a/warehouse/admin/templates/admin/projects/detail.html
+++ b/warehouse/admin/templates/admin/projects/detail.html
@@ -56,9 +56,9 @@
                   <td>Upload limit</td>
                   <td>
                     {% if project.upload_limit %}
-                      {{ project.upload_limit / ONE_MB }} MB ({{ "{:,.0f}".format(project.upload_limit) }} bytes)
+                      {{ project.upload_limit|filesizeformat(binary=True) }}
                     {% else %}
-                      Default ({{ MAX_FILESIZE / ONE_MB }} MB)
+                      Default ({{ MAX_FILESIZE|filesizeformat(binary=True) }})
                     {% endif %}
                   </td>
                 </tr>


### PR DESCRIPTION
* Uses a number field instead of a text field.
* The text field now uses megabytes instead of bytes.
* The detail page now shows the value in megabytes as well as the full value in bytes.
* The detail page now shows "Default" as well as indicating what the default limit is in MB instead of just displaying "None".
* The form field should prevent numbers lower than the default, but the backend also now gives an invalid request error if the value is lower than the default.
* Simplified the flash message as the full value will be displayed on the detail page.

Unfortunately, I couldn't use "step" in the form field as it would have limited the input to multiples of the step value.

Fixes #2471