### PR TITLE
Generic Token Service

### DIFF
--- a/dev/environment
+++ b/dev/environment
@@ -33,4 +33,4 @@ MAIL_SSL=false
 
 STATUSPAGE_URL=https://2p66nmmycsj3.statuspage.io
 
-PASSWORD_RESET_SECRET_KEY="an insecure password reset secret key"
+TOKEN_PASSWORD_SECRET="an insecure password reset secret key"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -154,7 +154,11 @@ def user_service(db_session, app_config):
 
 @pytest.yield_fixture
 def token_service(app_config):
-    return services.TokenService("secret", "salt", 21600)
+    return services.TokenService(
+        secret="secret",
+        salt="salt",
+        max_age=21600,
+    )
 
 
 class QueryRecorder:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -107,7 +107,6 @@ def app_config(database):
             "elasticsearch.url": "https://localhost/warehouse",
             "files.backend": "warehouse.packaging.services.LocalFileStorage",
             "files.url": "http://localhost:7000/",
-            "password_reset.secret": "insecure secret",
             "sessions.secret": "123456",
             "sessions.url": "redis://localhost:0/",
             "statuspage.url": "https://2p66nmmycsj3.statuspage.io",
@@ -154,10 +153,8 @@ def user_service(db_session, app_config):
 
 
 @pytest.yield_fixture
-def token_service(app_config, user_service):
-    return services.UserTokenService(
-        user_service, app_config.registry.settings
-    )
+def token_service(app_config):
+    return services.TokenService("secret", "salt", 21600)
 
 
 class QueryRecorder:

--- a/tests/unit/accounts/test_services.py
+++ b/tests/unit/accounts/test_services.py
@@ -234,34 +234,34 @@ class TestTokenService:
             pretend.call(secret, salt=salt)
         ]
 
-    def test_generate_token(self, token_service):
-        assert token_service.generate_token({'foo': 'bar'})
+    def test_dumps(self, token_service):
+        assert token_service.dumps({'foo': 'bar'})
 
-    def test_extract_data(self, token_service):
-        token = token_service.generate_token({'foo': 'bar'})
-        assert token_service.extract_data(token) == {'foo': 'bar'}
+    def test_loads(self, token_service):
+        token = token_service.dumps({'foo': 'bar'})
+        assert token_service.loads(token) == {'foo': 'bar'}
 
     @pytest.mark.parametrize('token', ['', None])
-    def test_extract_data_token_is_none(self, token_service, token):
+    def test_loads_token_is_none(self, token_service, token):
         with pytest.raises(TokenMissing):
-            token_service.extract_data(token)
+            token_service.loads(token)
 
-    def test_extract_data_token_is_expired(self, token_service):
+    def test_loads_token_is_expired(self, token_service):
         now = datetime.datetime.utcnow()
 
         with freezegun.freeze_time(now) as frozen_time:
-            token = token_service.generate_token({'foo': 'bar'})
+            token = token_service.dumps({'foo': 'bar'})
 
             frozen_time.tick(
                 delta=datetime.timedelta(seconds=token_service.max_age + 1),
             )
 
             with pytest.raises(TokenExpired):
-                token_service.extract_data(token)
+                token_service.loads(token)
 
-    def test_extract_data_token_is_invalid(self, token_service):
+    def test_loads_token_is_invalid(self, token_service):
         with pytest.raises(TokenInvalid):
-            token_service.extract_data("invalid")
+            token_service.loads("invalid")
 
 
 def test_database_login_factory(monkeypatch):

--- a/tests/unit/accounts/test_views.py
+++ b/tests/unit/accounts/test_views.py
@@ -21,9 +21,9 @@ from pyramid.httpexceptions import HTTPMovedPermanently, HTTPSeeOther
 
 from warehouse.accounts import views
 from warehouse.accounts.interfaces import (
-    IUserService, IUserTokenService, TooManyFailedLogins
+    IUserService, ITokenService, TokenExpired, TokenInvalid, TokenMissing,
+    TooManyFailedLogins
 )
-from warehouse.accounts.services import InvalidPasswordResetToken
 
 from ...common.db.accounts import UserFactory
 
