### PR TITLE
fixes case of title in docs

### DIFF
--- a/docs/development/database-migrations.rst
+++ b/docs/development/database-migrations.rst
@@ -1,4 +1,4 @@
-Database Migrations
+Database migrations
 ===================
 
 Modifying database schemata will need database migrations (even for adding and


### PR DESCRIPTION
This changes the case of the title "Database Migrations" to "Database migrations", to make it match the title format of the other sections in the documentation. 