### PR TITLE
Add links to and reorganize documentation

### DIFF
--- a/docs/development/frontend.rst
+++ b/docs/development/frontend.rst
@@ -2,7 +2,7 @@ Frontend
 ========
 
 The Warehouse frontend is (as you might suspect) written in JavaScript with the
-CSS handled by SCSS. It uses gulp to process these files and prepare them for
+CSS handled by SCSS. It uses ``gulp`` to process these files and prepare them for
 serving.
 
 All of the static files are located in ``warehouse/static/`` and external
@@ -12,8 +12,8 @@ libraries are found in ``package.json``.
 Building
 --------
 
-Static files should be automatically built when ``make serve`` is running,
-however you can trigger a manual build of them by installing all of the
+Static files should be automatically built when ``make serve`` is running;
+however, you can trigger a manual build of them by installing all of the
 dependencies using ``npm install`` and then running ``gulp dist``.
 
 
@@ -35,33 +35,38 @@ Browser Support
 HTML Code Style
 ---------------
 
-Warehouse follows the `Google HTML style guide <http://bit.ly/29gepl6>`_,
-which is enforced via linting with `HTML Linter <http://bit.ly/29sf7Aa>`_.
+Warehouse follows the `Google HTML style guide
+<https://google.github.io/styleguide/htmlcssguide.html>`_, which is
+enforced via linting with `HTML Linter
+<https://github.com/deezer/html-linter>`_.
 
 Exceptions to these rules include:
 
-- Protocols can be included in links - we prefer to include https protocols
+- Protocols can be included in links - we prefer to include ``https`` protocols
 - All HTML tags should be closed
 
-We also allow both dashes and underscores in our class names, as we follow the
-`Nicholas Gallagher variation <http://bit.ly/1g8225q>`_
+We also allow both dashes and underscores in our class names, as we
+follow the `Nicholas Gallagher variation
+<http://nicolasgallagher.com/about-html-semantics-front-end-architecture/>`_
 of the `BEM naming methodology <https://en.bem.info/>`_.
 
-More information on how BEM works can be found in
-`this article from CSS Wizardry <http://bit.ly/1dM4LGz>`_.
+More information on how BEM works can be found in `this article from
+CSS Wizardry
+<https://csswizardry.com/2013/01/mindbemding-getting-your-head-round-bem-syntax/>`_.
 
 
 SCSS Style and Structure
 ------------------------
 
-Warehouse follows the `Airbnb CSS / Sass style guide <http://bit.ly/29geHZj>`_,
+Warehouse follows the `Airbnb CSS/Sass style guide <https://github.com/airbnb/css>`_,
 with the exception that JS hooks should be prefixed with ``-js`` rather
 than ``js``.
 
 Our SCSS codebase is structured according to the `ITCSS system
-<http://bit.ly/1OHRsEw>`_.  The principle of this system is to break SCSS code
-into layers and import them into a main stylesheet in an order moving from
-generic to specific. This tightly controls the cascade of styles.
+<https://www.creativebloq.com/web-design/manage-large-scale-web-projects-new-css-architecture-itcss-41514731>`_.
+The principle of this system is to break SCSS code into layers and
+import them into a main stylesheet in an order moving from generic to
+specific. This tightly controls the cascade of styles.
 
 The majority of the SCSS styles are found within the 'blocks' layer,
 with each BEM block in its own file. All blocks are documented at the top of

--- a/docs/development/getting-started.rst
+++ b/docs/development/getting-started.rst
@@ -3,9 +3,21 @@ Getting started
 
 We're pleased that you are interested in working on Warehouse.
 
+Your first pull request
+-----------------------
+
+After you set up your development environment and ensure you can run
+the tests and build the documentation (using the instructions in this
+document), please look at our `open issues that are labelled "good
+first issue"`_, find one you want to work on, comment on it to say
+you're working on it, then submit a pull request. Use our
+:doc:`submitting-patches` documentation to help.
+
 Setting up a development environment to work on Warehouse should be a
