### PR TITLE
Add a `Project.latest_release` property

### DIFF
--- a/tests/common/db/base.py
+++ b/tests/common/db/base.py
@@ -32,6 +32,8 @@ class WarehouseFactory(SQLAlchemyModelFactory):
     @classmethod
     def _create(cls, *args, **kwargs):
         r = super()._create(*args, **kwargs)
+        if hasattr(r, 'init_on_load'):
+            r.init_on_load()
         session = cls._meta.sqlalchemy_session
         session.flush()
         return r

--- a/tests/unit/manage/test_views.py
+++ b/tests/unit/manage/test_views.py
@@ -749,7 +749,7 @@ class TestManageProjectSettings:
 
         assert views.manage_project_settings(project, db_request) == {
             "project": project,
-            "n_releases": 1,
+            "release_count": 1,
         }
 
     def test_delete_project_no_confirm(self):

--- a/tests/unit/manage/test_views.py
+++ b/tests/unit/manage/test_views.py
@@ -743,12 +743,13 @@ class TestManageProjects:
 
 class TestManageProjectSettings:
 
-    def test_manage_project_settings(self):
-        request = pretend.stub()
-        project = pretend.stub()
+    def test_manage_project_settings(self, db_request):
+        project = ProjectFactory()
+        ReleaseFactory(project=project)
 
-        assert views.manage_project_settings(project, request) == {
+        assert views.manage_project_settings(project, db_request) == {
             "project": project,
+            "n_releases": 1,
         }
 
     def test_delete_project_no_confirm(self):
@@ -824,12 +825,13 @@ class TestManageProjectSettings:
 
 class TestManageProjectReleases:
 
-    def test_manage_project_releases(self):
-        request = pretend.stub()
-        project = pretend.stub()
+    def test_manage_project_releases(self, db_request):
+        project = ProjectFactory()
+        release = ReleaseFactory(project=project)
 
-        assert views.manage_project_releases(project, request) == {
+        assert views.manage_project_releases(project, db_request) == {
             "project": project,
+            "releases": [(release.summary, release.created, release.version)],
         }
 
 

--- a/tests/unit/packaging/test_models.py
+++ b/tests/unit/packaging/test_models.py
@@ -10,6 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import datetime
 from collections import OrderedDict
 
 import pretend
@@ -115,6 +116,23 @@ class TestProject:
             (Allow, str(maintainer1.user.id), ["upload"]),
             (Allow, str(maintainer2.user.id), ["upload"]),
         ]
+
+    def test_latest_release(self, db_session):
+        project = DBProjectFactory.create()
+        DBReleaseFactory.create(
+            project=project,
+            created=datetime.datetime(2017, 1, 1),
+        )
+        new = DBReleaseFactory.create(
+            project=project,
+            created=datetime.datetime(2018, 1, 1),
+        )
+
+        latest = project.latest_release
+
+        assert latest.name == new.name
+        assert latest.created == new.created
+        assert latest.summary == new.summary
 
 
 class TestRelease:

--- a/warehouse/manage/views.py
+++ b/warehouse/manage/views.py
@@ -29,7 +29,9 @@ from warehouse.manage.forms import (
     AddEmailForm, ChangePasswordForm, CreateRoleForm, ChangeRoleForm,
     SaveAccountForm,
 )
-from warehouse.packaging.models import File, JournalEntry, Project, Role
+from warehouse.packaging.models import (
+    File, JournalEntry, Project, Release, Role,
+)
 from warehouse.utils.project import confirm_project, remove_project
 
 
@@ -337,7 +339,16 @@ def manage_projects(request):
     effective_principals=Authenticated,
 )
 def manage_project_settings(project, request):
-    return {"project": project}
+    n_releases = (
+        request.db.query(Release)
+        .filter(Release.project == project)
+        .count()
+    )
+
+    return {
+        "n_releases": n_releases,
+        "project": project,
+    }
 
 
 @view_config(
@@ -361,7 +372,16 @@ def delete_project(project, request):
     effective_principals=Authenticated,
 )
 def manage_project_releases(project, request):
