### PR TITLE
Fix `gpg_signature` upload.

### DIFF
--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -676,10 +676,11 @@ def file_upload(request):
         raise _exc_with_message(HTTPBadRequest, "Unknown protocol version.")
 
     # Check if any fields were supplied as a tuple and have become a
-    # FieldStorage. The 'content' field _should_ be a FieldStorage, however.
+    # FieldStorage. The 'content' and 'gpg_signature' fields _should_ be a
+    # FieldStorage, however.
     # ref: https://github.com/pypa/warehouse/issues/2185
     # ref: https://github.com/pypa/warehouse/issues/2491
-    for field in set(request.POST) - {'content'}:
+    for field in set(request.POST) - {'content', 'gpg_signature'}:
         values = request.POST.getall(field)
         if any(isinstance(value, FieldStorage) for value in values):
             raise _exc_with_message(


### PR DESCRIPTION
Fixes #3059, missed in #3049. Uploads shouldn't fail if `gpg_signature` is a `FieldStorage`.