### PR TITLE
Don't set DEVEL in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,14 +3,12 @@ TRAVIS := $(shell echo "$${TRAVIS:-false}")
 PR := $(shell echo "$${TRAVIS_PULL_REQUEST:-false}")
 BRANCH := $(shell echo "$${TRAVIS_BRANCH:-master}")
 DB := example
-DEVEL := no
 IPYTHON := no
 
 # set environment variable WAREHOUSE_IPYTHON_SHELL=1 if IPython
 # needed in development environment
 ifeq ($(WAREHOUSE_IPYTHON_SHELL), 1)
     IPYTHON = yes
-    DEVEL = yes
 endif
 
 # Default to the reCAPTCHA testing keys from https://developers.google.com/recaptcha/docs/faq
@@ -71,7 +69,7 @@ endif
 
 .state/docker-build: Dockerfile package.json requirements/main.txt requirements/deploy.txt
 	# Build our docker containers for this project.
-	docker-compose build --build-arg IPYTHON=$(IPYTHON) --build-arg DEVEL=$(DEVEL) web
+	docker-compose build --build-arg IPYTHON=$(IPYTHON) web
 	docker-compose build worker
 	docker-compose build static
 
@@ -80,7 +78,7 @@ endif
 	touch .state/docker-build
 
 build:
-	docker-compose build --build-arg IPYTHON=$(IPYTHON) --build-arg DEVEL=$(DEVEL) web
+	docker-compose build --build-arg IPYTHON=$(IPYTHON) web
 	docker-compose build worker
 	docker-compose build static
 


### PR DESCRIPTION
This was added in #2702 but the effect is that by default, `DEVEL=no` and `--build-args` was overriding what was in `docker-compose.yml`. Thus running `make serve` with no other environmental vars set would not build the web container in development mode as it originally did.

(cc @mbacchi @ewdurbin)