-    return {"project": project}
+    releases = (
+        request.db.query(Release.summary, Release.created, Release.version)
+        .filter(Release.project == project)
+        .order_by(Release.created.desc())
+        .all()
+    )
+    return {
+        "project": project,
+        "releases": releases,
+    }
 
 
 @view_defaults(

--- a/warehouse/manage/views.py
+++ b/warehouse/manage/views.py
@@ -339,14 +339,14 @@ def manage_projects(request):
     effective_principals=Authenticated,
 )
 def manage_project_settings(project, request):
-    n_releases = (
+    release_count = (
         request.db.query(Release)
         .filter(Release.project == project)
         .count()
     )
 
     return {
-        "n_releases": n_releases,
+        "release_count": release_count,
         "project": project,
     }
 

--- a/warehouse/manage/views.py
+++ b/warehouse/manage/views.py
@@ -309,8 +309,8 @@ class ManageAccountViews:
 def manage_projects(request):
 
     def _key(project):
-        if project.releases:
-            return project.releases[0].created
+        if project.latest_release:
+            return project.latest_release.created
         return project.created
 
     projects_owned = set(

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -11,6 +11,7 @@
 # limitations under the License.
 
 import enum
+import functools
 
 from collections import OrderedDict
 
@@ -174,6 +175,17 @@ class Project(SitemapMixin, db.ModelBase):
             return
 
         return request.route_url("legacy.docs", project=self.name)
+
+    @property
+    @functools.lru_cache()
+    def latest_release(self):
+        return(
+            orm.object_session(self)
+            .query(Release.name, Release.created, Release.summary)
+            .filter(Release.name == self.name)
+            .order_by(Release.created.desc())
+            .first()
+        )
 
 
 class DependencyKind(enum.IntEnum):

--- a/warehouse/templates/accounts/profile.html
+++ b/warehouse/templates/accounts/profile.html
@@ -56,9 +56,9 @@
         <div class="package-snippet">
           <h3 class="package-snippet__title"><a href="{{ request.route_path('packaging.project', name=project.normalized_name) }}">{{ project.name }}</a></h3>
           <p class="package-snippet__meta">
-            <em>Last released on {{ project.releases[0].created|format_date() }}</em>
+            <em>Last released on {{ project.latest_release.created|format_date() }}</em>
           </p>
-          <p class="package-snippet__description">{{ project.releases[0].summary }}</p>
+          <p class="package-snippet__description">{{ project.latest_release.summary }}</p>
         </div>
         {% endfor %}
         {% else %}

--- a/warehouse/templates/manage/manage_project_base.html
+++ b/warehouse/templates/manage/manage_project_base.html
@@ -47,9 +47,8 @@
             <div class="split-layout split-layout--middle split-layout--spaced">
               <div>
                 <h1 class="package-snippet__title package-snippet__title--page-title">{{ project.name }}</h1>
-                {% set release = project.releases[0] if project.releases else None %}
-                {% if release %}
-                  <p class="package-snippet__description">{{ release.summary }}</p>
+                {% if project.latest_release %}
+                  <p class="package-snippet__description">{{ project.latest_release.summary }}</p>
                 {% endif %}
               </div>
               <div>

--- a/warehouse/templates/manage/projects.html
+++ b/warehouse/templates/manage/projects.html
@@ -23,7 +23,7 @@
   <div class="package-list">
     {% if projects %}
     {% for project in projects %}
-    {% set release = project.releases[0] if project.releases else None %}
+    {% set release = project.latest_release %}
     <div class="package-snippet">
       <div class="split-layout split-layout--table split-layout--wrap-on-tablet">
         <div>
@@ -55,7 +55,7 @@
           <a
             href="{{ request.route_path('packaging.project', name=project.normalized_name) }}"
             class="button"
-            {% if project.releases %}
+            {% if release %}
             title="View this project's public page"
             {% else %}
             disabled

--- a/warehouse/templates/manage/releases.html
+++ b/warehouse/templates/manage/releases.html
@@ -18,8 +18,8 @@
 {% block title %}Manage '{{ project.name }}' releases{% endblock %}
 
 {% block main %}
-  <h2>Releases ({{ project.releases|length }})</h2>
-  {% if project.releases %}
+  <h2>Releases ({{ releases|length }})</h2>
+  {% if releases %}
     <table class="table table--light table--releases no-top-margin">
       <thead>
         <th class="table__version">Version</th>
@@ -28,7 +28,7 @@
         <th class="table__options"></th>
       </thead>
       <tbody>
-      {% for release in project.releases %}
+      {% for release in releases %}
         <tr>
           <td class="table__version">
             <a href="{{ request.route_path('manage.project.release', project_name=project.name, version=release.version) }}">
@@ -57,7 +57,7 @@
                   <i class="fa fa-pencil" aria-hidden="true"></i>
                   Edit
                 </a>
-                <a href="{{ request.route_path('packaging.release', name=release.project.name, version=release.version) }}" class="dropdown__link">
+                <a href="{{ request.route_path('packaging.release', name=project.name, version=release.version) }}" class="dropdown__link">
                   <i class="fa fa-eye" aria-hidden="true"></i>
                   View
                 </a>
@@ -78,7 +78,7 @@
   {% endif %}
 
   <div class="callout-block">
-    {% if project.releases %}
+    {% if releases %}
     <h3>Creating a New Release</h3>
     {% else %}
     <h3>No Releases Found</h3>
@@ -87,7 +87,7 @@
   </div>
 
   {# TODO: https://github.com/pypa/warehouse/issues/2808
-  {% for release in project.releases %}
+  {% for release in releases %}
     <div id="delete-release-modal-{{ loop.index }}" class="modal">
       <div class="modal__content" role="dialog">
         <a href="#modal-close" title="Close" class="modal__close">

--- a/warehouse/templates/manage/settings.html
+++ b/warehouse/templates/manage/settings.html
@@ -23,11 +23,11 @@
   <div class="callout-block">
     <h3>Delete Project</h3>
     <p>
-    {% if project.releases %}
+    {% if n_releases %}
       Deleting will irreversibly delete this project along with
       <a href="{{ request.route_path('manage.project.releases', project_name=project.name) }}">
-        {{ project.releases|length() }}
-        {% trans count=project.releases|length %}
+        {{ n_releaes }}
+        {% trans count=n_releases %}
           release.
         {% pluralize %}
           releases.

--- a/warehouse/templates/manage/settings.html
+++ b/warehouse/templates/manage/settings.html
@@ -23,11 +23,11 @@
   <div class="callout-block">
     <h3>Delete Project</h3>
     <p>
-    {% if n_releases %}
+    {% if release_count %}
       Deleting will irreversibly delete this project along with
       <a href="{{ request.route_path('manage.project.releases', project_name=project.name) }}">
-        {{ n_releaes }}
-        {% trans count=n_releases %}
+        {{ release_count }}
+        {% trans count=release_count %}
           release.
         {% pluralize %}
           releases.

--- a/warehouse/templates/rss/packages.xml
+++ b/warehouse/templates/rss/packages.xml
@@ -7,7 +7,7 @@
     <title>{{ project.normalized_name }} added to PyPI</title>
     <link>{{ request.route_url('packaging.project', name=project.normalized_name) }}</link>
     <guid>{{ request.route_url('packaging.project', name=project.normalized_name) }}</guid>
-    <description>{{ project.releases[0].summary }}</description>
+    <description>{{ project.latest_release.summary }}</description>
     <pubDate>{{ project.created|format_rfc822_datetime() }}</pubDate>
   </item>
   {% endfor %}


### PR DESCRIPTION
This PR provides a `latest_release` property, which gives a pared-down `Release`-like named tuple for when we don't need the full release (and all the memory consumption that comes with it).

This PR also adds two more lightweight queries where we were originally using `project.releases` and didn't need to be.

