### PR TITLE
Fix password gauge setup conditional

### DIFF
--- a/warehouse/static/js/warehouse/utils/forms.js
+++ b/warehouse/static/js/warehouse/utils/forms.js
@@ -137,7 +137,7 @@ const validateForm = (event) => {
 };
 
 export function registerFormValidation() {
-  if (document.querySelector("#password_confirm") === null) return;
+  if (document.querySelector(".password-strength") === null) return;
   setupPasswordStrengthGauge();
   const submitButton = document.querySelector("#content input[type='submit']");
   submitButton.addEventListener("click", validateForm, false);


### PR DESCRIPTION
Fixes #3116. 

This was being added on any page with a `#password_confirm` element, but we really only want it when the password gauge is present.