### PR TITLE
Revert "Use python3.6.3 everywhere"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-python: 3.6.3
+python: 3.6.1
 
 env:
   global:

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ RUN gulp dist
 
 # Now we're going to build our actual application image, which will eventually
 # pull in the static files that were built above.
-FROM python:3.6.3-alpine3.6
+FROM python:3.6.2-alpine3.6
 
 # Setup some basic environment variables that are ~never going to change.
 ENV PYTHONUNBUFFERED 1

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.6.3
+python-3.6.1


### PR DESCRIPTION
Reverts pypa/warehouse#2508

Heroku doesn't have this yet, reverting for now.