### PR TITLE
"implement" package_urls and package_data which were deprecated/renamed 12 years ago

### DIFF
--- a/tests/unit/legacy/api/test_xmlrpc.py
+++ b/tests/unit/legacy/api/test_xmlrpc.py
@@ -305,6 +305,38 @@ def test_top_packages(num):
         "RuntimeError: This API has been removed. Please Use BigQuery instead."
 
 
+@pytest.mark.parametrize("domain", [None, 'example.com'])
+def test_package_urls(domain, db_request):
+    db_request.registry.settings = {}
+    if domain:
+        db_request.registry.settings = {'warehouse.domain': domain}
+    db_request.domain = 'example.org'
+    with pytest.raises(xmlrpc.XMLRPCWrappedError) as exc:
+        xmlrpc.package_urls(db_request, 'foo', '1.0.0')
+
+    assert exc.value.faultString == \
+        ("RuntimeError: This API has been deprecated. Use "
+         f"https://{domain if domain else 'example.org'}/foo/1.0.0/json "
+         "instead. The XMLRPC method release_urls can be used in the "
+         "interim, but will be deprecated in the future.")
+
+
+@pytest.mark.parametrize("domain", [None, 'example.com'])
+def test_package_data(domain, db_request):
+    db_request.registry.settings = {}
+    if domain:
+        db_request.registry.settings = {'warehouse.domain': domain}
+    db_request.domain = 'example.org'
+    with pytest.raises(xmlrpc.XMLRPCWrappedError) as exc:
+        xmlrpc.package_data(db_request, 'foo', '1.0.0')
+
+    assert exc.value.faultString == \
+        ("RuntimeError: This API has been deprecated. Use "
+         f"https://{domain if domain else 'example.org'}/foo/1.0.0/json "
+         "instead. The XMLRPC method release_data can be used in the "
+         "interim, but will be deprecated in the future.")
+
+
 def test_package_releases(db_request):
     project1 = ProjectFactory.create()
     releases1 = [ReleaseFactory.create(project=project1) for _ in range(10)]

--- a/warehouse/legacy/api/xmlrpc.py
+++ b/warehouse/legacy/api/xmlrpc.py
@@ -165,6 +165,20 @@ def package_releases(request, package_name, show_hidden=False):
     return [v[0] for v in versions]
 
 
+@pypi_xmlrpc(method="package_data")
+def package_data(request, package_name, version):
+    settings = request.registry.settings
+    domain = settings.get("warehouse.domain", request.domain)
+    raise XMLRPCWrappedError(
+        RuntimeError(
+            ("This API has been deprecated. Use "
+             f"https://{domain}/{package_name}/{version}/json "
+             "instead. The XMLRPC method release_data can be used in the "
+             "interim, but will be deprecated in the future.")
+        )
+    )
+
+
 @pypi_xmlrpc(method="release_data")
 def release_data(request, package_name, version):
     try:
@@ -224,6 +238,20 @@ def release_data(request, package_name, version):
             "last_month": -1,
         },
     }
+
+
+@pypi_xmlrpc(method="package_urls")
+def package_urls(request, package_name, version):
+    settings = request.registry.settings
+    domain = settings.get("warehouse.domain", request.domain)
+    raise XMLRPCWrappedError(
+        RuntimeError(
+            ("This API has been deprecated. Use "
+             f"https://{domain}/{package_name}/{version}/json "
+             "instead. The XMLRPC method release_urls can be used in the "
+             "interim, but will be deprecated in the future.")
+        )
+    )
 
 
 @pypi_xmlrpc(method="release_urls")


### PR DESCRIPTION
See "deprecation": https://github.com/pypa/pypi-legacy/commit/2019e7ee41e59dd45ea32c8c5723b4a2f7cdef9b#diff-ec1fe428ebe5fee80070816321e3b023R54

This deprecates these names permanently and helpfully redirects users to the JSON API.