### PR TITLE
Eliminate `project.owners` property

### DIFF
--- a/tests/unit/packaging/test_models.py
+++ b/tests/unit/packaging/test_models.py
@@ -116,15 +116,6 @@ class TestProject:
             (Allow, str(maintainer2.user.id), ["upload"]),
         ]
 
-    def test_owners(self, db_session):
-        project = DBProjectFactory.create()
-        owner1 = DBRoleFactory.create(project=project)
-        owner2 = DBRoleFactory.create(project=project)
-        DBRoleFactory.create(project=project, role_name="Maintainer")
-        DBRoleFactory.create(project=project, role_name="Maintainer")
-
-        assert set(project.owners) == set([owner1.user, owner2.user])
-
 
 class TestRelease:
 

--- a/warehouse/manage/views.py
+++ b/warehouse/manage/views.py
@@ -313,8 +313,19 @@ def manage_projects(request):
             return project.releases[0].created
         return project.created
 
+    projects_owned = set(
+        project.name
+        for project in (
+            request.db.query(Project.name)
+            .join(Role.project)
+            .filter(Role.role_name == 'Owner', Role.user == request.user)
+            .all()
+        )
+    )
+
     return {
-        'projects': sorted(request.user.projects, key=_key, reverse=True)
+        'projects': sorted(request.user.projects, key=_key, reverse=True),
+        'projects_owned': projects_owned,
     }
 
 

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -175,16 +175,6 @@ class Project(SitemapMixin, db.ModelBase):
 
         return request.route_url("legacy.docs", project=self.name)
 
-    @property
-    def owners(self):
-        return (
-            orm.object_session(self)
-            .query(User)
-            .join(Role.user)
-            .filter(Role.project == self, Role.role_name == 'Owner')
-            .all()
-        )
-
 
 class DependencyKind(enum.IntEnum):
 

--- a/warehouse/templates/manage/projects.html
+++ b/warehouse/templates/manage/projects.html
@@ -45,7 +45,7 @@
           <a
             href="{{ request.route_path('manage.project.releases', project_name=project.normalized_name) }}"
             class="button button--primary"
-            {% if request.user in project.owners %}
+            {% if project.name in projects_owned %}
             title="Edit this project"
             {% else %}
             disabled


### PR DESCRIPTION
This resulted in a query for every project when rendering.