### PR TITLE
Always show skip to content link on top

### DIFF
--- a/warehouse/static/sass/blocks/_skip-to-content.scss
+++ b/warehouse/static/sass/blocks/_skip-to-content.scss
@@ -25,6 +25,7 @@
   width: 1px;
   height: 1px;
   overflow: hidden;
+  z-index: index($z-index-scale, "skip-to-content");
 
   &:focus {
     top: 7px;

--- a/warehouse/static/sass/settings/_z-index.scss
+++ b/warehouse/static/sass/settings/_z-index.scss
@@ -34,4 +34,5 @@ $z-index-scale: "tabs-border",
                 "dropdown",
                 "sticky-top",
                 "dark-overlay",
-                "filter-panel";
+                "filter-panel",
+                "skip-to-content";


### PR DESCRIPTION
Closes #2872 

To test:

Temporarily move the 'donate' `notification-bar` on `warehouse/templates/base.html` inside `<section class="stick-to-top js-stick-to-top">`