### PR TITLE
WIP: End to end tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ warehouse/static/dist
 warehouse/admin/static/dist
 
 tags
+selenium-report

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,7 @@ matrix:
     - script: make tests_e2e BINDIR="$(dirname $(which python))"
       env:
         - SUITE=End2end
+      install: []
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ matrix:
     - script: make licenses BINDIR="$(dirname $(which python))"
       env:
         - SUITE=Licenses
-    - script: make tests_e2e BINDIR="$(dirname $(which python))"
+    - script: make mindb && make tests_e2e BINDIR="$(dirname $(which python))"
       env:
         - SUITE=End2end
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ matrix:
     - script: make licenses BINDIR="$(dirname $(which python))"
       env:
         - SUITE=Licenses
-    - script: make mindb && make tests_e2e BINDIR="$(dirname $(which python))"
+    - script: make tests_e2e BINDIR="$(dirname $(which python))"
       env:
         - SUITE=End2end
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,9 @@ matrix:
     - script: make licenses BINDIR="$(dirname $(which python))"
       env:
         - SUITE=Licenses
+    - script: make tests_e2e BINDIR="$(dirname $(which python))"
+      env:
+        - SUITE=End2end
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/Makefile
+++ b/Makefile
@@ -95,8 +95,8 @@ tests:
 								  PATH="/opt/warehouse/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
 								  bin/tests --postgresql-host db $(T) $(TESTARGS)
 
-tests_e2e: .state/docker-build
-	docker-compose up -d
+tests_e2e:
+	docker-compose up -d --build
 	$(MAKE) mindb
 	docker-compose run --rm tests env -i ENCODING="C.UTF-8" \
 								PATH="/opt/warehouse/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \

--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,7 @@ build:
 	docker-compose build --build-arg IPYTHON=$(IPYTHON) web
 	docker-compose build worker
 	docker-compose build static
+	docker-compose build tests
 
 	# Mark this state so that the other target will known it's recently been
 	# rebuilt.
@@ -93,6 +94,11 @@ tests:
 	docker-compose run --rm web env -i ENCODING="C.UTF-8" \
 								  PATH="/opt/warehouse/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
 								  bin/tests --postgresql-host db $(T) $(TESTARGS)
+
+tests_e2e: .state/docker-build
+	docker-compose run --rm tests env -i ENCODING="C.UTF-8" \
+								PATH="/opt/warehouse/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
+								bin/tests-e2e --postgresql-host db $(T) $(TESTARGS)
 
 lint: .state/env/pyvenv.cfg
 	$(BINDIR)/flake8 .

--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,9 @@ tests:
 								  PATH="/opt/warehouse/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
 								  bin/tests --postgresql-host db $(T) $(TESTARGS)
 
-tests_e2e: .state/docker-build mindb
+tests_e2e: .state/docker-build
+	docker-compose up -d
+	$(MAKE) mindb
 	docker-compose run --rm tests env -i ENCODING="C.UTF-8" \
 								PATH="/opt/warehouse/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
 								bin/tests-e2e --postgresql-host db $(T) $(TESTARGS)
@@ -143,7 +145,7 @@ createdb:
 	docker-compose run --rm web psql -h db -d postgres -U postgres -c "DROP DATABASE IF EXISTS warehouse"
 	docker-compose run --rm web psql -h db -d postgres -U postgres -c "CREATE DATABASE warehouse ENCODING 'UTF8'"
 
-initdb: createdb
+initdb:
 	xz -d -k dev/$(DB).sql.xz
 	docker-compose run --rm web psql -h db -d warehouse -U postgres -v ON_ERROR_STOP=1 -1 -f dev/$(DB).sql
 	rm dev/$(DB).sql

--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ tests:
 								  PATH="/opt/warehouse/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
 								  bin/tests --postgresql-host db $(T) $(TESTARGS)
 
-tests_e2e: .state/docker-build
+tests_e2e: .state/docker-build mindb
 	docker-compose run --rm tests env -i ENCODING="C.UTF-8" \
 								PATH="/opt/warehouse/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
 								bin/tests-e2e --postgresql-host db $(T) $(TESTARGS)

--- a/bin/tests
+++ b/bin/tests
@@ -9,6 +9,6 @@ export LC_ALL="${ENCODING:-en_US.UTF-8}"
 export LANG="${ENCODING:-en_US.UTF-8}"
 
 # Actually run our tests.
