### PR TITLE
Add XML-RPC /RPC2 endpoint

### DIFF
--- a/tests/unit/test_routes.py
+++ b/tests/unit/test_routes.py
@@ -334,6 +334,12 @@ def test_routes(warehouse):
             header="Content-Type:text/xml",
             domain=warehouse,
         ),
+        pretend.call(
+            "RPC2",
+            pattern="/RPC2",
+            header="Content-Type:text/xml",
+            domain=warehouse,
+        ),
     ]
 
     assert config.add_policy.calls == [

--- a/warehouse/legacy/api/xmlrpc/views.py
+++ b/warehouse/legacy/api/xmlrpc/views.py
@@ -30,22 +30,18 @@ from warehouse.packaging.models import (
     Role, Project, Release, File, JournalEntry, release_classifiers,
 )
 
-_xmlrpc_method_partial = functools.partial(
-    _xmlrpc_method,
-    require_csrf=False,
-    require_methods=["POST"],
-)
-
 
 def xmlrpc_method(**kwargs):
     """
     Support multiple endpoints serving the same views by chaining calls to
     xmlrpc_method
     """
+    # Add some default arguments
+    kwargs.update(require_csrf=False, require_methods=["POST"])
 
     def decorator(f):
-        rpc2 = _xmlrpc_method_partial(endpoint='RPC2', **kwargs)
-        pypi = _xmlrpc_method_partial(endpoint='pypi', **kwargs)
+        rpc2 = _xmlrpc_method(endpoint='RPC2', **kwargs)
+        pypi = _xmlrpc_method(endpoint='pypi', **kwargs)
         return rpc2(pypi(f))
 
     return decorator

--- a/warehouse/routes.py
+++ b/warehouse/routes.py
@@ -281,6 +281,12 @@ def includeme(config):
         header="Content-Type:text/xml",
         domain=warehouse,
     )
+    config.add_xmlrpc_endpoint(
+        "RPC2",
+        pattern="/RPC2",
+        header="Content-Type:text/xml",
+        domain=warehouse,
+    )
 
     # Legacy Documentation
     config.add_route("legacy.docs", config.registry.settings["docs.url"])


### PR DESCRIPTION
Per #3436, add a `/RPC2` endpoint for XML-RPC clients that will use this endpoint when the root does not support XML-RPC.