### PR TITLE
Use proper casing for GitHub-Flavored Markdown variant

### DIFF
--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -304,7 +304,7 @@ class TestValidation:
             "text/plain; charset=UTF-8",
             "text/x-rst; charset=UTF-8",
             "text/markdown; charset=UTF-8; variant=CommonMark",
-            "text/markdown; charset=UTF-8; variant=gfm",
+            "text/markdown; charset=UTF-8; variant=GFM",
             "text/markdown",
         ],
     )

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -144,7 +144,7 @@ _valid_description_content_types = {
 
 _valid_markdown_variants = {
     'CommonMark',
-    'gfm',
+    'GFM',
 }
 
 


### PR DESCRIPTION
Related: https://github.com/pypa/readme_renderer/pull/74
Follow-up from: https://github.com/pypa/warehouse/pull/3322