### PR TITLE
Add API endpoint to list all packages with latest versions

### DIFF
--- a/docs/api-reference/xml-rpc.rst
+++ b/docs/api-reference/xml-rpc.rst
@@ -180,3 +180,7 @@ Mirroring Support
 ``list_packages_with_serial()``
   Retrieve a dictionary mapping package names to the last serial for each
   package.
+
+``list_packages_with_version()``
+  Retrieve a dictionary mapping package names to the latest version for each
+  package.

--- a/warehouse/legacy/api/xmlrpc.py
+++ b/warehouse/legacy/api/xmlrpc.py
@@ -115,6 +115,12 @@ def list_packages_with_serial(request):
     return dict((serial[0], serial[1]) for serial in serials)
 
 
+@pypi_xmlrpc(method="list_packages_with_version")
+def list_packages_with_version(request):
+    versions = request.db.query(Project.name, Project.latest_version).all()
+    return dict((version[0], version[1]) for version in versions)
+
+
 @pypi_xmlrpc(method="package_hosting_mode")
 def package_hosting_mode(request, package_name):
     try:


### PR DESCRIPTION
Should fix #347. Lacks tests and completely untested yet.