### PR TITLE
reduce memory consumption of uploads and reindex task

### DIFF
--- a/tests/unit/packaging/test_search.py
+++ b/tests/unit/packaging/test_search.py
@@ -21,14 +21,14 @@ def test_build_search():
         project=pretend.stub(
             name="Foobar",
             normalized_name="foobar",
-            all_releases=[
-                pretend.stub(version="5.0.dev0", is_prerelease=True),
-                pretend.stub(version="4.0", is_prerelease=False),
-                pretend.stub(version="3.0", is_prerelease=False),
-                pretend.stub(version="2.0", is_prerelease=False),
-                pretend.stub(version="1.0", is_prerelease=False),
+            all_versions=[
+                pretend.stub(version="5.0.dev0"),
+                pretend.stub(version="4.0"),
+                pretend.stub(version="3.0"),
+                pretend.stub(version="2.0"),
+                pretend.stub(version="1.0"),
             ],
-            latest_release=pretend.stub(version="4.0", is_prerelease=False),
+            latest_version=pretend.stub(version="4.0"),
         ),
         summary="This is my summary",
         description="This is my description",

--- a/tests/unit/packaging/test_search.py
+++ b/tests/unit/packaging/test_search.py
@@ -21,13 +21,14 @@ def test_build_search():
         project=pretend.stub(
             name="Foobar",
             normalized_name="foobar",
-            releases=[
-                pretend.stub(version="1.0", is_prerelease=False),
-                pretend.stub(version="2.0", is_prerelease=False),
-                pretend.stub(version="3.0", is_prerelease=False),
-                pretend.stub(version="4.0", is_prerelease=False),
+            all_releases=[
                 pretend.stub(version="5.0.dev0", is_prerelease=True),
+                pretend.stub(version="4.0", is_prerelease=False),
+                pretend.stub(version="3.0", is_prerelease=False),
+                pretend.stub(version="2.0", is_prerelease=False),
+                pretend.stub(version="1.0", is_prerelease=False),
             ],
+            latest_release=pretend.stub(version="4.0", is_prerelease=False),
         ),
         summary="This is my summary",
         description="This is my description",

--- a/tests/unit/packaging/test_views.py
+++ b/tests/unit/packaging/test_views.py
@@ -180,9 +180,9 @@ class TestReleaseDetail:
             "project": project,
             "release": releases[1],
             "files": [files[1]],
-            "latest_release": project.latest_release,
-            "all_releases": [
-                r for r in reversed(releases)
+            "latest_version": project.latest_version,
+            "all_versions": [
+                (r.version, r.created) for r in reversed(releases)
             ],
             "maintainers": sorted(users, key=lambda u: u.username.lower()),
             "license": None

--- a/tests/unit/packaging/test_views.py
+++ b/tests/unit/packaging/test_views.py
@@ -12,7 +12,6 @@
 
 import pretend
 
-from first import first
 from pyramid.httpexceptions import HTTPMovedPermanently, HTTPNotFound
 
 from warehouse.packaging import views
@@ -155,10 +154,6 @@ class TestReleaseDetail:
             ReleaseFactory.create(project=project, version=v)
             for v in ["1.0", "2.0", "3.0", "4.0.dev0"]
         ]
-        latest_release = first(
-            reversed(releases),
-            key=lambda r: not r.is_prerelease,
-        )
         files = [
             FileFactory.create(
                 release=r,
@@ -185,14 +180,9 @@ class TestReleaseDetail:
             "project": project,
             "release": releases[1],
             "files": [files[1]],
-            "latest_release": (
-                latest_release.version,
-                latest_release.is_prerelease,
-                latest_release.created,
-            ),
+            "latest_release": project.latest_release,
             "all_releases": [
-                (r.version, r.is_prerelease, r.created)
-                for r in reversed(releases)
+                r for r in reversed(releases)
             ],
             "maintainers": sorted(users, key=lambda u: u.username.lower()),
             "license": None

--- a/tests/unit/packaging/test_views.py
+++ b/tests/unit/packaging/test_views.py
@@ -182,7 +182,8 @@ class TestReleaseDetail:
             "files": [files[1]],
             "latest_version": project.latest_version,
             "all_versions": [
-                (r.version, r.created) for r in reversed(releases)
+                (r.version, r.created, r.is_prerelease)
+                for r in reversed(releases)
             ],
             "maintainers": sorted(users, key=lambda u: u.username.lower()),
             "license": None

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -989,11 +989,7 @@ def file_upload(request):
     # TODO: We need a better solution to this than to just do it inline inside
     #       this method. Ideally the version field would just be sortable, but
     #       at least this should be some sort of hook or trigger.
-    releases = (
-        request.db.query(Release)
-                  .filter(Release.project == project)
-                  .all()
-    )
+    releases = project.all_releases
     for i, r in enumerate(sorted(
             releases, key=lambda x: packaging.version.parse(x.version))):
         r._pypi_ordering = i

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -199,7 +199,10 @@ class Project(SitemapMixin, db.ModelBase):
     @property
     def all_versions(self):
         return (orm.object_session(self)
-                   .query(Release.version, Release.created)
+                   .query(
+                       Release.version,
+                       Release.created,
+                       Release.is_prerelease)
                    .filter(Release.project == self)
                    .order_by(Release._pypi_ordering.desc())
                    .all())
@@ -207,7 +210,10 @@ class Project(SitemapMixin, db.ModelBase):
     @property
     def latest_version(self):
         return (orm.object_session(self)
-                   .query(Release.version, Release.created)
+                   .query(
+                       Release.version,
+                       Release.created,
+                       Release.is_prerelease)
                    .filter(Release.project == self)
                    .order_by(
                        Release.is_prerelease.nullslast(),

--- a/warehouse/packaging/search.py
+++ b/warehouse/packaging/search.py
@@ -11,8 +11,6 @@
 # limitations under the License.
 
 from elasticsearch_dsl import DocType, Text, Keyword, analyzer, MetaField, Date
-from first import first
-from packaging.version import parse as parse_version
 
 from warehouse.search.utils import doc_type
 
@@ -60,23 +58,8 @@ class Project(DocType):
         obj = cls(meta={"id": release.project.normalized_name})
         obj["name"] = release.project.name
         obj["normalized_name"] = release.project.normalized_name
-        obj["version"] = [
-            r.version
-            for r in sorted(
-                release.project.releases,
-                key=lambda r: parse_version(r.version),
-                reverse=True,
-            )
-        ]
-        obj["latest_version"] = first(
-            sorted(
-                release.project.releases,
-                key=lambda r: parse_version(r.version),
-                reverse=True,
-            ),
-            key=lambda r: not r.is_prerelease,
-            default=release.project.releases[0],
-        ).version
+        obj["version"] = [r.version for r in release.project.all_releases]
+        obj["latest_version"] = release.project.latest_release.version
         obj["summary"] = release.summary
         obj["description"] = release.description
         obj["author"] = release.author

--- a/warehouse/packaging/search.py
+++ b/warehouse/packaging/search.py
@@ -58,8 +58,8 @@ class Project(DocType):
         obj = cls(meta={"id": release.project.normalized_name})
         obj["name"] = release.project.name
         obj["normalized_name"] = release.project.normalized_name
-        obj["version"] = [r.version for r in release.project.all_releases]
-        obj["latest_version"] = release.project.latest_release.version
+        obj["version"] = [r.version for r in release.project.all_versions]
+        obj["latest_version"] = release.project.latest_version.version
         obj["summary"] = release.summary
         obj["description"] = release.description
         obj["author"] = release.author

--- a/warehouse/packaging/views.py
+++ b/warehouse/packaging/views.py
@@ -10,7 +10,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from first import first
 from pyramid.httpexceptions import HTTPMovedPermanently, HTTPNotFound
 from pyramid.view import view_config
 from sqlalchemy.orm.exc import NoResultFound
@@ -88,27 +87,6 @@ def release_detail(release, request):
             request.current_route_path(name=project.name),
         )
 
-    # Get all of the registered versions for this Project, in order of newest
-    # to oldest.
-    all_releases = (
-        request.db.query(Release)
-                  .filter(Release.project == project)
-                  .with_entities(
-                      Release.version,
-                      Release.is_prerelease,
-                      Release.created)
-                  .order_by(Release._pypi_ordering.desc())
-                  .all()
-    )
-
-    # Get the latest non-prerelease of this Project, or the latest release if
-    # all releases are prereleases.
-    latest_release = first(
-        all_releases,
-        key=lambda r: not r.is_prerelease,
-        default=all_releases[0],
-    )
-
     # Get all of the maintainers for this project.
     maintainers = [
         r.user
@@ -142,8 +120,8 @@ def release_detail(release, request):
         "project": project,
         "release": release,
         "files": release.files.all(),
-        "latest_release": latest_release,
-        "all_releases": all_releases,
+        "latest_release": project.latest_release,
+        "all_releases": project.all_releases,
         "maintainers": maintainers,
         "license": license,
     }

--- a/warehouse/packaging/views.py
+++ b/warehouse/packaging/views.py
@@ -120,8 +120,8 @@ def release_detail(release, request):
         "project": project,
         "release": release,
         "files": release.files.all(),
-        "latest_release": project.latest_release,
-        "all_releases": project.all_releases,
+        "latest_version": project.latest_version,
+        "all_versions": project.all_versions,
         "maintainers": maintainers,
         "license": license,
     }

--- a/warehouse/search/tasks.py
+++ b/warehouse/search/tasks.py
@@ -14,6 +14,7 @@ import binascii
 import os
 
 from elasticsearch.helpers import parallel_bulk
+from sqlalchemy import and_
 from sqlalchemy.orm import lazyload, joinedload, load_only
 
 from warehouse.packaging.models import Release, Project
@@ -24,7 +25,19 @@ from warehouse.utils.db import windowed_query
 
 
 def _project_docs(db):
-    releases = (
+
+    releases_list = (
+        db.query(Release)
+          .options(load_only(
+                   "name", "version"))
+          .distinct(Release.name)
+          .order_by(
+              Release.name,
+              Release.is_prerelease.nullslast(),
+              Release._pypi_ordering.desc())
+    ).subquery('release_list')
+
+    release_data = (
         db.query(Release)
           .options(load_only(
                    "summary", "description", "author",
@@ -37,13 +50,12 @@ def _project_docs(db):
                     .joinedload(Project.releases)
                     .load_only("version", "is_prerelease")),
                    joinedload(Release._classifiers).load_only("classifier"))
-          .distinct(Release.name)
-          .order_by(
-              Release.name,
-              Release.is_prerelease.nullslast(),
-              Release._pypi_ordering.desc())
+          .filter(and_(
+              Release.name == releases_list.c.name,
+              Release.version == releases_list.c.version))
     )
-    for release in windowed_query(releases, Release.name, 1000):
+
+    for release in windowed_query(release_data, Release.name, 1000):
         p = ProjectDocType.from_db(release)
         p.full_clean()
         yield p.to_dict(include_meta=True)

--- a/warehouse/search/tasks.py
+++ b/warehouse/search/tasks.py
@@ -38,7 +38,10 @@ def _project_docs(db):
                     .load_only("version", "is_prerelease")),
                    joinedload(Release._classifiers).load_only("classifier"))
           .distinct(Release.name)
-          .order_by(Release.name, Release._pypi_ordering.desc())
+          .order_by(
+              Release.name,
+              Release.is_prerelease.nullslast(),
+              Release._pypi_ordering.desc())
     )
     for release in windowed_query(releases, Release.name, 1000):
         p = ProjectDocType.from_db(release)

--- a/warehouse/search/tasks.py
+++ b/warehouse/search/tasks.py
@@ -17,7 +17,7 @@ from elasticsearch.helpers import parallel_bulk
 from sqlalchemy import and_
 from sqlalchemy.orm import lazyload, joinedload, load_only
 
-from warehouse.packaging.models import Release, Project
+from warehouse.packaging.models import Release
 from warehouse.packaging.search import Project as ProjectDocType
 from warehouse.search.utils import get_index
 from warehouse import tasks
@@ -46,9 +46,7 @@ def _project_docs(db):
                    "created"))
           .options(lazyload("*"),
                    (joinedload(Release.project)
-                    .load_only("normalized_name", "name")
-                    .joinedload(Project.releases)
-                    .load_only("version", "is_prerelease")),
+                    .load_only("normalized_name", "name")),
                    joinedload(Release._classifiers).load_only("classifier"))
           .filter(and_(
               Release.name == releases_list.c.name,

--- a/warehouse/templates/packaging/detail.html
+++ b/warehouse/templates/packaging/detail.html
@@ -84,10 +84,10 @@
     </div>
 
     <div class="package-header__right">
-      {% if release.version|parse_version > latest_release.version|parse_version %}
-      <a class="status-badge status-badge--warn" href="{{ request.route_path('packaging.project', name=release.project.name) }}">Stable version available ({{ latest_release.version }})</a>
-      {% elif release.version|parse_version != latest_release.version|parse_version %}
-      <a class="status-badge status-badge--bad" href="{{ request.route_path('packaging.project', name=release.project.name) }}">Newer version available ({{ latest_release.version }})</a>
+      {% if release.version|parse_version > latest_version.version|parse_version %}
+      <a class="status-badge status-badge--warn" href="{{ request.route_path('packaging.project', name=release.project.name) }}">Stable version available ({{ latest_version.version }})</a>
+      {% elif release.version|parse_version != latest_version.version|parse_version %}
+      <a class="status-badge status-badge--bad" href="{{ request.route_path('packaging.project', name=release.project.name) }}">Newer version available ({{ latest_version.version }})</a>
       {% else %}
       <a class="status-badge status-badge--good" href="{{ request.route_path('packaging.project', name=release.project.name) }}">Latest version</a>
       {% endif %}
@@ -279,8 +279,8 @@
           <section class="release-timeline">
             {% set blue_cube = request.static_url('warehouse:static/dist/images/blue-cube.svg') %}
             {% set white_cube = request.static_url('warehouse:static/dist/images/white-cube.svg') %}
-            {% for hrelease in all_releases %}
-            {% set is_current = (hrelease.version == release.version) %}
+            {% for hversion in all_versions %}
+            {% set is_current = (hversion.version == release.version) %}
             <div class="release{{ ' release--latest' if loop.first else ' release--oldest' if loop.last }}{{ ' release--current' if is_current }}">
               <div class="release__meta">
                 {% if is_current %}
@@ -300,8 +300,8 @@
               </div>
 
               <div class="card release__card">
-                <p class="release__version"><a href="{{ request.route_path('packaging.release', name=release.project.name, version=hrelease.version) }}">{{ hrelease.version }}</a></p>
-                <p class="release__version-date">{{ humanize(hrelease.created) }}</p>
+                <p class="release__version"><a href="{{ request.route_path('packaging.release', name=release.project.name, version=hversion.version) }}">{{ hversion.version }}</a></p>
+                <p class="release__version-date">{{ humanize(hversion.created) }}</p>
               </div>
             </div>
             {% endfor %}


### PR DESCRIPTION
Resolves two memory consumption issues for projects with long/large release histories:

Uploads:

https://github.com/pypa/warehouse/blob/ce894db254d2f9097da784768f5e8b55252c169b/warehouse/forklift/legacy.py#L966-L970

Search indexing:

https://github.com/pypa/warehouse/blob/ce894db254d2f9097da784768f5e8b55252c169b/warehouse/packaging/search.py#L63-L79