### PR TITLE
Confirm your username instead of the username

### DIFF
--- a/warehouse/templates/manage/manage_base.html
+++ b/warehouse/templates/manage/manage_base.html
@@ -58,7 +58,7 @@
 {% macro modal_slug(title, index) %}
 {% endmacro %}
 
-{% macro confirm_modal(title, confirm_name, confirm_string, slug, index=None, extra_fields=None, action=None) %}
+{% macro confirm_modal(title, confirm_name, confirm_string, slug, context, index=None, extra_fields=None, action=None) %}
   <div id="{{ slug }}" class="modal" data-controller="confirm">
     <div class="modal__content" role="dialog">
       <form method="POST" class="modal__form" action="{{ action or request.current_route_path() }}">
@@ -76,7 +76,8 @@
             This action cannot be undone!
           </p>
         </div>
-        <p>Confirm the {{ confirm_name|lower }} to continue.</p>
+        {% set context = 'your' if confirm_name.lower() == 'username' else 'the' %}
+        <p>Confirm {{ context }} {{ confirm_name|lower }} to continue.</p>
         {% set name = "confirm_" + confirm_name.lower().replace(' ', '_') %}
         <label for="{{ name }}">{{ confirm_name }}</label>
         <input name="{{ name }}" data-action="input->confirm#check" data-target="confirm.input" type="text" placeholder="{{ confirm_string }}" autocomplete="off" autocorrect="off" autocapitalize="off">


### PR DESCRIPTION
In reference to #3198:

![mar-25-2018 16-53-38 your_the](https://user-images.githubusercontent.com/29470576/37879902-fca45f88-304d-11e8-8f17-b491af7837b1.gif)

Let me know if there is anything other then those instances to change, other then only the or your