### PR TITLE
Handle multiple releases with same canonical version

### DIFF
--- a/tests/unit/packaging/test_models.py
+++ b/tests/unit/packaging/test_models.py
@@ -79,6 +79,13 @@ class TestProject:
 
         assert project['1.0.0'] == release
 
+    def test_traversal_finds_canonical_version_if_multiple(self, db_request):
+        project = DBProjectFactory.create()
+        release = DBReleaseFactory.create(version='1.0.0', project=project)
+        DBReleaseFactory.create(version='1.0', project=project)
+
+        assert project['1.0.0'] == release
+
     def test_traversal_cant_find(self, db_request):
         project = DBProjectFactory.create()
 


### PR DESCRIPTION
Since it's possible that multiple releases of the same project with equivalent canonical versions were created before #3113, we need to handle the edge case where they exist by getting the release with the exact version requested.