### PR TITLE
Warn if notification target is missing id attribute

### DIFF
--- a/warehouse/static/js/warehouse/controllers/notification_controller.js
+++ b/warehouse/static/js/warehouse/controllers/notification_controller.js
@@ -27,8 +27,8 @@ export default class extends Controller {
    */
   _getNotificationId() {
     /** Get data from `data-notification-version` attribute */
-    const version = this.data.get("version");
-    if (this.notificationTarget.id && version) {
+    const version = this.data.get("version") || "-1";
+    if (this.notificationTarget.id) {
       return `${this.notificationTarget.id}_${version}__dismissed`;
     }
   }
@@ -46,7 +46,9 @@ export default class extends Controller {
     const notificationId = this._getNotificationId();
     if (notificationId) {
       localStorage.setItem(notificationId, 1);
+      this.notificationTarget.classList.remove("notification-bar--visible");
+    } else {
+      console.warn(`${this.notificationTarget} is dismissable but has no id attribute`); // eslint-disable-line no-console
     }
-    this.notificationTarget.classList.remove("notification-bar--visible");
   }
 }


### PR DESCRIPTION
Use a version of `-1` by default, and give a warning if we try to dismiss a notification that has no `id`.

(Towards fixing #3361)