### PR TITLE
update tab indexing and autofocus for views that have password fields

### DIFF
--- a/warehouse/templates/accounts/register.html
+++ b/warehouse/templates/accounts/register.html
@@ -40,7 +40,7 @@
 
         <div class="form-group">
           <label for="full_name" class="form-group__label">Name</label>
-          {{ form.full_name(placeholder="Your name", required="required", class_="form-group__input") }}
+          {{ form.full_name(placeholder="Your name", required="required", class_="form-group__input", autofocus=true, tabindex="1") }}
           {% if form.full_name.errors %}
           <ul class="form-errors">
             {% for error in form.full_name.errors %}
@@ -52,7 +52,7 @@
 
         <div class="form-group">
           <label for="full_name" class="form-group__label">Email Address</label>
-          {{ form.email(placeholder="Your email address", autocomplete="email", required="required", class_="form-group__input") }}
+          {{ form.email(placeholder="Your email address", autocomplete="email", required="required", class_="form-group__input", tabindex="2") }}
           {% if form.email.errors %}
           <ul class="form-errors">
             {% for error in form.email.errors %}
@@ -70,7 +70,7 @@
 
         <div class="form-group">
           <label for="username" class="form-group__label">Username</label>
-          {{ form.username(placeholder="Select a username", autocorrect="off", autocapitalize="off", autocomplete="username", spellcheck="false", required="required", class_="form-group__input") }}
+          {{ form.username(placeholder="Select a username", autocorrect="off", autocapitalize="off", autocomplete="username", spellcheck="false", required="required", class_="form-group__input", tabindex="3") }}
           {% if form.username.errors %}
           <ul class="form-errors">
             {% for error in form.username.errors %}
@@ -86,12 +86,12 @@
               <label for="password" class="form-group__label">Password</label>
               <label for="show-password">
                 <input data-action="change->password#togglePasswords" data-target="password.showPassword"
