### PR TITLE
Include Site Name in generated emails

### DIFF
--- a/warehouse/email/__init__.py
+++ b/warehouse/email/__init__.py
@@ -23,6 +23,12 @@ from warehouse.email.ses.tasks import cleanup as ses_cleanup
 def send_email(task, request, subject, body, *, recipient=None):
     sender = request.find_service(IEmailSender)
 
+    # We want to include the site name into the lead in for every subject
+    # to reduce possible confusion about what site an email is talking
+    # about.
+    sitename = request.registry.settings["site.name"]
+    subject = f"[{sitename}] {subject}"
+
     try:
         sender.send(subject, body, recipient=recipient)
     except Exception as exc:

--- a/warehouse/templates/email/account-deleted.subject.txt
+++ b/warehouse/templates/email/account-deleted.subject.txt
@@ -1,1 +1,1 @@
-PyPI Account Deletion Notification
+Account deletion notification

--- a/warehouse/templates/email/added-as-collaborator.subject.txt
+++ b/warehouse/templates/email/added-as-collaborator.subject.txt
@@ -1,1 +1,1 @@
-PyPI Collaborator Added Notification
+Collaborator added notification

--- a/warehouse/templates/email/collaborator-added.subject.txt
+++ b/warehouse/templates/email/collaborator-added.subject.txt
@@ -1,1 +1,1 @@
-PyPI collaborator added notification
+Collaborator added notification

--- a/warehouse/templates/email/password-change.subject.txt
+++ b/warehouse/templates/email/password-change.subject.txt
@@ -1,1 +1,1 @@
-PyPI password change notification
+Password change notification

--- a/warehouse/templates/email/password-reset.subject.txt
+++ b/warehouse/templates/email/password-reset.subject.txt
@@ -1,1 +1,1 @@
-PyPI password reset request
+Password reset request

--- a/warehouse/templates/email/primary-email-change.subject.txt
+++ b/warehouse/templates/email/primary-email-change.subject.txt
@@ -1,1 +1,1 @@
-PyPI primary email change notification
+Primary email change notification

--- a/warehouse/templates/email/verify-email.subject.txt
+++ b/warehouse/templates/email/verify-email.subject.txt
@@ -1,1 +1,1 @@
-PyPI email verification
+Email verification


### PR DESCRIPTION
Instead of having emails only come from a plain email address and without having any identifier what site they're for in the subject, we will instead inject the site name in both locations.

This ends up looking like:

```
From: PyPI <noreply@pypi.org>
Subject: [PyPI] PyPI email verification
```

We probably want to refactor the subjects of the emails we're sending currently since they all include the hardcoded string "PyPI" at the front of them (which is confusing when those emails come from TestPyPI instead!). We can probably just drop that string entirely from them and let the subjects focus on what is actually happening.
