### PR TITLE
Switch the build process to use Debian w/ multi stage builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,27 +46,22 @@ COPY Gulpfile.babel.js /app/
 
 RUN gulp dist
 
-
-# Now we're going to build our actual application image, which will eventually
-# pull in the static files that were built above.
-FROM python:3.6.2-alpine3.6
-
-# Setup some basic environment variables that are ~never going to change.
-ENV PYTHONUNBUFFERED 1
-ENV PYTHONPATH /app/
-
-WORKDIR /app/
+# Now we're going to build our actual application, but not the actual production
+# image that it gets deployed into.
+FROM python:3.6.3-stretch as build
 
 # Define whether we're building a production or a development image. This will
 # generally be used to control whether or not we install our development and
 # test dependencies.
 ARG DEVEL=no
 
-# Install System level Warehouse requirements, this is done before everything
-# else because these are rarely ever going to change.
+# Install System level Warehouse build requirements, this is done before
+# everything else because these are rarely ever going to change.
 RUN set -x \
-    && apk --no-cache add libpq libxml2 libxslt \
-        $(if [ "$DEVEL" = "yes" ]; then echo 'bash libjpeg postgresql-client'; fi)
+    && apt-get update \
+    && apt-get install --no-install-recommends -y \
+        build-essential libffi-dev libxml2-dev libxslt-dev libpq-dev \
+        $(if [ "$DEVEL" = "yes" ]; then echo 'libjpeg-dev'; fi)
 
 # We need a way for the build system to pass in a repository that will be used
 # to install our theme from. For this we'll add the THEME_REPO build argument
@@ -79,27 +74,53 @@ ARG THEME_REPO
 # that has changed is the Warehouse code itself.
 COPY requirements /tmp/requirements
 
+# Install our development dependencies if we're building a development install
+# otherwise this will do nothing.
+RUN set -x \
+    && if [ "$DEVEL" = "yes" ]; then pip --no-cache-dir --disable-pip-version-check install -r /tmp/requirements/dev.txt; fi
+
+
+
 # Install the Python level Warehouse requirements, this is done after copying
 # the requirements but prior to copying Warehouse itself into the container so
 # that code changes don't require triggering an entire install of all of
 # Warehouse's dependencies.
 RUN set -x \
-    && apk --no-cache add --virtual build-dependencies \
-        build-base libffi-dev libxml2-dev libxslt-dev postgresql-dev \
-        $(if [ "$DEVEL" = "yes" ]; then echo 'jpeg-dev linux-headers'; fi) \
-    && if [ "$DEVEL" = "yes" ]; then pip --no-cache-dir --disable-pip-version-check install -r /tmp/requirements/dev.txt; fi \
     && PIP_EXTRA_INDEX_URL=$THEME_REPO \
         pip --no-cache-dir --disable-pip-version-check \
             install -r /tmp/requirements/deploy.txt \
                     -r /tmp/requirements/main.txt \
                     $(if [ "$DEVEL" = "yes" ]; then echo '-r /tmp/requirements/tests.txt'; fi) \
                     $(if [ "$THEME_REPO" != "" ]; then echo '-r /tmp/requirements/theme.txt'; fi) \
-    && find /usr/local -name '*.pyc' -delete \
-    && apk del build-dependencies
+    && find /usr/local -name '*.pyc' -delete
+
+# Now we're going to build our actual application image, which will eventually
+# pull in the static files that were built above.
+FROM python:3.6.3-stretch
+
+# Setup some basic environment variables that are ~never going to change.
+ENV PYTHONUNBUFFERED 1
+ENV PYTHONPATH /app/
+
+# Define whether we're building a production or a development image. This will
+# generally be used to control whether or not we install our development and
+# test dependencies.
+ARG DEVEL=no
+
+# Install System level Warehouse requirements, this is done before everything
+# else because these are rarely ever going to change.
+RUN set -x \
+    && apt-get update \
+    && apt-get install --no-install-recommends -y \
+        libpq5 libxml2 libxslt1.1  \
+        $(if [ "$DEVEL" = "yes" ]; then echo 'bash libjpeg62 postgresql-client'; fi) \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Copy the directory into the container, this is done last so that changes to
 # Warehouse itself require the least amount of layers being invalidated from
 # the cache. This is most important in development, but it also useful for
 # deploying new code changes.
 COPY --from=static /app/warehouse/static/dist/ /app/warehouse/static/dist/
+COPY --from=build /usr/local/ /usr/local/
 COPY . /app/

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,12 +50,6 @@ FROM python:3.6.3-slim-stretch as build
 # test dependencies.
 ARG DEVEL=no
 
-# This is a work around because otherwise libpq-dev bombs out trying
-# to create symlinks to these directories.
-RUN set -x \
-    && mkdir -p /usr/share/man/man1 \
-    && mkdir -p /usr/share/man/man7
-
 # Install System level Warehouse build requirements, this is done before
 # everything else because these are rarely ever going to change.
 RUN set -x \

--- a/Dockerfile.static
+++ b/Dockerfile.static
@@ -1,24 +1,23 @@
 FROM node:6.11.1 as static
 
-WORKDIR /app/
+WORKDIR /opt/warehouse/src/
 
+# The list of C packages we need are almost never going to change, so installing
+# them first, right off the bat lets us cache that and having node.js level
+# dependency changes not trigger a reinstall.
 RUN set -x \
     && apt-get update \
     && apt-get install --no-install-recommends -y \
