### PR TITLE
Add back admin JS

### DIFF
--- a/warehouse/admin/templates/admin/base.html
+++ b/warehouse/admin/templates/admin/base.html
@@ -163,5 +163,11 @@
 {% endblock %}
 
 <script src="{{ request.static_url('warehouse.admin:static/dist/js/admin.js') }}"></script>
+<script src="{{ request.static_url('warehouse.admin:static/js/jquery-2.2.3.min.js') }}"></script>
+<script src="{{ request.static_url('warehouse.admin:static/js/bootstrap.min.js') }}"></script>
+<script src="{{ request.static_url('warehouse.admin:static/js/jquery.slimscroll.min.js') }}"></script>
+<script src="{{ request.static_url('warehouse.admin:static/js/fastclick.min.js') }}"></script>
+<script src="{{ request.static_url('warehouse.admin:static/js/app.min.js') }}"></script>
+
 </body>
 </html>


### PR DESCRIPTION
Fixes #3263.

These were not actually getting bundled into `admin.js` as I had thought.