### PR TITLE
Fix TestPyPI title

### DIFF
--- a/warehouse/templates/base.html
+++ b/warehouse/templates/base.html
@@ -46,7 +46,7 @@
       {% set testPyPI = true %}
     {% endif %}
 
-    <title>{% if testPyPI %}Test{% endif %}{% block title_base %}{% block title %}{% endblock %}{% if self.title() %} · {% endif %}{{ request.registry.settings['site.name'] }}{% endblock %}</title>
+    <title>{% block title_base %}{% block title %}{% endblock %}{% if self.title() %} · {% endif %}{{ request.registry.settings['site.name'] }}{% endblock %}</title>
     <meta name="description" content="{% block description %}The Python Package Index (PyPI) is a repository of software for the Python programming language.{% endblock %}">
 
     <link rel="stylesheet" href="{{ request.static_path('warehouse:static/dist/css/warehouse.css') }}">

--- a/warehouse/templates/index.html
+++ b/warehouse/templates/index.html
@@ -13,7 +13,7 @@
 -#}
 {% extends "base.html" %}
 
-{% block title %}PyPI - the Python Package Index{% endblock %}
+{% block title %}{% if testPyPI %}Test{% endif %}PyPI - the Python Package Index{% endblock %}
 
 {% macro project_snippet(release) -%}
 <div class="package-snippet">


### PR DESCRIPTION
This was putting "Test" in front of every title.