### PR TITLE
Destroy documentation

### DIFF
--- a/dev/environment
+++ b/dev/environment
@@ -20,7 +20,8 @@ CAMO_KEY="insecure camo key"
 
 DOCS_URL="https://pythonhosted.org/{project}/"
 
-FILES_BACKEND=warehouse.packaging.services.LocalFileStorage path=/var/opt/warehouse/packages/ url=http://files.example.com/packages/{path}
+FILES_BACKEND=warehouse.packaging.services.LocalFileStorage path=/var/opt/warehouse/packages/ url=http://files.example.com/packages/{path} name=files
+DOCS_BACKEND=warehouse.packaging.services.LocalFileStorage path=/var/opt/warehouse/docs/ name=docs
 
 MAIL_HOST=smtp
 MAIL_PORT=2525

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -117,6 +117,7 @@ def app_config(database):
             "ratelimit.url": "memory://",
             "elasticsearch.url": "https://localhost/warehouse",
             "files.backend": "warehouse.packaging.services.LocalFileStorage",
+            "docs.backend": "warehouse.packaging.services.LocalFileStorage",
             "files.url": "http://localhost:7000/",
             "sessions.secret": "123456",
             "sessions.url": "redis://localhost:0/",

--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -1196,13 +1196,15 @@ class TestFileUpload:
 
         storage_service = pretend.stub(store=storage_service_store)
         db_request.find_service = pretend.call_recorder(
-            lambda svc: storage_service
+            lambda svc, name=None: storage_service
         )
 
         resp = legacy.file_upload(db_request)
 
         assert resp.status_code == 200
