### PR TITLE
Lint JS and SCSS inside static container

### DIFF
--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -14,7 +14,7 @@ rules:
     - 2
     - convention: '0'
   brace-style:
-    - 1
+    - 2
     - allow-single-line: false
   class-name-format:
     - 2
@@ -30,6 +30,6 @@ rules:
     - 2
     - convention: hyphenatedbem
   quotes:
-    - 1
+    - 2
     - style: double
   variable-name-format: 2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,3 +76,4 @@ services:
       - ./warehouse:/opt/warehouse/src/warehouse:z
       - ./Gulpfile.babel.js:/opt/warehouse/src/Gulpfile.babel.js:z
       - ./.babelrc:/opt/warehouse/src/.babelrc:z
+      - ./.sass-lint.yml:/opt/warehouse/src/.sass-lint.yml:z


### PR DESCRIPTION
This PR should eliminate the issues raised in #2624 -- by linting our JS and SCSS inside the static container rather than locally, a new Warehouse contributor will not need to have `node`, `npm` or any of the JS development dependencies installed at all.

This also raises two SCSS linter rules from warning-level to error-level, since all instances were fixed in #2307.