### PR TITLE
Remove the <meta api-version="2"> tag from /simple/

### DIFF
--- a/warehouse/templates/legacy/api/simple/detail.html
+++ b/warehouse/templates/legacy/api/simple/detail.html
@@ -15,7 +15,6 @@
 <html>
   <head>
     <title>Links for {{ project.name }}</title>
-    <meta name="api-version" value="2" />
   </head>
   <body>
     <h1>Links for {{ project.name }}</h1>

--- a/warehouse/templates/legacy/api/simple/index.html
+++ b/warehouse/templates/legacy/api/simple/index.html
@@ -15,7 +15,6 @@
 <html>
   <head>
     <title>Simple Index</title>
-    <meta name="api-version" value="2" />
   </head>
   <body>
     {% for project in projects -%}


### PR DESCRIPTION
This tag was for the failed --allow-external PEP, which is no longer being used. However, some of these clients are still in the wild and are still interpreting it. This is, I believe, causing pip 1.5.4 to break and I believe this will also resolve that issue.