### PR TITLE
Return empty response when include fails

### DIFF
--- a/tests/unit/test_views.py
+++ b/tests/unit/test_views.py
@@ -25,7 +25,7 @@ from warehouse import views
 from warehouse.views import (
     SEARCH_BOOSTS, SEARCH_FIELDS, current_user_indicator, forbidden, health,
     httpexception_view, index, robotstxt, opensearchxml, search, force_status,
-    flash_messages
+    flash_messages, forbidden_include
 )
 
 from ..common.db.accounts import UserFactory
@@ -145,6 +145,19 @@ class TestForbiddenView:
         assert resp.status_code == 303
         assert resp.headers["Location"] == \
             "/accounts/login/?next=/foo/bar/%3Fb%3Ds"
+
+
+class TestForbiddenIncludeView:
+
+    def test_forbidden_include(self):
+        exc = pretend.stub()
+        request = pretend.stub()
+
+        resp = forbidden_include(exc, request)
+
+        assert resp.status_code == 200
+        assert resp.content_type == 'text/html'
+        assert resp.content_length == 0
 
 
 def test_robotstxt(pyramid_request):

--- a/warehouse/views.py
+++ b/warehouse/views.py
@@ -125,6 +125,14 @@ def forbidden(exc, request, redirect_to="accounts.login"):
     return httpexception_view(exc, request)
 
 
+@forbidden_view_config(path_info=r"^/_includes/")
+@exception_view_config(PredicateMismatch, path_info=r"^/_includes/")
+def forbidden_include(exc, request):
+    # If the forbidden error is for a client-side-include, just return an empty
+    # response instead of redirecting
+    return Response()
+
+
 @view_config(
     route_name="robots.txt",
     renderer="robots.txt",


### PR DESCRIPTION
Fixes #2843.

If the client side include fails for some reason, return an empty response. For example, if there is a permissions error, don't redirect to the login page, just show an empty view.