### PR TITLE
Show more button on home page implementation

### DIFF
--- a/warehouse/static/js/warehouse/controllers/increment_controller.js
+++ b/warehouse/static/js/warehouse/controllers/increment_controller.js
@@ -1,0 +1,61 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Controller } from "stimulus";
+import $ from "jquery";
+
+export default class extends Controller {
+  static targets = ["button"];
+
+  constructor() {
+    super();
+    this.trending_projects_visible = 5;
+    this.latest_releases_visible = 5;
+  }
+  addFiveTrending() {
+    const trendingElements = document.getElementsByClassName(
+      "hide-by-index-trending"
+    );
+    let j = this.trending_projects_visible;
+    const end = (this.trending_projects_visible += 5);
+    if (this.trending_projects_visible <= 20) {
+      for (; j < end; j++) {
+        if (trendingElements[j]) {
+          trendingElements[j].style.display = "block";
+        }
+      }
+      console.log(end);
+      if (end === 20) {
+        document.getElementById("increment-button-trending").style.display = "none";
+      }
+    }
+  }
+  addFiveLatest() {
+    const latestElements = document.getElementsByClassName(
+      "hide-by-index-latest"
+    );
+    let j = this.latest_releases_visible;
+    const end = (this.latest_releases_visible += 5);
+    if (this.latest_releases_visible <= 20) {
+      for (; j < end; j++) {
+        if (latestElements[j]) {
+          latestElements[j].style.display = "block";
+        }
+      }
+    }
+    console.log(end);
+    if (end === 20) {
+      document.getElementById("increment-button-latest").style.display = "none";
+    }
+  }
+}

--- a/warehouse/static/js/warehouse/controllers/increment_controller.js
+++ b/warehouse/static/js/warehouse/controllers/increment_controller.js
@@ -12,50 +12,36 @@
  * limitations under the License.
  */
 import { Controller } from "stimulus";
