### PR TITLE
Optimize Release History view for projects with long release histories.

### DIFF
--- a/warehouse/templates/packaging/detail.html
+++ b/warehouse/templates/packaging/detail.html
@@ -248,6 +248,8 @@
           <h2 class="page-title">Release History</h2>
 
           <section class="release-timeline">
+            {% set blue_cube = request.static_url('warehouse:static/dist/images/blue-cube.svg') %}
+            {% set white_cube = request.static_url('warehouse:static/dist/images/white-cube.svg') %}
             {% for hrelease in all_releases %}
             {% set is_current = (hrelease.version == release.version) %}
             <div class="release{{ ' release--latest' if loop.first else ' release--oldest' if loop.last }}{{ ' release--current' if is_current }}">
@@ -262,9 +264,9 @@
                 <div class="release__line"></div>
                 {% endif %}
                 {% if is_current %}
-                <img class="release__node" alt="History Node" src="{{ request.static_url('warehouse:static/dist/images/blue-cube.svg') }}">
+                <img class="release__node" alt="History Node" src="{{ blue_cube }}">
                 {% else %}
-                <img class="release__node" alt="History Node" src="{{ request.static_url('warehouse:static/dist/images/white-cube.svg') }}">
+                <img class="release__node" alt="History Node" src="{{ white_cube }}">
                 {% endif %}
               </div>
 


### PR DESCRIPTION
for large project release histories, repetitively rendering url for cubes is costly

Locally, debug toolbar showed a 10x render improvement for `cs18-sidecar` which has >1000 releases.