### PR TITLE
Add surrogate keys for HTML templates

### DIFF
--- a/docs/development/frontend.rst
+++ b/docs/development/frontend.rst
@@ -17,6 +17,27 @@ however, you can trigger a manual build of them by installing all of the
 dependencies using ``npm install`` and then running ``gulp dist``.
 
 
+Deploying
+---------
+
+When deploying changes to the frontend, to see the changes immediately it is
+necessary to purge the cache.
+
+Individual pages can be purged from the command line by issuing a ``XPURGE``
+request, e.g.::
+
+    curl -XPURGE https://pypi.org/the/page/to/purge
+
+All HTML pages can be dropped from the cache by purging the `all-html`
+surrogate key via our CDN provider.
+
+The entire cache can be purged by issuing a "Purge All" via our CDN provider.
+
+Purging the cache is not usually necesasry when making frontend changes, unless
+it would be unacceptable for the site to simultaneously have an "old" version
+of some pages, but the "new" version of others.
+
+
 Browser Support
 ---------------
 

--- a/docs/development/frontend.rst
+++ b/docs/development/frontend.rst
@@ -28,7 +28,7 @@ request, e.g.::
 
     curl -XPURGE https://pypi.org/the/page/to/purge
 
-All HTML pages can be dropped from the cache by purging the `all-html`
+All HTML pages can be dropped from the cache by purging the ``all-html``
 surrogate key via our CDN provider.
 
 The entire cache can be purged by issuing a "Purge All" via our CDN provider.

--- a/tests/unit/cache/origin/test_derivers.py
+++ b/tests/unit/cache/origin/test_derivers.py
@@ -1,0 +1,93 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pretend
+
+from warehouse.cache.origin.derivers import html_cache_deriver
+
+
+def test_no_renderer():
+    view = pretend.stub()
+    info = pretend.stub(options={})
+
+    assert html_cache_deriver(view, info) == view
+
+
+def test_non_html_renderer():
+    view = pretend.stub()
+    renderer = pretend.stub(name='foo.txt')
+    info = pretend.stub(options={'renderer': renderer})
+
+    assert html_cache_deriver(view, info) == view
+
+
+def test_no_origin_cache_found():
+    view_result = pretend.stub()
+    view = pretend.call_recorder(lambda context, request: view_result)
+    renderer = pretend.stub(name='foo.html')
+    info = pretend.stub(options={'renderer': renderer})
+    context = pretend.stub()
+
+    def raise_valueerror(*a):
+        raise ValueError
+
+    request = pretend.stub(
+        find_service=raise_valueerror,
+        add_response_callback=pretend.call_recorder(lambda a: None)
+    )
+
+    assert html_cache_deriver(view, info)(context, request) == view_result
+    assert request.add_response_callback.calls == []
+
+
+def test_response_hook():
+
+    class Cache:
+
+        @staticmethod
+        @pretend.call_recorder
+        def cache(keys, request, response, seconds, stale_while_revalidate,
+                  stale_if_error):
+            pass
+
+    response = pretend.stub()
+
+    @pretend.call_recorder
+    def view(context, request):
+        return response
+
+    context = pretend.stub()
+    cacher = Cache()
+    callbacks = []
+    request = pretend.stub(
+        find_service=lambda iface: cacher,
+        add_response_callback=callbacks.append,
+    )
+    info = pretend.stub(options={'renderer': pretend.stub(name='foo.html')})
+    derived_view = html_cache_deriver(view, info)
+
+    assert derived_view(context, request) is response
+    assert view.calls == [pretend.call(context, request)]
+    assert len(callbacks) == 1
+
+    callbacks[0](request, response)
+
+    assert cacher.cache.calls == [
+        pretend.call(
+            ['all-html', 'foo.html'],
+            request,
+            response,
+            seconds=86400,
+            stale_while_revalidate=300,
+            stale_if_error=86400,
+        ),
+    ]

