### PR TITLE
Project page tweaks

### DIFF
--- a/tests/unit/manage/test_views.py
+++ b/tests/unit/manage/test_views.py
@@ -111,9 +111,33 @@ class TestManageProfile:
 class TestManageProjects:
 
     def test_manage_projects(self):
-        request = pretend.stub()
+        project_with_older_release = pretend.stub(
+            releases=[pretend.stub(created=0)]
+        )
+        project_with_newer_release = pretend.stub(
+            releases=[pretend.stub(created=2)]
+        )
+        older_project_with_no_releases = pretend.stub(releases=[], created=1)
+        newer_project_with_no_releases = pretend.stub(releases=[], created=3)
+        request = pretend.stub(
+            user=pretend.stub(
+                projects=[
+                    project_with_older_release,
+                    project_with_newer_release,
+                    newer_project_with_no_releases,
+                    older_project_with_no_releases,
+                ],
+            ),
+        )
 
-        assert views.manage_projects(request) == {}
+        assert views.manage_projects(request) == {
+            'projects': [
+                newer_project_with_no_releases,
+                project_with_newer_release,
+                older_project_with_no_releases,
+                project_with_older_release,
+            ],
+        }
 
 
 class TestManageProjectSettings:

--- a/tests/unit/packaging/test_models.py
+++ b/tests/unit/packaging/test_models.py
@@ -116,6 +116,15 @@ class TestProject:
             (Allow, str(maintainer2.user.id), ["upload"]),
         ]
 
+    def test_owners(self, db_session):
+        project = DBProjectFactory.create()
+        owner1 = DBRoleFactory.create(project=project)
+        owner2 = DBRoleFactory.create(project=project)
+        DBRoleFactory.create(project=project, role_name="Maintainer")
+        DBRoleFactory.create(project=project, role_name="Maintainer")
+
+        assert set(project.owners) == set([owner1.user, owner2.user])
+
 
 class TestRelease:
 

--- a/warehouse/manage/views.py
+++ b/warehouse/manage/views.py
@@ -71,7 +71,15 @@ class ManageProfileViews:
     effective_principals=Authenticated,
 )
 def manage_projects(request):
-    return {}
+
+    def _key(project):
+        if project.releases:
+            return project.releases[0].created
+        return project.created
+
+    return {
+        'projects': sorted(request.user.projects, key=_key, reverse=True)
+    }
 
 
 @view_config(

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -175,6 +175,16 @@ class Project(SitemapMixin, db.ModelBase):
 
         return request.route_url("legacy.docs", project=self.name)
 
+    @property
+    def owners(self):
+        return (
+            orm.object_session(self)
+            .query(User)
+            .join(Role.user)
+            .filter(Role.project == self, Role.role_name == 'Owner')
+            .all()
+        )
+
 
 class DependencyKind(enum.IntEnum):
 

--- a/warehouse/templates/manage/projects.html
+++ b/warehouse/templates/manage/projects.html
@@ -48,7 +48,16 @@
             title="You are not an owner of this project"
             {% endif %}
             >Edit</a>
-          <a href="{{ request.route_path('packaging.project', name=project.normalized_name) }}" class="button">View</a>
+          <a
+            href="{{ request.route_path('packaging.project', name=project.normalized_name) }}"
+            class="button"
+            {% if project.releases %}
+            title="View this project's public page"
+            {% else %}
+            disabled
+            title="This project has no releases"
+            {% endif %}
+            >View</a>
         </div>
       </div>
     </div>

--- a/warehouse/templates/manage/projects.html
+++ b/warehouse/templates/manage/projects.html
@@ -35,6 +35,10 @@
           <p class="package-snippet__description">
             {{ release.summary }}
           </p>
+          {% else %}
+          <p class="package-snippet__meta">
+            <em>Created on {{ project.created|format_date() }}</em>
+          </p>
           {% endif %}
         </div>
         <div class="package-snippet__buttons">

--- a/warehouse/templates/manage/projects.html
+++ b/warehouse/templates/manage/projects.html
@@ -38,7 +38,16 @@
           {% endif %}
         </div>
         <div class="package-snippet__buttons">
-          <a href="{{ request.route_path('manage.project.releases', project_name=project.normalized_name) }}" class="button button--primary">Edit</a>
+          <a
+            href="{{ request.route_path('manage.project.releases', project_name=project.normalized_name) }}"
+            class="button button--primary"
+            {% if request.user in project.owners %}
+            title="Edit this project"
+            {% else %}
+            disabled
+            title="You are not an owner of this project"
+            {% endif %}
+            >Edit</a>
           <a href="{{ request.route_path('packaging.project', name=project.normalized_name) }}" class="button">View</a>
         </div>
       </div>

--- a/warehouse/templates/manage/projects.html
+++ b/warehouse/templates/manage/projects.html
@@ -19,10 +19,10 @@
 {% block title %}{{ title }}{% endblock %}
 
 {% block main %}
-  <h1 class="page-title">Your Projects ({{ request.user.projects|length }})</h1>
+  <h1 class="page-title">Your Projects ({{ projects|length }})</h1>
   <div class="package-list">
-    {% if request.user.projects %}
-    {% for project in request.user.projects %}
+    {% if projects %}
+    {% for project in projects %}
     {% set release = project.releases[0] if project.releases else None %}
     <div class="package-snippet">
       <div class="split-layout split-layout--table split-layout--wrap-on-tablet">


### PR DESCRIPTION
A few tweaks to the 'Manage Projects' page:

* 'Edit' button is disabled if the user is not an owner (Fixes #2876);
* 'View' button is disabled if the project has no releases (Fixes #2828);
* Add tooltips for 'View' and 'Edit' buttons (both disabled and enabled);
* Sort the listed projects from most recently released to oldest (falls back on project creation date if the project has no releases);
* Show the project creation date if it has no releases.