### PR TITLE
Add a shortlink for projects

### DIFF
--- a/tests/unit/test_routes.py
+++ b/tests/unit/test_routes.py
@@ -269,6 +269,7 @@ def test_routes(warehouse):
     ]
 
     assert config.add_redirect.calls == [
+        pretend.call("/p/{name}/", "/project/{name}/", domain=warehouse),
         pretend.call("/pypi/{name}/", "/project/{name}/", domain=warehouse),
         pretend.call(
             "/pypi/{name}/{version}/",

--- a/warehouse/routes.py
+++ b/warehouse/routes.py
@@ -178,6 +178,7 @@ def includeme(config):
     )
 
     # Packaging
+    config.add_redirect('/p/{name}/', '/project/{name}/', domain=warehouse)
     config.add_route(
         "packaging.project",
         "/project/{name}/",


### PR DESCRIPTION
To make it easier for people who want to type project URLs, this will
redirect all requests for `/p/<project>/` to `/project/<project>/`.

Closes #3143