### PR TITLE
Better stop and purge

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,7 @@ clean:
 	rm -rf warehouse/static/components
 	rm -rf warehouse/static/dist
 
-purge: clean
+purge: stop clean
 	rm -rf .state
 	docker-compose rm --force --all
 

--- a/Makefile
+++ b/Makefile
@@ -157,6 +157,6 @@ purge: clean
 	docker-compose rm --force --all
 
 stop:
-	docker ps -aq --filter name=warehouse | xargs docker stop
+	docker-compose down -v
 
 .PHONY: default build serve initdb shell tests docs deps travis-deps clean purge debug stop

--- a/Makefile
+++ b/Makefile
@@ -154,7 +154,7 @@ clean:
 
 purge: stop clean
 	rm -rf .state
-	docker-compose rm --force --all
+	docker-compose rm --force
 
 stop:
 	docker-compose down -v


### PR DESCRIPTION
Towards #3476:

* Use `docker-compose down` instead for `make stop` since the existing command seems to miss some containers for some reason
* Stop running containers before purging
* Remove `--all` flag to suppress warning message