### PR TITLE
deterministicly order journal entrys by id

### DIFF
--- a/tests/unit/admin/views/test_journals.py
+++ b/tests/unit/admin/views/test_journals.py
@@ -29,7 +29,7 @@ class TestProjectList:
     def test_no_query(self, db_request):
         journals = sorted(
             [JournalEntryFactory.create() for _ in range(30)],
-            key=lambda j: j.submitted_date,
+            key=lambda j: j.id,
             reverse=True,
         )
         result = views.journals_list(db_request)
@@ -42,7 +42,7 @@ class TestProjectList:
     def test_with_page(self, db_request):
         journals = sorted(
             [JournalEntryFactory.create() for _ in range(30)],
-            key=lambda j: j.submitted_date,
+            key=lambda j: j.id,
             reverse=True,
         )
         db_request.GET["page"] = "2"
@@ -65,7 +65,7 @@ class TestProjectList:
         journals0 = sorted(
             [JournalEntryFactory.create(name=project0.normalized_name)
              for _ in range(30)],
-            key=lambda j: j.submitted_date,
+            key=lambda j: j.id,
             reverse=True,
         )
         [JournalEntryFactory.create(name=project1.normalized_name)
@@ -85,7 +85,7 @@ class TestProjectList:
         journals0 = sorted(
             [JournalEntryFactory.create(name=project0.normalized_name)
              for _ in range(30)],
-            key=lambda j: j.submitted_date,
+            key=lambda j: j.id,
             reverse=True,
         )
         [JournalEntryFactory.create(name=project1.normalized_name)
@@ -105,7 +105,7 @@ class TestProjectList:
         journals0 = sorted(
             [JournalEntryFactory.create(submitted_by=user0)
              for _ in range(30)],
-            key=lambda j: j.submitted_date,
+            key=lambda j: j.id,
             reverse=True,
         )
         [JournalEntryFactory.create(submitted_by=user1)
@@ -139,13 +139,13 @@ class TestProjectList:
         journals0 = sorted(
             [JournalEntryFactory.create(submitted_from=ipv4)
              for _ in range(10)],
-            key=lambda j: j.submitted_date,
+            key=lambda j: j.id,
             reverse=True,
         )
         journals1 = sorted(
             [JournalEntryFactory.create(submitted_from=ipv6)
              for _ in range(10)],
-            key=lambda j: j.submitted_date,
+            key=lambda j: j.id,
             reverse=True,
         )
 

--- a/tests/unit/admin/views/test_journals.py
+++ b/tests/unit/admin/views/test_journals.py
@@ -29,7 +29,7 @@ class TestProjectList:
     def test_no_query(self, db_request):
         journals = sorted(
             [JournalEntryFactory.create() for _ in range(30)],
-            key=lambda j: j.id,
+            key=lambda j: (j.submitted_date, j.id),
             reverse=True,
         )
         result = views.journals_list(db_request)
@@ -42,7 +42,7 @@ class TestProjectList:
     def test_with_page(self, db_request):
         journals = sorted(
             [JournalEntryFactory.create() for _ in range(30)],
-            key=lambda j: j.id,
+            key=lambda j: (j.submitted_date, j.id),
             reverse=True,
         )
         db_request.GET["page"] = "2"
@@ -65,7 +65,7 @@ class TestProjectList:
         journals0 = sorted(
             [JournalEntryFactory.create(name=project0.normalized_name)
              for _ in range(30)],
-            key=lambda j: j.id,
+            key=lambda j: (j.submitted_date, j.id),
             reverse=True,
         )
         [JournalEntryFactory.create(name=project1.normalized_name)
@@ -85,7 +85,7 @@ class TestProjectList:
         journals0 = sorted(
             [JournalEntryFactory.create(name=project0.normalized_name)
              for _ in range(30)],
-            key=lambda j: j.id,
+            key=lambda j: (j.submitted_date, j.id),
             reverse=True,
         )
         [JournalEntryFactory.create(name=project1.normalized_name)
@@ -105,7 +105,7 @@ class TestProjectList:
         journals0 = sorted(
             [JournalEntryFactory.create(submitted_by=user0)
              for _ in range(30)],
-            key=lambda j: j.id,
+            key=lambda j: (j.submitted_date, j.id),
             reverse=True,
         )
         [JournalEntryFactory.create(submitted_by=user1)
@@ -139,13 +139,13 @@ class TestProjectList:
         journals0 = sorted(
             [JournalEntryFactory.create(submitted_from=ipv4)
              for _ in range(10)],
-            key=lambda j: j.id,
+            key=lambda j: (j.submitted_date, j.id),
             reverse=True,
         )
         journals1 = sorted(
             [JournalEntryFactory.create(submitted_from=ipv6)
              for _ in range(10)],
-            key=lambda j: j.id,
+            key=lambda j: (j.submitted_date, j.id),
             reverse=True,
         )
 

--- a/tests/unit/admin/views/test_projects.py
+++ b/tests/unit/admin/views/test_projects.py
@@ -96,7 +96,7 @@ class TestProjectDetail:
         journals = sorted(
             [JournalEntryFactory(name=project.name)
              for _ in range(75)],
-            key=lambda x: x.id,
+            key=lambda x: (x.submitted_date, x.id),
             reverse=True,
         )
         roles = sorted(
@@ -257,7 +257,7 @@ class TestProjectJournalsList:
         journals = sorted(
             [JournalEntryFactory(name=project.name)
              for _ in range(30)],
-            key=lambda x: x.id,
+            key=lambda x: (x.submitted_date, x.id),
             reverse=True,
         )
         db_request.matchdict["project_name"] = project.normalized_name
@@ -274,7 +274,7 @@ class TestProjectJournalsList:
         journals = sorted(
             [JournalEntryFactory(name=project.name)
              for _ in range(30)],
-            key=lambda x: x.id,
+            key=lambda x: (x.submitted_date, x.id),
             reverse=True,
         )
         db_request.matchdict["project_name"] = project.normalized_name
@@ -300,7 +300,7 @@ class TestProjectJournalsList:
         journals = sorted(
             [JournalEntryFactory(name=project.name)
              for _ in range(30)],
-            key=lambda x: x.id,
+            key=lambda x: (x.submitted_date, x.id),
             reverse=True,
         )
         db_request.matchdict["project_name"] = project.normalized_name
@@ -318,7 +318,7 @@ class TestProjectJournalsList:
         journals = sorted(
             [JournalEntryFactory(name=project.name)
              for _ in range(30)],
-            key=lambda x: x.id,
+            key=lambda x: (x.submitted_date, x.id),
             reverse=True,
         )
         db_request.matchdict["project_name"] = project.normalized_name
@@ -336,7 +336,7 @@ class TestProjectJournalsList:
         journals = sorted(
             [JournalEntryFactory(name=project.name)
              for _ in range(30)],
-            key=lambda x: x.id,
+            key=lambda x: (x.submitted_date, x.id),
             reverse=True,
         )
         db_request.matchdict["project_name"] = project.normalized_name

--- a/tests/unit/admin/views/test_projects.py
+++ b/tests/unit/admin/views/test_projects.py
@@ -96,7 +96,7 @@ class TestProjectDetail:
         journals = sorted(
             [JournalEntryFactory(name=project.name)
              for _ in range(75)],
-            key=lambda x: x.submitted_date,
+            key=lambda x: x.id,
             reverse=True,
         )
         roles = sorted(
@@ -257,7 +257,7 @@ class TestProjectJournalsList:
         journals = sorted(
             [JournalEntryFactory(name=project.name)
              for _ in range(30)],
-            key=lambda x: x.submitted_date,
+            key=lambda x: x.id,
             reverse=True,
         )
         db_request.matchdict["project_name"] = project.normalized_name
@@ -274,7 +274,7 @@ class TestProjectJournalsList:
         journals = sorted(
             [JournalEntryFactory(name=project.name)
              for _ in range(30)],
-            key=lambda x: x.submitted_date,
+            key=lambda x: x.id,
             reverse=True,
         )
         db_request.matchdict["project_name"] = project.normalized_name
@@ -300,7 +300,7 @@ class TestProjectJournalsList:
         journals = sorted(
             [JournalEntryFactory(name=project.name)
              for _ in range(30)],
-            key=lambda x: x.submitted_date,
+            key=lambda x: x.id,
             reverse=True,
         )
         db_request.matchdict["project_name"] = project.normalized_name
@@ -318,7 +318,7 @@ class TestProjectJournalsList:
         journals = sorted(
             [JournalEntryFactory(name=project.name)
              for _ in range(30)],
-            key=lambda x: x.submitted_date,
+            key=lambda x: x.id,
             reverse=True,
         )
         db_request.matchdict["project_name"] = project.normalized_name
@@ -336,7 +336,7 @@ class TestProjectJournalsList:
         journals = sorted(
             [JournalEntryFactory(name=project.name)
              for _ in range(30)],
-            key=lambda x: x.submitted_date,
+            key=lambda x: x.id,
             reverse=True,
         )
         db_request.matchdict["project_name"] = project.normalized_name

--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -1255,7 +1255,7 @@ class TestFileUpload:
         # Ensure that all of our journal entries have been created
         journals = (
             db_request.db.query(JournalEntry)
-                         .order_by("submitted_date")
+                         .order_by("id")
                          .all()
         )
         assert [
@@ -2160,7 +2160,7 @@ class TestFileUpload:
         # Ensure that all of our journal entries have been created
         journals = (
             db_request.db.query(JournalEntry)
-                         .order_by("submitted_date")
+                         .order_by("id")
                          .all()
         )
         assert [
@@ -2270,7 +2270,7 @@ class TestFileUpload:
         # Ensure that all of our journal entries have been created
         journals = (
             db_request.db.query(JournalEntry)
-                         .order_by("submitted_date")
+                         .order_by("id")
                          .all()
         )
         assert [
@@ -2506,7 +2506,7 @@ class TestFileUpload:
         # Ensure that all of our journal entries have been created
         journals = (
             db_request.db.query(JournalEntry)
-                         .order_by("submitted_date")
+                         .order_by("id")
                          .all()
         )
         assert [
@@ -2679,7 +2679,7 @@ class TestFileUpload:
         # Ensure that all of our journal entries have been created
         journals = (
             db_request.db.query(JournalEntry)
-                         .order_by("submitted_date")
+                         .order_by("id")
                          .all()
         )
         assert [

--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -1255,7 +1255,7 @@ class TestFileUpload:
         # Ensure that all of our journal entries have been created
         journals = (
             db_request.db.query(JournalEntry)
-                         .order_by("id")
+                         .order_by("submitted_date", "id")
                          .all()
         )
         assert [
@@ -2160,7 +2160,7 @@ class TestFileUpload:
         # Ensure that all of our journal entries have been created
         journals = (
             db_request.db.query(JournalEntry)
-                         .order_by("id")
+                         .order_by("submitted_date", "id")
                          .all()
         )
         assert [
@@ -2270,7 +2270,7 @@ class TestFileUpload:
         # Ensure that all of our journal entries have been created
         journals = (
             db_request.db.query(JournalEntry)
-                         .order_by("id")
+                         .order_by("submitted_date", "id")
                          .all()
         )
         assert [
@@ -2506,7 +2506,7 @@ class TestFileUpload:
         # Ensure that all of our journal entries have been created
         journals = (
             db_request.db.query(JournalEntry)
-                         .order_by("id")
+                         .order_by("submitted_date", "id")
                          .all()
         )
         assert [
@@ -2679,7 +2679,7 @@ class TestFileUpload:
         # Ensure that all of our journal entries have been created
         journals = (
             db_request.db.query(JournalEntry)
-                         .order_by("id")
+                         .order_by("submitted_date", "id")
                          .all()
         )
         assert [

--- a/tests/unit/legacy/api/xmlrpc/test_xmlrpc.py
+++ b/tests/unit/legacy/api/xmlrpc/test_xmlrpc.py
@@ -525,7 +525,7 @@ def test_changelog(db_request, with_ids):
         for _ in range(10):
             entries.append(JournalEntryFactory.create(name=project.name))
 
-    entries = sorted(entries, key=lambda x: x.submitted_date)
+    entries = sorted(entries, key=lambda x: x.id)
 
     since = int(
         entries[int(len(entries) / 2)].submitted_date

--- a/warehouse/admin/views/journals.py
+++ b/warehouse/admin/views/journals.py
@@ -37,7 +37,7 @@ def journals_list(request):
 
     journals_query = (
         request.db.query(JournalEntry)
-                  .order_by(JournalEntry.submitted_date.desc())
+                  .order_by(JournalEntry.id.desc())
     )
 
     if q:

--- a/warehouse/admin/views/journals.py
+++ b/warehouse/admin/views/journals.py
@@ -37,7 +37,9 @@ def journals_list(request):
 
     journals_query = (
         request.db.query(JournalEntry)
-                  .order_by(JournalEntry.id.desc())
+                  .order_by(
+                      JournalEntry.submitted_date.desc(),
+                      JournalEntry.id.desc())
     )
 
     if q:

--- a/warehouse/admin/views/projects.py
+++ b/warehouse/admin/views/projects.py
@@ -105,7 +105,7 @@ def project_detail(project, request):
         for entry in (
             request.db.query(JournalEntry)
             .filter(JournalEntry.name == project.name)
-            .order_by(JournalEntry.submitted_date.desc())
+            .order_by(JournalEntry.id.desc())
             .limit(30)
         )
     ]
@@ -208,7 +208,7 @@ def journals_list(project, request):
 
     journals_query = (request.db.query(JournalEntry)
                       .filter(JournalEntry.name == project.name)
-                      .order_by(JournalEntry.submitted_date.desc()))
+                      .order_by(JournalEntry.id.desc()))
 
     if q:
         terms = shlex.split(q)

--- a/warehouse/admin/views/projects.py
+++ b/warehouse/admin/views/projects.py
@@ -105,7 +105,10 @@ def project_detail(project, request):
         for entry in (
             request.db.query(JournalEntry)
             .filter(JournalEntry.name == project.name)
-            .order_by(JournalEntry.id.desc())
+            .order_by(
+                JournalEntry.submitted_date.desc(),
+                JournalEntry.id.desc(),
+            )
             .limit(30)
         )
     ]
@@ -208,7 +211,9 @@ def journals_list(project, request):
 
     journals_query = (request.db.query(JournalEntry)
                       .filter(JournalEntry.name == project.name)
-                      .order_by(JournalEntry.id.desc()))
+                      .order_by(
+                          JournalEntry.submitted_date.desc(),
+                          JournalEntry.id.desc()))
 
     if q:
         terms = shlex.split(q)

--- a/warehouse/legacy/api/xmlrpc/views.py
+++ b/warehouse/legacy/api/xmlrpc/views.py
@@ -346,7 +346,7 @@ def changelog(request, since, with_ids=False):
     entries = (
         request.db.query(JournalEntry)
                   .filter(JournalEntry.submitted_date > since)
-                  .order_by(JournalEntry.submitted_date)
+                  .order_by(JournalEntry.id)
                   .limit(50000)
     )
 

--- a/warehouse/manage/views.py
+++ b/warehouse/manage/views.py
@@ -774,7 +774,7 @@ def manage_project_history(project, request):
     journals = (
         request.db.query(JournalEntry)
         .filter(JournalEntry.name == project.name)
-        .order_by(JournalEntry.submitted_date.desc())
+        .order_by(JournalEntry.id.desc())
         .all()
     )
     return {

--- a/warehouse/manage/views.py
+++ b/warehouse/manage/views.py
@@ -774,7 +774,7 @@ def manage_project_history(project, request):
     journals = (
         request.db.query(JournalEntry)
         .filter(JournalEntry.name == project.name)
-        .order_by(JournalEntry.id.desc())
+        .order_by(JournalEntry.submitted_date.desc(), JournalEntry.id.desc())
         .all()
     )
     return {

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -362,7 +362,7 @@ class Release(db.ModelBase):
         secondaryjoin=lambda: (
             (User.username == orm.foreign(JournalEntry._submitted_by))
         ),
-        order_by=lambda: JournalEntry.submitted_date.desc(),
+        order_by=lambda: JournalEntry.id.desc(),
         # TODO: We have uselist=False here which raises a warning because
         # multiple items were returned. This should only be temporary because
         # we should add a nullable FK to JournalEntry so we don't need to rely


### PR DESCRIPTION
Previously we sorted by submitted_date, which was troublesome as many JournalEntry objects may be committed in a single transaction, leading to identical timestamps.

SQLAlchemy retains the order of jounal creation, and flushes in order so ordering by id is deterministic and represents the logical order of operations.

Closes #3474, thanks to @anowlcalledjosh for reporting