@@ -347,14 +347,20 @@ class TestRequestPasswordReset:
         ]
         assert pyramid_request.find_service.calls == [
             pretend.call(IUserService, context=None),
-            pretend.call(IUserTokenService, context=None),
+            pretend.call(ITokenService, name="password"),
         ]
 
     def test_request_password_reset(
             self, monkeypatch, pyramid_request, pyramid_config, user_service,
             token_service):
 
-        stub_user = pretend.stub(email="email", username="username_value")
+        stub_user = pretend.stub(
+            id="id",
+            email="email",
+            username="username_value",
+            last_login="last_login",
+            password_date="password_date",
+        )
         pyramid_request.method = "POST"
         token_service.generate_token = pretend.call_recorder(lambda a: "TOK")
         user_service.get_user_by_username = pretend.call_recorder(
@@ -363,7 +369,7 @@ class TestRequestPasswordReset:
         pyramid_request.find_service = pretend.call_recorder(
             lambda interface, **kwargs: {
                 IUserService: user_service,
-                IUserTokenService: token_service,
+                ITokenService: token_service,
             }[interface]
         )
         pyramid_request.POST = {"username": stub_user.username}
@@ -394,18 +400,23 @@ class TestRequestPasswordReset:
             pyramid_request, _form_class=form_class
         )
 