-        assert db_request.find_service.calls == [pretend.call(IFileStorage)]
+        assert db_request.find_service.calls == [
+            pretend.call(IFileStorage, name="files"),
+        ]
         assert len(storage_service.store.calls) == 2 if has_signature else 1
         assert storage_service.store.calls[0] == pretend.call(
             "/".join([
@@ -2110,7 +2112,7 @@ class TestFileUpload:
 
         storage_service = pretend.stub(store=storage_service_store)
         db_request.find_service = pretend.call_recorder(
-            lambda svc: storage_service
+            lambda svc, name=None: storage_service
         )
 
         monkeypatch.setattr(
@@ -2121,7 +2123,9 @@ class TestFileUpload:
         resp = legacy.file_upload(db_request)
 
         assert resp.status_code == 200
-        assert db_request.find_service.calls == [pretend.call(IFileStorage)]
+        assert db_request.find_service.calls == [
+            pretend.call(IFileStorage, name="files"),
+        ]
         assert storage_service.store.calls == [
             pretend.call(
                 "/".join([
@@ -2218,7 +2222,7 @@ class TestFileUpload:
 
         storage_service = pretend.stub(store=storage_service_store)
         db_request.find_service = pretend.call_recorder(
-            lambda svc: storage_service
+            lambda svc, name=None: storage_service
         )
 
         monkeypatch.setattr(
@@ -2229,7 +2233,9 @@ class TestFileUpload:
         resp = legacy.file_upload(db_request)
 
         assert resp.status_code == 200
-        assert db_request.find_service.calls == [pretend.call(IFileStorage)]
+        assert db_request.find_service.calls == [
+            pretend.call(IFileStorage, name="files"),
+        ]
         assert storage_service.store.calls == [
             pretend.call(
                 "/".join([
@@ -2315,7 +2321,7 @@ class TestFileUpload:
                 assert fp.read() == b"A fake file."
 
         storage_service = pretend.stub(store=storage_service_store)
-        db_request.find_service = lambda svc: storage_service
+        db_request.find_service = lambda svc, name=None: storage_service
 
         monkeypatch.setattr(
             legacy,
@@ -2361,7 +2367,7 @@ class TestFileUpload:
                 assert fp.read() == b"A fake file."
 
         storage_service = pretend.stub(store=storage_service_store)
-        db_request.find_service = lambda svc: storage_service
+        db_request.find_service = lambda svc, name=None: storage_service
 
         monkeypatch.setattr(
             legacy,
@@ -2463,7 +2469,7 @@ class TestFileUpload:
         ])
 
         storage_service = pretend.stub(store=lambda path, filepath, meta: None)
-        db_request.find_service = lambda svc: storage_service
+        db_request.find_service = lambda svc, name=None: storage_service
 
         resp = legacy.file_upload(db_request)
 
@@ -2554,7 +2560,7 @@ class TestFileUpload:
         })
 
         storage_service = pretend.stub(store=lambda path, filepath, meta: None)
-        db_request.find_service = lambda svc: storage_service
+        db_request.find_service = lambda svc, name=None: storage_service
 
         resp = legacy.file_upload(db_request)
 
@@ -2601,7 +2607,7 @@ class TestFileUpload:
         })
 
         storage_service = pretend.stub(store=lambda path, filepath, meta: None)
-        db_request.find_service = lambda svc: storage_service
+        db_request.find_service = lambda svc, name=None: storage_service
 
         legacy.file_upload(db_request)
 
@@ -2631,7 +2637,7 @@ class TestFileUpload:
         })
 
         storage_service = pretend.stub(store=lambda path, filepath, meta: None)
-        db_request.find_service = lambda svc: storage_service
+        db_request.find_service = lambda svc, name=None: storage_service
         db_request.remote_addr = "10.10.10.10"
 
         resp = legacy.file_upload(db_request)
@@ -2733,7 +2739,7 @@ class TestFileUpload:
         })
 
         storage_service = pretend.stub(store=lambda path, filepath, meta: None)
-        db_request.find_service = lambda svc: storage_service
+        db_request.find_service = lambda svc, name=None: storage_service
         db_request.remote_addr = "10.10.10.10"
 
         if expected_success:
@@ -2777,7 +2783,7 @@ class TestFileUpload:
         })
 
         storage_service = pretend.stub(store=lambda path, filepath, meta: None)
-        db_request.find_service = lambda svc: storage_service
+        db_request.find_service = lambda svc, name=None: storage_service
         db_request.remote_addr = "10.10.10.10"
 
         tm = pretend.stub(
@@ -2873,7 +2879,7 @@ class TestFileUpload:
         ])
 
         storage_service = pretend.stub(store=lambda path, filepath, meta: None)
-        db_request.find_service = lambda svc: storage_service
+        db_request.find_service = lambda svc, name=None: storage_service
 
         resp = legacy.file_upload(db_request)
 
@@ -2954,7 +2960,7 @@ class TestFileUpload:
         ])
 
         storage_service = pretend.stub(store=lambda path, filepath, meta: None)
-        db_request.find_service = lambda svc: storage_service
+        db_request.find_service = lambda svc, name=None: storage_service
 
         resp = legacy.file_upload(db_request)
 