--- a/tests/unit/cache/origin/test_derivers.py
+++ b/tests/unit/cache/origin/test_derivers.py
@@ -55,8 +55,7 @@ def test_response_hook():
 
         @staticmethod
         @pretend.call_recorder
-        def cache(keys, request, response, seconds, stale_while_revalidate,
-                  stale_if_error):
+        def cache(keys, request, response):
             pass
 
     response = pretend.stub()
@@ -86,8 +85,5 @@ def test_response_hook():
             ['all-html', 'foo.html'],
             request,
             response,
-            seconds=86400,
-            stale_while_revalidate=300,
-            stale_if_error=86400,
         ),
     ]

--- a/tests/unit/cache/origin/test_fastly.py
+++ b/tests/unit/cache/origin/test_fastly.py
@@ -138,6 +138,18 @@ class TestFastlyCache:
             ),
         }
 
+    def test_multiple_calls_to_cache_dont_overwrite_surrogate_keys(self):
+        request = pretend.stub()
+        response = pretend.stub(headers={})
+
+        cacher = fastly.FastlyCache(api_key=None, service_id=None, purger=None)
+        cacher.cache(["abc"], request, response)
+        cacher.cache(["defg"], request, response)
+
+        assert response.headers == {
+            "Surrogate-Key": "abc defg",
+        }
+
     def test_purge(self, monkeypatch):
         purge_delay = pretend.call_recorder(lambda *a, **kw: None)
         cacher = fastly.FastlyCache(

--- a/tests/unit/cache/origin/test_fastly.py
+++ b/tests/unit/cache/origin/test_fastly.py
@@ -150,6 +150,23 @@ class TestFastlyCache:
             "Surrogate-Key": "abc defg",
         }
 
