### PR TITLE
Require at least one verified email address to register new projects.

### DIFF
--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -2463,7 +2463,6 @@ class TestFileUpload:
         db_request.find_service = lambda svc: storage_service
         db_request.remote_addr = "10.10.10.10"
 
-
         if expected_success:
             resp = legacy.file_upload(db_request)
             assert resp.status_code == 200
@@ -2472,13 +2471,14 @@ class TestFileUpload:
                 legacy.file_upload(db_request)
             resp = excinfo.value
             assert resp.status_code == 400
-            assert resp.status == (("400 User {!r} has no verified email "
-                                    "addresses, please verify at least one "
-                                    "address before registering a new project "
-                                    "on PyPI. See "
-                                    "https://pypi.org/help/#verified-email "
-                                    "for more information.")
-                                    .format(user.username))
+            assert resp.status == (
+                ("400 User {!r} has no verified email "
+                 "addresses, please verify at least one "
+                 "address before registering a new project "
+                 "on PyPI. See "
+                 "https://pypi.org/help/#verified-email "
+                 "for more information.").format(user.username)
+            )
 
     def test_upload_purges_legacy(self, pyramid_config, db_request,
                                   monkeypatch):

--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -37,7 +37,7 @@ from warehouse.packaging.models import (
     JournalEntry,
 )
 
-from ...common.db.accounts import UserFactory
+from ...common.db.accounts import UserFactory, EmailFactory
 from ...common.db.packaging import (
     ProjectFactory, ReleaseFactory, FileFactory, RoleFactory,
 )
@@ -543,6 +543,7 @@ class TestIsDuplicateFile:
         pyramid_config.testing_securitypolicy(userid=1)
 
         user = UserFactory.create()
+        EmailFactory.create(user=user)
         project = ProjectFactory.create()
         release = ReleaseFactory.create(project=project, version="1.0")
         RoleFactory.create(user=user, project=project)
@@ -578,6 +579,7 @@ class TestIsDuplicateFile:
         pyramid_config.testing_securitypolicy(userid=1)
 
         user = UserFactory.create()
+        EmailFactory.create(user=user)
         project = ProjectFactory.create()
         release = ReleaseFactory.create(project=project, version="1.0")
         RoleFactory.create(user=user, project=project)
@@ -617,6 +619,7 @@ class TestIsDuplicateFile:
         pyramid_config.testing_securitypolicy(userid=1)
 
         user = UserFactory.create()
+        EmailFactory.create(user=user)
         project = ProjectFactory.create()
         release = ReleaseFactory.create(project=project, version="1.0")
         RoleFactory.create(user=user, project=project)
@@ -855,6 +858,10 @@ class TestFileUpload:
     @pytest.mark.parametrize("name", ["requirements.txt", "rrequirements.txt"])
     def test_fails_with_invalid_names(self, pyramid_config, db_request, name):
         pyramid_config.testing_securitypolicy(userid=1)
+        user = UserFactory.create()
+        EmailFactory.create(user=user)
+        db_request.user = user
+
         db_request.POST = MultiDict({
             "metadata_version": "1.2",
             "name": name,
@@ -889,6 +896,9 @@ class TestFileUpload:
                                       "encodings.idna", "encodings",
                                       "CGIHTTPServer", "cgihttpserver"])
     def test_fails_with_stdlib_names(self, pyramid_config, db_request, name):
