### PR TITLE
Catch DetachedInstanceError from DebugToolbar

### DIFF
--- a/tests/unit/utils/test_attrs.py
+++ b/tests/unit/utils/test_attrs.py
@@ -10,6 +10,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from sqlalchemy.orm.exc import DetachedInstanceError
+
 from warehouse.utils.attrs import make_repr
 
 
@@ -31,3 +33,13 @@ class TestMakeRepr:
                 return self.__repr__()
 
         assert repr(Fake()) == "Fake(foo={})".format(repr("bar"))
+
+    def test_with_raise(self):
+        class Fake:
+            __repr__ = make_repr("foo")
+
+            @property
+            def foo(self):
+                raise DetachedInstanceError
+
+        assert repr(Fake()) == "Fake(<detached>)"

--- a/warehouse/utils/attrs.py
+++ b/warehouse/utils/attrs.py
@@ -10,16 +10,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from sqlalchemy.orm.exc import DetachedInstanceError
+
 
 def make_repr(*attrs, _self=None):
     def _repr(self=None):
         if self is None and _self is not None:
             self = _self
 
-        return "{}({})".format(
-            self.__class__.__name__,
-            ", ".join(
-                "{}={}".format(a, repr(getattr(self, a))) for a in attrs
-            ),
-        )
+        try:
+            return "{}({})".format(
+                self.__class__.__name__,
+                ", ".join(
+                    "{}={}".format(a, repr(getattr(self, a))) for a in attrs
+                ),
+            )
+        except DetachedInstanceError:
+            return "{}(<detached>)".format(self.__class__.__name__)
+
     return _repr


### PR DESCRIPTION
Occasionally, the DebugToobar attempts to `__repr__` a SQLAlchemy instance that has become detached from it's session. Instead, catch the exception and return a different representation when it's detached and we can't get the attributes anymore.