### PR TITLE
Added pointer-events:none to disabled button styling

### DIFF
--- a/warehouse/static/sass/blocks/_button.scss
+++ b/warehouse/static/sass/blocks/_button.scss
@@ -100,6 +100,7 @@
     border: 2px solid darken($background-color, 5%);
     color: darken($background-color, 12%);
     text-decoration: line-through;
+    pointer-events: none;
 
     &:focus,
     &:hover,


### PR DESCRIPTION
Fixes #3070, closes #3074.

- Added `pointer-events:none` to disabled button styling.