### PR TITLE
Sort simple on Release.filename

### DIFF
--- a/tests/unit/legacy/api/test_simple.py
+++ b/tests/unit/legacy/api/test_simple.py
@@ -202,7 +202,7 @@ class TestSimpleDetail:
 
         files = []
         for files_release in \
-                zip(egg_files, wheel_files, tar_files):
+                zip(egg_files, tar_files, wheel_files):
             files += files_release
 
         db_request.matchdict["name"] = project.normalized_name
@@ -212,9 +212,6 @@ class TestSimpleDetail:
         # Make sure that we get any changes made since the JournalEntry was
         # saved.
         db_request.db.refresh(project)
-        import pprint
-        pprint.pprint(simple.simple_detail(project, db_request)['files'])
-        pprint.pprint(files)
 
         assert simple.simple_detail(project, db_request) == {
             "project": project,

--- a/warehouse/legacy/api/simple.py
+++ b/warehouse/legacy/api/simple.py
@@ -87,7 +87,7 @@ def simple_detail(project, request):
             )
         )
         .all(),
-        key=lambda f: (parse(f.version), f.packagetype)
+        key=lambda f: (parse(f.version), f.filename)
     )
 
     return {"project": project, "files": files}


### PR DESCRIPTION
Fixes #3284.

The order is still (intentionally) different from pypi-legacy, but `.tar` sdists will come before `.zip`s as before, and visually it makes more sense as links within the same version are just alphabetically sorted.