### PR TITLE
Drop the use of load_only() where no longer needed

### DIFF
--- a/warehouse/accounts/views.py
+++ b/warehouse/accounts/views.py
@@ -19,7 +19,6 @@ from pyramid.httpexceptions import (
 )
 from pyramid.security import Authenticated, remember, forget
 from pyramid.view import view_config
-from sqlalchemy.orm import Load
 from sqlalchemy.orm.exc import NoResultFound
 
 from warehouse.accounts import REDIRECT_FIELD_NAME
@@ -83,7 +82,6 @@ def profile(user, request):
         request.db.query(Project)
         .filter(Project.users.contains(user))
         .join(Project.releases)
-        .options(Load(Release).load_only('summary', 'created'))
         .order_by(Release.created.desc())
         .all()
     )

--- a/warehouse/admin/views/projects.py
+++ b/warehouse/admin/views/projects.py
@@ -20,7 +20,6 @@ from pyramid.httpexceptions import (
 )
 from pyramid.view import view_config
 from sqlalchemy import or_
-from sqlalchemy.orm import load_only
 
 from warehouse.accounts.models import User
 from warehouse.packaging.models import Project, Release, Role, JournalEntry
@@ -83,8 +82,6 @@ def project_detail(project, request):
         )
 
     releases = (request.db.query(Release)
-                .options(load_only('name', 'version', 'created',
-                                   'author_email'))
                 .filter(Release.project == project)
                 .order_by(Release._pypi_ordering.desc())
                 .limit(10).all())
@@ -146,8 +143,6 @@ def releases_list(project, request):
         raise HTTPBadRequest("'page' must be an integer.") from None
 
     releases_query = (request.db.query(Release)
-                      .options(load_only('name', 'version', 'created',
-                                         'author_email'))
                       .filter(Release.project == project)
                       .order_by(Release._pypi_ordering.desc()))
 

--- a/warehouse/legacy/api/json.py
+++ b/warehouse/legacy/api/json.py
@@ -96,9 +96,9 @@ def json_release(release, request):
     # Get all of the releases and files for this project.
     release_files = (
         request.db.query(Release, File)
+               .options(Load(Release).load_only('version'))
                .outerjoin(File)
                .filter(Release.project == project)
-               .options(Load(Release).load_only('version'))
                .order_by(Release._pypi_ordering.desc(), File.filename)
                .all()
     )

--- a/warehouse/rss/views.py
+++ b/warehouse/rss/views.py
@@ -11,7 +11,7 @@
 # limitations under the License.
 
 from pyramid.view import view_config
-from sqlalchemy.orm import joinedload, load_only
+from sqlalchemy.orm import joinedload
 
 from warehouse.cache.origin import origin_cache
 from warehouse.packaging.models import Project, Release
@@ -63,9 +63,7 @@ def rss_packages(request):
 
     newest_projects = (
         request.db.query(Project)
-                  .options(load_only("created", "normalized_name"))
-                  .options(joinedload(Project.releases, innerjoin=True)
-                           .load_only("summary"))
+                  .options(joinedload(Project.releases, innerjoin=True))
                   .order_by(Project.created.desc())
                   .limit(40)
                   .all()


### PR DESCRIPTION
Since Release.description is now deferred by default, we no longer need to bend over backwards with load_only to attempt to minimize data. While the minimized queries are still *technically* more efficient since we're only pulling over exactly what we need, they are not meaningfully more efficient and are more likely to accidentally trigger N+1 query issues.