### PR TITLE
block top-level module namespaces not covered by stdlib-list

### DIFF
--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -883,6 +883,9 @@ class TestFileUpload:
                                       "encodings.utf_8_sig",
                                       "distutils.command.build_clib",
                                       "xmlrpc", "xmlrpc.server",
+                                      "xml.etree", "xml.etree.ElementTree",
+                                      "xml.parsers", "xml.parsers.expat",
+                                      "xml.parsers.expat.errors",
                                       "encodings.idna", "encodings",
                                       "CGIHTTPServer", "cgihttpserver"])
     def test_fails_with_stdlib_names(self, pyramid_config, db_request, name):

--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -882,6 +882,8 @@ class TestFileUpload:
                                       "main", "future", "al", "uU", "test",
                                       "encodings.utf_8_sig",
                                       "distutils.command.build_clib",
+                                      "xmlrpc", "xmlrpc.server",
+                                      "encodings.idna", "encodings",
                                       "CGIHTTPServer", "cgihttpserver"])
     def test_fails_with_stdlib_names(self, pyramid_config, db_request, name):
         pyramid_config.testing_securitypolicy(userid=1)

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -52,10 +52,19 @@ MAX_SIGSIZE = 8 * 1024           # 8K
 
 PATH_HASHER = "blake2_256"
 
+
+def namespace_stdlib_list(module_list):
+    for module_name in module_list:
+        parts = module_name.split('.')
+        for i, part in enumerate(parts):
+            yield '.'.join(parts[:i + 1])
+
+
 STDLIB_PROHIBITTED = {
     packaging.utils.canonicalize_name(s.rstrip('-_.').lstrip('-_.'))
-    for s in chain.from_iterable(stdlib_list.stdlib_list(version)
-                                 for version in stdlib_list.short_versions)
+    for s in chain.from_iterable(
+        namespace_stdlib_list(stdlib_list.stdlib_list(version))
+        for version in stdlib_list.short_versions)
 }
 
 # Wheel platform checking


### PR DESCRIPTION
fixes #2940, initial work failed to take this into consideration.

one other thing to consider is situations noted in the initial report...

should we block packages like:

`encodings.magicencoding`
or
`xml.painville`

that "squat" by appearing to belong to top level namespaces?