### PR TITLE
improve testsuite runtime

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,7 +89,7 @@ def database(request):
     return "postgresql://{}@{}:{}/{}".format(pg_user, pg_host, pg_port, pg_db)
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def app_config(database):
     config = configure(
         settings={


### PR DESCRIPTION
pytest fixtures [allow scoping at many levels](https://docs.pytest.org/en/latest/fixture.html#scope-sharing-a-fixture-instance-across-tests-in-a-class-module-or-session) to reuse objects between tests. by moving our migrations to the "session" scope, we can skip the expensive process.

since the db_session already uses PostgreSQL SAVEPOINT statements to isolate tests, this works without a hitch!

this change reduced testing time (comparing between two runs only) by about 90%

before:

```
real	7m29.159s
user	0m0.652s
sys	0m0.254s
```

after:

```
real	0m40.297s
user	0m0.666s
sys	0m0.279s
```