### PR TITLE
Make dropdowns tabbable

### DIFF
--- a/warehouse/static/sass/blocks/_dropdown.scss
+++ b/warehouse/static/sass/blocks/_dropdown.scss
@@ -44,21 +44,21 @@
 
   &__content {
     position: absolute;
-    right: 0;
+    right: 100000px;
     margin-bottom: -4px;
     box-shadow: 1px 1px 2px 1px rgba(0, 0, 0, 0.05);
     z-index: index($z-index-scale, "dropdown");
     border: 1px solid $border-color;
     border-bottom: 0; // Each link has a bottom border, so we don't need one here
-    display: none;
   }
 
   // Show content if triggered
   &__trigger:hover + &__content,
   &__trigger:focus + &__content,
   &__trigger:active + &__content,
-  &__content:hover {
-    display: block;
+  &__content:hover,
+  &__content--visible {
+    right: 0;
   }
 
   &__link,


### PR DESCRIPTION
This change makes it so that the browser no longer ignores the hidden links in a dropdown when tabbing through the page with a keyboard.

However, this PR is not complete, because the dropdown is still hidden while the active link is focused by keyboard. (to see what I mean, log in and tab through the page to the user dropdown).

Unfortunately, because CSS has no parent selector, I cannot display the dropdown with CSS alone.  We need some JS:

- When `.dropdown__link` is `:active` by keyboard
- add `.dropdown__content--visible` to the containing (`.dropdown__content`)

- when the user tabs off the dropdown
- remove `.dropdown__content--visible`

@di would you be able to help with this?  Have I provided enough information?  Does it make sense? Thx