### PR TITLE
Add registration and login autocomplete hints

### DIFF
--- a/warehouse/admin/templates/admin/login.html
+++ b/warehouse/admin/templates/admin/login.html
@@ -51,7 +51,7 @@
       </div>
 
       <div class="form-group{% if form.password.errors %} has-error{% endif %}">
-        {{ form.password(class="form-control", placeholder="Password") }}
+        {{ form.password(class="form-control", placeholder="Password", autocomplete="current-password") }}
 
         {% if form.password.errors %}
         <span class="help-block">

--- a/warehouse/admin/templates/admin/login.html
+++ b/warehouse/admin/templates/admin/login.html
@@ -39,7 +39,7 @@
       {% endif %}
 
       <div class="form-group{% if form.username.errors %} has-error{% endif %}">
-        {{ form.username(class="form-control", placeholder="Username", autocorrect="off", autocapitalize="off", spellcheck="false") }}
+        {{ form.username(class="form-control", placeholder="Username", autocorrect="off", autocapitalize="off", autocomplete="username", required="required", spellcheck="false") }}
 
         {% if form.username.errors %}
         <span class="help-block">
@@ -51,7 +51,7 @@
       </div>
 
       <div class="form-group{% if form.password.errors %} has-error{% endif %}">
-        {{ form.password(class="form-control", placeholder="Password", autocomplete="current-password") }}
+        {{ form.password(class="form-control", placeholder="Password", required="required", autocomplete="current-password") }}
 
         {% if form.password.errors %}
         <span class="help-block">

--- a/warehouse/templates/accounts/login.html
+++ b/warehouse/templates/accounts/login.html
@@ -54,7 +54,7 @@
               <input id="show-password" type="checkbox">&nbsp;Show password
             </label>
           </div>
-          {{ form.password(placeholder="Your Password", required="required", class_="form-group__input") }}
+          {{ form.password(placeholder="Your Password", required="required", class_="form-group__input", autocomplete="current-password") }}
           {% if form.password.errors %}
           <ul class="form-errors">
             {% for error in form.password.errors %}

--- a/warehouse/templates/accounts/login.html
+++ b/warehouse/templates/accounts/login.html
@@ -37,7 +37,7 @@
 
         <div class="form-group">
           <label for="username" class="form-group__label">Username</label>
-          {{ form.username(placeholder="Your Username", autocorrect="off", autocapitalize="off", spellcheck="false", required="required", class_="form-group__input") }}
+          {{ form.username(placeholder="Your Username", autocorrect="off", autocapitalize="off", autocomplete="username", spellcheck="false", required="required", class_="form-group__input") }}
           {% if form.username.errors %}
           <ul class="form-errors">
             {% for error in form.username.errors %}

--- a/warehouse/templates/accounts/register.html
+++ b/warehouse/templates/accounts/register.html
@@ -48,7 +48,7 @@
 
         <div class="form-group">
           <label for="full_name" class="form-group__label">Email Address</label>
-          {{ form.email(placeholder="Your email address", required="required", class_="form-group__input") }}
+          {{ form.email(placeholder="Your email address", autocomplete="email", required="required", class_="form-group__input") }}
           {% if form.email.errors %}
           <ul class="form-errors">
             {% for error in form.email.errors %}
@@ -60,7 +60,7 @@
 
         <div class="form-group">
           <label for="username" class="form-group__label">Username</label>
-          {{ form.username(placeholder="Select a username", autocorrect="off", autocapitalize="off", spellcheck="false", required="required", class_="form-group__input") }}
+          {{ form.username(placeholder="Select a username", autocorrect="off", autocapitalize="off", autocomplete="username", spellcheck="false", required="required", class_="form-group__input") }}
           {% if form.username.errors %}
           <ul class="form-errors">
             {% for error in form.username.errors %}

--- a/warehouse/templates/accounts/register.html
+++ b/warehouse/templates/accounts/register.html
@@ -77,7 +77,7 @@
               <input id="show-password" type="checkbox">&nbsp;Show passwords
             </label>
           </div>
-          {{ form.password(placeholder="Select a password", required="required", class_="form-group__input") }}
+          {{ form.password(placeholder="Select a password", required="required", class_="form-group__input", autocomplete="new-password") }}
           <p class="form-group__help-text">
             Choose a strong password that contains letters (uppercase and lowercase), numbers and special characters. Avoid common words or repetition.
           </p>


### PR DESCRIPTION
- Add appropriate `new-password` and `current-password` autocomplete values to password inputs on registration and login pages.
- Add autocomplete values for usernames and emails
- Add missing `required` attributes on the affected fields

Fixes #411.