-python -m coverage run -m pytest --strict $@
+python -m coverage run -m pytest --strict -m "not e2e" $@
 python -m coverage report -m
 python -m coverage html

--- a/bin/tests-e2e
+++ b/bin/tests-e2e
@@ -9,4 +9,4 @@ export LC_ALL="${ENCODING:-en_US.UTF-8}"
 export LANG="${ENCODING:-en_US.UTF-8}"
 
 # Actually run our tests.
-python -m pytest --driver Remote --host selenium --port 4444 --capability browserName firefox --base-url http://web:8000 --sensitive-url "pypi\.org" -m e2e $@
+python -m pytest --driver Remote --host selenium --port 4444 --capability browserName firefox --base-url http://web:8000 --sensitive-url "pypi\.org" --html selenium-report/index.html -m e2e $@

--- a/bin/tests-e2e
+++ b/bin/tests-e2e
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+set -x
+
+# Click requires us to ensure we have a well configured environment to run
+# our click commands. So we'll set our environment to ensure our locale is
+# correct.
+export LC_ALL="${ENCODING:-en_US.UTF-8}"
+export LANG="${ENCODING:-en_US.UTF-8}"
+
+# Actually run our tests.
+python -m pytest --driver Remote --host selenium --port 4444 --capability browserName firefox --base-url http://web:8000 --sensitive-url "pypi\.org" $@ tests/e2e

--- a/bin/tests-e2e
+++ b/bin/tests-e2e
@@ -9,4 +9,4 @@ export LC_ALL="${ENCODING:-en_US.UTF-8}"
 export LANG="${ENCODING:-en_US.UTF-8}"
 
 # Actually run our tests.
-python -m pytest --driver Remote --host selenium --port 4444 --capability browserName firefox --base-url http://web:8000 --sensitive-url "pypi\.org" $@ tests/e2e
+python -m pytest --driver Remote --host selenium --port 4444 --capability browserName firefox --base-url http://web:8000 --sensitive-url "pypi\.org" -m e2e $@

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -119,6 +119,7 @@ services:
         DEVEL: "yes"
         IPYTHON: "no"
     depends_on:
+      - db
       - selenium
       - web
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: postgres:10.1
     ports:
       # 5432 may already in use by another PostgreSQL on host
-      - "5433:5432"
+      - "5434:5432"
 
   redis:
     image: redis:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,11 @@ services:
   elasticsearch:
     image: elasticsearch:5
 
+  selenium:
+    image: selenium/standalone-firefox-debug
+    ports:
+      - "4444:4444"
+
   camo:
     image: pypa/warehouse-camo:latest
     ports:
@@ -106,3 +111,15 @@ services:
       - "8125:8125/udp"
     volumes:
       - ./dev/notdatadog.py:/opt/warehouse/dev/notdatadog.py
+
+  tests:
+    build:
+      context: .
+      args:
+        DEVEL: "yes"
+        IPYTHON: "no"
+    depends_on:
+      - selenium
+      - web
+    volumes:
+      - ./tests:/opt/warehouse/src/tests:z

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -123,3 +123,4 @@ services:
       - web
     volumes:
       - ./tests:/opt/warehouse/src/tests:z
+      - ./selenium-report:/opt/warehouse/src/selenium-report:z

--- a/requirements/tests.in
+++ b/requirements/tests.in
@@ -6,5 +6,6 @@ freezegun
 pretend
 pytest>=3.0.0
 pytest-postgresql
+pytest-selenium
 responses>=0.5.1
 webtest

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -189,6 +189,12 @@ psycopg2==2.7.4 \
 py==1.5.3 \
     --hash=sha256:983f77f3331356039fdd792e9220b7b8ee1aa6bd2b25f567a963ff1de5a64f6a \
     --hash=sha256:29c9fab495d7528e80ba1e343b958684f4ace687327e6f789a94bf3d1915f881
