### PR TITLE
Advise project maintainers on Project Links

### DIFF
--- a/warehouse/templates/manage/settings.html
+++ b/warehouse/templates/manage/settings.html
@@ -21,6 +21,21 @@
   <h2>Project Settings</h2>
 
   <div class="callout-block">
+    <h3>Project Links</h3>
+    <p>
+      To set the Project Links in the '{{ project.name }}' sidebar for
+      your next release, use
+      the <a href="https://packaging.python.org/tutorials/distributing-packages/#url"><tt>url</tt></a>
+      and <a href="https://packaging.python.org/tutorials/distributing-packages/#project-urls"><tt>project_urls</tt></a>
+      fields in your <tt>setup.py</tt> file. Updating these fields
+      will not change the Project Links for past
+      releases. See <a href="https://packaging.python.org/tutorials/distributing-packages/">the
+      Python Packaging User Guide</a> for more help.
+    </p>
+  </div>
+
+
+  <div class="callout-block">
     <h3>Delete Project</h3>
     <p>
     {% if project.releases %}


### PR DESCRIPTION
Add help text in Project Settings (where maintainers would naturally look for it) telling them how to update the Project Links sidebar using fields in `setup.py`.

Fixes #3119.

![project-url-help-screenshot](https://user-images.githubusercontent.com/842790/37129388-c2736232-224c-11e8-90ac-1936f32a65b5.png)
