### PR TITLE
Use red in UI to indicate danger

### DIFF
--- a/warehouse/static/sass/blocks/_button.scss
+++ b/warehouse/static/sass/blocks/_button.scss
@@ -77,6 +77,21 @@
     }
   }
 
+  &--danger {
+    border-color: $danger-color;
+    background-color: $danger-color;
+    color: $white;
+
+    &:focus,
+    &:hover,
+    &:active {
+      border-color: darken($danger-color, 5);
+      background-color: darken($danger-color, 4);
+      text-decoration-color: transparentize($white, 0.8);
+      color: $white;
+    }
+  }
+
   &[disabled],
   &--disabled {
     cursor: not-allowed;

--- a/warehouse/static/sass/blocks/_button.scss
+++ b/warehouse/static/sass/blocks/_button.scss
@@ -22,6 +22,7 @@
   Modifiers:
     - small: Makes button small.
     - primary: Makes button bright blue.
+    - danger: Makes button red.
 */
 
 .button {

--- a/warehouse/static/sass/blocks/_callout-block.scss
+++ b/warehouse/static/sass/blocks/_callout-block.scss
@@ -54,6 +54,19 @@
   &--danger {
     border-color: $danger-color;
 
+    > :not(.modal):not(.button) {
+      color: $danger-color;
+
+      a:not(.button) {
+        color: $danger-color;
+        text-decoration: underline;
+
+        &:hover {
+          color: darken($danger-color, 4);
+        }
+      }
+    }
+
     &:before {
       background-color: $danger-color;
     }

--- a/warehouse/static/sass/settings/_colours.scss
+++ b/warehouse/static/sass/settings/_colours.scss
@@ -18,7 +18,7 @@ $brand-color:                 #006dad;
 $primary-color:               #ffd343;
 $success-color:               #169428;
 $warn-color:                  #f05d22;
-$danger-color:                #f41f1f;
+$danger-color:                #D52D40;
 $brand-color-soft:            lighten($brand-color, 45);
 
 $white:                       #fff;

--- a/warehouse/templates/manage/account.html
+++ b/warehouse/templates/manage/account.html
@@ -240,7 +240,7 @@
   <hr>
 
   <h2>Delete Account</h2>
-  <div class="callout-block">
+  <div class="callout-block callout-block--danger">
     {% if active_projects %}
     <h3>Cannot Delete Account</h3>
     <p>
@@ -273,8 +273,11 @@
       {% endfor %}
     </ul>
     {% else %}
-    <h3>Proceed with caution!</h3>
-    <p>You will not be able to recover your account after you delete it.</p>
+    <h3 class="danger">Proceed with caution!</h3>
+    <p>
+      <i class="fa fa-warning danger" aria-hidden="true"><span class="sr-only">Warning</span></i>
+      You will not be able to recover your account after you delete it.
+    </p>
     {{ confirm_button("Delete your PyPI Account", "Username", user.username) }}
     {% endif %}
   </div>

--- a/warehouse/templates/manage/account.html
+++ b/warehouse/templates/manage/account.html
@@ -240,7 +240,7 @@
   <hr>
 
   <h2>Delete Account</h2>
-  <div class="callout-block callout-block--danger">
+  <div class="callout-block{% if not active_projects %} callout-block--danger{% endif %}">
     {% if active_projects %}
     <h3>Cannot Delete Account</h3>
     <p>
@@ -273,9 +273,9 @@
       {% endfor %}
     </ul>
     {% else %}
-    <h3 class="danger">Proceed with caution!</h3>
+    <h3>Proceed with caution!</h3>
     <p>
-      <i class="fa fa-warning danger" aria-hidden="true"><span class="sr-only">Warning</span></i>
+      <i class="fa fa-warning" aria-hidden="true"><span class="sr-only">Warning</span></i>
       You will not be able to recover your account after you delete it.
     </p>
     {{ confirm_button("Delete your PyPI Account", "Username", user.username) }}

--- a/warehouse/templates/manage/manage_base.html
+++ b/warehouse/templates/manage/manage_base.html
@@ -72,7 +72,7 @@
           <h3 class="modal__title">{{ title }} {{ confirm_string }}?</h3>
         <div class="callout-block callout-block--danger callout-block--bottom-margin no-top-margin">
           <p>
-            <i class="fa fa-warning danger" aria-hidden="true"><span class="sr-only">Warning</span></i>
+            <i class="fa fa-warning" aria-hidden="true"><span class="sr-only">Warning</span></i>
             This action cannot be undone!
           </p>
         </div>

--- a/warehouse/templates/manage/manage_base.html
+++ b/warehouse/templates/manage/manage_base.html
@@ -71,7 +71,10 @@
         <div class="modal__body">
           <h3 class="modal__title">{{ title }} {{ confirm_string }}?</h3>
         <div class="callout-block callout-block--danger callout-block--bottom-margin no-top-margin">
-          <p>Warning: This action cannot be undone!</p>
+          <p>
+            <i class="fa fa-warning danger" aria-hidden="true"><span class="sr-only">Warning</span></i>
+            This action cannot be undone!
+          </p>
         </div>
         <p>Confirm the {{ confirm_name|lower }} to continue.</p>
         {% set name = "confirm_" + confirm_name.lower().replace(' ', '_') %}

--- a/warehouse/templates/manage/manage_base.html
+++ b/warehouse/templates/manage/manage_base.html
@@ -80,7 +80,7 @@
         </div>
         <div class="modal__footer">
           <a href="#modal-close" data-action="click->confirm#cancel" class="button modal__action">Cancel</a>
-          <button class="button button--primary modal__action" data-target="confirm.button" data-expected="{{ confirm_string }}" type="submit">
+          <button class="button button--danger modal__action" data-target="confirm.button" data-expected="{{ confirm_string }}" type="submit">
             {{ title }}
           </button>
         </div>
@@ -91,7 +91,7 @@
 
 {% macro confirm_button(title, confirm_name, confirm_string, index=None, extra_fields=None, action=None) %}
   {% set slug = title.lower().replace(' ', '-') + '-modal' + ('-{}'.format(index) if index else '') %}
-  <a href="#{{ slug }}" class="button button--primary">
+  <a href="#{{ slug }}" class="button button--danger">
     {{ title }}
   </a>
   {{ confirm_modal(title, confirm_name, confirm_string, slug, index=None, extra_fields=extra_fields, action=action) }}

--- a/warehouse/templates/manage/release.html
+++ b/warehouse/templates/manage/release.html
@@ -99,9 +99,9 @@
   <h3>Release Settings</h3>
 
   <div class="callout-block callout-block--danger">
-    <h3 class="danger">Delete Release</h3>
+    <h3>Delete Release</h3>
     <p>
-      <i class="fa fa-warning danger" aria-hidden="true"><span class="sr-only">Warning</span></i>
+      <i class="fa fa-warning" aria-hidden="true"><span class="sr-only">Warning</span></i>
     {% if files %}
       Deleting will irreversibly delete this release along with {{ files|length() }}
       {% trans count=files|length %}

--- a/warehouse/templates/manage/release.html
+++ b/warehouse/templates/manage/release.html
@@ -98,9 +98,10 @@
 
   <h3>Release Settings</h3>
 
-  <div class="callout-block">
-    <h3>Delete Release</h3>
+  <div class="callout-block callout-block--danger">
+    <h3 class="danger">Delete Release</h3>
     <p>
+      <i class="fa fa-warning danger" aria-hidden="true"><span class="sr-only">Warning</span></i>
     {% if files %}
       Deleting will irreversibly delete this release along with {{ files|length() }}
       {% trans count=files|length %}

--- a/warehouse/templates/manage/settings.html
+++ b/warehouse/templates/manage/settings.html
@@ -34,9 +34,10 @@
   </div>
 
 
-  <div class="callout-block">
+  <div class="callout-block callout-block--danger">
     <h3>Delete Project</h3>
     <p>
+      <i class="fa fa-warning danger" aria-hidden="true"><span class="sr-only">Warning</span></i>
     {% if project.releases %}
       Deleting will irreversibly delete this project along with
       <a href="{{ request.route_path('manage.project.releases', project_name=project.name) }}">

--- a/warehouse/templates/manage/settings.html
+++ b/warehouse/templates/manage/settings.html
@@ -37,7 +37,7 @@
   <div class="callout-block callout-block--danger">
     <h3>Delete Project</h3>
     <p>
-      <i class="fa fa-warning danger" aria-hidden="true"><span class="sr-only">Warning</span></i>
+      <i class="fa fa-warning" aria-hidden="true"><span class="sr-only">Warning</span></i>
     {% if project.releases %}
       Deleting will irreversibly delete this project along with
       <a href="{{ request.route_path('manage.project.releases', project_name=project.name) }}">


### PR DESCRIPTION
Closes #3199

**From user testing**

- The delete section of each page could do with having a different visual indicator (red) to illustrate that it is a danger zone.
- Several test participants mentioned GitHub as an inspiration for this

This PR:

- Updates the default red color to be WCAG 2.0 AA compliant
- Adds a 'button--danger' modifier
- Updates the delete UI and confirmation modal to use `--danger` modifiers
- Adds a 'warning' icon for color blind users

![screenshot from 2018-03-07 21-45-04](https://user-images.githubusercontent.com/3323703/37120079-3b34266c-2251-11e8-9ea7-5550000b1c6e.png)

![screenshot from 2018-03-07 21-45-15](https://user-images.githubusercontent.com/3323703/37120078-3b19ead6-2251-11e8-84eb-fec0204c8643.png)
