### PR TITLE
Consistency between file tables

### DIFF
--- a/warehouse/static/sass/blocks/_table.scss
+++ b/warehouse/static/sass/blocks/_table.scss
@@ -264,7 +264,7 @@
     }
 
     .table__version {
-      width: 110px;
+      width: 140px;
     }
 
     .table__upload {

--- a/warehouse/templates/manage/release.html
+++ b/warehouse/templates/manage/release.html
@@ -33,7 +33,7 @@
       <tr>
         <th class="table__name">Filename, Size</th>
         <th class="table__type">Type</th>
-        <th class="table__version">Py Version</th>
+        <th class="table__version">Python Version</th>
         <th class="table__upload">Upload Date</th>
         <th></th>
       </tr>
@@ -54,7 +54,7 @@
           {% if file.size %}({{ file.size|filesizeformat() }}){% endif %}<br>
         </td>
         <td class="table__type">{{ file.packagetype|format_package_type }}</td>
-        <td class="table__version">{{ file.requires_python }}</td>
+        <td class="table__version">{{ file.python_version if file.python_version != 'source' else 'None' }}</td>
         <td class="table__upload">{{ file.upload_time|format_date() }}</td>
         <td class="table__options">
           <div class="dropdown dropdown--with-icons pull-right">

--- a/warehouse/templates/packaging/detail.html
+++ b/warehouse/templates/packaging/detail.html
@@ -287,14 +287,14 @@
               <thead>
                 <tr>
                   <th class="table__filename">
-                    File Name &amp; Hash
+                    Filename, Size &amp; Hash
                     <a href="https://pip.pypa.io/en/stable/reference/pip_install/#hash-checking-mode" class="tooltipped tooltipped-n" aria-label="what's this?" data-original-label="what's this?">
                       <i class="fa fa-question-circle" aria-hidden="true"></i>
                       <span class="sr-only">SHA256 Hash Help</span>
                     </a>
                   </th>
-                  <th class="table__version">Version</th>
                   <th class="table__type">File Type</th>
+                  <th class="table__version">Python Version</th>
                   <th class="table__upload-date">Upload Date</th>
                 </tr>
               </thead>
@@ -314,14 +314,14 @@
                     </a>
                   </td>
                   <td>
+                    {{ file.packagetype|format_package_type }}
+                  </td>
+                  <td>
                     {% if file.python_version != "source" %}
                       {{ file.python_version }}
                     {% else %}
-                      –
+                      None
                     {% endif %}
-                  </td>
-                  <td>
-                    {{ file.packagetype|format_package_type }}
                   </td>
                   <td>{{ file.upload_time|format_date() }}</td>
                 </tr>


### PR DESCRIPTION
Fixes #3007. Public file table:

<img width="821" alt="screen shot 2018-02-20 at 5 20 23 pm" src="https://user-images.githubusercontent.com/294415/36454634-6dff9d2e-1662-11e8-81d5-e6a42852d28c.png">

Maintainer's file table:

<img width="810" alt="screen shot 2018-02-20 at 5 20 31 pm" src="https://user-images.githubusercontent.com/294415/36454643-757c6d02-1662-11e8-9956-fb75b34b20c3.png">