-import $ from "jquery";
 
 export default class extends Controller {
   static targets = ["button"];
 
+  // initially set default to 5 projects visible
   constructor() {
     super();
-    this.trending_projects_visible = 5;
-    this.latest_releases_visible = 5;
+    this.trending_visible = 5;
+    this.latest_visible = 5;
   }
-  addFiveTrending() {
-    const trendingElements = document.getElementsByClassName(
-      "hide-by-index-trending"
+  // Increase amount visible during each click event of Show More button
+  addFive(e) {
+    const eventType = e.target.value;
+    const elements = document.getElementsByClassName(
+      `hide-by-index-${eventType}`
     );
-    let j = this.trending_projects_visible;
-    const end = (this.trending_projects_visible += 5);
-    if (this.trending_projects_visible <= 20) {
+    // j is previous amount visible, end is how many will be
+    let j = this[`${eventType}_visible`];
+    const end = (this[`${eventType}_visible`] += 5);
+    if (end <= 20) {
       for (; j < end; j++) {
-        if (trendingElements[j]) {
-          trendingElements[j].style.display = "block";
+        if (elements[j]) {
+          elements[j].style.display = "block";
         }
       }
-      console.log(end);
+      // Hide Show More button when max amount is visible
       if (end === 20) {
-        document.getElementById("increment-button-trending").style.display = "none";
+        document.getElementById(`increment-button-${eventType}`).style.display =
+          "none";
       }
-    }
-  }
-  addFiveLatest() {
-    const latestElements = document.getElementsByClassName(
-      "hide-by-index-latest"
-    );
-    let j = this.latest_releases_visible;
-    const end = (this.latest_releases_visible += 5);
-    if (this.latest_releases_visible <= 20) {
-      for (; j < end; j++) {
-        if (latestElements[j]) {
-          latestElements[j].style.display = "block";
-        }
-      }
-    }
-    console.log(end);
-    if (end === 20) {
-      document.getElementById("increment-button-latest").style.display = "none";
     }
   }
 }

--- a/warehouse/static/js/warehouse/index.js
+++ b/warehouse/static/js/warehouse/index.js
@@ -57,6 +57,28 @@ docReady(() => {
 // Kick off the client side HTML includes.
 docReady(HTMLInclude);
 
+docReady(() => {
+  const trendingElements = document.getElementsByClassName(
+    "hide-by-index-trending"
+  );
+  const latestElements = document.getElementsByClassName(
+    "hide-by-index-latest"
+  );
+  let i = 0;
+  for (; i < 5; i++) {
+    trendingElements[i].style.display = "block";
+    latestElements[i].style.display = "block";
+  }
+  for (; i <= 20; i++) {
+    if (trendingElements[i]) {
+      trendingElements[i].style.display = "none";
+    }
+    if (latestElements[i]) {
+      latestElements[i].style.display = "none";
+    }
+  }
+});
+
 // Trigger our analytics code.
 docReady(Analytics);
 

--- a/warehouse/static/js/warehouse/index.js
+++ b/warehouse/static/js/warehouse/index.js
@@ -37,6 +37,7 @@ import timeAgo from "warehouse/utils/timeago";
 import projectTabs from "warehouse/utils/project-tabs";
 import searchFilterToggle from "warehouse/utils/search-filter-toggle";
 import YouTubeIframeLoader from "youtube-iframe";
+import showMoreInitial from "warehouse/utils/show-more-initial";
 
 // Human-readable timestamps for project histories
 docReady(() => {
@@ -57,27 +58,7 @@ docReady(() => {
 // Kick off the client side HTML includes.
 docReady(HTMLInclude);
 
-docReady(() => {
-  const trendingElements = document.getElementsByClassName(
-    "hide-by-index-trending"
-  );
-  const latestElements = document.getElementsByClassName(
-    "hide-by-index-latest"
-  );
-  let i = 0;
-  for (; i < 5; i++) {
-    trendingElements[i].style.display = "block";
-    latestElements[i].style.display = "block";
-  }
-  for (; i <= 20; i++) {
-    if (trendingElements[i]) {
-      trendingElements[i].style.display = "none";
-    }
-    if (latestElements[i]) {
-      latestElements[i].style.display = "none";
-    }
-  }
-});
+docReady(showMoreInitial);
 
 // Trigger our analytics code.
 docReady(Analytics);

--- a/warehouse/static/js/warehouse/utils/show-more-initial.js
+++ b/warehouse/static/js/warehouse/utils/show-more-initial.js
@@ -1,0 +1,31 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export default () => {
+  const trendingElements = document.getElementsByClassName(
+    "hide-by-index-trending"
+  );
+  const latestElements = document.getElementsByClassName(
+    "hide-by-index-latest"
+  );
+  // Hide all elements beyond 5 initially
+  for (let i = 5; i <= 20; i++) {
+    // ATM, with mock data? There are someimtes only 19 trending projects
+    if (trendingElements[i]) {
+      trendingElements[i].style.display = "none";
+    }
+    if (latestElements[i]) {
+      latestElements[i].style.display = "none";
+    }
+  }
+};

--- a/warehouse/static/sass/blocks/_package-snippet.scss
+++ b/warehouse/static/sass/blocks/_package-snippet.scss
@@ -24,6 +24,10 @@
   </div>
 */
 
+.package-snippet.hide-by-index-latest .package-snippet.hide-by-index-trending {
+  display: none;
+}
+
 .package-snippet {
   @include card;
   padding: ($spacing-unit / 2) 20px ($spacing-unit / 2) 75px;
@@ -39,7 +43,6 @@
     padding: 10px;
     background-image: none;
   }
-
   &__title {
     @include ellipsis;
     @include h3;

--- a/warehouse/static/sass/blocks/_package-snippet.scss
+++ b/warehouse/static/sass/blocks/_package-snippet.scss
@@ -24,10 +24,6 @@
   </div>
 */
 
-.package-snippet.hide-by-index-latest .package-snippet.hide-by-index-trending {
-  display: none;
-}
-
 .package-snippet {
   @include card;
   padding: ($spacing-unit / 2) 20px ($spacing-unit / 2) 75px;
@@ -43,6 +39,7 @@
     padding: 10px;
     background-image: none;
   }
+  
   &__title {
     @include ellipsis;
     @include h3;

--- a/warehouse/templates/index.html
+++ b/warehouse/templates/index.html
@@ -15,13 +15,28 @@
 
 {% block title %}PyPI - the Python Package Index{% endblock %}
 
-{% macro project_snippet(release) -%}
-<div class="package-snippet">
+{% set trending_projects_visible = namespace(amount=20) %}
+{% set latest_releases_visible = namespace(amount=20) %}
+
+{% macro project_snippet_latest(release, summary, index) -%}
+<div class='package-snippet hide-by-index-latest'>
   <h3 class="package-snippet__title">
     <a href="{{ request.route_path('packaging.project', name=release.project.normalized_name) }}">{{ release.project.name }}</a>
     <span class="package-snippet__version">{{ release.version }}</span>
   </h3>
-  <p class="package-snippet__description">{{ release.summary }}</p>
+  {% set summary = release.summary if release.summary else "No description provided" %}
+  <p class="package-snippet__description">{{ summary }}</p>
+</div>
+{%- endmacro %}
+
+{% macro project_snippet_trending(release, summary, index) -%}
+<div style="display:'none'" class='package-snippet hide-by-index-trending'>
+  <h3 class="package-snippet__title">
+    <a href="{{ request.route_path('packaging.project', name=release.project.normalized_name) }}">{{ release.project.name }}</a>
+    <span class="package-snippet__version">{{ release.version }}</span>
+  </h3>
+  {% set summary = release.summary if release.summary else "No description provided" %}
+  <p class="package-snippet__description">{{ summary }}</p>
 </div>
 {%- endmacro %}
 
@@ -84,21 +99,23 @@
   </div>
 </section>
 
-<section class="horizontal-section horizontal-section--grey">
-  <div class="site-container">
+<section class="horizontal-section horizontal-section--grey" data-controller="increment">
+  <div class="site-container" >
     <div class="col-half">
       <div class="heading-wsubtitle">
         <h2 class="heading-wsubtitle__heading">Trending Projects</h2>
         <p class="heading-wsubtitle__subtitle">Trending projects as downloaded by the community</p>
       </div>
       <div class="package-list">
+        {% set counter = namespace(idx=0) %}
         {% for release in trending_projects %}
-          {{ project_snippet(release) }}
+          {% if counter.idx < trending_projects_visible.amount %}
+            {{ project_snippet_trending(release, release.summary, counter.idx) }}
+            {% set counter.idx = counter.idx + 1 %}
+          {% endif %}
         {% endfor %}
       </div>
-      {#
-      <a class="button" href="TODO">Show More</a>
-      #}
+      <button id="increment-button-trending" class="button" type="button" data-action="click->increment#addFiveTrending" data-target="increment.button">Show More</button>
     </div>
     <div class="col-half">
       <div class="heading-wsubtitle">
@@ -106,13 +123,15 @@
         <p class="heading-wsubtitle__subtitle">Hot off the press: the newest project releases</p>
       </div>
       <div class="package-list">
+        {% set counter = namespace(idx=0) %}
         {% for release in latest_releases %}
-          {{ project_snippet(release) }}
+          {% if counter.idx < latest_releases_visible.amount %}
+            {{ project_snippet_latest(release, release.summary, counter.idx) }}
+            {% set counter.idx = counter.idx + 1 %}
+          {% endif %}
         {% endfor %}
       </div>
-      {#
-      <a class="button" href="TODO">Show More</a>
-      #}
+      <button id="increment-button-latest" class="button" data-action="click->increment#addFiveLatest" data-target="increment.button">Show More</button>
     </div>
   </div>
 </section>

--- a/warehouse/templates/index.html
+++ b/warehouse/templates/index.html
@@ -15,29 +15,27 @@
 
 {% block title %}PyPI - the Python Package Index{% endblock %}
 
-{% set trending_projects_visible = namespace(amount=20) %}
-{% set latest_releases_visible = namespace(amount=20) %}
+{% set trending_projects_visible = namespace(total=20) %}
+{% set latest_releases_visible = namespace(total=20) %}
 
 {% macro project_snippet_latest(release, summary, index) -%}
 <div class='package-snippet hide-by-index-latest'>
-  <h3 class="package-snippet__title">
-    <a href="{{ request.route_path('packaging.project', name=release.project.normalized_name) }}">{{ release.project.name }}</a>
-    <span class="package-snippet__version">{{ release.version }}</span>
-  </h3>
-  {% set summary = release.summary if release.summary else "No description provided" %}
-  <p class="package-snippet__description">{{ summary }}</p>
+  {{ project_snippet(release, summary, index)}}
+</div>
+{%- endmacro %}
+{% macro project_snippet_trending(release, summary, index) -%}
+<div class='package-snippet hide-by-index-trending'>
+  {{ project_snippet(release, summary, index)}}
 </div>
 {%- endmacro %}
 
-{% macro project_snippet_trending(release, summary, index) -%}
-<div style="display:'none'" class='package-snippet hide-by-index-trending'>
-  <h3 class="package-snippet__title">
+{% macro project_snippet(release, summary, index) -%}
+<h3 class="package-snippet__title">
     <a href="{{ request.route_path('packaging.project', name=release.project.normalized_name) }}">{{ release.project.name }}</a>
     <span class="package-snippet__version">{{ release.version }}</span>
   </h3>
   {% set summary = release.summary if release.summary else "No description provided" %}
   <p class="package-snippet__description">{{ summary }}</p>
-</div>
 {%- endmacro %}
 
 
@@ -106,32 +104,32 @@
         <h2 class="heading-wsubtitle__heading">Trending Projects</h2>
         <p class="heading-wsubtitle__subtitle">Trending projects as downloaded by the community</p>
       </div>
-      <div class="package-list">
-        {% set counter = namespace(idx=0) %}
+      <div class="package-list-timeout">
+        {% set current = namespace(amount_to_show=0) %}
         {% for release in trending_projects %}
-          {% if counter.idx < trending_projects_visible.amount %}
-            {{ project_snippet_trending(release, release.summary, counter.idx) }}
-            {% set counter.idx = counter.idx + 1 %}
+          {% if current.amount_to_show < trending_projects_visible.total %}
+            {{ project_snippet_trending(release, release.summary, current.amount_to_show) }}
+            {% set current.amount_to_show = current.amount_to_show + 1 %}
           {% endif %}
         {% endfor %}
       </div>
-      <button id="increment-button-trending" class="button" type="button" data-action="click->increment#addFiveTrending" data-target="increment.button">Show More</button>
+      <button id="increment-button-trending" class="button" type="button" value="trending" data-action="click->increment#addFive">Show More</button>
     </div>
     <div class="col-half">
       <div class="heading-wsubtitle">
         <h2 class="heading-wsubtitle__heading">New Releases</h2>
         <p class="heading-wsubtitle__subtitle">Hot off the press: the newest project releases</p>
       </div>
-      <div class="package-list">
-        {% set counter = namespace(idx=0) %}
+      <div class="package-list-timeout">
+        {% set current = namespace(amount_to_show=0) %}
         {% for release in latest_releases %}
-          {% if counter.idx < latest_releases_visible.amount %}
-            {{ project_snippet_latest(release, release.summary, counter.idx) }}
-            {% set counter.idx = counter.idx + 1 %}
+          {% if current.amount_to_show < latest_releases_visible.total %}
+            {{ project_snippet_latest(release, release.summary, current.amount_to_show) }}
+            {% set current.amount_to_show = current.amount_to_show + 1 %}
           {% endif %}
         {% endfor %}
       </div>
-      <button id="increment-button-latest" class="button" data-action="click->increment#addFiveLatest" data-target="increment.button">Show More</button>
+      <button id="increment-button-latest" class="button" value="latest" data-action="click->increment#addFive">Show More</button>
     </div>
   </div>
 </section>

--- a/warehouse/views.py
+++ b/warehouse/views.py
@@ -185,7 +185,7 @@ def index(request):
             request.db.query(Project.name)
                    .order_by(Project.zscore.desc().nullslast(),
                              func.random())
-                   .limit(5)
+                   .limit(20)
                    .all())
     ]
     release_a = aliased(
@@ -209,7 +209,7 @@ def index(request):
         request.db.query(Release)
                   .options(joinedload(Release.project))
                   .order_by(Release.created.desc())
-                  .limit(5)
+                  .limit(20)
                   .all()
     )
 


### PR DESCRIPTION
Hi, in reference to #1303. This is what I did:

![pypi_issue_1303](https://user-images.githubusercontent.com/29470576/37924523-1d214160-3100-11e8-8239-288d6bf9d3c8.gif)

Some things to mention: 
- If you look at the video you'll notice that there is sometimes this gimicky behaviour when I reload quickly. I tried a handful of ways to fix this but think the only real way is inline styling, setting `display:none` automatically when the package box is created but that is not allowed. This or something can be done in python in which case I have no clue where to even begin.
- I added this little bit of logic: `{% set summary = release.summary if release.summary else "No description provided" %}` to get rid of the creation of an empty paragraph element that caused the boxes being even which you'll notice exists in the issue image.
- Last, basically all these frameworks are new to me so I am not sure if I am doing best practices.

Thanks!