+    def test_multiple_calls_with_different_requests(self):
+        request_a = pretend.stub()
+        request_b = pretend.stub()
+        response_a = pretend.stub(headers={})
+        response_b = pretend.stub(headers={})
+
+        cacher = fastly.FastlyCache(api_key=None, service_id=None, purger=None)
+        cacher.cache(["abc"], request_a, response_a)
+        cacher.cache(["defg"], request_b, response_b)
+
+        assert response_a.headers == {
+            "Surrogate-Key": "abc",
+        }
+        assert response_b.headers == {
+            "Surrogate-Key": "defg",
+        }
+
     def test_purge(self, monkeypatch):
         purge_delay = pretend.call_recorder(lambda *a, **kw: None)
         cacher = fastly.FastlyCache(

--- a/tests/unit/cache/origin/test_init.py
+++ b/tests/unit/cache/origin/test_init.py
@@ -190,7 +190,7 @@ class TestOriginCache:
 
         assert cacher.cache.calls == [
             pretend.call(
-                sorted(["one", "two"] + ([] if keys is None else keys)),
+                ["one", "two"] + ([] if keys is None else keys),
                 request,
                 response,
                 seconds=seconds,

--- a/tests/unit/cache/origin/test_init.py
+++ b/tests/unit/cache/origin/test_init.py
@@ -14,6 +14,7 @@ import pretend
 import pytest
 
 from warehouse.cache import origin
+from warehouse.cache.origin.derivers import html_cache_deriver
 from warehouse.cache.origin.interfaces import IOriginCache
 
 
@@ -306,6 +307,7 @@ def test_includeme_with_origin_cache():
     cache_class = pretend.stub(create_service=pretend.stub())
     config = pretend.stub(
         add_directive=pretend.call_recorder(lambda name, func: None),
+        add_view_deriver=pretend.call_recorder(lambda deriver: None),
         registry=pretend.stub(
             settings={
                 "origin_cache.backend":
@@ -323,6 +325,9 @@ def test_includeme_with_origin_cache():
             "register_origin_cache_keys",
             origin.register_origin_cache_keys,
         ),
+    ]
+    assert config.add_view_deriver.calls == [
+        pretend.call(html_cache_deriver),
     ]
     assert config.maybe_dotted.calls == [
         pretend.call("warehouse.cache.origin.fastly.FastlyCache"),

--- a/warehouse/cache/origin/__init__.py
+++ b/warehouse/cache/origin/__init__.py
@@ -76,7 +76,7 @@ def origin_cache(seconds, keys=None, stale_while_revalidate=None,
                 request.add_response_callback(
                     functools.partial(
                         cacher.cache,
-                        sorted(context_keys + keys),
+                        context_keys + keys,
                         seconds=seconds,
                         stale_while_revalidate=stale_while_revalidate,
                         stale_if_error=stale_if_error,

--- a/warehouse/cache/origin/__init__.py
+++ b/warehouse/cache/origin/__init__.py
@@ -18,6 +18,7 @@ from itertools import chain
 from sqlalchemy.orm.session import Session
 
 from warehouse import db
+from warehouse.cache.origin.derivers import html_cache_deriver
 from warehouse.cache.origin.interfaces import IOriginCache
 
 
@@ -152,6 +153,7 @@ def includeme(config):
             cache_class.create_service,
             IOriginCache,
         )
+        config.add_view_deriver(html_cache_deriver)
 
     config.add_directive(
         "register_origin_cache_keys",

--- a/warehouse/cache/origin/derivers.py
+++ b/warehouse/cache/origin/derivers.py
@@ -27,7 +27,7 @@ def html_cache_deriver(view, info):
                 request.add_response_callback(
                     functools.partial(
                         cacher.cache,
-                        sorted(['all-html', renderer.name]),
+                        ['all-html', renderer.name],
                     )
                 )
             return view(context, request)

--- a/warehouse/cache/origin/derivers.py
+++ b/warehouse/cache/origin/derivers.py
@@ -28,9 +28,6 @@ def html_cache_deriver(view, info):
                     functools.partial(
                         cacher.cache,
                         sorted(['all-html', renderer.name]),
-                        seconds=1 * 24 * 60 * 60,                 # 1 day
-                        stale_while_revalidate=5 * 60,    # 5 minutes
-                        stale_if_error=1 * 24 * 60 * 60,  # 1 day
                     )
                 )
             return view(context, request)

--- a/warehouse/cache/origin/derivers.py
+++ b/warehouse/cache/origin/derivers.py
@@ -1,0 +1,38 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import functools
+
+from warehouse.cache.origin.interfaces import IOriginCache
+
+
+def html_cache_deriver(view, info):
+    renderer = info.options.get('renderer')
+    if renderer and renderer.name.endswith('.html'):
+        def wrapper_view(context, request):
+            try:
+                cacher = request.find_service(IOriginCache)
+            except ValueError:
+                pass
+            else:
+                request.add_response_callback(
+                    functools.partial(
+                        cacher.cache,
+                        sorted(['all-html', renderer.name]),
+                        seconds=1 * 24 * 60 * 60,                 # 1 day
+                        stale_while_revalidate=5 * 60,    # 5 minutes
+                        stale_if_error=1 * 24 * 60 * 60,  # 1 day
+                    )
+                )
+            return view(context, request)
+        return wrapper_view
+    return view

--- a/warehouse/cache/origin/fastly.py
+++ b/warehouse/cache/origin/fastly.py
@@ -45,6 +45,7 @@ class FastlyCache:
         self.api_key = api_key
         self.service_id = service_id
         self._purger = purger
+        self.keys = set()
 
     @classmethod
     def create_service(cls, context, request):
@@ -56,7 +57,9 @@ class FastlyCache:
 
     def cache(self, keys, request, response, *, seconds=None,
               stale_while_revalidate=None, stale_if_error=None):
-        response.headers["Surrogate-Key"] = " ".join(keys)
+
+        self.keys.update(keys)
+        response.headers["Surrogate-Key"] = " ".join(sorted(self.keys))
 
         values = []
 


### PR DESCRIPTION
Fixes #778.

This adds a surrogate key `all-html` which can be used to purge all views rendered from an HTML template.

It also adds per-template surrogate keys as well, corresponding to the HTML template name (e.g. `accounts/request-password-reset.html`), so we can purge individual pages if they change.