### PR TITLE
Add stub of new architecture overview

### DIFF
--- a/docs/application.rst
+++ b/docs/application.rst
@@ -1,0 +1,80 @@
+The Warehouse codebase
+======================
+
+Warehouse uses the
+`Pyramid <https://docs.pylonsproject.org/projects/pyramid/en/latest/index.html>`__
+web framework, the
+`SQLAlchemy <https://docs.sqlalchemy.org/en/latest/>`__ ORM, and
+`Postgres <https://www.postgresql.org/docs/>`__ for its database.
+Warehouse's front end uses Jinja2 templates.
+
+The production deployment for Warehouse is in progress and currently
+doesn't use any containers, although we may change that in the
+future. In the development environment, we use several `Docker
+<https://docs.docker.com/>`__ containers, and use `Docker Compose
+<https://docs.docker.com/compose/overview/>`__ to `manage
+<https://github.com/pypa/warehouse/blob/master/docker-compose.yml#L3>`__
+running the containers and the connections between them. In the future
+we will probably reduce that number to two containers, one of which
+contains static files for the website, and the other which contains
+the Python web application code running in a virtual environment and
+the database.
+
+Since Warehouse was built on top of a pre-existing database and
+developers had to fit our ORM to the existing tables, some of the code
+in the ORM may not look like code from SQLAlchemy’s documentation. There
+are some places where joins are done using name-based logic instead of a
+foreign key (but this may change in the future).
+
+Warehouse also uses `Pyramid's hybrid URL traversal and dispatch
+<https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/hybrid.html>`__.
+Using factory classes, resources are provided directly to the views
+based on the URL pattern.
+
+Since reads are *much* more common than writes (much more goes out than
+goes in), we try to cache as much as possible. This is a big reason
+that, although we have supported localization in the past, `we currently
+don't <https://github.com/pypa/warehouse/issues/1453>`__.
+
+File and directory structure
+----------------------------
+
+The top-level directory of the Warehouse repo contains files including:
+
+-  ``LICENSE``
+-  ``CONTRIBUTING.rst`` (the contribution guide)
+-  ``README.rst``
+-  ``requirements.txt`` for the Warehouse virtual environment
+-  ``Dockerfile``: creates the Docker containers that Warehouse runs in
+-  ``docker-compose.yml`` file configures Docker Compose
+-  ``setup.cfg`` for test configuration
+-  ``runtime.txt`` for Heroku
+-  ``Makefile``: commands to spin up Docker Compose and the Docker
+   containers, run the linter and other tests, etc.
+-  files associated with Warehouse's front end, e.g.,
+   ``Gulpfile.babel.js``
+
+Directories within the repository:
+
+::
+
+    bin/ - high-level scripts for Docker, Travis, and Makefile commands
+    dev/ - assets for developer environment
+    tests/ - tests
+    warehouse/ - code in modules
+        legacy/ - most of the read-only APIs implemented here
+        forklift/ - APIs for upload
+        accounts/ - user accounts
+        admin/ - application-administrator-specific
+        cache/ - caching
+        classifiers/ - frame trove classifiers
+        cli/ - entry scripts and [the interactive shell](https://warehouse.readthedocs.io/development/getting-started/#running-the-interactive-shell)
+        i18n/ - internationalization
+        locales/ - internationalization
+        manage/ - logged-in user functionality (i.e., manage account & owned projects)
+        migrations/ - DB
+        packaging/ - models
+        rate_limiting/ - rate limiting to prevent abuse
+        rss/ - RSS feeds
+        sitemap/ - site maps
+        utils/ - various utilities Warehouse uses

--- a/docs/development/index.rst
+++ b/docs/development/index.rst
@@ -27,6 +27,7 @@ You can also join ``#pypa`` or ``#pypa-dev`` `on Freenode`_, or the
     database-migrations
     submitting-patches
     reviewing-patches
+    legacy-application-structure
 
 .. _`GitHub`: https://github.com/pypa/warehouse
 .. _`"What to put in your bug report"`: http://www.contribution-guide.org/#what-to-put-in-your-bug-report

--- a/docs/development/legacy-application-structure.rst
+++ b/docs/development/legacy-application-structure.rst
@@ -18,7 +18,7 @@ URL           Purpose
 /security     Page giving contact and other information regarding site security
 /id           OpenID endpoint
 /oauth        OAuth endpoint
-/simple       Simple API as given in :doc:`api-reference/legacy`
+/simple       Simple API as given in :doc:`../api-reference/legacy`
 /packages     Serve up a package file
 /mirrors      Page listing legacy mirrors (not to be retained)
 /serversig    Legacy mirroring support (no-one uses it: not to be retained)

--- a/docs/development/legacy-application-structure.rst
+++ b/docs/development/legacy-application-structure.rst
@@ -1,11 +1,9 @@
-Application Structure
-=====================
+Legacy Application URL Structure
+================================
 
-Note: this is a brain dump and its contents may be moved to a more
-appropriate location eventually.
+Note: this is a brain dump, mostly written by Donald Stufft in early 2015.
 
-At the moment it *just* lists the legacy structure and none of the intended
-new structure.
+It *just* lists the legacy structure and none of the intended new structure.
 
 The following documents the current URLs in the legacy PyPI application.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,6 +7,7 @@ Contents:
    :maxdepth: 2
 
    development/index
+   application
    api-reference/index
    ui-principles
    security

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,7 +7,6 @@ Contents:
    :maxdepth: 2
 
    development/index
-   application
    api-reference/index
    ui-principles
    security


### PR DESCRIPTION
@lgh2 interviewed @ewdurbin and got down some rough notes that I've polished a bit. I know this is just a sketch and not very detailed, but I suggest we review this for accuracy and get this merged, and then iteratively improve this page as Laura and other newer contributors learn more and use their experiences to add to it.

It's probably best to review this commit-by-commit so you see the `git mv` of the legacy URL structure doc separately from the new architecture overview.

Partially gets at #2794 but not entirely.