### PR TITLE
Use node 8.9.4 everywhere

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # our static assets with. It is important that the steps in this remain the
 # same as the steps in Dockerfile.static, EXCEPT this may include additional
 # steps appended onto the end.
-FROM node:6.11.1 as static
+FROM node:8.9.4 as static
 
 WORKDIR /opt/warehouse/src/
 

--- a/Dockerfile.static
+++ b/Dockerfile.static
@@ -1,4 +1,4 @@
-FROM node:8.9.1 as static
+FROM node:8.9.4 as static
 
 WORKDIR /opt/warehouse/src/
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "repository": "pypa/warehouse",
   "license": "Apache-2.0",
   "engines": {
-    "node": "8.9.1"
+    "node": "8.9.4"
   },
   "dependencies": {
     "babel-core": "6.26.0",


### PR DESCRIPTION
The change to `Dockerfile` was missed in #2652. Also might as well upgrade to `8.9.4` while we're at it.