-        libjpeg62 \
-    && apt-get autoremove -y \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+        libjpeg-dev
 
-COPY package.json .babelrc /app/
+# However, we do want to trigger a reinstall of our node.js dependencies anytime
+# our package.json changes, so we'll ensure that we're copying that into our
+# static container prior to actually installing the npm dependencies.
+COPY package.json .babelrc /opt/warehouse/src/
 
+# Installing npm dependencies is done as a distinct step and *prior* to copying
+# over our static files so that, you guessed it, we don't invalidate the cache
+# of installed dependencies just because files have been modified.
 RUN set -x \
-    && apt-get update \
-    && apt-get install --no-install-recommends -y \
-        libjpeg-dev \
     && npm install -g gulp-cli \
-    && npm install \
-    && apt-get remove --purge -y libjpeg-dev \
-    && apt-get autoremove -y \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    && npm install

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ debug: .state/docker-build
 
 tests:
 	docker-compose run --rm web env -i ENCODING="C.UTF-8" \
-								  PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
+								  PATH="/opt/warehouse/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
 								  bin/tests --postgresql-host db $(T) $(TESTARGS)
 
 lint: .state/env/pyvenv.cfg

--- a/dev/environment
+++ b/dev/environment
@@ -21,7 +21,7 @@ CAMO_KEY="insecure camo key"
 
 DOCS_URL="https://pythonhosted.org/{project}/"
 
-FILES_BACKEND=warehouse.packaging.services.LocalFileStorage path=/app/data/packages/ url=http://files.example.com/packages/{path}
+FILES_BACKEND=warehouse.packaging.services.LocalFileStorage path=/var/opt/warehouse/packages/ url=http://files.example.com/packages/{path}
 
 RECAPTCHA_SITE_KEY="${RECAPTCHA_SITE_KEY}"
 RECAPTCHA_SECRET_KEY="${RECAPTCHA_SECRET_KEY}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,11 +39,11 @@ services:
       # or any file not in these directories will require a rebuild.
       # The :z option fixes permission issues with SELinux by setting a
       # permissive security context.
-      - ./dev:/app/dev:z
-      - ./docs:/app/docs:z
-      - ./warehouse:/app/warehouse:z
-      - ./tests:/app/tests:z
-      - ./htmlcov:/app/htmlcov:z
+      - ./dev:/opt/warehouse/src/dev:z
+      - ./docs:/opt/warehouse/src/docs:z
+      - ./warehouse:/opt/warehouse/src/warehouse:z
+      - ./tests:/opt/warehouse/src/tests:z
+      - ./htmlcov:/opt/warehouse/src/htmlcov:z
     ports:
       - "80:8000"
     links:
@@ -73,6 +73,6 @@ services:
       dockerfile: Dockerfile.static
     command: gulp watch
     volumes:
-      - ./warehouse:/app/warehouse:z
-      - ./Gulpfile.babel.js:/app/Gulpfile.babel.js:z
-      - ./.babelrc:/app/.babelrc:z
+      - ./warehouse:/opt/warehouse/src/warehouse:z
+      - ./Gulpfile.babel.js:/opt/warehouse/src/Gulpfile.babel.js:z
+      - ./.babelrc:/opt/warehouse/src/.babelrc:z

--- a/docs/development/getting-started.rst
+++ b/docs/development/getting-started.rst
@@ -93,7 +93,7 @@ Once you have Docker and Docker Compose installed, run:
 
 This will pull down all of the required docker containers, build
 Warehouse and run all of the needed services. The Warehouse repository will be
-mounted inside of the docker container at ``/app/``.
+mounted inside of the docker container at ``/opt/warehouse/src/``.
 
 
 Running the Warehouse Container and Services
@@ -147,8 +147,8 @@ Web container is listening on port 80. It's accessible at
 What did we just do and what is happening behind the scenes?
 ------------------------------------------------------------
 
-The repository is exposed inside of the web container at ``/app/`` and
-Warehouse will automatically reload when it detects any changes made to the
+The repository is exposed inside of the web container at ``/opt/warehouse/src/``
+and Warehouse will automatically reload when it detects any changes made to the
 code.
 
 The example data located in ``dev/example.sql.xz`` is taken from

--- a/docs/development/getting-started.rst
+++ b/docs/development/getting-started.rst
@@ -147,9 +147,9 @@ Web container is listening on port 80. It's accessible at
 What did we just do and what is happening behind the scenes?
 ------------------------------------------------------------
 
-The repository is exposed inside of the web container at ``/opt/warehouse/src/``
-and Warehouse will automatically reload when it detects any changes made to the
-code.
+The repository is exposed inside of the web container at
+``/opt/warehouse/src/`` and Warehouse will automatically reload when it detects
+any changes made to the code.
 
 The example data located in ``dev/example.sql.xz`` is taken from
 `Test PyPI <https://testpypi.python.org/>`_ and has been sanitized to remove


### PR DESCRIPTION
This switches us back to using a Debian based Docker image and also refactors the build support to further take advantage of multi stage builds. The resulting image is 394MB large (compared to 261MB with Alpine) when built with DEVEL=yes.

This also restructures things a bit so that instead of ``/app/`` and ``/usr/local`` we move everything into ``/opt/warehouse``.

Fixes #2523 (I hope?)