### PR TITLE
Add a <!DOCTYPE html> declaration to /simple pages

### DIFF
--- a/warehouse/templates/legacy/api/simple/detail.html
+++ b/warehouse/templates/legacy/api/simple/detail.html
@@ -11,6 +11,7 @@
  # See the License for the specific language governing permissions and
  # limitations under the License.
 -#}
+<!DOCTYPE html>
 <html>
   <head>
     <title>Links for {{ project.name }}</title>
@@ -20,6 +21,6 @@
     <h1>Links for {{ project.name }}</h1>
     {% for file in files -%}
     <a href="{{ request.route_url('packaging.file', path=file.path) }}#sha256={{ file.sha256_digest }}"{% if file.release.requires_python %} data-requires-python="{{ file.release.requires_python }}"{% endif %}>{{ file.filename }}</a><br>
-    {% endfor %}
+    {% endfor -%}
   </body>
 </html>

--- a/warehouse/templates/legacy/api/simple/index.html
+++ b/warehouse/templates/legacy/api/simple/index.html
@@ -11,6 +11,7 @@
  # See the License for the specific language governing permissions and
  # limitations under the License.
 -#}
+<!DOCTYPE html>
 <html>
   <head>
     <title>Simple Index</title>
@@ -19,6 +20,6 @@
   <body>
     {% for project in projects -%}
     <a href="{{ request.route_path('legacy.api.simple.detail', name=project.normalized_name) }}">{{ project.name }}</a>
-    {% endfor %}
+    {% endfor -%}
   </body>
 </html>


### PR DESCRIPTION
also removes stray line break after the list of files.