### PR TITLE
Add default text to browse page

### DIFF
--- a/warehouse/static/sass/blocks/_applied-filters.scss
+++ b/warehouse/static/sass/blocks/_applied-filters.scss
@@ -26,6 +26,7 @@
 
 .applied-filters {
   margin-top: 10px;
+  margin-bottom: 15px;
   @include clearfix;
 
   &__add-button {

--- a/warehouse/static/sass/settings/_fonts.scss
+++ b/warehouse/static/sass/settings/_fonts.scss
@@ -27,7 +27,7 @@ $code-font: "Source Code Pro", monospace;
 
 $em-base:          17px;
 $base-font-size:   17px;
-$small-font-size:  $base-font-size * 0.9;
+$small-font-size:  14px;
 $button-font-size: $base-font-size;
 $input-font-size:  $base-font-size * 1.1;
 

--- a/warehouse/templates/search/results.html
+++ b/warehouse/templates/search/results.html
@@ -133,9 +133,21 @@
         <p>Enter a search query above, or select a filter from the list of classifiers on the left.</p>
         <p>You can combine searches and classifier filters. Examples:</p>
         <ul class="no-bottom-margin">
-          <li><a href="/search/?q=&o=&c=Programming+Language+%3A%3A+Python+%3A%3A+3">New Python 3 project releases</a></li>
-          <li><a href="/search/?q=&o=&c=Framework+%3A%3A+Sphinx+%3A%3A+Extension&c=Development+Status+%3A%3A+5+-+Production%2FStable">Sphinx extensions that are stable/production status</a></li>
-          <li><a href="/search/?q=graphics&o=&c=License+%3A%3A+OSI+Approved">Graphics projects under OSI-approved licenses</a></li>
+          <li>
+            <a href="{{ request.route_path('search', _query=[('c', 'Programming Language :: Python :: 3')]) }}">
+              New Python 3 project releases
+            </a>
+          </li>
+          <li>
+            <a href="{{ request.route_path('search', _query=[('c', 'Framework :: Sphinx :: Extension'), ('c', 'Development Status :: 5 - Production/Stable')]) }}">
+              Sphinx extensions that are stable/production status
+            </a>
+          </li>
+          <li>
+            <a href="{{ request.route_path('search', _query=[('q', 'graphics'), ('c', 'License :: OSI Approved')]) }}">
+              Graphics projects under OSI-approved licenses
+            </a>
+          </li>
         </ul>
       </div>
       {% endif %}

--- a/warehouse/templates/search/results.html
+++ b/warehouse/templates/search/results.html
@@ -157,12 +157,12 @@
           </div>
           <div>
             {% if term or applied_filters %}
-              <input id="search" type="hidden" name="q" value="{{ term }}">
-              <label for="order">Order by &nbsp;</label>
-              <select class="-js-form-submit-trigger" id="order" name="o">
-                {{ search_option("Relevance", "") }}
-                {{ search_option("Date Last Updated", "-created") }}
-              </select>
+            <input id="search" type="hidden" name="q" value="{{ term }}">
+            <label for="order">Order by &nbsp;</label>
+            <select class="-js-form-submit-trigger" id="order" name="o">
+              {{ search_option("Relevance", "") }}
+              {{ search_option("Date Last Updated", "-created") }}
+            </select>
             {% endif %}
           </div>
         </section>

--- a/warehouse/templates/search/results.html
+++ b/warehouse/templates/search/results.html
@@ -128,81 +128,94 @@
     </div>
 
     <div class="left-layout__main">
-      <form action="{{ request.route_path('search') }}">
-      <section class="split-layout split-layout--table">
-        <div>
-        {% if term %}
-          <p>
-            <strong>{{ page.item_count|format_number }}</strong> projects match "<em>{{ term }}</em>".
-            {% if page.collection.best_guess and page.collection.best_guess.freq > page.item_count %}
-              {{ suggestion_link(page.collection.best_guess) }}
-            {% endif %}
-          </p>
-        {% else %}
-        <p>
-          <strong>{{ page.item_count|format_number }}{%if page.item_count == 10000 %}+{% endif %}</strong> projects.
-        </p>
-        {% endif %}
-        </div>
-          <div>
-            <input id="search" type="hidden" name="q" value="{{ term }}">
-            <label for="order">Order by &nbsp;</label>
-            <select class="-js-form-submit-trigger" id="order" name="o">
-              {{ search_option("Relevance", "") }}
-              {{ search_option("Date Last Updated", "-created") }}
-            </select>
-          </div>
-      </section>
-
-      <div class="applied-filters">
-      {% if applied_filters %}
-        {% for filter in applied_filters %}
-        <div class="filter-badge">
-          <input type="hidden" name="c" value="{{ filter }}">
-          <span class="filter-badge__icon">
-            <i class="fa fa-filter" aria-hidden="true"></i>
-            <span class="sr-only">Filter</span>
-          </span>
-          <span class="filter-badge__description">{{ filter }}</span>
-          <a class="filter-badge__remove-button" href="#">
-            <i class="fa fa-close" aria-hidden="true"></i>
-            <span class="sr-only">Close</span>
-          </a>
-        </div>
-        {% endfor %}
-      {% endif %}
-        <span class="applied-filters__add-button">
-          <a class="-js-add-filter button button--small" href="#">Add Filter</a>
-        </span>
+      {% if not term and not applied_filters %}
+      <div class="callout-block no-top-margin">
+        <p>Enter a search query above, or select a filter from the list of classifiers on the left.</p>
+        <p>You can combine searches and classifier filters. Examples:</p>
+        <ul class="no-bottom-margin">
+          <li><a href="/search/?q=&o=&c=Programming+Language+%3A%3A+Python+%3A%3A+3">New Python 3 project releases</a></li>
+          <li><a href="/search/?q=&o=&c=Framework+%3A%3A+Sphinx+%3A%3A+Extension&c=Development+Status+%3A%3A+5+-+Production%2FStable">Sphinx extensions that are stable/production status</a></li>
+          <li><a href="/search/?q=graphics&o=&c=License+%3A%3A+OSI+Approved">Graphics projects under OSI-approved licenses</a></li>
+        </ul>
       </div>
-
-      <section>
-        <div class="package-list">
-        {% for item in page.items %}
-          {{ project_snippet(item) }}
-        {% else %}
-          <div class="callout-block">
+      {% endif %}
+      <form action="{{ request.route_path('search') }}">
+        <section class="split-layout split-layout--table">
+          <div>
+            {% if term or applied_filters %}
             <p>
-              {% if term %}
-                There were no results for '<em>{{ term }}</em>'.
-              {% elif applied_filters %}
-                {% trans count=applied_filters|length, filters=applied_filters|join(", ") %}
-                  There were no results for '<em>{{ filters }}</em>' filter.
-                {% pluralize %}
-                  There were no results for '<em>{{ filters }}</em>' filters.
-                {% endtrans %}
-              {% endif %}
-              {% if page.collection.best_guess %}
-                {{ suggestion_link(page.collection.best_guess) }}
-              {% endif %}
+              <strong>{{ page.item_count|format_number }}{%if page.item_count == 10000 %}+{% endif %}</strong>
+                projects
+                {% if term %}for "<em>{{ term }}</em>"{% endif %}
+                {% if applied_filters %} with the selected classifier{% if applied_filters|length > 1 %}s{% endif %}{% endif %}
+
+                {% if page.collection.best_guess and page.collection.best_guess.freq > page.item_count %}
+                  {{ suggestion_link(page.collection.best_guess) }}
+                {% endif %}
             </p>
+            {% endif %}
           </div>
-        {% endfor %}
+          <div>
+            {% if term or applied_filters %}
+              <input id="search" type="hidden" name="q" value="{{ term }}">
+              <label for="order">Order by &nbsp;</label>
+              <select class="-js-form-submit-trigger" id="order" name="o">
+                {{ search_option("Relevance", "") }}
+                {{ search_option("Date Last Updated", "-created") }}
+              </select>
+            {% endif %}
+          </div>
+        </section>
+
+        <div class="applied-filters">
+        {% if applied_filters %}
+          {% for filter in applied_filters %}
+          <div class="filter-badge">
+            <input type="hidden" name="c" value="{{ filter }}">
+            <span class="filter-badge__icon">
+              <i class="fa fa-filter" aria-hidden="true"></i>
+              <span class="sr-only">Filter</span>
+            </span>
+            <span class="filter-badge__description">{{ filter }}</span>
+            <a class="filter-badge__remove-button" href="#">
+              <i class="fa fa-close" aria-hidden="true"></i>
+              <span class="sr-only">Close</span>
+            </a>
+          </div>
+          {% endfor %}
+        {% endif %}
+          <span class="applied-filters__add-button">
+            <a class="-js-add-filter button button--small" href="#">Add Filter</a>
+          </span>
         </div>
 
-        {{ pagination(page) }}
-      </section>
-
+        {% if term or applied_filters %}
+        <section>
+          <div class="package-list">
+          {% for item in page.items %}
+            {{ project_snippet(item) }}
+          {% else %}
+            <div class="callout-block">
+              <p>
+                {% if term %}
+                  There were no results for '<em>{{ term }}</em>'.
+                {% elif applied_filters %}
+                  {% trans count=applied_filters|length, filters=applied_filters|join(", ") %}
+                    There were no results for '<em>{{ filters }}</em>' filter.
+                  {% pluralize %}
+                    There were no results for '<em>{{ filters }}</em>' filters.
+                  {% endtrans %}
+                {% endif %}
+                {% if page.collection.best_guess %}
+                  {{ suggestion_link(page.collection.best_guess) }}
+                {% endif %}
+              </p>
+            </div>
+          {% endfor %}
+          </div>
+          {{ pagination(page) }}
+        </section>
+        {% endif %}
       </form>
     </div>
   </div>

--- a/warehouse/templates/search/results.html
+++ b/warehouse/templates/search/results.html
@@ -135,17 +135,17 @@
         <ul class="no-bottom-margin">
           <li>
             <a href="{{ request.route_path('search', _query=[('c', 'Programming Language :: Python :: 3')]) }}">
-              New Python 3 project releases
+              Python 3 compatible projects
             </a>
           </li>
           <li>
             <a href="{{ request.route_path('search', _query=[('c', 'Framework :: Sphinx :: Extension'), ('c', 'Development Status :: 5 - Production/Stable')]) }}">
-              Sphinx extensions that are stable/production status
+              Sphinx extensions that have a stable/production status
             </a>
           </li>
           <li>
             <a href="{{ request.route_path('search', _query=[('q', 'graphics'), ('c', 'License :: OSI Approved')]) }}">
-              Graphics projects under OSI-approved licenses
+              Projects related to "graphics" with OSI-approved licenses
             </a>
           </li>
         </ul>


### PR DESCRIPTION
Closes #3062 

![screenshot from 2018-03-21 07-04-34](https://user-images.githubusercontent.com/3323703/37697721-4ec34412-2cd6-11e8-9113-7864c8c22300.png)

Includes:

- Small restyle of the filter buttons (to give them more room)
- Adjustment of results message to reflect applied filters, examples:

### Search only
![screenshot from 2018-03-21 07-07-36](https://user-images.githubusercontent.com/3323703/37697761-8d8a3872-2cd6-11e8-8b50-cbd3164ce33a.png)

### Classifiers only
![screenshot from 2018-03-21 07-07-00](https://user-images.githubusercontent.com/3323703/37697750-7ea5f544-2cd6-11e8-95fb-18baa2b3e5f2.png)
![screenshot from 2018-03-21 07-06-53](https://user-images.githubusercontent.com/3323703/37697751-7ec3885c-2cd6-11e8-92a8-fcdf5eae668e.png)

### Search and classifiers
![screenshot from 2018-03-21 07-08-07](https://user-images.githubusercontent.com/3323703/37697776-a0ae1234-2cd6-11e8-9117-f1153b1fe164.png)
