### PR TITLE
Add repository and license fields to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,6 @@
 {
+  "repository": "pypa/warehouse",
+  "license": "Apache-2.0",
   "engines": {
     "node": "6.6.0"
   },


### PR DESCRIPTION
This stops npm from emitting noisy warnings every time the `npm` command is run:

```
npm WARN warehouse No repository field.
npm WARN warehouse No license field.
```