-        assert result == {"n_hours": token_service.token_max_age // 60 // 60}
+        assert result == {"n_hours": token_service.max_age // 60 // 60}
         subject_renderer.assert_()
         body_renderer.assert_(token="TOK", username=stub_user.username)
         assert token_service.generate_token.calls == [
-            pretend.call(stub_user),
+            pretend.call({
+                "action": "password-reset",
+                "user.id": str(stub_user.id),
+                "user.last_login": str(stub_user.last_login),
+                "user.password_date": str(stub_user.password_date),
+            }),
         ]
         assert user_service.get_user_by_username.calls == [
             pretend.call(stub_user.username),
         ]
         assert pyramid_request.find_service.calls == [
             pretend.call(IUserService, context=None),
-            pretend.call(IUserTokenService, context=None),
+            pretend.call(ITokenService, name="password"),
         ]
         assert form_obj.validate.calls == [
             pretend.call(),
@@ -423,58 +434,24 @@ class TestRequestPasswordReset:
 
 class TestResetPassword:
 
-    def test_invalid_token(self, pyramid_request, user_service, token_service):
-        form_inst = pretend.stub()
-        form_class = pretend.call_recorder(lambda *args, **kwargs: form_inst)
-
-        def get_user_by_token(token):
-            raise InvalidPasswordResetToken('message')
-
-        pyramid_request.GET.update({"token": "RANDOM_KEY"})
-        token_service.get_user_by_token = pretend.call_recorder(
-            get_user_by_token
-        )
-        pyramid_request.find_service = pretend.call_recorder(
-            lambda interface, **kwargs: {
-                IUserService: user_service,
-                IUserTokenService: token_service,
-            }[interface]
-        )
-        pyramid_request.route_path = pretend.call_recorder(lambda name: "/")
-        pyramid_request.session.flash = pretend.call_recorder(
-            lambda *a, **kw: None
-        )
-
-        views.reset_password(pyramid_request, _form_class=form_class)
-
-        assert form_class.calls == []
-        assert pyramid_request.find_service.calls == [
-            pretend.call(IUserService, context=None),
-            pretend.call(IUserTokenService, context=None),
-        ]
-        assert token_service.get_user_by_token.calls == [
-            pretend.call("RANDOM_KEY"),
-        ]
-        assert pyramid_request.route_path.calls == [
-            pretend.call('accounts.request-password-reset'),
-        ]
-        assert pyramid_request.session.flash.calls == [
-            pretend.call('message', queue='error'),
-        ]
-
     def test_get(self, db_request, user_service, token_service):
         user = UserFactory.create()
         form_inst = pretend.stub()
         form_class = pretend.call_recorder(lambda *args, **kwargs: form_inst)
 
         db_request.GET.update({"token": "RANDOM_KEY"})
-        token_service.get_user_by_token = pretend.call_recorder(
-            lambda token: user
+        token_service.extract_data = pretend.call_recorder(
+            lambda token: {
+                'action': 'password-reset',
+                'user.id': str(user.id),
+                'user.last_login': str(user.last_login),
+                'user.password_date': str(user.password_date),
+            }
         )
         db_request.find_service = pretend.call_recorder(
             lambda interface, **kwargs: {
                 IUserService: user_service,
-                IUserTokenService: token_service,
+                ITokenService: token_service,
             }[interface]
         )
 
@@ -490,12 +467,12 @@ class TestResetPassword:
                 user_service=user_service,
             )
         ]
-        assert token_service.get_user_by_token.calls == [
+        assert token_service.extract_data.calls == [
             pretend.call("RANDOM_KEY"),
         ]
         assert db_request.find_service.calls == [
             pretend.call(IUserService, context=None),
-            pretend.call(IUserTokenService, context=None),
+            pretend.call(ITokenService, name="password"),
         ]
 
     def test_reset_password(self, db_request, user_service, token_service):
@@ -510,12 +487,19 @@ class TestResetPassword:
         form_class = pretend.call_recorder(lambda *args, **kwargs: form_obj)
 
         db_request.route_path = pretend.call_recorder(lambda name: "/")
-        token_service.get_user_by_token = pretend.call_recorder(lambda a: user)
+        token_service.extract_data = pretend.call_recorder(
+            lambda token: {
+                'action': 'password-reset',
+                'user.id': str(user.id),
+                'user.last_login': str(user.last_login),
+                'user.password_date': str(user.password_date),
+            }
+        )
         user_service.update_user = pretend.call_recorder(lambda *a, **kw: None)
         db_request.find_service = pretend.call_recorder(
             lambda interface, **kwargs: {
                 IUserService: user_service,
-                IUserTokenService: token_service,
+                ITokenService: token_service,
             }[interface]
         )
         db_request.session.flash = pretend.call_recorder(
@@ -540,7 +524,7 @@ class TestResetPassword:
             ),
         ]
         assert db_request.route_path.calls == [pretend.call('index')]
-        assert token_service.get_user_by_token.calls == [
+        assert token_service.extract_data.calls == [
             pretend.call('RANDOM_KEY'),
         ]
         assert user_service.update_user.calls == [
@@ -554,8 +538,188 @@ class TestResetPassword:
         ]
         assert db_request.find_service.calls == [
             pretend.call(IUserService, context=None),
-            pretend.call(IUserTokenService, context=None),
+            pretend.call(ITokenService, name="password"),
             pretend.call(IUserService, context=None),
+        ]
+
+    @pytest.mark.parametrize(
+        ("exception", "message"),
+        [
+            (
+                TokenInvalid,
+                "Invalid token - Request a new password reset link",
+            ), (
+                TokenExpired,
+                "Expired token - Request a new password reset link",
+            ), (
+                TokenMissing,
+                "Invalid token - No token supplied"
+            ),
+        ],
+    )
+    def test_reset_password_extract_data_failure(
+            self, pyramid_request, exception, message):
+
+        def extract_data(token):
+            raise exception
+
+        pyramid_request.find_service = lambda interface, **kwargs: {
+            IUserService: pretend.stub(),
+            ITokenService: pretend.stub(extract_data=extract_data),
+        }[interface]
+        pyramid_request.params = {"token": "RANDOM_KEY"}
+        pyramid_request.route_path = pretend.call_recorder(lambda name: "/")
+        pyramid_request.session.flash = pretend.call_recorder(
+            lambda *a, **kw: None
+        )
+
+        views.reset_password(pyramid_request)
+
+        assert pyramid_request.route_path.calls == [
+            pretend.call('accounts.request-password-reset'),
+        ]
+        assert pyramid_request.session.flash.calls == [
+            pretend.call(message, queue='error'),
+        ]
+
+    def test_reset_password_invalid_action(self, pyramid_request):
+        data = {
+            'action': 'invalid-action',
+        }
+        token_service = pretend.stub(
+            extract_data=pretend.call_recorder(lambda token: data),
+        )
+        pyramid_request.find_service = lambda interface, **kwargs: {
+            IUserService: pretend.stub(),
+            ITokenService: token_service,
+        }[interface]
+        pyramid_request.params = {"token": "RANDOM_KEY"}
+        pyramid_request.route_path = pretend.call_recorder(lambda name: "/")
+        pyramid_request.session.flash = pretend.call_recorder(
+            lambda *a, **kw: None
+        )
+
+        views.reset_password(pyramid_request)
+
+        assert pyramid_request.route_path.calls == [
+            pretend.call('accounts.request-password-reset'),
+        ]
+        assert pyramid_request.session.flash.calls == [
+            pretend.call(
+                "Invalid token - Not a password reset token", queue='error'
+            ),
+        ]
+
+    def test_reset_password_invalid_user(self, pyramid_request):
+        data = {
+            'action': 'password-reset',
+            'user.id': '8ad1a4ac-e016-11e6-bf01-fe55135034f3',
+        }
+        token_service = pretend.stub(
+            extract_data=pretend.call_recorder(lambda token: data),
+        )
+        user_service = pretend.stub(
+            get_user=pretend.call_recorder(lambda userid: None),
+        )
+        pyramid_request.find_service = lambda interface, **kwargs: {
+            IUserService: user_service,
+            ITokenService: token_service,
+        }[interface]
+        pyramid_request.params = {"token": "RANDOM_KEY"}
+        pyramid_request.route_path = pretend.call_recorder(lambda name: "/")
+        pyramid_request.session.flash = pretend.call_recorder(
+            lambda *a, **kw: None
+        )
+
+        views.reset_password(pyramid_request)
+
+        assert pyramid_request.route_path.calls == [
+            pretend.call('accounts.request-password-reset'),
+        ]
+        assert pyramid_request.session.flash.calls == [
+            pretend.call(
+                "Invalid token - User not found", queue='error'
+            ),
+        ]
+        assert user_service.get_user.calls == [
+            pretend.call(uuid.UUID(data['user.id'])),
+        ]
+
+    def test_reset_password_last_login_changed(self, pyramid_request):
+        now = datetime.datetime.utcnow()
+        later = now + datetime.timedelta(hours=1)
+        data = {
+            'action': 'password-reset',
+            'user.id': '8ad1a4ac-e016-11e6-bf01-fe55135034f3',
+            'user.last_login': str(now),
+        }
+        token_service = pretend.stub(
+            extract_data=pretend.call_recorder(lambda token: data),
+        )
+        user = pretend.stub(last_login=later)
+        user_service = pretend.stub(
+            get_user=pretend.call_recorder(lambda userid: user),
+        )
+        pyramid_request.find_service = lambda interface, **kwargs: {
+            IUserService: user_service,
+            ITokenService: token_service,
+        }[interface]
+        pyramid_request.params = {"token": "RANDOM_KEY"}
+        pyramid_request.route_path = pretend.call_recorder(lambda name: "/")
+        pyramid_request.session.flash = pretend.call_recorder(
+            lambda *a, **kw: None
+        )
+
+        views.reset_password(pyramid_request)
+
+        assert pyramid_request.route_path.calls == [
+            pretend.call('accounts.request-password-reset'),
+        ]
+        assert pyramid_request.session.flash.calls == [
+            pretend.call(
+                "Invalid token - User has logged in since this token was "
+                "requested",
+                queue='error',
+            ),
+        ]
+
+    def test_reset_password_password_date_changed(self, pyramid_request):
+        now = datetime.datetime.utcnow()
+        later = now + datetime.timedelta(hours=1)
+        data = {
+            'action': 'password-reset',
+            'user.id': '8ad1a4ac-e016-11e6-bf01-fe55135034f3',
+            'user.last_login': str(now),
+            'user.password_date': str(now),
+        }
+        token_service = pretend.stub(
+            extract_data=pretend.call_recorder(lambda token: data),
+        )
+        user = pretend.stub(last_login=now, password_date=later)
+        user_service = pretend.stub(
+            get_user=pretend.call_recorder(lambda userid: user),
+        )
+        pyramid_request.find_service = lambda interface, **kwargs: {
+            IUserService: user_service,
+            ITokenService: token_service,
+        }[interface]
+        pyramid_request.params = {"token": "RANDOM_KEY"}
+        pyramid_request.route_path = pretend.call_recorder(lambda name: "/")
+        pyramid_request.session.flash = pretend.call_recorder(
+            lambda *a, **kw: None
+        )
+
+        views.reset_password(pyramid_request)
+
+        assert pyramid_request.route_path.calls == [
+            pretend.call('accounts.request-password-reset'),
+        ]
+        assert pyramid_request.session.flash.calls == [
+            pretend.call(
+                "Invalid token - Password has already been changed since this "
+                "token was requested",
+                queue='error',
+            ),
         ]
 
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -256,7 +256,7 @@ def test_configure(monkeypatch, settings, environment, other_settings):
         "warehouse.commit": None,
         "site.name": "Warehouse",
         "mail.ssl": True,
-        'password_reset.token_max_age': 21600,
+        'token.default.max_age': 21600,
     }
 
     if environment == config.Environment.development:

--- a/tests/unit/test_email.py
+++ b/tests/unit/test_email.py
@@ -18,6 +18,7 @@ from pyramid_mailer.message import Message
 from pyramid_mailer.interfaces import IMailer
 
 from warehouse import email
+from warehouse.accounts.interfaces import ITokenService
 
 
 class TestSendEmail:
@@ -89,3 +90,69 @@ class TestSendEmail:
         assert request.registry.settings.get.calls == [
             pretend.call("mail.sender")]
         assert task.retry.calls == [pretend.call(exc=exc)]
+
+
+class TestSendPasswordResetEmail:
+
+    def test_send_password_reset_email(
+            self, pyramid_request, pyramid_config, token_service, monkeypatch):
+
+        stub_user = pretend.stub(
+            id='id',
+            email='email',
+            username='username_value',
+            last_login='last_login',
+            password_date='password_date',
+        )
+        pyramid_request.method = 'POST'
+        token_service.dumps = pretend.call_recorder(lambda a: 'TOKEN')
+        pyramid_request.find_service = pretend.call_recorder(
+            lambda *a, **kw: token_service
+        )
+
+        subject_renderer = pyramid_config.testing_add_renderer(
+            'email/password-reset.subject.txt'
+        )
+        subject_renderer.string_response = 'Email Subject'
+        body_renderer = pyramid_config.testing_add_renderer(
+            'email/password-reset.body.txt'
+        )
+        body_renderer.string_response = 'Email Body'
+
+        send_email = pretend.stub(
+            delay=pretend.call_recorder(lambda *args, **kwargs: None)
+        )
+        pyramid_request.task = pretend.call_recorder(
+            lambda *args, **kwargs: send_email
+        )
+        monkeypatch.setattr(email, 'send_email', send_email)
+
+        result = email.send_password_reset_email(
+            pyramid_request,
+            user=stub_user,
+        )
+
+        assert result == {
+            'token': 'TOKEN',
+            'username': stub_user.username,
+            'n_hours': token_service.max_age // 60 // 60,
+        }
+        subject_renderer.assert_()
+        body_renderer.assert_(token='TOKEN', username=stub_user.username)
+        assert token_service.dumps.calls == [
+            pretend.call({
+                'action': 'password-reset',
+                'user.id': str(stub_user.id),
+                'user.last_login': str(stub_user.last_login),
+                'user.password_date': str(stub_user.password_date),
+            }),
+        ]
+        assert pyramid_request.find_service.calls == [
+            pretend.call(ITokenService, name='password'),
+        ]
+        assert pyramid_request.task.calls == [
+            pretend.call(send_email),
+        ]
+        assert send_email.delay.calls == [
+            pretend.call('Email Body', [stub_user.email], 'Email Subject'),
+        ]

--- a/warehouse/accounts/__init__.py
+++ b/warehouse/accounts/__init__.py
@@ -15,9 +15,9 @@ import datetime
 from pyramid.authorization import ACLAuthorizationPolicy
 from pyramid_multiauth import MultiAuthenticationPolicy
 
-from warehouse.accounts.interfaces import IUserService, IUserTokenService
+from warehouse.accounts.interfaces import IUserService, ITokenService
 from warehouse.accounts.services import (
-    database_login_factory, user_token_factory
+    database_login_factory, TokenServiceFactory
 )
 from warehouse.accounts.auth_policy import (
     BasicAuthAuthenticationPolicy, SessionAuthenticationPolicy,
@@ -68,7 +68,13 @@ def _user(request):
 def includeme(config):
     # Register our login service
     config.register_service_factory(database_login_factory, IUserService)
-    config.register_service_factory(user_token_factory, IUserTokenService)
+
+    # Register our token services
+    config.register_service_factory(
+        TokenServiceFactory(name="password"),
+        ITokenService,
+        name="password",
+    )
 
     # Register our authentication and authorization policies
     config.set_authentication_policy(

--- a/warehouse/accounts/interfaces.py
+++ b/warehouse/accounts/interfaces.py
@@ -21,11 +21,16 @@ class TooManyFailedLogins(Exception):
         return super().__init__(*args, **kwargs)
 
 
-class InvalidPasswordResetToken(Exception):
-    def __init__(self, message, *args, **kwargs):
-        self.message = message
+class TokenExpired(Exception):
+    pass
 
-        return super().__init__(*args, **kwargs)
+
+class TokenInvalid(Exception):
+    pass
+
+
+class TokenMissing(Exception):
+    pass
 
 
 class IUserService(Interface):
@@ -74,14 +79,14 @@ class IUserService(Interface):
         """
 
 
-class IUserTokenService(Interface):
+class ITokenService(Interface):
 
-    def generate_token(user):
+    def generate_token(data):
         """
-        Generates a unique token based on user attributes
+        Generates a unique token based on the data provided
         """
 
-    def get_user_by_token(token):
+    def extract_data(token):
         """
-        Gets the user corresponding to the token provided
+        Gets the data corresponding to the token provided
         """

--- a/warehouse/accounts/interfaces.py
+++ b/warehouse/accounts/interfaces.py
@@ -81,12 +81,12 @@ class IUserService(Interface):
 
 class ITokenService(Interface):
 
-    def generate_token(data):
+    def dumps(data):
         """
         Generates a unique token based on the data provided
         """
 
-    def extract_data(token):
+    def loads(token):
         """
         Gets the data corresponding to the token provided
         """

--- a/warehouse/accounts/services.py
+++ b/warehouse/accounts/services.py
@@ -232,7 +232,7 @@ class TokenServiceFactory:
 
     def __call__(self, context, request):
         secret = request.registry.settings[f"token.{self.name}.secret"]
-        salt = self.name
+        salt = self.name  # Use the service name as the unique salt
         max_age = request.registry.settings.get(
             f"token.{self.name}.max_age",
             request.registry.settings["token.default.max_age"],

--- a/warehouse/accounts/services.py
+++ b/warehouse/accounts/services.py
@@ -186,13 +186,13 @@ class TokenService:
         self.serializer = URLSafeTimedSerializer(secret, salt=salt)
         self.max_age = max_age
 
-    def generate_token(self, data):
+    def dumps(self, data):
         return self.serializer.dumps({
             key: str(value)
             for key, value in data.items()
         })
 
-    def extract_data(self, token):
+    def loads(self, token):
         if not token:
             raise TokenMissing
 

--- a/warehouse/accounts/views.py
+++ b/warehouse/accounts/views.py
@@ -256,7 +256,7 @@ def request_password_reset(request, _form_class=RequestPasswordResetForm):
     if request.method == "POST" and form.validate():
         username = form.username.data
         user = user_service.get_user_by_username(username)
-        token = token_service.generate_token({
+        token = token_service.dumps({
             "action": "password-reset",
             "user.id": str(user.id),
             "user.last_login": str(user.last_login),
@@ -301,7 +301,7 @@ def reset_password(request, _form_class=ResetPasswordForm):
 
     try:
         token = request.params.get('token')
-        data = token_service.extract_data(token)
+        data = token_service.loads(token)
     except TokenExpired:
         return _error("Expired token - Request a new password reset link")
     except TokenInvalid:

--- a/warehouse/accounts/views.py
+++ b/warehouse/accounts/views.py
@@ -12,6 +12,7 @@
 
 import datetime
 import hashlib
+import uuid
 
 from pyramid.httpexceptions import (
     HTTPMovedPermanently, HTTPSeeOther, HTTPTooManyRequests,
@@ -26,7 +27,7 @@ from warehouse.accounts.forms import (
     LoginForm, RegistrationForm, RequestPasswordResetForm, ResetPasswordForm,
 )
 from warehouse.accounts.interfaces import (
-    InvalidPasswordResetToken, IUserService, IUserTokenService,
+    IUserService, ITokenService, TokenExpired, TokenInvalid, TokenMissing,
     TooManyFailedLogins,
 )
 from warehouse.cache.origin import origin_cache
@@ -249,14 +250,19 @@ def register(request, _form_class=RegistrationForm):
 )
 def request_password_reset(request, _form_class=RequestPasswordResetForm):
     user_service = request.find_service(IUserService, context=None)
-    user_token_service = request.find_service(IUserTokenService, context=None)
+    token_service = request.find_service(ITokenService, name="password")
     form = _form_class(request.POST, user_service=user_service)
 
     if request.method == "POST" and form.validate():
         username = form.username.data
         user = user_service.get_user_by_username(username)
-        token = user_token_service.generate_token(user)
-        n_hours = user_token_service.token_max_age // 60 // 60
+        token = token_service.generate_token({
+            "action": "password-reset",
+            "user.id": str(user.id),
+            "user.last_login": str(user.last_login),
+            "user.password_date": str(user.password_date),
+        })
+        n_hours = token_service.max_age // 60 // 60
 
         subject = render(
             'email/password-reset.subject.txt',
@@ -285,16 +291,47 @@ def request_password_reset(request, _form_class=RequestPasswordResetForm):
 )
 def reset_password(request, _form_class=ResetPasswordForm):
     user_service = request.find_service(IUserService, context=None)
-    user_token_service = request.find_service(IUserTokenService, context=None)
+    token_service = request.find_service(ITokenService, name="password")
+
+    def _error(message):
+        request.session.flash(message, queue="error")
+        return HTTPSeeOther(
+            request.route_path("accounts.request-password-reset"),
+        )
 
     try:
         token = request.params.get('token')
-        user = user_token_service.get_user_by_token(token)
-    except InvalidPasswordResetToken as e:
-        # Fail if the token is invalid for any reason
-        request.session.flash(e.message, queue="error")
-        return HTTPSeeOther(
-            request.route_path("accounts.request-password-reset"),
+        data = token_service.extract_data(token)
+    except TokenExpired:
+        return _error("Expired token - Request a new password reset link")
+    except TokenInvalid:
+        return _error("Invalid token - Request a new password reset link")
+    except TokenMissing:
+        return _error("Invalid token - No token supplied")
+
+    # Check whether this token is being used correctly
+    if data.get('action') != "password-reset":
+        return _error("Invalid token - Not a password reset token")
+
+    # Check whether a user with the given user ID exists
+    user = user_service.get_user(uuid.UUID(data.get("user.id")))
+    if user is None:
+        return _error("Invalid token - User not found")
+
+    # Check whether the user has logged in since the token was created
+    last_login = data.get("user.last_login")
+    if str(user.last_login) > last_login:
+        # TODO: track and audit this, seems alertable
+        return _error(
+            "Invalid token - User has logged in since this token was requested"
+        )
+
+    # Check whether the password has been changed since the token was created
+    password_date = data.get("user.password_date")
+    if str(user.password_date) > password_date:
+        return _error(
+            "Invalid token - Password has already been changed since this "
+            "token was requested"
         )
 
     form = _form_class(

--- a/warehouse/config.py
+++ b/warehouse/config.py
@@ -172,15 +172,17 @@ def configure(settings=None):
     maybe_set(settings, "mail.ssl", "MAIL_SSL", default=True)
     maybe_set(settings, "ga.tracking_id", "GA_TRACKING_ID")
     maybe_set(settings, "statuspage.url", "STATUSPAGE_URL")
+    maybe_set(settings, "token.password.secret", "TOKEN_PASSWORD_SECRET")
     maybe_set(
         settings,
-        "password_reset.secret",
-        "PASSWORD_RESET_SECRET_KEY"
+        "token.password.max_age",
+        "TOKEN_PASSWORD_MAX_AGE",
+        coercer=int,
     )
     maybe_set(
         settings,
-        "password_reset.token_max_age",
-        "PASSWORD_RESET_TOKEN_MAX_AGE",
+        "token.default.max_age",
+        "TOKEN_DEFAULT_MAX_AGE",
         coercer=int,
         default=21600,  # 6 hours
     )


### PR DESCRIPTION
This PR turns the `UserTokenService` added in #2764 into a generic token service that can be
reused, and register the existing service in a way that allows for multiple token services to coexist.

The goal of this is to be able to add a token service for email confirmation that shares the same serialization and configuration scheme, but can be configured and used independently.