### PR TITLE
Show License field along with classifiers

### DIFF
--- a/tests/unit/packaging/test_views.py
+++ b/tests/unit/packaging/test_views.py
@@ -206,11 +206,11 @@ class TestReleaseDetail:
             classifier="License :: OSI Approved :: BSD License")
         release = ReleaseFactory.create(
             _classifiers=[other_classifier, classifier],
-            license="Will not be used")
+            license="Will be added at the end")
 
         result = views.release_detail(release, db_request)
 
-        assert result["license"] == "BSD License"
+        assert result["license"] == "BSD License (Will be added at the end)"
 
     def test_license_with_no_classifier(self, db_request):
         """With no classifier, a license is used from metadata."""

--- a/warehouse/packaging/views.py
+++ b/warehouse/packaging/views.py
@@ -122,16 +122,21 @@ def release_detail(release, request):
         )
     ]
 
-    # Get the license from the classifiers or metadata, preferring classifiers.
-    license = None
-    if release.license:
-        # Make a best effort when the entire license text is given
-        # by using the first line only.
-        license = release.license.split('\n')[0]
-    license_classifiers = [c.split(" :: ")[-1] for c in release.classifiers
-                           if c.startswith("License")]
-    if license_classifiers:
-        license = ', '.join(license_classifiers)
+    # Get the license from both the `Classifier` and `License` metadata fields
+    license_classifiers = ', '.join(
+        c.split(" :: ")[-1]
+        for c in release.classifiers
+        if c.startswith("License")
+    )
+
+    # Make a best effort when the entire license text is given by using the
+    # first line only.
+    short_license = release.license.split('\n')[0] if release.license else None
+
+    if license_classifiers and short_license:
+        license = f'{license_classifiers} ({short_license})'
+    else:
+        license = license_classifiers or short_license or None
 
     return {
         "project": project,


### PR DESCRIPTION
Fixes #3225.

[The specification for the `License` field](https://packaging.python.org/specifications/core-metadata/#license-optional) says:

> This field may also be used to specify a particular version of a licencse which is named via the Classifier field, or to indicate a variation or exception to such a license.

This means that instead of omitting the field if both it and license classifiers are present, we should be including it _as well as_ the classifiers.