### PR TITLE
Add edit project button on project detail page

### DIFF
--- a/tests/unit/packaging/test_views.py
+++ b/tests/unit/packaging/test_views.py
@@ -231,3 +231,12 @@ class TestReleaseDetail:
         result = views.release_detail(release, db_request)
 
         assert result["license"] == "BSD License, MIT License"
+
+
+class TestEditProjectButton:
+
+    def test_edit_project_button_returns_project(self):
+        project = pretend.stub()
+        assert views.edit_project_button(project, pretend.stub()) == {
+            'project': project
+        }

--- a/tests/unit/test_routes.py
+++ b/tests/unit/test_routes.py
@@ -100,6 +100,13 @@ def test_routes(warehouse):
             traverse="/{username}",
             domain=warehouse,
         ),
+        pretend.call(
+            "includes.edit-project-button",
+            "/_includes/edit-project-button/{project_name}",
+            factory="warehouse.packaging.models:ProjectFactory",
+            traverse="/{project_name}",
+            domain=warehouse,
+        ),
         pretend.call("search", "/search/", domain=warehouse),
         pretend.call(
             "accounts.profile",

--- a/warehouse/packaging/views.py
+++ b/warehouse/packaging/views.py
@@ -126,3 +126,13 @@ def release_detail(release, request):
         "maintainers": maintainers,
         "license": license,
     }
+
+
+@view_config(
+    route_name="includes.edit-project-button",
+    renderer="includes/edit-project-button.html",
+    uses_session=True,
+    permission="manage",
+)
+def edit_project_button(project, request):
+    return {'project': project}

--- a/warehouse/routes.py
+++ b/warehouse/routes.py
@@ -68,6 +68,13 @@ def includeme(config):
         traverse="/{username}",
         domain=warehouse,
     )
+    config.add_route(
+        "includes.edit-project-button",
+        "/_includes/edit-project-button/{project_name}",
+        factory="warehouse.packaging.models:ProjectFactory",
+        traverse="/{project_name}",
+        domain=warehouse,
+    )
 
     # Search Routes
     config.add_route("search", "/search/", domain=warehouse)

--- a/warehouse/static/sass/blocks/_button.scss
+++ b/warehouse/static/sass/blocks/_button.scss
@@ -50,7 +50,6 @@
   display: inline-block;
   white-space: nowrap;
   vertical-align: center;
-  overflow: hidden;
 
   &:focus,
   &:hover,

--- a/warehouse/static/sass/blocks/_package-description.scss
+++ b/warehouse/static/sass/blocks/_package-description.scss
@@ -19,9 +19,17 @@
 */
 
 .package-description {
-  font-size: 1.1rem;
-  font-style: italic;
-  margin: 0;
-  padding: 0;
-  line-height: 42px;
+  min-height: 58px;
+  margin-top: -10px;
+
+  &__summary {
+    font-size: 1.1rem;
+    font-style: italic;
+    padding: 0;
+    margin-top: 10px;
+  }
+
+  &__edit-button {
+    margin-top: 10px;
+  }
 }

--- a/warehouse/templates/includes/edit-project-button.html
+++ b/warehouse/templates/includes/edit-project-button.html
@@ -13,5 +13,5 @@
 -#}
 
 {% if request.user %}
-  <a href="{{ request.route_path('manage.project.settings', name=project.name) }}" class="button button--highlight">Edit Project</a>
+  <a href="{{ request.route_path('manage.project.settings', name=project.name) }}" class="button button--primary package-description__edit-button">Edit Project</a>
 {% endif %}

--- a/warehouse/templates/includes/edit-project-button.html
+++ b/warehouse/templates/includes/edit-project-button.html
@@ -1,0 +1,17 @@
+{#
+ # Licensed under the Apache License, Version 2.0 (the "License");
+ # you may not use this file except in compliance with the License.
+ # You may obtain a copy of the License at
+ #
+ # http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+-#}
+
+{% if request.user %}
+  <a href="{{ request.route_path('manage.project.settings', name=project.name) }}" class="button button--highlight">Edit Project</a>
+{% endif %}

--- a/warehouse/templates/packaging/detail.html
+++ b/warehouse/templates/packaging/detail.html
@@ -98,19 +98,19 @@
   </div>
 </section>
 
-{% if release.summary %}
 <section class="horizontal-section horizontal-section--grey horizontal-section--thin">
   <div class="site-container">
-    <div class="split-layout split-layout--middle">
+    <div class="split-layout split-layout--middle package-description">
     {% if release.summary %}
-      <p class="package-description">{{ release.summary }}</p>
+      <p class="package-description__summary">{{ release.summary }}</p>
+    {% else %}
+      <p class="package-description__summary">No project description provided.</p>
     {% endif %}
     {% csi request.route_path("includes.edit-project-button", project_name=project.normalized_name) %}
     {% endcsi %}
     </div>
   </div>
 </section>
-{% endif %}
 
 
 <section>

--- a/warehouse/templates/packaging/detail.html
+++ b/warehouse/templates/packaging/detail.html
@@ -98,16 +98,15 @@
   </div>
 </section>
 
-{% if release.summary %}{# TODO: https://github.com/pypa/warehouse/issues/2810 - add "or logged in user can edit package" #}
+{% if release.summary %}
 <section class="horizontal-section horizontal-section--grey horizontal-section--thin">
   <div class="site-container">
     <div class="split-layout split-layout--middle">
     {% if release.summary %}
       <p class="package-description">{{ release.summary }}</p>
     {% endif %}
-    {# TODO: https://github.com/pypa/warehouse/issues/2810 (if logged in user can edit package)
-    <a href="{{ request.route_path('manage.project.settings', name=project.normalized_name) }}" class="button button--primary">Edit Project</a>
-    #}
+    {% csi request.route_path("includes.edit-project-button", project_name=project.normalized_name) %}
+    {% endcsi %}
     </div>
   </div>
 </section>


### PR DESCRIPTION
Fixes #2810.

The button is only shown for logged-in project owners via a client-side include.