### PR TITLE
Make two upload tests URL-independent

### DIFF
--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -926,16 +926,24 @@ class TestFileUpload:
             ),
         })
 
+        db_request.route_url = pretend.call_recorder(
+            lambda route, **kw: "/the/help/url/"
+        )
+
         with pytest.raises(HTTPBadRequest) as excinfo:
             legacy.file_upload(db_request)
 
         resp = excinfo.value
 
+        assert db_request.route_url.calls == [
+            pretend.call('help', _anchor='project-name')
+        ]
+
         assert resp.status_code == 400
         assert resp.status == (("400 The name {!r} is not allowed (conflict "
                                 "with Python Standard Library module name). "
-                                "See https://pypi.org/help/#project-name "
-                                "for more information.").format(name))
+                                "See /the/help/url/ "
+                                "for more information.")).format(name)
 
     def test_fails_with_admin_flag_set(self, pyramid_config, db_request):
         admin_flag = (db_request.db.query(AdminFlag)

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -790,10 +790,12 @@ def file_upload(request):
                 STDLIB_PROHIBITTED):
             raise _exc_with_message(
                 HTTPBadRequest,
-                ("The name {!r} is not allowed (conflict with Python "
+                ("The name {name!r} is not allowed (conflict with Python "
                  "Standard Library module name). See "
-                 "https://pypi.org/help/#project-name for more information.")
-                .format(form.name.data),
+                 "{projecthelp} for more information.").format(
+                     name=form.name.data,
+                     projecthelp=request.route_url(
+                         'help', _anchor='project-name')),
             ) from None
 
         # The project doesn't exist in our database, so we'll add it along with

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -830,8 +830,10 @@ def file_upload(request):
         raise _exc_with_message(
             HTTPForbidden,
             ("The user '{0}' is not allowed to upload to project '{1}'. "
-             "See https://pypi.org/help#project-name for more information.")
-            .format(request.user.username, project.name)
+             "See {2} for more information.")
+            .format(request.user.username, project.name, request.route_url(
+                'help', _anchor='project-name')
+            )
         )
 
     try:


### PR DESCRIPTION
Followup to #3175. Change the upload permissions check and project name/Python standard library collision check error messages refer to the URL of the PyPI in question, thus ensuring that we send error messages that, as appropriate, refer to pypi.org, test.pypi.org, or any other future PyPI.