### PR TITLE
Add project.last_serial to simple.detail and legacy.api.json routes

### DIFF
--- a/tests/unit/legacy/api/test_json.py
+++ b/tests/unit/legacy/api/test_json.py
@@ -210,7 +210,6 @@ class TestJSONRelease:
                 "requires_python": None,
                 "summary": None,
                 "version": "2.0",
-                "last_serial": je.id,
             },
             "releases": {
                 "1.0": [
@@ -275,4 +274,5 @@ class TestJSONRelease:
                     "url": "/the/fake/url/",
                 },
             ],
+            "last_serial": je.id,
         }

--- a/tests/unit/legacy/api/test_json.py
+++ b/tests/unit/legacy/api/test_json.py
@@ -210,6 +210,7 @@ class TestJSONRelease:
                 "requires_python": None,
                 "summary": None,
                 "version": "2.0",
+                "last_serial": je.id,
             },
             "releases": {
                 "1.0": [

--- a/warehouse/legacy/api/json.py
+++ b/warehouse/legacy/api/json.py
@@ -186,6 +186,7 @@ def json_release(release, request):
             "bugtrack_url": project.bugtrack_url,
             "home_page": release.home_page,
             "download_url": release.download_url,
+            "last_serial": project.last_serial,
         },
         "urls": releases[release.version],
         "releases": releases,

--- a/warehouse/legacy/api/json.py
+++ b/warehouse/legacy/api/json.py
@@ -186,8 +186,8 @@ def json_release(release, request):
             "bugtrack_url": project.bugtrack_url,
             "home_page": release.home_page,
             "download_url": release.download_url,
-            "last_serial": project.last_serial,
         },
         "urls": releases[release.version],
         "releases": releases,
+        "last_serial": project.last_serial,
     }

--- a/warehouse/templates/legacy/api/simple/detail.html
+++ b/warehouse/templates/legacy/api/simple/detail.html
@@ -23,3 +23,4 @@
     {% endfor -%}
   </body>
 </html>
+<!--SERIAL {{ project.last_serial }}-->


### PR DESCRIPTION
This adds the project's latest serial to `/simple/<project_name>/` and `/pypi/<project_name>/json`.

As Warehouse uses Fastly Soft Purges, we need to tweak the ETag in order to notify the CDN that the page has changed. Currently the CDN performs a conditional GET in order to decide if it needs to pull refreshed content, and since the contents of these pages don't change for maintainer and role updates it skips purging them.

This is primarily a concern for clients like bandersnatch which use the X-PyPI-Last-Serial header to determine if they're getting the latest goods.