-                  id="show-password" type="checkbox">&nbsp;Show passwords
+                  id="show-password" type="checkbox" tabindex="7">&nbsp;Show passwords
               </label>
             </div>
             {# the password field needs to be wrapped in a div to properly place tooltips #}
             <div>
-              {{ form.new_password(placeholder="Select a password", required="required", class_="form-group__input", autocomplete="new-password", data_target="password.password password-match.passwordMatch password-strength-gauge.password", data_action="keyup->password-match#checkPasswordsMatch keyup->password-strength-gauge#checkPasswordStrength") }}
+              {{ form.new_password(placeholder="Select a password", required="required", class_="form-group__input", autocomplete="new-password", data_target="password.password password-match.passwordMatch password-strength-gauge.password", data_action="keyup->password-match#checkPasswordsMatch keyup->password-strength-gauge#checkPasswordStrength", tabindex="4") }}
             </div>
             {% if form.new_password.errors %}
             <ul class="form-errors">
@@ -105,7 +105,7 @@
 
           <div class="form-group">
             <label for="password_confirm" class="form-group__label">Confirm Password</label>
-            {{ form.password_confirm(placeholder="Confirm password", required="required", class_="form-group__input", data_target="password.password password-match.passwordMatch", data_action="keyup->password-match#checkPasswordsMatch") }}
+            {{ form.password_confirm(placeholder="Confirm password", required="required", class_="form-group__input", data_target="password.password password-match.passwordMatch", data_action="keyup->password-match#checkPasswordsMatch", tabindex="5") }}
             {% if form.password_confirm.errors %}
             <ul class="form-errors">
               {% for error in form.password_confirm.errors %}
@@ -122,7 +122,7 @@
           </ul>
         </div>
 
-        <input type="submit" value="Create Account" class="button button--primary" data-target="password-match.submit">
+        <input type="submit" value="Create Account" class="button button--primary" data-target="password-match.submit" tabindex="6">
       </form>
     </div>
   </section>

--- a/warehouse/templates/accounts/reset-password.html
+++ b/warehouse/templates/accounts/reset-password.html
@@ -34,12 +34,12 @@
             <label for="password" class="form-group__label">Password</label>
             <label for="show-password">
               <input data-action="change->password#togglePasswords" data-target="password.showPassword"
-                id="show-password" type="checkbox">&nbsp;Show passwords
+                id="show-password" type="checkbox", tabindex="4">&nbsp;Show passwords
             </label>
           </div>
           {# the password field needs to be wrapped in a div to properly place tooltips #}
           <div>
-            {{ form.new_password(placeholder="Select a new password", required="required", class_="form-group__input", data_target="password.password password-match.passwordMatch password-strength-gauge.password", data_action="keyup->password-match#checkPasswordsMatch keyup->password-strength-gauge#checkPasswordStrength") }}
+            {{ form.new_password(placeholder="Select a new password", required="required", class_="form-group__input", data_target="password.password password-match.passwordMatch password-strength-gauge.password", data_action="keyup->password-match#checkPasswordsMatch keyup->password-strength-gauge#checkPasswordStrength", tabindex="1", autofocus=true) }}
           </div>
           {% if form.new_password.errors %}
           <ul class="form-errors">
@@ -53,7 +53,7 @@
 
         <div class="form-group">
           <label for="password_confirm" class="form-group__label">Confirm Password</label>
-          {{ form.password_confirm(placeholder="Confirm password", required="required", class_="form-group__input", data_target="password.password password-match.passwordMatch", data_action="keyup->password-match#checkPasswordsMatch") }}
+          {{ form.password_confirm(placeholder="Confirm password", required="required", class_="form-group__input", data_target="password.password password-match.passwordMatch", data_action="keyup->password-match#checkPasswordsMatch", tabindex="2") }}
           {% if form.password_confirm.errors %}
           <ul class="form-errors">
             {% for error in form.password_confirm.errors %}
@@ -69,7 +69,7 @@
           </ul>
         </div>
 
-        <input type="submit" value="Reset Password" class="button button--primary" data-target="password-match.submit">
+        <input type="submit" value="Reset Password" class="button button--primary" data-target="password-match.submit", tabindex="3">
       </form>
     </div>
   </section>

--- a/warehouse/templates/includes/input-user-name.html
+++ b/warehouse/templates/includes/input-user-name.html
@@ -11,7 +11,7 @@
  # See the License for the specific language governing permissions and
  # limitations under the License.
 -#}
-{{ form.username_or_email(placeholder="Your username or email", autocorrect="off", autocapitalize="off", spellcheck="false", class="form-group__input", required="true") }}
+{{ form.username_or_email(placeholder="Your username or email", autocorrect="off", autocapitalize="off", spellcheck="false", class="form-group__input", required="true", autofocus="true") }}
 {% if form.username_or_email.errors %}
   <ul class="form-errors">
     {% for error in form.username_or_email.errors %}

--- a/warehouse/templates/manage/account.html
+++ b/warehouse/templates/manage/account.html
@@ -124,7 +124,7 @@
       <p>
       We use <a href="https://gravatar.com/">gravatar.com</a> to generate your profile picture based on your primary email address — <code class="break-on-mobile">{{ user.email }}</code>
       </p>
-      <a href="{{ gravatar_profile(user.email) }}" target="_blank" rel="noopener" class="button">
+      <a href="{{ gravatar_profile(user.email) }}" target="_blank" rel="noopener" class="button" tabindex="1">
         Change image<span class="hide-on-mobile"> on gravatar.com</span>
         <i class="fa fa-external-link" aria-hidden="true"></i>
         <span class="sr-only">Opens in new window</span>
@@ -148,11 +148,11 @@
     {{ form_errors(save_account_form) }}
     <div class="form-group">
       <label class="form-group__label" for="name">Full Name</label>
-      {{ save_account_form.name(placeholder="No name set", class_="form-group__input") }}
+      {{ save_account_form.name(placeholder="No name set", class_="form-group__input", tabindex="2") }}
       {{ field_errors(save_account_form.name) }}
       <p class="form-group__help-text">Displayed on your <a href="{{ request.route_path('accounts.profile', username=user.username) }}">public profile</a>.</p>
     </div>
-    <input value="Update Account" class="button button--primary" type="submit">
+    <input value="Update Account" class="button button--primary" type="submit" tabindex="3">
   </form>
 
   <hr>
@@ -189,11 +189,11 @@
       <label class="form-group__label" for="email">Add Email</label>
       <div class="form-group__horizontal">
         <div class="form-group__horizontal-left">
-          {{ add_email_form.email(placeholder="Your email address", autocomplete="email", required="required", class_="form-group__input") }}
+          {{ add_email_form.email(placeholder="Your email address", autocomplete="email", required="required", class_="form-group__input", tabindex="4") }}
           {{ field_errors(add_email_form.email) }}
         </div>
         <div class="form-group__horizontal-right">
-          <input value="Add" class="button button--primary" type="submit">
+          <input value="Add" class="button button--primary" type="submit" tabindex="5">
         </div>
       </div>
     </div>
@@ -211,24 +211,24 @@
         <label class="form-group__label" for="name">Old Password</label>
         <label for="show-password">
           <input data-action="change->password#togglePasswords" data-target="password.showPassword"
-            id="show-password" type="checkbox" tabindex="4">&nbsp;Show passwords
+            id="show-password" type="checkbox" tabindex="10">&nbsp;Show passwords
         </label>
       </div>
-      {{ change_password_form.password(placeholder="Your current password", required="required", class_="form-group__input", data_target="password.password")}}
+      {{ change_password_form.password(placeholder="Your current password", required="required", class_="form-group__input", data_target="password.password", tabindex="6")}}
       {{ field_errors(change_password_form.password) }}
     </div>
     <div class="form-group">
       <label class="form-group__label" for="name">New Password</label>
       {# the password field needs to be wrapped in a div to properly place tooltips #}
       <div>
-        {{ change_password_form.new_password(placeholder="Select a new password", required="required", class_="form-group__input", data_target="password.password password-match.passwordMatch password-strength-gauge.password", data_action="keyup->password-match#checkPasswordsMatch keyup->password-strength-gauge#checkPasswordStrength") }}
+        {{ change_password_form.new_password(placeholder="Select a new password", required="required", class_="form-group__input", data_target="password.password password-match.passwordMatch password-strength-gauge.password", data_action="keyup->password-match#checkPasswordsMatch keyup->password-strength-gauge#checkPasswordStrength", tabindex="7") }}
       </div>
       {{ field_errors(change_password_form.new_password) }}
       {{ password_strength_gauge(data_target="password-strength-gauge.strengthGauge") }}
     </div>
     <div class="form-group">
       <label class="form-group__label" for="name">Confirm New Password</label>
-      {{ change_password_form.password_confirm(placeholder="Confirm password", required="required", class_="form-group__input", data_target="password.password password-match.passwordMatch", data_action="keyup->password-match#checkPasswordsMatch") }}
+      {{ change_password_form.password_confirm(placeholder="Confirm password", required="required", class_="form-group__input", data_target="password.password password-match.passwordMatch", data_action="keyup->password-match#checkPasswordsMatch", tabindex="8") }}
       {{ field_errors(change_password_form.password_confirm) }}
     </div>
     <div class="form-group">
@@ -237,7 +237,7 @@
       </ul>
     </div>
     <div>
-      <input value="Update Password" class="button button--primary" type="submit" data-target="password-match.submit">
+      <input value="Update Password" class="button button--primary" type="submit" data-target="password-match.submit" tabindex="9">
     </div>
   </form>
 
@@ -282,7 +282,7 @@
       <i class="fa fa-warning" aria-hidden="true"><span class="sr-only">Warning</span></i>
       You will not be able to recover your account after you delete it.
     </p>
-    {{ confirm_button("Delete your PyPI Account", "Username", user.username) }}
+    {{ confirm_button("Delete your PyPI Account", "Username", user.username, tabindex="11") }}
     {% endif %}
   </div>
 {% endblock %}

--- a/warehouse/templates/manage/account.html
+++ b/warehouse/templates/manage/account.html
@@ -124,7 +124,7 @@
       <p>
       We use <a href="https://gravatar.com/">gravatar.com</a> to generate your profile picture based on your primary email address — <code class="break-on-mobile">{{ user.email }}</code>
       </p>
-      <a href="{{ gravatar_profile(user.email) }}" target="_blank" rel="noopener" class="button" tabindex="1">
+      <a href="{{ gravatar_profile(user.email) }}" target="_blank" rel="noopener" class="button">
         Change image<span class="hide-on-mobile"> on gravatar.com</span>
         <i class="fa fa-external-link" aria-hidden="true"></i>
         <span class="sr-only">Opens in new window</span>
@@ -148,11 +148,11 @@
     {{ form_errors(save_account_form) }}
     <div class="form-group">
       <label class="form-group__label" for="name">Full Name</label>
-      {{ save_account_form.name(placeholder="No name set", class_="form-group__input", tabindex="2") }}
+      {{ save_account_form.name(placeholder="No name set", class_="form-group__input") }}
       {{ field_errors(save_account_form.name) }}
       <p class="form-group__help-text">Displayed on your <a href="{{ request.route_path('accounts.profile', username=user.username) }}">public profile</a>.</p>
     </div>
-    <input value="Update Account" class="button button--primary" type="submit" tabindex="3">
+    <input value="Update Account" class="button button--primary" type="submit">
   </form>
 
   <hr>
@@ -189,11 +189,11 @@
       <label class="form-group__label" for="email">Add Email</label>
       <div class="form-group__horizontal">
         <div class="form-group__horizontal-left">
-          {{ add_email_form.email(placeholder="Your email address", autocomplete="email", required="required", class_="form-group__input", tabindex="4") }}
+          {{ add_email_form.email(placeholder="Your email address", autocomplete="email", required="required", class_="form-group__input") }}
           {{ field_errors(add_email_form.email) }}
         </div>
         <div class="form-group__horizontal-right">
-          <input value="Add" class="button button--primary" type="submit" tabindex="5">
+          <input value="Add" class="button button--primary" type="submit">
         </div>
       </div>
     </div>
@@ -211,24 +211,24 @@
         <label class="form-group__label" for="name">Old Password</label>
         <label for="show-password">
           <input data-action="change->password#togglePasswords" data-target="password.showPassword"
-            id="show-password" type="checkbox" tabindex="10">&nbsp;Show passwords
+            id="show-password" type="checkbox">&nbsp;Show passwords
         </label>
       </div>
-      {{ change_password_form.password(placeholder="Your current password", required="required", class_="form-group__input", data_target="password.password", tabindex="6")}}
+      {{ change_password_form.password(placeholder="Your current password", required="required", class_="form-group__input", data_target="password.password")}}
       {{ field_errors(change_password_form.password) }}
     </div>
     <div class="form-group">
       <label class="form-group__label" for="name">New Password</label>
       {# the password field needs to be wrapped in a div to properly place tooltips #}
       <div>
-        {{ change_password_form.new_password(placeholder="Select a new password", required="required", class_="form-group__input", data_target="password.password password-match.passwordMatch password-strength-gauge.password", data_action="keyup->password-match#checkPasswordsMatch keyup->password-strength-gauge#checkPasswordStrength", tabindex="7") }}
+        {{ change_password_form.new_password(placeholder="Select a new password", required="required", class_="form-group__input", data_target="password.password password-match.passwordMatch password-strength-gauge.password", data_action="keyup->password-match#checkPasswordsMatch keyup->password-strength-gauge#checkPasswordStrength") }}
       </div>
       {{ field_errors(change_password_form.new_password) }}
       {{ password_strength_gauge(data_target="password-strength-gauge.strengthGauge") }}
     </div>
     <div class="form-group">
       <label class="form-group__label" for="name">Confirm New Password</label>
-      {{ change_password_form.password_confirm(placeholder="Confirm password", required="required", class_="form-group__input", data_target="password.password password-match.passwordMatch", data_action="keyup->password-match#checkPasswordsMatch", tabindex="8") }}
+      {{ change_password_form.password_confirm(placeholder="Confirm password", required="required", class_="form-group__input", data_target="password.password password-match.passwordMatch", data_action="keyup->password-match#checkPasswordsMatch") }}
       {{ field_errors(change_password_form.password_confirm) }}
     </div>
     <div class="form-group">
@@ -237,7 +237,7 @@
       </ul>
     </div>
     <div>
-      <input value="Update Password" class="button button--primary" type="submit" data-target="password-match.submit" tabindex="9">
+      <input value="Update Password" class="button button--primary" type="submit" data-target="password-match.submit">
     </div>
   </form>
 
@@ -282,7 +282,7 @@
       <i class="fa fa-warning" aria-hidden="true"><span class="sr-only">Warning</span></i>
       You will not be able to recover your account after you delete it.
     </p>
-    {{ confirm_button("Delete your PyPI Account", "Username", user.username, tabindex="11") }}
+    {{ confirm_button("Delete your PyPI Account", "Username", user.username) }}
     {% endif %}
   </div>
 {% endblock %}

--- a/warehouse/templates/manage/manage_base.html
+++ b/warehouse/templates/manage/manage_base.html
@@ -93,9 +93,9 @@
   </div>
 {% endmacro %}
 
-{% macro confirm_button(title, confirm_name, confirm_string, index=None, extra_fields=None, action=None, tabindex=None) %}
+{% macro confirm_button(title, confirm_name, confirm_string, index=None, extra_fields=None, action=None) %}
   {% set slug = title.lower().replace(' ', '-') + '-modal' + ('-{}'.format(index) if index else '') %}
-  <a href="#{{ slug }}" class="button button--danger" {%if tabindex is not none %} tabindex="{{ tabindex }}"{% endif %}>
+  <a href="#{{ slug }}" class="button button--danger">
     {{ title }}
   </a>
   {{ confirm_modal(title, confirm_name, confirm_string, slug, index=None, extra_fields=extra_fields, action=action) }}

--- a/warehouse/templates/manage/manage_base.html
+++ b/warehouse/templates/manage/manage_base.html
@@ -93,9 +93,9 @@
   </div>
 {% endmacro %}
 
-{% macro confirm_button(title, confirm_name, confirm_string, index=None, extra_fields=None, action=None) %}
+{% macro confirm_button(title, confirm_name, confirm_string, index=None, extra_fields=None, action=None, tabindex=None) %}
   {% set slug = title.lower().replace(' ', '-') + '-modal' + ('-{}'.format(index) if index else '') %}
-  <a href="#{{ slug }}" class="button button--danger">
+  <a href="#{{ slug }}" class="button button--danger" {%if tabindex is not none %} tabindex="{{ tabindex }}"{% endif %}>
     {{ title }}
   </a>
   {{ confirm_modal(title, confirm_name, confirm_string, slug, index=None, extra_fields=extra_fields, action=action) }}


### PR DESCRIPTION
Closes #3381 

The `Show passwords` checkbox comes after the password fields and submit buttons in each view. 

- For the registration view, that'd be the `register` button
- For reset-password.html, that'd be the `reset` button
- For the manage account view, that'd be the `update password` button

The first input field for some of the views is now focused on load.

- For the registration view, that'd be the `name` field
- For reset-password.html, that'd be the `new password` field
- For request-password-reset.html, that'd be the `username/email` field

I can take screenshots of all this if that's desirable but I think the behavior is pretty self-explanatory. If not, then please let me know!