### PR TITLE
Fix broken recaptcha testing variables in dev

### DIFF
--- a/dev/environment
+++ b/dev/environment
@@ -23,8 +23,8 @@ DOCS_URL="https://pythonhosted.org/{project}/"
 
 FILES_BACKEND=warehouse.packaging.services.LocalFileStorage path=/var/opt/warehouse/packages/ url=http://files.example.com/packages/{path}
 
-RECAPTCHA_SITE_KEY="${RECAPTCHA_SITE_KEY}"
-RECAPTCHA_SECRET_KEY="${RECAPTCHA_SECRET_KEY}"
+RECAPTCHA_SITE_KEY
+RECAPTCHA_SECRET_KEY
 
 MAIL_HOST=smtp
 MAIL_PORT=2525


### PR DESCRIPTION
Docker's env-files don't support variable substitution in this manner.
With the current configuration, the site and secret keys are passed to
the application as the literal strings `"${RECAPTCHA_SITE_KEY}"` and
`"${RECAPTCHA_SECRET_KEY}"` respectively. By only including the
environment variable's name in the env-file rather than giving it a
value as well, the variable is propagated from the local environment as
desired.