### PR TITLE
Add timeout for placing warning message on top (#3380)

### DIFF
--- a/warehouse/static/js/warehouse/controllers/notification_controller.js
+++ b/warehouse/static/js/warehouse/controllers/notification_controller.js
@@ -12,6 +12,7 @@
  * limitations under the License.
  */
 import { Controller } from "stimulus";
+import positionWarning from "../utils/position-warning";
 
 export default class extends Controller {
   static targets = ["notification", "notificationDismiss"];
@@ -33,10 +34,6 @@ export default class extends Controller {
     }
   }
 
-  get isSticky() {
-    return this.notificationTarget.parentNode.classList.contains("js-stick-to-top");
-  }
-
   initialize() {
     const notificationId = this._getNotificationId();
     const isDismissable = this.notificationTarget.classList.contains("notification-bar--dismissable");
@@ -55,9 +52,6 @@ export default class extends Controller {
       localStorage.setItem(notificationId, 1);
     }
     this.notificationTarget.classList.remove("notification-bar--visible");
-    if (this.isSticky) {
-      let bodyElement = document.querySelector("body");
-      bodyElement.style.paddingTop = "0px";
-    }
+    positionWarning();
   }
 }

--- a/warehouse/static/js/warehouse/controllers/notification_controller.js
+++ b/warehouse/static/js/warehouse/controllers/notification_controller.js
@@ -33,6 +33,10 @@ export default class extends Controller {
     }
   }
 
+  get isSticky() {
+    return this.notificationTarget.parentNode.classList.contains("js-stick-to-top");
+  }
+
   initialize() {
     const notificationId = this._getNotificationId();
     const isDismissable = this.notificationTarget.classList.contains("notification-bar--dismissable");
@@ -51,5 +55,9 @@ export default class extends Controller {
       localStorage.setItem(notificationId, 1);
     }
     this.notificationTarget.classList.remove("notification-bar--visible");
+    if (this.isSticky) {
+      let bodyElement = document.querySelector("body");
+      bodyElement.style.paddingTop = "0px";
+    }
   }
 }

--- a/warehouse/static/js/warehouse/index.js
+++ b/warehouse/static/js/warehouse/index.js
@@ -105,7 +105,9 @@ docReady(() => {
 });
 
 // Position sticky bar
-docReady(PositionWarning);
+docReady(() => {
+  setTimeout(PositionWarning, 200);
+});
 
 docReady(() => {
   let resizeTimer;


### PR DESCRIPTION
Fixes #3380 

![preprod_warning](https://user-images.githubusercontent.com/6739793/37904968-479ad6fa-30f5-11e8-8363-4a1f9e74443e.gif)

Disclaimer: I didn't hack the private repo, just copied and pasted the content into `warning-banner.html` 😅 