### PR TITLE
Improve default ordering of classifier categories

### DIFF
--- a/warehouse/views.py
+++ b/warehouse/views.py
@@ -52,15 +52,15 @@ SEARCH_BOOSTS = {
     "summary": 5,
 }
 SEARCH_FILTER_ORDER = (
-    "Programming Language",
-    "License",
     "Framework",
     "Topic",
-    "Intended Audience",
-    "Environment",
-    "Operating System",
-    "Natural Language",
     "Development Status",
+    "License",
+    "Programming Language",
+    "Operating System",
+    "Environment",
+    "Intended Audience",
+    "Natural Language",
 )
 
 


### PR DESCRIPTION
An iterative improvement to reflect the usefulness and usage frequency of trove classifiers for filtering. Probably only one in a series of reorderings.

Ref.: #1935.

![new-filter-order](https://user-images.githubusercontent.com/842790/38116480-3b69b708-337e-11e8-8a37-2874c2809e2e.png)