--- a/tests/unit/packaging/test_init.py
+++ b/tests/unit/packaging/test_init.py
@@ -34,11 +34,12 @@ def test_includme(monkeypatch, with_trending):
     config = pretend.stub(
         maybe_dotted=lambda dotted: storage_class,
         register_service_factory=pretend.call_recorder(
-            lambda factory, iface: None,
+            lambda factory, iface, name=None: None,
         ),
         registry=pretend.stub(
             settings={
                 "files.backend": "foo.bar",
+                "docs.backend": "wu.tang",
             },
         ),
         register_origin_cache_keys=pretend.call_recorder(lambda c, **kw: None),
@@ -50,7 +51,8 @@ def test_includme(monkeypatch, with_trending):
     packaging.includeme(config)
 
     assert config.register_service_factory.calls == [
-        pretend.call(storage_class.create_service, IFileStorage),
+        pretend.call(storage_class.create_service, IFileStorage, name='files'),
+        pretend.call(storage_class.create_service, IFileStorage, name='docs'),
     ]
     assert config.register_origin_cache_keys.calls == [
         pretend.call(

--- a/tests/unit/test_routes.py
+++ b/tests/unit/test_routes.py
@@ -169,6 +169,13 @@ def test_routes(warehouse):
             domain=warehouse,
         ),
         pretend.call(
+            "manage.project.destroy_docs",
+            "/manage/project/{project_name}/delete_project_docs/",
+            factory="warehouse.packaging.models:ProjectFactory",
+            traverse="/{project_name}",
+            domain=warehouse,
+        ),
+        pretend.call(
             "manage.project.releases",
             "/manage/project/{project_name}/releases/",
             factory="warehouse.packaging.models:ProjectFactory",
@@ -199,6 +206,13 @@ def test_routes(warehouse):
         pretend.call(
             "manage.project.delete_role",
             "/manage/project/{project_name}/collaboration/delete/",
+            factory="warehouse.packaging.models:ProjectFactory",
+            traverse="/{project_name}",
+            domain=warehouse,
+        ),
+        pretend.call(
+            "manage.project.documentation",
+            "/manage/project/{project_name}/documentation/",
             factory="warehouse.packaging.models:ProjectFactory",
             traverse="/{project_name}",
             domain=warehouse,

--- a/warehouse/config.py
+++ b/warehouse/config.py
@@ -192,6 +192,7 @@ def configure(settings=None):
         default=21600,  # 6 hours
     )
     maybe_set_compound(settings, "files", "backend", "FILES_BACKEND")
+    maybe_set_compound(settings, "docs", "backend", "DOCS_BACKEND")
     maybe_set_compound(settings, "origin_cache", "backend", "ORIGIN_CACHE")
 
     # Add the settings we use when the environment is set to development.

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -1216,7 +1216,7 @@ def file_upload(request):
         #       this won't take affect until after a commit has happened, for
         #       now we'll just ignore it and save it before the transaction is
         #       committed.
-        storage = request.find_service(IFileStorage)
+        storage = request.find_service(IFileStorage, name='files')
         storage.store(
             file_.path,
             os.path.join(tmpdir, filename),

--- a/warehouse/manage/views.py
+++ b/warehouse/manage/views.py
@@ -31,7 +31,11 @@ from warehouse.manage.forms import (
     SaveAccountForm,
 )
 from warehouse.packaging.models import File, JournalEntry, Project, Role
-from warehouse.utils.project import confirm_project, remove_project
+from warehouse.utils.project import (
+    confirm_project,
+    destroy_docs,
+    remove_project,
+)
 
 
 @view_defaults(
@@ -356,6 +360,24 @@ def delete_project(project, request):
     remove_project(project, request)
 
     return HTTPSeeOther(request.route_path('manage.projects'))
+
+
+@view_config(
+    route_name="manage.project.destroy_docs",
+    uses_session=True,
+    require_methods=["POST"],
+    permission="manage",
+)
+def destroy_project_docs(project, request):
+    confirm_project(project, request, fail_route="manage.project.settings")
+    destroy_docs(project, request)
+
+    return HTTPSeeOther(
+        request.route_path(
+            'manage.project.documentation',
+            project_name=project.normalized_name,
+        )
+    )
 
 
 @view_config(
@@ -756,4 +778,16 @@ def manage_project_history(project, request):
     return {
         'project': project,
         'journals': journals,
+    }
+
+
+@view_config(
+    route_name="manage.project.documentation",
+    renderer="manage/documentation.html",
+    uses_session=True,
+    permission="manage",
+)
+def manage_project_documentation(project, request):
+    return {
+        'project': project,
     }

--- a/warehouse/manage/views.py
+++ b/warehouse/manage/views.py
@@ -369,7 +369,9 @@ def delete_project(project, request):
     permission="manage",
 )
 def destroy_project_docs(project, request):
-    confirm_project(project, request, fail_route="manage.project.settings")
+    confirm_project(
+        project, request, fail_route="manage.project.documentation"
+    )
     destroy_docs(project, request)
 
     return HTTPSeeOther(

--- a/warehouse/packaging/__init__.py
+++ b/warehouse/packaging/__init__.py
@@ -39,12 +39,16 @@ def includeme(config):
     files_storage_class = config.maybe_dotted(
         config.registry.settings["files.backend"],
     )
-    config.register_service_factory(files_storage_class.create_service, IFileStorage, name='files')
+    config.register_service_factory(
+        files_storage_class.create_service, IFileStorage, name='files'
+    )
 
     docs_storage_class = config.maybe_dotted(
         config.registry.settings["docs.backend"],
     )
-    config.register_service_factory(docs_storage_class.create_service, IFileStorage, name='docs')
+    config.register_service_factory(
+        docs_storage_class.create_service, IFileStorage, name='docs'
+    )
 
     # Register our origin cache keys
     config.register_origin_cache_keys(

--- a/warehouse/packaging/__init__.py
+++ b/warehouse/packaging/__init__.py
@@ -36,10 +36,15 @@ def email_primary_receive_set(config, target, value, oldvalue, initiator):
 def includeme(config):
     # Register whatever file storage backend has been configured for storing
     # our package files.
-    storage_class = config.maybe_dotted(
+    files_storage_class = config.maybe_dotted(
         config.registry.settings["files.backend"],
     )
-    config.register_service_factory(storage_class.create_service, IFileStorage)
+    config.register_service_factory(files_storage_class.create_service, IFileStorage, name='files')
+
+    docs_storage_class = config.maybe_dotted(
+        config.registry.settings["docs.backend"],
+    )
+    config.register_service_factory(docs_storage_class.create_service, IFileStorage, name='docs')
 
     # Register our origin cache keys
     config.register_origin_cache_keys(

--- a/warehouse/packaging/interfaces.py
+++ b/warehouse/packaging/interfaces.py
@@ -33,3 +33,8 @@ class IFileStorage(Interface):
         specified by path. An additional meta keyword argument may contain
         extra information that an implementation may or may not store.
         """
+
+    def remove_by_prefix(prefix):
+        """
+        Remove all files matching the given prefix.
+        """

--- a/warehouse/routes.py
+++ b/warehouse/routes.py
@@ -135,6 +135,13 @@ def includeme(config):
         domain=warehouse,
     )
     config.add_route(
+        "manage.project.destroy_docs",
+        "/manage/project/{project_name}/delete_project_docs/",
+        factory="warehouse.packaging.models:ProjectFactory",
+        traverse="/{project_name}",
+        domain=warehouse,
+    )
+    config.add_route(
         "manage.project.releases",
         "/manage/project/{project_name}/releases/",
         factory="warehouse.packaging.models:ProjectFactory",
@@ -165,6 +172,13 @@ def includeme(config):
     config.add_route(
         "manage.project.delete_role",
         "/manage/project/{project_name}/collaboration/delete/",
+        factory="warehouse.packaging.models:ProjectFactory",
+        traverse="/{project_name}",
+        domain=warehouse,
+    )
+    config.add_route(
+        "manage.project.documentation",
+        "/manage/project/{project_name}/documentation/",
         factory="warehouse.packaging.models:ProjectFactory",
         traverse="/{project_name}",
         domain=warehouse,

--- a/warehouse/templates/includes/manage/manage-project-menu.html
+++ b/warehouse/templates/includes/manage/manage-project-menu.html
@@ -24,6 +24,11 @@
     <i class="fa fa-history" aria-hidden="true"></i>
     History
   </a>
+  {% if project.has_docs %}
+  <a href="{{ request.route_path('manage.project.documentation', project_name=project.normalized_name)}}" class="vertical-tabs__tab vertical-tabs__tab--with-icon {% if active_tab == 'documentation' %}vertical-tabs__tab--is-active{% endif %} {% if mode == 'mobile' %}vertical-tabs__tab--mobile{% endif %}"> <i class="fa fa-book" aria-hidden="true"></i>
+    Documentation
+  </a>
+  {% endif %}
   <a href="{{ request.route_path('manage.project.settings', project_name=project.normalized_name)}}" class="vertical-tabs__tab vertical-tabs__tab--with-icon {% if active_tab == 'settings' %}vertical-tabs__tab--is-active{% endif %} {% if mode == 'mobile' %}vertical-tabs__tab--mobile{% endif %}">
     <i class="fa fa-wrench" aria-hidden="true"></i>
     Settings

--- a/warehouse/templates/manage/documentation.html
+++ b/warehouse/templates/manage/documentation.html
@@ -1,0 +1,47 @@
+{#
+ # Licensed under the Apache License, Version 2.0 (the "License");
+ # you may not use this file except in compliance with the License.
+ # You may obtain a copy of the License at
+ #
+ # http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+-#}
+{% extends "manage_project_base.html" %}
+
+{% set active_tab = 'documentation' %}
+
+{% block title %}Manage '{{ project.name }}' documentation{% endblock %}
+
+{% block main %}
+  <h2>Documentation</h2>
+
+  {% if project.has_docs %}
+  <div class="callout-block callout-block--danger">
+    <h3>Destroy Documentation</h3>
+    <p>
+      <i class="fa fa-warning" aria-hidden="true"><span class="sr-only">Warning</span></i>
+      If you would like to DESTROY any existing documentation hosted at
+      <a href="{{ project.documentation_url}}">
+          {{ project.documentation_url }}
+      </a>
+    </p>
+    <p>
+      There is <b>no</b> undo as uploading new documentaiton is no longer supported.
+    </p>
+    {% set action = request.route_path('manage.project.destroy_docs', project_name=project.normalized_name) %}
+    {{ confirm_button("Destroy Documentation for project", "Project name", project.normalized_name, action=action) }}
+  </div>
+  {% else %}
+  <div class="callout-block callout-block--info">
+    <h3>Project Documentation</h3>
+    <p>
+      Uploading new documentation is no longer supported.
+    </p>
+  </div>
+  {% endif %}
+{% endblock %}

--- a/warehouse/templates/manage/settings.html
+++ b/warehouse/templates/manage/settings.html
@@ -33,7 +33,6 @@
     </p>
   </div>
 
-
   <div class="callout-block callout-block--danger">
     <h3>Delete Project</h3>
     <p>

--- a/warehouse/utils/project.py
+++ b/warehouse/utils/project.py
@@ -88,8 +88,6 @@ def destroy_docs(project, request, flash=True):
     request.task(remove_documentation).delay(project.name)
 
     project.has_docs = False
-    # Flush so we can repeat this multiple times if necessary
-    request.db.flush()
 
     if flash:
         request.session.flash(

--- a/warehouse/utils/project.py
+++ b/warehouse/utils/project.py
@@ -61,3 +61,24 @@ def remove_project(project, request, flash=True):
             f"Successfully deleted the project {project.name!r}.",
             queue="success",
         )
+
+
+def destroy_docs(project, request, flash=True):
+    request.db.add(
+        JournalEntry(
+            name=project.name,
+            action="docdestroy",
+            submitted_by=request.user,
+            submitted_from=request.remote_addr,
+        )
+    )
+
+    project.has_docs = False
+    # Flush so we can repeat this multiple times if necessary
+    request.db.flush()
+
+    if flash:
+        request.session.flash(
+            f"Successfully deleted docs for project {project.name!r}.",
+            queue="success",
+        )


### PR DESCRIPTION
Resolves #582 

Only displays admin tab for projects which have documentation on pythonhosted.org

I'm going to spot check the bucket and our DB and make sure it's in sync before we deploy

~~Requires new configuration~~ New configuration added:

## test.pypi.org
```
DOCS_BACKEND=warehouse.packaging.services.S3FileStorage bucket=pypi-docs-staging
```

## pypi.org
```
DOCS_BACKEND=warehouse.packaging.services.S3FileStorage bucket=pypi-docs
```