-straightforward process. If you have any difficulty, please contact us so
-we can improve the process.
+straightforward process. If you have any difficulty, please contact us
+so we can improve the process. You can find us via a `GitHub`_ issue,
+``#pypa`` or ``#pypa-dev`` `on Freenode`_, or the `pypa-dev mailing
+list`_, to ask questions or get involved.
 
 
 Quickstart for Developers with Docker experience
@@ -22,9 +34,9 @@ View Warehouse in the browser at ``http://localhost:80/``.
 Detailed Installation Instructions
 ----------------------------------
 
-Getting the warehouse source code
+Getting the Warehouse source code
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Clone the warehouse repository from GitHub:
+Clone the Warehouse repository from `GitHub`_:
 
 .. code-block:: console
 
@@ -92,7 +104,7 @@ in the repository root directory.
 
 This will pull down all of the required docker containers, build
 Warehouse and run all of the needed services. The Warehouse repository will be
-mounted inside of the docker container at ``/opt/warehouse/src/``.
+mounted inside of the Docker container at ``/opt/warehouse/src/``.
 
 
 Running the Warehouse Container and Services
@@ -222,7 +234,7 @@ into the message "no space left on device", try running the following command
    docker volume rm $(docker volume ls -qf dangling=true)
 
 .. note:: This will delete orphaned volumes as well as directories that are not
-   volumes in /var/lib/docker/volumes
+   volumes in ``/var/lib/docker/volumes``
 
 (Solution found and further details available at
 https://github.com/chadoe/docker-cleanup-volumes)
@@ -231,8 +243,9 @@ https://github.com/chadoe/docker-cleanup-volumes)
 Building Styles
 ---------------
 
-Styles are written in the scss variant of Sass and compiled using Gulp. They
-will be automatically built when changed when ``make serve`` is running.
+Styles are written in the scss variant of Sass and compiled using
+``gulp``. They will be automatically built when changed when ``make
+serve`` is running.
 
 
 Running the Interactive Shell
@@ -271,7 +284,7 @@ shell.
 Running tests and linters
 -------------------------
 
-.. note:: PostgreSQL 9.4 is required because of pgcrypto extension
+.. note:: PostgreSQL 9.4 is required because of ``pgcrypto`` extension
 
 The Warehouse tests are found in the ``tests/`` directory and are designed to
 be run using make.
@@ -325,3 +338,7 @@ command will give the following error message:
 .. _`pip`: https://pypi.python.org/pypi/pip
 .. _`sphinx`: https://pypi.python.org/pypi/Sphinx
 .. _`reStructured Text`: http://sphinx-doc.org/rest.html
+.. _`open issues that are labelled "good first issue"`: https://github.com/pypa/warehouse/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22
+.. _`GitHub`: https://github.com/pypa/warehouse
+.. _`on Freenode`: https://webchat.freenode.net/?channels=%23pypa-dev,pypa
+.. _`pypa-dev mailing list`: https://groups.google.com/forum/#!forum/pypa-dev

--- a/docs/development/index.rst
+++ b/docs/development/index.rst
@@ -7,22 +7,28 @@ documentation.
 
 Please contribute issues, submit bug reports, and file feature requests on our
 issue tracker on `GitHub`_. If submitting a bug report for the first time,
-please check out `what to put in your bug report`_ for guidance.
+please check out `"What to put in your bug report"`_ for guidance.
 
 .. important:: We take security very seriously. As such, security issues should
                be emailed to the maintainers instead of being submitted on the
                GitHub issue tracker. Please read the :ref:`security` documentation
                for details.
 
+You can also join ``#pypa`` or ``#pypa-dev`` `on Freenode`_, or the
+`pypa-dev mailing list`_, to ask questions or get involved.
+
+
 .. toctree::
     :maxdepth: 2
 
     getting-started
-    submitting-patches
     frontend
     patterns
     database-migrations
+    submitting-patches
     reviewing-patches
 
 .. _`GitHub`: https://github.com/pypa/warehouse
-.. _`what to put in your bug report`: http://www.contribution-guide.org/#what-to-put-in-your-bug-report
+.. _`"What to put in your bug report"`: http://www.contribution-guide.org/#what-to-put-in-your-bug-report
+.. _`on Freenode`: https://webchat.freenode.net/?channels=%23pypa-dev,pypa
+.. _`pypa-dev mailing list`: https://groups.google.com/forum/#!forum/pypa-dev

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,17 +12,17 @@ Contents:
    ui-principles
    security
 
-Warehouse is a new code base that implements a Python package repository.
-It is being actively developed and
-the plan is that it will eventually power PyPI_ and
-replace an older code base that is currently powering PyPI.
-You can see Warehouse in production at https://pypi.org/
+Warehouse is a new code base that implements a `Python package index
+(repository)`_.  It is being `actively developed`_ and will eventually
+power PyPI_ and replace an older code base that is currently powering
+PyPI.  You can see Warehouse in production at https://pypi.org/ and
+you can read the `Warehouse roadmap`_.
 
 The goal is to improve PyPI by making it:
 
 - be more user-friendly
 - have a more modern look
-- more features
+- have more features
 - remove legacy APIs
 - have more maintainable code with test coverage, docs, etc.
 
@@ -35,5 +35,7 @@ Indices and tables
 * :ref:`modindex`
 * :ref:`search`
 
-
+.. _`Python package index (repository)`: https://packaging.python.org/glossary/#term-package-index
+.. _`actively developed`: https://github.com/pypa/warehouse
 .. _PyPI: https://pypi.python.org
+.. _`Warehouse roadmap`: https://wiki.python.org/psf/WarehouseRoadmap

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -4,4 +4,6 @@ Security
 ========
 
 To read the most up to date version of our security policy, please visit
-the application security page, available via the site footer.
+the application security page, available via the site_ footer.
+
+.. _site: https://pypi.org


### PR DESCRIPTION
Add contact information and links, expand shortened `bit.ly` links, reorder development help pages, add guidance for first-time contributors, and fix prose style.

Relevant to #1322.