### PR TITLE
Defer the Release.description column

### DIFF
--- a/warehouse/legacy/api/xmlrpc.py
+++ b/warehouse/legacy/api/xmlrpc.py
@@ -18,7 +18,7 @@ import xmlrpc.server
 from elasticsearch_dsl import Q
 from pyramid.view import view_config
 from pyramid_rpc.xmlrpc import exception_view as _exception_view, xmlrpc_method
-from sqlalchemy import func, select
+from sqlalchemy import func, orm, select
 from sqlalchemy.orm.exc import NoResultFound
 
 from warehouse.accounts.models import User
@@ -171,6 +171,7 @@ def release_data(request, package_name, version):
     try:
         release = (
             request.db.query(Release)
+                      .options(orm.undefer("description"))
                       .join(Project)
                       .filter((Project.normalized_name ==
                                func.normalize_pep426_name(package_name)) &

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -297,7 +297,7 @@ class Release(db.ModelBase):
         server_default=sql.func.now(),
     )
 
-    # We deferr this column because it is a very large column (it can be MB in
+    # We defer this column because it is a very large column (it can be MB in
     # size) and we very rarely actually want to access it. Typically we only
     # need it when rendering the page for a single project, but many of our
     # queries only need to access a few of the attributes of a Release. Instead

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -272,7 +272,6 @@ class Release(db.ModelBase):
     home_page = Column(Text)
     license = Column(Text)
     summary = Column(Text)
-    description = Column(Text)
     keywords = Column(Text)
     platform = Column(Text)
     download_url = Column(Text)
@@ -297,6 +296,15 @@ class Release(db.ModelBase):
         nullable=False,
         server_default=sql.func.now(),
     )
+
+    # We deferr this column because it is a very large column (it can be MB in
+    # size) and we very rarely actually want to access it. Typically we only
+    # need it when rendering the page for a single project, but many of our
+    # queries only need to access a few of the attributes of a Release. Instead
+    # of playing whack-a-mole and using load_only() or defer() on each of
+    # those queries, deferring this here makes the default case more
+    # performant.
+    description = orm.deferred(Column(Text))
 
     _classifiers = orm.relationship(
         Classifier,


### PR DESCRIPTION
The vast bulk of the time, when querying against a Release we do not want the description column, because the column is very large and can easily spike memory and make queries take longer, particularly when loading multiple Releases.

Instead we will defer the column so that fetching it requires making another query or explicitly un-defering it. This will cause an extra query to happen on views that do not have direct control over the query (e.g. ones using the Pyramid Context objects) but the impact of a single extra query on these pages is pretty low while the impact of loading this column by default is playing a whack-a-mole game with any query against Release to add a load_only() or defer() option.