### PR TITLE
Style focus states, use buttons where needed

### DIFF
--- a/warehouse/static/sass/base/_forms.scss
+++ b/warehouse/static/sass/base/_forms.scss
@@ -34,7 +34,10 @@ select {
 #{$all-text-inputs-active},
 select:focus,
 select:hover,
-select:active {
+select:active,
+input[type="checkbox"]:focus,
+input[type="checkbox"]:hover,
+input[type="checkbox"]:active {
   box-shadow: inset 0 0 0 2px $primary-color-light;
   border-color: $primary-color-light;
   outline: none;

--- a/warehouse/static/sass/base/_typography.scss
+++ b/warehouse/static/sass/base/_typography.scss
@@ -114,7 +114,11 @@ a {
     text-decoration: underline;
   }
 
-  @include link-focus
+  @include link-focus;
+}
+
+button {
+  @include link-focus;
 }
 
 @include selection {

--- a/warehouse/static/sass/blocks/_accordion.scss
+++ b/warehouse/static/sass/blocks/_accordion.scss
@@ -31,6 +31,9 @@
     display: block;
     text-decoration: none;
     cursor: pointer;
+    border: 0;
+    background-color: transparent;
+    color: $primary-color;
 
     &:hover {
       text-decoration: none;
@@ -41,6 +44,11 @@
       content: "\f139";
       margin-right: $spacing-unit / 2;
     }
+
+    @media only screen and (max-width: $desktop) {
+      color: $white;
+    }
+
   }
 
   &__content {

--- a/warehouse/static/sass/blocks/_button.scss
+++ b/warehouse/static/sass/blocks/_button.scss
@@ -57,6 +57,8 @@
     outline: none;
   }
 
+  @include link-focus;
+
   &--small {
     font-size: $small-font-size;
     height: 32px;

--- a/warehouse/static/sass/blocks/_filter-badge.scss
+++ b/warehouse/static/sass/blocks/_filter-badge.scss
@@ -56,6 +56,8 @@
   &__remove-button {
     display: table-cell;
     color: $white;
+    background: transparent;
+    border: 0;
     border-left: 1px solid transparentize($white, 0.8);
     padding: 6px;
 

--- a/warehouse/static/sass/blocks/_filter-panel.scss
+++ b/warehouse/static/sass/blocks/_filter-panel.scss
@@ -31,6 +31,9 @@
 
   &__close {
     display: none;
+    border: 0;
+    color: $white;
+    background: transparent;
   }
 
   @media only screen and (max-width: $desktop) {

--- a/warehouse/static/sass/blocks/_package-header.scss
+++ b/warehouse/static/sass/blocks/_package-header.scss
@@ -73,7 +73,7 @@
   }
 
   &__name {
-    @include ellipsis;
+    @include add-ellipsis;
     padding: 0;
     margin-top: -10px;
   }

--- a/warehouse/static/sass/blocks/_package-snippet.scss
+++ b/warehouse/static/sass/blocks/_package-snippet.scss
@@ -41,13 +41,15 @@
   }
 
   &__title {
-    @include ellipsis;
+    @include add-ellipsis;
     @include h3;
     padding-bottom: 0;
     display: block;
 
-    &--page-title {
+    &--page-title,
+    &--page-title:first-child {
       @include h1-title;
+      padding-top: 1px;
       padding-bottom: 5px;
     }
   }
@@ -62,7 +64,7 @@
   }
 
   &__description {
-    @include ellipsis;
+    @include add-ellipsis;
     clear: both;
     font-size: 1rem;
     font-style: italic;

--- a/warehouse/static/sass/blocks/_release.scss
+++ b/warehouse/static/sass/blocks/_release.scss
@@ -96,7 +96,7 @@
   }
 
   &__version {
-    @include ellipsis;
+    @include add-ellipsis;
     padding-bottom: 0;
     font-size: 20px;
     font-weight: $bold-font-weight;

--- a/warehouse/static/sass/blocks/_search-form.scss
+++ b/warehouse/static/sass/blocks/_search-form.scss
@@ -41,8 +41,8 @@
     position: absolute;
     right: 0;
     top: 0;
-    height: 38px;
-    width: 38px;
+    height: 40px;
+    width: 40px;
     border: 0;
     background-color: transparent;
     color: mix($text-color, $border-color, 50);

--- a/warehouse/static/sass/blocks/_skip-to-content.scss
+++ b/warehouse/static/sass/blocks/_skip-to-content.scss
@@ -25,6 +25,7 @@
   width: 1px;
   height: 1px;
   overflow: hidden;
+  color: $white;
   z-index: index($z-index-scale, "skip-to-content");
 
   &:focus {
@@ -34,5 +35,7 @@
     height: 41px;
     line-height: 41px;
     padding: 0 ($spacing-unit / 2);
+    color: $white;
+    background-color: #235589;
   }
 }

--- a/warehouse/static/sass/blocks/_vertical-tabs.scss
+++ b/warehouse/static/sass/blocks/_vertical-tabs.scss
@@ -45,6 +45,7 @@
 
   &__tabs {
     @include span-columns(3);
+    padding-left: 1px;
 
     @media only screen and (max-width: $tablet) {
       display: none;
@@ -56,7 +57,8 @@
     padding: $spacing-unit / 2;
     cursor: pointer;
 
-    &:hover {
+    &:hover,
+    &:focus {
       text-decoration: none;
       color: darken($primary-color, 10)
     }

--- a/warehouse/static/sass/settings/_colours.scss
+++ b/warehouse/static/sass/settings/_colours.scss
@@ -15,13 +15,13 @@
 // SETTINGS - COLOURS
 
 $primary-color:               #006dad;
-$highlight-color:             #ffd343;
-$success-color:               #169428;
+$primary-color-light:         lighten($primary-color, 45);
+$primary-color-dark:          darken($primary-color, 10);
+$success-color:               #148024;
 $warn-color:                  #ffdf76;
 $warn-text:                   #664e04;
 $danger-color:                #D52D40;
-$primary-color-light:         lighten($primary-color, 45);
-$primary-color-dark:          darken($primary-color, 10);
+$highlight-color:             #ffd343;
 
 $white:                       #fff;
 $black:                       #000;

--- a/warehouse/static/sass/tools/_design-utilities.scss
+++ b/warehouse/static/sass/tools/_design-utilities.scss
@@ -20,8 +20,8 @@
 
 @mixin link-focus {
   &:focus {
-    background-color: $highlight-color;
-    color: darken($highlight-color, 50);
+    outline: 1px solid $primary-color-light;
+    background-color: transparentize($primary-color-light, 0.9            );
     cursor: pointer;
   }
 }
@@ -78,4 +78,10 @@
       background-color: darken($background-color, 2);
     }
   }
+}
+
+@mixin add-ellipsis {
+  @include ellipsis;
+  padding-left: 1px;
+  padding-right: 1px;
 }

--- a/warehouse/templates/includes/current-user-indicator.html
+++ b/warehouse/templates/includes/current-user-indicator.html
@@ -15,7 +15,7 @@
   {% if request.user %}
   <div id="user-indicator" class="horizontal-menu horizontal-menu--light horizontal-menu--tall">
     <div class="dropdown dropdown--on-menu dropdown--with-icons">
-      <button class="horizontal-menu__link dropdown__trigger">
+      <button type="button" class="horizontal-menu__link dropdown__trigger">
         <span class="hide-on-mobile">Welcome back, </span>{{ request.user.username }}
         <span class="dropdown__trigger-caret">
           <i class="fa fa-caret-down" aria-hidden="true"></i>

--- a/warehouse/templates/includes/flash-messages.html
+++ b/warehouse/templates/includes/flash-messages.html
@@ -15,20 +15,20 @@
 {% for message in request.session.pop_flash(queue="error") %}
 <div class="notification-bar notification-bar--danger notification-bar--dismissable" data-controller="notification" data-target="notification.notification">
   <span class="notification-bar__message">{{ message }}</span>
-  <button title="Dismiss this notification" data-target="notification.dismissButton" data-action="click->notification#dismiss" class="notification-bar__dismiss" aria-label="close"><i class="fa fa-times" aria-hidden="true"></i></button>
+  <button type="button" title="Dismiss this notification" data-target="notification.dismissButton" data-action="click->notification#dismiss" class="notification-bar__dismiss" aria-label="close"><i class="fa fa-times" aria-hidden="true"></i></button>
 </div>
 {% endfor %}
 
 {% for message in request.session.pop_flash() %}
 <div class="notification-bar notification-bar--dismissable" data-controller="notification" data-target="notification.notification">
   <span class="notification-bar__message">{{ message }}</span>
-  <button title="Dismiss this notification" data-target="notification.dismissButton" data-action="click->notification#dismiss" class="notification-bar__dismiss" aria-label="close"><i class="fa fa-times" aria-hidden="true"></i></button>
+  <button type="button" title="Dismiss this notification" data-target="notification.dismissButton" data-action="click->notification#dismiss" class="notification-bar__dismiss" aria-label="close"><i class="fa fa-times" aria-hidden="true"></i></button>
 </div>
 {% endfor %}
 
 {% for message in request.session.pop_flash(queue="success") %}
 <div class="notification-bar notification-bar--success notification-bar--dismissable" data-controller="notification" data-target="notification.notification">
   <span class="notification-bar__message">{{ message }}</span>
-  <button title="Dismiss this notification" data-target="notification.dismissButton" data-action="click->notification#dismiss" class="notification-bar__dismiss" aria-label="dismiss"><i class="fa fa-times" aria-hidden="true"></i></button>
+  <button type="button" title="Dismiss this notification" data-target="notification.dismissButton" data-action="click->notification#dismiss" class="notification-bar__dismiss" aria-label="dismiss"><i class="fa fa-times" aria-hidden="true"></i></button>
 </div>
 {% endfor %}

--- a/warehouse/templates/manage/account.html
+++ b/warehouse/templates/manage/account.html
@@ -67,7 +67,7 @@
     <td class="table__action">
       {% if not email.verified or user.emails|length > 1 and not email.primary%}
       <div class="dropdown dropdown--with-icons dropdown--wide">
-        <button class="dropdown__trigger button button--primary">
+        <button type="button" class="dropdown__trigger button button--primary">
           Options
           <span class="dropdown__trigger-caret">
             <i class="fa fa-caret-down" aria-hidden="true"></i>

--- a/warehouse/templates/manage/release.html
+++ b/warehouse/templates/manage/release.html
@@ -57,7 +57,7 @@
         <td class="table__upload">{{ file.upload_time|format_date() }}</td>
         <td class="table__options">
           <div class="dropdown dropdown--with-icons pull-right">
-            <button class="dropdown__trigger button button--primary">
+            <button type="button" class="dropdown__trigger button button--primary">
               Options
               <span class="dropdown__trigger-caret">
                 <i class="fa fa-caret-down" aria-hidden="true"></i>

--- a/warehouse/templates/manage/releases.html
+++ b/warehouse/templates/manage/releases.html
@@ -45,7 +45,7 @@
             </td>
           <td class="table__options">
             <div class="dropdown dropdown--with-icons">
-              <button class="dropdown__trigger button button--primary">
+              <button type="button" class="dropdown__trigger button button--primary">
                 Options
                 <span class="dropdown__trigger-caret">
                   <i class="fa fa-caret-down" aria-hidden="true"></i>

--- a/warehouse/templates/search/results.html
+++ b/warehouse/templates/search/results.html
@@ -96,10 +96,10 @@
     <div class="left-layout__sidebar">
       <div class="dark-overlay -js-dark-overlay"></div>
       <aside class="filter-panel -js-filter-panel">
-        <a class="filter-panel__close -js-close-panel">
+        <button type="button" class="filter-panel__close -js-close-panel">
           <i class="fa fa-close" aria-hidden="true"></i>
           <span class="sr-only">Close</span>
-        </a>
+        </button>
         <h2 class="no-top-padding">
           Filter by classifier
           <a href="{{ request.route_path('help')}}#trove-classifier"
@@ -117,7 +117,7 @@
         {% set applied_filters_str = applied_filters|join(' ') %}
         {% for top_level, classifiers in available_filters %}
           <div class="accordion{{ ' accordion--closed' if top_level not in applied_filters_str else '' }}">
-            <a class="accordion__link -js-accordion-trigger">By {{ top_level }}</a>
+            <button type="button" class="accordion__link -js-accordion-trigger">By {{ top_level }}</button>
             <div class="accordion__content">
               <div class="checkbox-tree">
               {% for classifier in classifiers %}
@@ -199,15 +199,15 @@
               <span class="sr-only">Filter</span>
             </span>
             <span class="filter-badge__description">{{ filter }}</span>
-            <a class="filter-badge__remove-button" href="#">
+            <button type="button" class="filter-badge__remove-button">
               <i class="fa fa-close" aria-hidden="true"></i>
               <span class="sr-only">Close</span>
-            </a>
+            </button>
           </div>
           {% endfor %}
         {% endif %}
           <span class="applied-filters__add-button">
-            <a class="-js-add-filter button button--small" href="#">Add Filter</a>
+            <button type="button" class="-js-add-filter button button--small">Add Filter</button>
           </span>
         </div>
 


### PR DESCRIPTION
1. Restyle focus states

![screenshot from 2018-04-05 07-18-39](https://user-images.githubusercontent.com/3323703/38350090-b81a569a-38a1-11e8-9ee6-055699e6599b.png)
![screenshot from 2018-04-05 07-18-56](https://user-images.githubusercontent.com/3323703/38350091-b835d802-38a1-11e8-9548-9768887009da.png)

2. Use buttons instead of `<a>` with no `href` for actions. This allows the button to be focused with a keyboard.
