### PR TITLE
Change delete file modal confirmation process

### DIFF
--- a/tests/unit/manage/test_views.py
+++ b/tests/unit/manage/test_views.py
@@ -1096,7 +1096,7 @@ class TestManageProjectRelease:
         )
         request = pretend.stub(
             POST={
-                'confirm_filename': release_file.filename,
+                'confirm_project_name': release.project.name,
                 'file_id': release_file.id,
             },
             method="POST",
@@ -1156,7 +1156,7 @@ class TestManageProjectRelease:
             project=pretend.stub(name='foobar'),
         )
         request = pretend.stub(
-            POST={'confirm_filename': ''},
+            POST={'confirm_project_name': ''},
             method="POST",
             db=pretend.stub(delete=pretend.call_recorder(lambda a: None)),
             route_path=pretend.call_recorder(lambda *a, **kw: '/the-redirect'),
@@ -1195,7 +1195,7 @@ class TestManageProjectRelease:
             raise NoResultFound
 
         request = pretend.stub(
-            POST={'confirm_filename': 'whatever'},
+            POST={'confirm_project_name': 'whatever'},
             method="POST",
             db=pretend.stub(
                 delete=pretend.call_recorder(lambda a: None),
@@ -1239,7 +1239,7 @@ class TestManageProjectRelease:
             project=pretend.stub(name='foobar'),
         )
         request = pretend.stub(
-            POST={'confirm_filename': 'invalid'},
+            POST={'confirm_project_name': 'invalid'},
             method="POST",
             db=pretend.stub(
                 delete=pretend.call_recorder(lambda a: None),
@@ -1263,7 +1263,7 @@ class TestManageProjectRelease:
         assert request.session.flash.calls == [
             pretend.call(
                 "Could not delete file - " +
-                f"'invalid' is not the same as {release_file.filename!r}",
+                f"'invalid' is not the same as {release.project.name!r}",
                 queue="error",
             )
         ]

--- a/warehouse/manage/views.py
+++ b/warehouse/manage/views.py
@@ -473,7 +473,7 @@ class ManageProjectRelease:
 
     @view_config(
         request_method="POST",
-        request_param=["confirm_filename", "file_id"]
+        request_param=["confirm_project_name", "file_id"]
     )
     def delete_project_release_file(self):
 
@@ -487,9 +487,9 @@ class ManageProjectRelease:
                 )
             )
 
-        filename = self.request.POST.get('confirm_filename')
+        project_name = self.request.POST.get('confirm_project_name')
 
-        if not filename:
+        if not project_name:
             return _error("Must confirm the request.")
 
         try:
@@ -504,10 +504,11 @@ class ManageProjectRelease:
         except NoResultFound:
             return _error('Could not find file.')
 
-        if filename != release_file.filename:
+        if project_name != self.release.project.name:
             return _error(
                 "Could not delete file - " +
-                f"{filename!r} is not the same as {release_file.filename!r}",
+                f"{project_name!r} is not the same as "
+                f"{self.release.project.name!r}",
             )
 
         self.request.db.add(

--- a/warehouse/templates/manage/manage_base.html
+++ b/warehouse/templates/manage/manage_base.html
@@ -58,7 +58,7 @@
 {% macro modal_slug(title, index) %}
 {% endmacro %}
 
-{% macro confirm_modal(title, confirm_name, confirm_string, slug, context, index=None, extra_fields=None, extra_description=None, action=None) %}
+{% macro confirm_modal(title, confirm_name, confirm_string, slug, context, confirm_button_label=None, index=None, extra_fields=None, extra_description=None, action=None) %}
   <div id="{{ slug }}" class="modal" data-controller="confirm">
     <div class="modal__content" role="dialog">
       <form method="POST" class="modal__form" action="{{ action or request.current_route_path() }}">
@@ -86,7 +86,7 @@
         <div class="modal__footer">
           <a href="#modal-close" data-action="click->confirm#cancel" class="button modal__action">Cancel</a>
           <button class="button button--danger modal__action" data-target="confirm.button" data-expected="{{ confirm_string }}" type="submit">
-            {{ title }}
+            {{ confirm_button_label if confirm_button_label else title }}
           </button>
         </div>
       </form>

--- a/warehouse/templates/manage/manage_base.html
+++ b/warehouse/templates/manage/manage_base.html
@@ -58,7 +58,7 @@
 {% macro modal_slug(title, index) %}
 {% endmacro %}
 
-{% macro confirm_modal(title, confirm_name, confirm_string, slug, context, index=None, extra_fields=None, action=None) %}
+{% macro confirm_modal(title, confirm_name, confirm_string, slug, context, index=None, extra_fields=None, extra_description=None, action=None) %}
   <div id="{{ slug }}" class="modal" data-controller="confirm">
     <div class="modal__content" role="dialog">
       <form method="POST" class="modal__form" action="{{ action or request.current_route_path() }}">
@@ -77,6 +77,7 @@
           </p>
         </div>
         {% set context = 'your' if confirm_name.lower() == 'username' else 'the' %}
+        {{ extra_description if extra_description else '' }}
         <p>Confirm {{ context }} {{ confirm_name|lower }} to continue.</p>
         {% set name = "confirm_" + confirm_name.lower().replace(' ', '_') %}
         <label for="{{ name }}">{{ confirm_name }}</label>

--- a/warehouse/templates/manage/release.html
+++ b/warehouse/templates/manage/release.html
@@ -73,7 +73,7 @@
                 <i class="fa fa-hashtag" aria-hidden="true"></i>
                 View Hashes
               </a>
-              {% set title = "Delete File From" %}
+              {% set title = "Delete File" %}
               {% set slug = title.lower().replace(' ', '-') + '-modal-{}'.format(loop.index) %}
               <a href="#{{ slug }}" class="dropdown__link">
                 <i class="fa fa-trash" aria-hidden="true"></i>

--- a/warehouse/templates/manage/release.html
+++ b/warehouse/templates/manage/release.html
@@ -73,7 +73,7 @@
                 <i class="fa fa-hashtag" aria-hidden="true"></i>
                 View Hashes
               </a>
-              {% set title = "Delete File" %}
+              {% set title = "Delete File From" %}
               {% set slug = title.lower().replace(' ', '-') + '-modal-{}'.format(loop.index) %}
               <a href="#{{ slug }}" class="dropdown__link">
                 <i class="fa fa-trash" aria-hidden="true"></i>
@@ -82,9 +82,12 @@
               {% set extra_fields %}
                 <input name="file_id" type="hidden" value="{{ file.id }}">
               {% endset %}
+              {% set extra_description %}
+                <p><strong>Filename:</strong> {{ file.filename }}</p>
+              {% endset %}
             </div>
           </div>
-          {{ confirm_modal(title, "Filename", file.filename, slug, index=loop.index, extra_fields=extra_fields) }}
+          {{ confirm_modal(title, "Project Name", project.name, slug, index=loop.index, extra_fields=extra_fields, extra_description=extra_description) }}
         </td>
       </tr>
     {% endfor %}

--- a/warehouse/templates/manage/release.html
+++ b/warehouse/templates/manage/release.html
@@ -73,7 +73,9 @@
                 <i class="fa fa-hashtag" aria-hidden="true"></i>
                 View Hashes
               </a>
-              {% set title = "Delete File" %}
+
+              {% set title = "Delete File From" %}
+              {% set confirm_button_label = "Delete File" %}
               {% set slug = title.lower().replace(' ', '-') + '-modal-{}'.format(loop.index) %}
               <a href="#{{ slug }}" class="dropdown__link">
                 <i class="fa fa-trash" aria-hidden="true"></i>
@@ -87,7 +89,7 @@
               {% endset %}
             </div>
           </div>
-          {{ confirm_modal(title, "Project Name", project.name, slug, index=loop.index, extra_fields=extra_fields, extra_description=extra_description) }}
+          {{ confirm_modal(title, "Project Name", project.name, slug, confirm_button_label=confirm_button_label, index=loop.index, extra_fields=extra_fields, extra_description=extra_description) }}
         </td>
       </tr>
     {% endfor %}


### PR DESCRIPTION
Fixes #3163. 

* Adds an additional optional parameter for the `confirm_modal` macro which will display after the warning box.
* Project name will be used instead of filename to confirm delete.