### PR TITLE
Add visual design issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/good-first-issue.md
+++ b/.github/ISSUE_TEMPLATE/good-first-issue.md
@@ -4,3 +4,5 @@
 ---
 
 **Good First Issue**: This issue is good for first time contributors. If you've already contributed to Warehouse, please work on [another issue without this label](https://github.com/pypa/warehouse/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+-label%3A%22good+first+issue%22) instead. If there is not a corresponding pull request for this issue, it is up for grabs. For directions for getting set up, see our [Getting Started Guide](https://warehouse.pypa.io/development/getting-started/). If you are working on this issue and have questions, please feel free to ask them here, [`#pypa-dev` on Freenode](https://webchat.freenode.net/?channels=%23pypa-dev), or the [pypa-dev mailing list](https://groups.google.com/forum/#!forum/pypa-dev).
+
+**Screenshot Required**: *If your pull request makes a visual change*, please include a screenshot of your update. This helps our team give you feedback faster.

--- a/.github/ISSUE_TEMPLATE/visual-design.md
+++ b/.github/ISSUE_TEMPLATE/visual-design.md
@@ -1,0 +1,6 @@
+<!-- Issue text below -->
+
+<!-- End issue text, leave the following intact -->
+---
+
+**Screenshot Required**: This issue will require an update to the visual design of the site. To help our team give you faster feedback, please include a screenshot in your Pull Request.

--- a/README.rst
+++ b/README.rst
@@ -27,6 +27,7 @@ You can also file specific types of issues:
 
 - `Good First Issue`_: An easy issue reserved for people who haven't
   contributed before
+- `Visual Design Issue`_: An issue related to the visual design of the site
 
 You can also join ``#pypa`` or ``#pypa-dev`` `on Freenode`_, or the
 `pypa-dev mailing list`_, to ask questions or get involved.
@@ -45,4 +46,5 @@ Everyone interacting in the Warehouse project's codebases, issue trackers, chat
 rooms, and mailing lists is expected to follow the `PyPA Code of Conduct`_.
 
 .. _Good First Issue: https://github.com/pypa/warehouse/issues/new?template=good-first-issue.md
+.. _Visual Design Issue: https://github.com/pypa/warehouse/issues/new?template=visual-design.md
 .. _PyPA Code of Conduct: https://www.pypa.io/en/latest/code-of-conduct/


### PR DESCRIPTION
- Adds a template for requesting a screenshot in the PR.
- Updates 'good first issue' template to request screenshot if issue is design related