### PR TITLE
speed up `admin.project.releases` route

### DIFF
--- a/warehouse/admin/views/projects.py
+++ b/warehouse/admin/views/projects.py
@@ -20,6 +20,7 @@ from pyramid.httpexceptions import (
 )
 from pyramid.view import view_config
 from sqlalchemy import or_
+from sqlalchemy.orm import load_only
 
 from warehouse.accounts.models import User
 from warehouse.packaging.models import Project, Release, Role, JournalEntry
@@ -137,6 +138,8 @@ def releases_list(project, request):
         raise HTTPBadRequest("'page' must be an integer.") from None
 
     releases_query = (request.db.query(Release)
+                      .options(load_only('name', 'version', 'created',
+                                         'author_email'))
                       .filter(Release.project == project)
                       .order_by(Release._pypi_ordering.desc()))
 


### PR DESCRIPTION
Improve cost of admins browsing Projects and their releases.