### PR TITLE
Time ago: remove fullstop from readable text for consistency

### DIFF
--- a/warehouse/static/js/warehouse/utils/timeago.js
+++ b/warehouse/static/js/warehouse/utils/timeago.js
@@ -28,7 +28,7 @@ const convertToReadableText = (time) => {
   let { numDays, numMinutes, numHours } = time;
 
   if (numDays >= 1) {
-    return numDays == 1 ? "Yesterday." : `About ${numDays} days ago.`;
+    return numDays == 1 ? "Yesterday." : `About ${numDays} days ago`;
   }
 
   if (numHours > 0) {
@@ -36,9 +36,9 @@ const convertToReadableText = (time) => {
     return `About ${numHours} ago.`;
   } else if (numMinutes > 0) {
     numMinutes = numMinutes > 1 ? `${numMinutes} minutes` : "a minute";
-    return `About ${numMinutes} ago.`;
+    return `About ${numMinutes} ago`;
   } else {
-    return "Just now.";
+    return "Just now";
   }
 };
 


### PR DESCRIPTION
Would it be better to remove the period at the end of the readable "time ago" text?

Here are the three places I've found that displays it: two where the equivalent dates don't have a fullstop, and one as standalone text that doesn't really need it, and similar text doesn't.

---

https://pypi.org/project/pylast/#history

![image](https://user-images.githubusercontent.com/1324225/38468865-8e2bab94-3b54-11e8-9a07-2f9b5f3613e3.png)

---

https://pypi.org/manage/project/pylast/releases/

![image](https://user-images.githubusercontent.com/1324225/38468854-5ef9bc08-3b54-11e8-8666-baa4f5981199.png)

