### PR TITLE
Make <br> self-closing for /simple

### DIFF
--- a/warehouse/templates/legacy/api/simple/detail.html
+++ b/warehouse/templates/legacy/api/simple/detail.html
@@ -19,7 +19,7 @@
   <body>
     <h1>Links for {{ project.name }}</h1>
     {% for file in files -%}
-    <a href="{{ request.route_url('packaging.file', path=file.path) }}#sha256={{ file.sha256_digest }}"{% if file.release.requires_python %} data-requires-python="{{ file.release.requires_python }}"{% endif %}>{{ file.filename }}</a><br>
+    <a href="{{ request.route_url('packaging.file', path=file.path) }}#sha256={{ file.sha256_digest }}"{% if file.release.requires_python %} data-requires-python="{{ file.release.requires_python }}"{% endif %}>{{ file.filename }}</a><br/>
     {% endfor -%}
   </body>
 </html>


### PR DESCRIPTION
For parsers that misinterpret void elements.

Ref: https://github.com/pypa/pypi-legacy/issues/783