### PR TITLE
Security policy: change personal email addresses to Python Security list

### DIFF
--- a/warehouse/templates/pages/security.html
+++ b/warehouse/templates/pages/security.html
@@ -32,13 +32,8 @@
 
       <br>
 
-      <p>Instead, please email Donald Stufft and/or Ernest W. Durbin III directly, providing as much relevant information as possible.</p>
-      <p>Messages may be optionally encrypted with GPG using key fingerprints (these public keys are available from most commonly-used key servers):</p>
-
-      <ul>
-        <li><strong>Donald Stufft:</strong> donald@python.org <code>7C6B 7C5D 5E2B 6356 A926 F04F 6E3C BCE9 3372 DCFA</code></li>
-        <li><strong>Ernest W. Durbin III:</strong> ernest@python.org <code>11CD 3DD9 8D7E 61C7 6D1A  3224 8815 9C24 830F 6F7E</code></li>
-      </ul>
+      <p>Instead, please email <a href="mailto:security@python.org">security at python dot org</a> directly, providing as much relevant information as possible.</p>
+      <p>Messages may be optionally encrypted with GPG using key fingerprints available <a href="https://www.python.org/news/security/">at the Python Security page</a>.</p>
 
       <h2>What happens next?</h2>
 
@@ -46,7 +41,7 @@
       <p>Depending on the action to be taken, you may receive further follow-up emails.</p>
 
       <br>
-      <p><strong>This security policy was last updated on May 13, 2017</strong></p>
+      <p><strong>This security policy was last updated on March 14, 2018.</strong></p>
     </div>
   </section>
 {% endblock %}


### PR DESCRIPTION
Instead of asking security vulnerability reporters to email Ernest or Donald individually, make the process more robust by getting more eyes on reports.

Per [conversation in IRC](http://kafka.dcpython.org/day/pypa-dev/2018-03-14) with dstufft and EWDurbin today.

Marked as blocked till @dstufft confirms that Ernest is on security`@`python.org. Along with merging this, I should also update https://wiki.python.org/psf/WarehousePackageMaintainerTesting and https://wiki.python.org/psf/PackagingWG/PyPIBetaAnnouncement .