+pytest-base-url==1.4.1 \
+    --hash=sha256:31e42366a5fc22f450b398837dc819bb7569f5e6bd5d74e494b2b9ec239876d1
+pytest-html==1.14.0 \
+    --hash=sha256:fcd90a13d41abcc69a0388bf5da8b81c78ed07f92789f8058a1b9da6d2cedb59
+pytest-metadata==1.6.0 \
+    --hash=sha256:8ed7659de1b986c3bd53349e9ae10dd2ec0a998bbfa9faecff1737418e156e75
 pytest-postgresql==1.3.4 \
     --hash=sha256:dd9585d02bdf971cf0fd9b7787133e1829f7bb7ec620943cf251e462588d0a93 \
     --hash=sha256:9085d04bc3cb920b3264c5dccb73a989846c2700771e682f8037fdbb02a43b1f
@@ -198,6 +204,10 @@ pytest==3.5.1 \
 python-dateutil==2.7.2 \
     --hash=sha256:3220490fb9741e2342e1cf29a503394fdac874bc39568288717ee67047ff29df \
     --hash=sha256:9d8074be4c993fbe4947878ce593052f71dac82932a677d49194d8ce9778002e
+pytest-selenium==1.12.0 \
+    --hash=sha256:050a357a8bc9d38241052a277a5da3d67ff4801a807e8918113a88defee11c97
+pytest-variables==1.5.0 \
+    --hash=sha256:6784a2bf8c6c22c7d04a0e43db754178442a3ae8c924fc7b9d9e351b7cb1a3c8
 requests==2.18.4 \
     --hash=sha256:6a1b267aa90cac58ac3a765d067950e7dbbf75b1da07e895d1f594193a40a38b \
     --hash=sha256:9c443e7324ba5b85070c4a818ade28bfabedf16ea10206da1132edaa6dda237e

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,3 +7,4 @@ norecursedirs = build dist node_modules *.egg-info .state requirements
 markers =
     unit: Quick running unit tests which test small units of functionality.
     functional: Slower running tests which test the entire system is functioning.
+    e2e: Even slower actual-browser tests, useful for frontend features.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,6 +48,8 @@ def pytest_collection_modifyitems(items):
             item.add_marker(pytest.mark.functional)
         elif module_root_dir.startswith("unit"):
             item.add_marker(pytest.mark.unit)
+        elif module_root_dir.startswith("e2e"):
+            item.add_marker(pytest.mark.e2e)
         else:
             raise RuntimeError(
                 "Unknown test type (filename = {0})".format(module_path)

--- a/tests/e2e/__init__.py
+++ b/tests/e2e/__init__.py
@@ -1,0 +1,11 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/e2e/test_account.py
+++ b/tests/e2e/test_account.py
@@ -12,7 +12,6 @@
 
 from urllib.parse import urljoin
 
-import pytest
 
 def test_register_password_strength(selenium, base_url):
     register_url = urljoin(base_url, 'account/register')
@@ -20,7 +19,8 @@ def test_register_password_strength(selenium, base_url):
     new_password = selenium.find_element_by_id('new_password')
     new_password.send_keys('foo')
     assert selenium.find_element_by_xpath(
-        '//span[@class="password-strength__gauge password-strength__gauge--0"]')
+        '//span[@class="password-strength__gauge password-strength__gauge--0"]'
+    )
     assert selenium.find_element_by_xpath(
         '//li[text()="Passwords do not match"]')
     assert selenium.find_element_by_xpath(

--- a/tests/e2e/test_account.py
+++ b/tests/e2e/test_account.py
@@ -1,0 +1,27 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from urllib.parse import urljoin
+
+import pytest
+
+def test_register_password_strength(selenium, base_url):
+    register_url = urljoin(base_url, 'account/register')
+    selenium.get(register_url)
+    new_password = selenium.find_element_by_id('new_password')
+    new_password.send_keys('foo')
+    assert selenium.find_element_by_xpath(
+        '//span[@class="password-strength__gauge password-strength__gauge--0"]')
+    assert selenium.find_element_by_xpath(
+        '//li[text()="Passwords do not match"]')
+    assert selenium.find_element_by_xpath(
+        '//input[@type="submit"]').get_attribute('disabled')


### PR DESCRIPTION
For discussion. A way of performing end to end or frontend only tests using Selenium and separate tests container. This allows fully testing features that would rely on a combination of template generation, pure JS and Stimulus code and potentially end to end feature critical flows.

Biggest caveat is of course needing a complete dev setup to run, which would specially noticable in CI since would require a whole `make initdb`. This could be less of a problem if we used a minimal SQL fixture.

I added a simple test around the password strength frontend verification in the register page as an example.

Thoughts? 🤔 