+        user = UserFactory.create()
+        EmailFactory.create(user=user)
+        db_request.user = user
         pyramid_config.testing_securitypolicy(userid=1)
         db_request.POST = MultiDict({
             "metadata_version": "1.2",
@@ -998,6 +1008,7 @@ class TestFileUpload:
 
         pyramid_config.testing_securitypolicy(userid=1)
         user = UserFactory.create()
+        EmailFactory.create(user=user)
         project = ProjectFactory.create()
         release = ReleaseFactory.create(project=project, version="1.0")
         RoleFactory.create(user=user, project=project)
@@ -1132,6 +1143,7 @@ class TestFileUpload:
 
         pyramid_config.testing_securitypolicy(userid=1)
         user = UserFactory.create()
+        EmailFactory.create(user=user)
         project = ProjectFactory.create()
         release = ReleaseFactory.create(project=project, version="1.0")
         RoleFactory.create(user=user, project=project)
@@ -1171,6 +1183,7 @@ class TestFileUpload:
         pyramid_config.testing_securitypolicy(userid=1)
 
         user = UserFactory.create()
+        EmailFactory.create(user=user)
         project = ProjectFactory.create()
         release = ReleaseFactory.create(project=project, version="1.0")
         RoleFactory.create(user=user, project=project)
@@ -1203,6 +1216,7 @@ class TestFileUpload:
         pyramid_config.testing_securitypolicy(userid=1)
 
         user = UserFactory.create()
+        EmailFactory.create(user=user)
         project = ProjectFactory.create()
         release = ReleaseFactory.create(project=project, version="1.0")
         RoleFactory.create(user=user, project=project)
@@ -1237,6 +1251,7 @@ class TestFileUpload:
         pyramid_config.testing_securitypolicy(userid=1)
 
         user = UserFactory.create()
+        EmailFactory.create(user=user)
         project = ProjectFactory.create()
         release = ReleaseFactory.create(project=project, version="1.0")
         FileFactory.create(
@@ -1275,6 +1290,7 @@ class TestFileUpload:
         pyramid_config.testing_securitypolicy(userid=1)
 
         user = UserFactory.create()
+        EmailFactory.create(user=user)
         project = ProjectFactory.create()
         release = ReleaseFactory.create(project=project, version="1.0")
         RoleFactory.create(user=user, project=project)
@@ -1311,6 +1327,7 @@ class TestFileUpload:
         pyramid_config.testing_securitypolicy(userid=1)
 
         user = UserFactory.create()
+        EmailFactory.create(user=user)
         project = ProjectFactory.create()
         release = ReleaseFactory.create(project=project, version="1.0")
         RoleFactory.create(user=user, project=project)
@@ -1385,6 +1402,7 @@ class TestFileUpload:
         pyramid_config.testing_securitypolicy(userid=1)
 
         user = UserFactory.create()
+        EmailFactory.create(user=user)
         project = ProjectFactory.create()
         release = ReleaseFactory.create(project=project, version="1.0")
         RoleFactory.create(user=user, project=project)
@@ -1419,6 +1437,7 @@ class TestFileUpload:
         pyramid_config.testing_securitypolicy(userid=1)
 
         user = UserFactory.create()
+        EmailFactory.create(user=user)
         project = ProjectFactory.create()
         release = ReleaseFactory.create(project=project, version="1.0")
         RoleFactory.create(user=user, project=project)
@@ -1451,6 +1470,7 @@ class TestFileUpload:
         pyramid_config.testing_securitypolicy(userid=1)
 
         user = UserFactory.create()
+        EmailFactory.create(user=user)
         project = ProjectFactory.create(
             name='foobar',
             upload_limit=(60 * 1024 * 1024),  # 60MB
@@ -1488,6 +1508,7 @@ class TestFileUpload:
         pyramid_config.testing_securitypolicy(userid=1)
 
         user = UserFactory.create()
+        EmailFactory.create(user=user)
         project = ProjectFactory.create()
         release = ReleaseFactory.create(project=project, version="1.0")
         RoleFactory.create(user=user, project=project)
@@ -1524,6 +1545,7 @@ class TestFileUpload:
         pyramid_config.testing_securitypolicy(userid=1)
 
         user = UserFactory.create()
+        EmailFactory.create(user=user)
         project = ProjectFactory.create()
         release = ReleaseFactory.create(project=project, version="1.0")
         RoleFactory.create(user=user, project=project)
@@ -1563,6 +1585,7 @@ class TestFileUpload:
         pyramid_config.testing_securitypolicy(userid=1)
 
         user = UserFactory.create()
+        EmailFactory.create(user=user)
         project = ProjectFactory.create()
         release = ReleaseFactory.create(project=project, version="1.0")
         RoleFactory.create(user=user, project=project)
@@ -1612,6 +1635,7 @@ class TestFileUpload:
         pyramid_config.testing_securitypolicy(userid=1)
 
         user = UserFactory.create()
+        EmailFactory.create(user=user)
         project = ProjectFactory.create()
         release = ReleaseFactory.create(project=project, version="1.0")
         RoleFactory.create(user=user, project=project)
@@ -1664,6 +1688,7 @@ class TestFileUpload:
         pyramid_config.testing_securitypolicy(userid=1)
 
         user = UserFactory.create()
+        EmailFactory.create(user=user)
         project = ProjectFactory.create()
         release = ReleaseFactory.create(project=project, version="1.0")
         RoleFactory.create(user=user, project=project)
@@ -1701,6 +1726,7 @@ class TestFileUpload:
         pyramid_config.testing_securitypolicy(userid=1)
 
         user = UserFactory.create()
+        EmailFactory.create(user=user)
         project = ProjectFactory.create()
         release = ReleaseFactory.create(project=project, version="1.0")
         RoleFactory.create(user=user, project=project)
@@ -1737,6 +1763,7 @@ class TestFileUpload:
         pyramid_config.testing_securitypolicy(userid=1)
 
         user = UserFactory.create()
+        EmailFactory.create(user=user)
         project = ProjectFactory.create()
         release = ReleaseFactory.create(project=project, version="1.0")
         RoleFactory.create(user=user, project=project)
@@ -1772,7 +1799,9 @@ class TestFileUpload:
         pyramid_config.testing_securitypolicy(userid=1, permissive=False)
 
         user1 = UserFactory.create()
+        EmailFactory.create(user=user1)
         user2 = UserFactory.create()
+        EmailFactory.create(user=user2)
         project = ProjectFactory.create()
         release = ReleaseFactory.create(project=project, version="1.0")
         RoleFactory.create(user=user1, project=project)
@@ -1813,6 +1842,7 @@ class TestFileUpload:
         pyramid_config.testing_securitypolicy(userid=1)
 
         user = UserFactory.create()
+        EmailFactory.create(user=user)
         project = ProjectFactory.create()
         release = ReleaseFactory.create(project=project, version="1.0")
         RoleFactory.create(user=user, project=project)
@@ -1916,6 +1946,7 @@ class TestFileUpload:
         pyramid_config.testing_securitypolicy(userid=1)
 
         user = UserFactory.create()
+        EmailFactory.create(user=user)
         project = ProjectFactory.create()
         release = ReleaseFactory.create(project=project, version="1.0")
         FileFactory.create(
@@ -2022,6 +2053,7 @@ class TestFileUpload:
         pyramid_config.testing_securitypolicy(userid=1)
 
         user = UserFactory.create()
+        EmailFactory.create(user=user)
         project = ProjectFactory.create(allow_legacy_files=True)
         release = ReleaseFactory.create(project=project, version="1.0")
         RoleFactory.create(user=user, project=project)
@@ -2067,6 +2099,7 @@ class TestFileUpload:
         pyramid_config.testing_securitypolicy(userid=1)
 
         user = UserFactory.create()
+        EmailFactory.create(user=user)
         project = ProjectFactory.create(allow_legacy_files=True)
         release = ReleaseFactory.create(project=project, version="1.0")
         RoleFactory.create(user=user, project=project)
@@ -2112,6 +2145,7 @@ class TestFileUpload:
         pyramid_config.testing_securitypolicy(userid=1)
 
         user = UserFactory.create()
+        EmailFactory.create(user=user)
         project = ProjectFactory.create()
         release = ReleaseFactory.create(project=project, version="1.0")
         RoleFactory.create(user=user, project=project)
@@ -2156,6 +2190,7 @@ class TestFileUpload:
         pyramid_config.testing_securitypolicy(userid=1)
 
         user = UserFactory.create()
+        EmailFactory.create(user=user)
         project = ProjectFactory.create()
         RoleFactory.create(user=user, project=project)
 
@@ -2262,6 +2297,7 @@ class TestFileUpload:
         pyramid_config.testing_securitypolicy(userid=1)
 
         user = UserFactory.create()
+        EmailFactory.create(user=user)
         project = ProjectFactory.create()
         release = ReleaseFactory.create(project=project, version="1.0")
         RoleFactory.create(user=user, project=project)
@@ -2303,6 +2339,7 @@ class TestFileUpload:
         pyramid_config.testing_securitypolicy(userid=1)
 
         user = UserFactory.create()
+        EmailFactory.create(user=user)
 
         filename = "{}-{}.tar.gz".format("example", "1.0")
 
@@ -2388,11 +2425,67 @@ class TestFileUpload:
             ),
         ]
 
+    @pytest.mark.parametrize(
+        ("emails_verified", "expected_success"),
+        [
+            ((True,), True),
+            ((False,), False),
+            ((True, True), True),
+            ((True, False), True),
+            ((False, False), False),
+        ],
+    )
+    def test_upload_requires_verified_email(self, pyramid_config, db_request,
+                                            emails_verified, expected_success):
+        pyramid_config.testing_securitypolicy(userid=1)
+
+        user = UserFactory.create()
+        for verified in emails_verified:
+            EmailFactory.create(user=user, verified=verified)
+
+        filename = "{}-{}.tar.gz".format("example", "1.0")
+
+        db_request.user = user
+        db_request.POST = MultiDict({
+            "metadata_version": "1.2",
+            "name": "example",
+            "version": "1.0",
+            "filetype": "sdist",
+            "md5_digest": "335c476dc930b959dda9ec82bd65ef19",
+            "content": pretend.stub(
+                filename=filename,
+                file=io.BytesIO(b"A fake file."),
+                type="application/tar",
+            ),
+        })
+
+        storage_service = pretend.stub(store=lambda path, filepath, meta: None)
+        db_request.find_service = lambda svc: storage_service
+        db_request.remote_addr = "10.10.10.10"
+
+
+        if expected_success:
+            resp = legacy.file_upload(db_request)
+            assert resp.status_code == 200
+        else:
+            with pytest.raises(HTTPBadRequest) as excinfo:
+                legacy.file_upload(db_request)
+            resp = excinfo.value
+            assert resp.status_code == 400
+            assert resp.status == (("400 User {!r} has no verified email "
+                                    "addresses, please verify at least one "
+                                    "address before registering a new project "
+                                    "on PyPI. See "
+                                    "https://pypi.org/help/#verified-email "
+                                    "for more information.")
+                                    .format(user.username))
+
     def test_upload_purges_legacy(self, pyramid_config, db_request,
                                   monkeypatch):
         pyramid_config.testing_securitypolicy(userid=1)
 
         user = UserFactory.create()
+        EmailFactory.create(user=user)
 
         filename = "{}-{}.tar.gz".format("example", "1.0")
 
@@ -2449,6 +2542,7 @@ class TestFileUpload:
         pyramid_config.testing_securitypolicy(userid=1)
 
         user = UserFactory.create()
+        EmailFactory.create(user=user)
         project = ProjectFactory.create(autohide=True)
         ReleaseFactory.create(
             project=project,
@@ -2522,6 +2616,7 @@ class TestFileUpload:
         pyramid_config.testing_securitypolicy(userid=1)
 
         user = UserFactory.create()
+        EmailFactory.create(user=user)
         project = ProjectFactory.create(autohide=False)
         previous_releases = {
             "0.5": ReleaseFactory.create(

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -742,6 +742,8 @@ def file_upload(request):
     except NoResultFound:
         # Ensure that user has at least one verified email address. This should
         # reduce the ease of spam account creation and activity.
+        # TODO: Once legacy is shutdown consider the condition here, perhaps
+        # move to user.is_active or some other boolean
         if not any(email.verified for email in request.user.emails):
             raise _exc_with_message(
                 HTTPBadRequest,

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -740,6 +740,18 @@ def file_upload(request):
                           func.normalize_pep426_name(form.name.data)).one()
         )
     except NoResultFound:
+        # Ensure that user has at least one verified email address. This should
+        # reduce the ease of spam account creation and activity.
+        if not any(email.verified for email in request.user.emails):
+            raise _exc_with_message(
+                HTTPBadRequest,
+                ("User {!r} has no verified email addresses, please verify "
+                 "at least one address before registering a new project on "
+                 "PyPI. See https://pypi.org/help/#verified-email "
+                 "for more information.")
+                .format(request.user.username),
+            ) from None
+
         # Before we create the project, we're going to check our blacklist to
         # see if this project is even allowed to be registered. If it is not,
         # then we're going to deny the request to create this project.

--- a/warehouse/templates/pages/help.html
+++ b/warehouse/templates/pages/help.html
@@ -30,7 +30,7 @@
 {% macro preproduction() %}What does pre-production mean?{% endmacro %}
 {% macro project_name() %}Why isn't my desired project name available?{% endmacro %}
 {% macro project_name_claim() %}How do I claim an abandoned or previously registered project name?{% endmacro %}
-{% macro verified_email() %}Why do I need a verified email address to register a new project?{% endmacro %}
+{% macro verified_email() %}Why do I need a verified email address?{% endmacro %}
 {% macro maintainers() %}Who maintains PyPI?{% endmacro %}
 {% macro sponsors() %}What powers PyPI?{% endmacro %}
 {% macro availability() %}Can I depend on PyPI being available?{% endmacro %}

--- a/warehouse/templates/pages/help.html
+++ b/warehouse/templates/pages/help.html
@@ -30,6 +30,7 @@
 {% macro preproduction() %}What does pre-production mean?{% endmacro %}
 {% macro project_name() %}Why isn't my desired project name available?{% endmacro %}
 {% macro project_name_claim() %}How do I claim an abandoned or previously registered project name?{% endmacro %}
+{% macro verified_email() %}Why do I need a verified email address to register a new project?{% endmacro %}
 {% macro maintainers() %}Who maintains PyPI?{% endmacro %}
 {% macro sponsors() %}What powers PyPI?{% endmacro %}
 {% macro availability() %}Can I depend on PyPI being available?{% endmacro %}
@@ -51,6 +52,7 @@
         <li><a href="#preproduction">{{ preproduction() }}</a></li>
         <li><a href="#project-name">{{ project_name() }}</a></li>
         <li><a href="#project-name-claim">{{ project_name_claim() }}</a></li>
+        <li><a href="#verified-email">{{ verified_email() }}</a></li>
         <li><a href="#maintainers">{{ maintainers() }}</a></li>
         <li><a href="#accessibility">{{ accessibility() }}</a></li>
         <li><a href="#feedback">{{ feedback() }}</a></li>
@@ -144,6 +146,25 @@
         </p>
         <p>
           When <a href="https://www.python.org/dev/peps/pep-0541/">PEP 541</a> is accepted, the project will create a workflow, to be documented here.
+        </p>
+      </section>
+
+      <section id="verified-email" class="common-question">
+        <h2>{{ verified_email() }}</h2>
+        <p>
+          Currently, PyPI requires a verified email address to perform the following operations:
+        </p>
+        <ul>
+          <li>Register a new Project</li>
+        </ul>
+        <p>
+          The list of activities that require a verified email address is likely to grow over time.
+        </p>
+        <p>
+          This policy will allow us to enforce a key policy of <a href="https://www.python.org/dev/peps/pep-0541/">PEP 541</a> (once accepted) regarding maintainer reachability. It also reduces the viability of spam attacks to create many accounts in an automated fashion.
+        </p>
+        <p>
+          You can manage your Account's email addresses in your <a href="{{ request.route_path('manage.profile') }}">Profile</a>. This also allows for sending a new confirmation email for users who signed up in the past, before we began enforcing this policy.
         </p>
       </section>
 


### PR DESCRIPTION
Great policy anyway, but now that we have a working implementation, let's use it.

An ongoing spam wave is using a wide range of accounts, ip addresses, and variants of their content. This should dramatically increase the effort required on their part to continue their efforts.