### PR TITLE
Fix error message for invalid classifiers

### DIFF
--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -814,7 +814,7 @@ class TestFileUpload:
                     "version": "1.0",
                     "md5_digest": "bad",
                 },
-                "filetype: This field is required.",
+                "Invalid value for filetype. Error: This field is required.",
             ),
             (
                 {
@@ -835,7 +835,7 @@ class TestFileUpload:
                     "pyversion": "1.0",
                     "md5_digest": "bad",
                 },
-                "filetype: Unknown type of file.",
+                "Invalid value for filetype. Error: Unknown type of file.",
             ),
             (
                 {
@@ -867,8 +867,8 @@ class TestFileUpload:
                     "filetype": "sdist",
                     "sha256_digest": "an invalid sha256 digest",
                 },
-                "sha256_digest: "
-                "Must be a valid, hex encoded, SHA256 message digest."
+                "Invalid value for sha256_digest. "
+                "Error: Must be a valid, hex encoded, SHA256 message digest."
             ),
 
             # summary errors
@@ -1494,11 +1494,9 @@ class TestFileUpload:
 
         assert resp.status_code == 400
         assert resp.status == (
-            "400 ['Environment :: Other Environment'] "
-            "is an invalid value for Classifier. "
+            "400 Invalid value for classifiers. "
             "Error: 'Environment :: Other Environment' is not a valid choice "
-            "for this field "
-            "see https://packaging.python.org/specifications/core-metadata"
+            "for this field"
         )
 
     @pytest.mark.parametrize(

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -760,19 +760,22 @@ def file_upload(request):
             field_name = sorted(form.errors.keys())[0]
 
         if field_name in form:
-            if form[field_name].description:
+            field = form[field_name]
+            if field.description and isinstance(field, wtforms.StringField):
                 error_message = (
                     "{value!r} is an invalid value for {field}. ".format(
-                        value=form[field_name].data,
-                        field=form[field_name].description) +
+                        value=field.data,
+                        field=field.description) +
                     "Error: {} ".format(form.errors[field_name][0]) +
                     "see "
                     "https://packaging.python.org/specifications/core-metadata"
                 )
             else:
-                error_message = "{field}: {msgs[0]}".format(
-                    field=field_name,
-                    msgs=form.errors[field_name],
+                error_message = (
+                    "Invalid value for {field}. Error: {msgs[0]}".format(
+                        field=field_name,
+                        msgs=form.errors[field_name],
+                    )
                 )
         else:
             error_message = "Error: {}".format(form.errors[field_name][0])


### PR DESCRIPTION
Fixes #3430.

* Don't show the field value if it's not a `StringField`.
* Also updates the non-stringfield error to be more consistent.