### PR TITLE
wrap gravatar urls in camo

### DIFF
--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -316,6 +316,7 @@ def test_configure(monkeypatch, settings, environment, other_settings):
         ] + [
             pretend.call(".logging"),
             pretend.call("pyramid_jinja2"),
+            pretend.call(".filters"),
             pretend.call("pyramid_mailer"),
             pretend.call("pyramid_retry"),
             pretend.call("pyramid_tm"),

--- a/tests/unit/test_csp.py
+++ b/tests/unit/test_csp.py
@@ -220,7 +220,6 @@ def test_includeme():
                 "img-src": [
                     "'self'",
                     "camo.url.value",
-                    "https://secure.gravatar.com",
                 ],
                 "script-src": ["'self'", "www.google-analytics.com"],
                 "style-src": ["'self'", "fonts.googleapis.com"],

--- a/tests/unit/test_filters.py
+++ b/tests/unit/test_filters.py
@@ -12,6 +12,8 @@
 
 import urllib.parse
 
+from functools import partial
+
 import jinja2
 import packaging.version
 import pretend
@@ -22,9 +24,16 @@ from warehouse import filters
 
 
 def test_camo_url():
+    request = pretend.stub(
+        registry=pretend.stub(
+            settings={
+                "camo.url": "https://camo.example.net/",
+                "camo.key": "fake key",
+            },
+        ),
+    )
     c_url = filters._camo_url(
-        "https://camo.example.net/",
-        "fake key",
+        request,
         "http://example.com/image.jpg",
     )
     assert c_url == (
@@ -39,16 +48,18 @@ class TestReadmeRender:
         renderer = pretend.call_recorder(lambda raw: "rendered")
         monkeypatch.setattr(readme_renderer.rst, "render", renderer)
 
-        ctx = {
-            "request": pretend.stub(
-                registry=pretend.stub(
-                    settings={
-                        "camo.url": "https://camo.example.net/",
-                        "camo.key": "fake key",
-                    },
-                ),
+        request = pretend.stub(
+            registry=pretend.stub(
+                settings={
+                    "camo.url": "https://camo.example.net/",
+                    "camo.key": "fake key",
+                },
             ),
-        }
+        )
+        camo_url = partial(filters._camo_url, request)
+        request.camo_url = camo_url
+
+        ctx = {"request": request}
 
         result = filters.readme(
             ctx, "raw thing", description_content_type="text/x-rst",
@@ -63,16 +74,18 @@ class TestReadmeRender:
         monkeypatch.setattr(readme_renderer.rst, "render", rst_renderer)
         monkeypatch.setattr(readme_renderer.txt, "render", txt_renderer)
 
-        ctx = {
-            "request": pretend.stub(
-                registry=pretend.stub(
-                    settings={
-                        "camo.url": "https://camo.example.net/",
-                        "camo.key": "fake key",
-                    },
-                ),
+        request = pretend.stub(
+            registry=pretend.stub(
+                settings={
+                    "camo.url": "https://camo.example.net/",
+                    "camo.key": "fake key",
+                },
             ),
-        }
+        )
+        camo_url = partial(filters._camo_url, request)
+        request.camo_url = camo_url
+
+        ctx = {"request": request}
 
         result = filters.readme(
             ctx, "raw thing", description_content_type="text/x-rst",
@@ -86,16 +99,18 @@ class TestReadmeRender:
         renderer = pretend.call_recorder(lambda raw: "rendered")
         monkeypatch.setattr(readme_renderer.txt, "render", renderer)
 
-        ctx = {
-            "request": pretend.stub(
-                registry=pretend.stub(
-                    settings={
-                        "camo.url": "https://camo.example.net/",
-                        "camo.key": "fake key",
-                    },
-                ),
+        request = pretend.stub(
+            registry=pretend.stub(
+                settings={
+                    "camo.url": "https://camo.example.net/",
+                    "camo.key": "fake key",
+                },
             ),
-        }
+        )
+        camo_url = partial(filters._camo_url, request)
+        request.camo_url = camo_url
+
+        ctx = {"request": request}
 
         result = filters.readme(
             ctx, "raw thing", description_content_type="text/plain",
@@ -108,16 +123,18 @@ class TestReadmeRender:
         renderer = pretend.call_recorder(lambda raw: "rendered")
         monkeypatch.setattr(readme_renderer.markdown, "render", renderer)
 
-        ctx = {
-            "request": pretend.stub(
-                registry=pretend.stub(
-                    settings={
-                        "camo.url": "https://camo.example.net/",
-                        "camo.key": "fake key",
-                    },
-                ),
+        request = pretend.stub(
+            registry=pretend.stub(
+                settings={
+                    "camo.url": "https://camo.example.net/",
+                    "camo.key": "fake key",
+                },
             ),
-        }
+        )
+        camo_url = partial(filters._camo_url, request)
+        request.camo_url = camo_url
+
+        ctx = {"request": request}
 
         result = filters.readme(
             ctx, "raw thing", description_content_type="text/markdown",
@@ -130,16 +147,18 @@ class TestReadmeRender:
         renderer = pretend.call_recorder(lambda raw: "rendered")
         monkeypatch.setattr(readme_renderer.rst, "render", renderer)
 
-        ctx = {
-            "request": pretend.stub(
-                registry=pretend.stub(
-                    settings={
-                        "camo.url": "https://camo.example.net/",
-                        "camo.key": "fake key",
-                    },
-                ),
+        request = pretend.stub(
+            registry=pretend.stub(
+                settings={
+                    "camo.url": "https://camo.example.net/",
+                    "camo.key": "fake key",
+                },
             ),
-        }
+        )
+        camo_url = partial(filters._camo_url, request)
+        request.camo_url = camo_url
+
+        ctx = {"request": request}
 
         result = filters.readme(
             ctx, "raw thing", description_content_type=None,
@@ -152,56 +171,50 @@ class TestReadmeRender:
         html = "<img src=http://example.com/image.jpg>"
         monkeypatch.setattr(readme_renderer.rst, "render", lambda raw: html)
 
-        gen_camo_url = pretend.call_recorder(
-            lambda curl, ckey, url: "https://camo.example.net/image.jpg"
-        )
-        monkeypatch.setattr(filters, "_camo_url", gen_camo_url)
-
-        ctx = {
-            "request": pretend.stub(
-                registry=pretend.stub(
-                    settings={
-                        "camo.url": "https://camo.example.net/",
-                        "camo.key": "fake key",
-                    },
-                ),
+        request = pretend.stub(
+            registry=pretend.stub(
+                settings={
+                    "camo.url": "https://camo.example.net/",
+                    "camo.key": "fake key",
+                },
             ),
-        }
+        )
+        camo_url = partial(filters._camo_url, request)
+        request.camo_url = camo_url
+
+        ctx = {"request": request}
 
         result = filters.readme(
             ctx, "raw thing", description_content_type="text/x-rst",
         )
 
         assert result == jinja2.Markup(
-            '<img src="https://camo.example.net/image.jpg">'
+            '<img src="https://camo.example.net/'
+            'b410d235a3d2fc44b50ccab827e531dece213062/'
+            '687474703a2f2f6578616d706c652e636f6d2f696d6167652e6a7067">'
         )
-        assert gen_camo_url.calls == [
-            pretend.call(
-                "https://camo.example.net/",
-                "fake key",
-                "http://example.com/image.jpg",
-            ),
-        ]
 
     def test_renders_camo_no_src(self, monkeypatch):
         html = "<img>"
         monkeypatch.setattr(readme_renderer.rst, "render", lambda raw: html)
 
+        request = pretend.stub(
+            registry=pretend.stub(
+                settings={
+                    "camo.url": "https://camo.example.net/",
+                    "camo.key": "fake key",
+                },
+            ),
+        )
+        camo_url = partial(filters._camo_url, request)
+        request.camo_url = camo_url
+
+        ctx = {"request": request}
+
         gen_camo_url = pretend.call_recorder(
             lambda curl, ckey, url: "https://camo.example.net/image.jpg"
         )
         monkeypatch.setattr(filters, "_camo_url", gen_camo_url)
-
-        ctx = {
-            "request": pretend.stub(
-                registry=pretend.stub(
-                    settings={
-                        "camo.url": "https://camo.example.net/",
-                        "camo.key": "fake key",
-                    },
-                ),
-            ),
-        }
 
         result = filters.readme(
             ctx, "raw thing", description_content_type="text/x-rst",

--- a/tests/unit/utils/test_gravatar.py
+++ b/tests/unit/utils/test_gravatar.py
@@ -15,8 +15,6 @@ from functools import partial
 import pretend
 import pytest
 
-import pyramid.threadlocal
-
 from warehouse.filters import _camo_url
 from warehouse.utils.gravatar import gravatar, profile
 
@@ -91,12 +89,10 @@ def test_gravatar(email, size, expected, monkeypatch):
     )
     camo_url = partial(_camo_url, request)
     request.camo_url = camo_url
-    monkeypatch.setattr(
-        pyramid.threadlocal, "get_current_request", lambda: request)
     kwargs = {}
     if size is not None:
         kwargs["size"] = size
-    assert gravatar(email, **kwargs) == expected
+    assert gravatar(request, email, **kwargs) == expected
 
 
 def test_profile():

--- a/tests/unit/utils/test_gravatar.py
+++ b/tests/unit/utils/test_gravatar.py
@@ -10,7 +10,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pretend
 import pytest
+
+import pyramid.threadlocal
 
 from warehouse.utils.gravatar import gravatar, profile
 
@@ -21,42 +24,70 @@ from warehouse.utils.gravatar import gravatar, profile
         (
             None,
             None,
-            "https://secure.gravatar.com/avatar/"
-            "d41d8cd98f00b204e9800998ecf8427e?size=80",
+            "https://camo.example.net/"
+            "11c994d69863c3e9cc62a7467a79cc77daff5cad/"
+            "68747470733a2f2f7365637572652e67726176617461722e636f6d2f617661746"
+            "1722f643431643863643938663030623230346539383030393938656366383432"
+            "37653f73697a653d3830",
         ),
         (
             None,
             50,
-            "https://secure.gravatar.com/avatar/"
-            "d41d8cd98f00b204e9800998ecf8427e?size=50",
+            "https://camo.example.net/"
+            "5d174a434e25f7c26372e241c7aad866d6ed45e1/"
+            "68747470733a2f2f7365637572652e67726176617461722e636f6d2f617661746"
+            "1722f643431643863643938663030623230346539383030393938656366383432"
+            "37653f73697a653d3530",
         ),
         (
             "",
             None,
-            "https://secure.gravatar.com/avatar/"
-            "d41d8cd98f00b204e9800998ecf8427e?size=80",
+            "https://camo.example.net/"
+            "11c994d69863c3e9cc62a7467a79cc77daff5cad/"
+            "68747470733a2f2f7365637572652e67726176617461722e636f6d2f617661746"
+            "1722f643431643863643938663030623230346539383030393938656366383432"
+            "37653f73697a653d3830",
         ),
         (
             "",
             40,
-            "https://secure.gravatar.com/avatar/"
-            "d41d8cd98f00b204e9800998ecf8427e?size=40",
+            "https://camo.example.net/"
+            "e65ad014ae9afac08674c0b2201eb9fc52e944bc/"
+            "68747470733a2f2f7365637572652e67726176617461722e636f6d2f617661746"
+            "1722f643431643863643938663030623230346539383030393938656366383432"
+            "37653f73697a653d3430",
         ),
         (
             "foo@example.com",
             None,
-            "https://secure.gravatar.com/avatar/"
-            "b48def645758b95537d4424c84d1a9ff?size=80",
+            "https://camo.example.net/"
+            "32bd80f8aab1ac713fba756662716138ba97a75b/"
+            "68747470733a2f2f7365637572652e67726176617461722e636f6d2f617661746"
+            "1722f623438646566363435373538623935353337643434323463383464316139"
+            "66663f73697a653d3830",
         ),
         (
             "foo@example.com",
             100,
-            "https://secure.gravatar.com/avatar/"
-            "b48def645758b95537d4424c84d1a9ff?size=100",
+            "https://camo.example.net/"
+            "1d9822f304be5013ba8fef23dc5849fb3066ac66/"
+            "68747470733a2f2f7365637572652e67726176617461722e636f6d2f617661746"
+            "1722f623438646566363435373538623935353337643434323463383464316139"
+            "66663f73697a653d313030",
         ),
     ],
 )
-def test_gravatar(email, size, expected):
+def test_gravatar(email, size, expected, monkeypatch):
+    request = pretend.stub(
+        registry=pretend.stub(
+            settings={
+                "camo.url": "https://camo.example.net/",
+                "camo.key": "fake key",
+            },
+        ),
+    )
+    monkeypatch.setattr(
+        pyramid.threadlocal, "get_current_request", lambda: request)
     kwargs = {}
     if size is not None:
         kwargs["size"] = size

--- a/tests/unit/utils/test_gravatar.py
+++ b/tests/unit/utils/test_gravatar.py
@@ -10,11 +10,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from functools import partial
+
 import pretend
 import pytest
 
 import pyramid.threadlocal
 
+from warehouse.filters import _camo_url
 from warehouse.utils.gravatar import gravatar, profile
 
 
@@ -86,6 +89,8 @@ def test_gravatar(email, size, expected, monkeypatch):
             },
         ),
     )
+    camo_url = partial(_camo_url, request)
+    request.camo_url = camo_url
     monkeypatch.setattr(
         pyramid.threadlocal, "get_current_request", lambda: request)
     kwargs = {}

--- a/warehouse/admin/templates/admin/base.html
+++ b/warehouse/admin/templates/admin/base.html
@@ -55,7 +55,7 @@
         <ul class="nav navbar-nav">
           <li class="user user-menu">
             <a>
-              <img src="{{ gravatar(request.user.email, size=160) }}" class="user-image" alt="User Image">
+              <img src="{{ gravatar(request, request.user.email, size=160) }}" class="user-image" alt="User Image">
               <span class="hidden-xs">{{ request.user.name|default(request.user.username, true) }}</span>
             </a>
           </li>

--- a/warehouse/admin/templates/admin/users/detail.html
+++ b/warehouse/admin/templates/admin/users/detail.html
@@ -45,7 +45,7 @@
       <div class="col-md-3">
         <div class="box box-primary">
           <div class="box-body box-profile">
-            <img class="profile-user-img img-responsive img-circle" src="{{ gravatar(user.email, size=128) }}" alt="User profile picture">
+            <img class="profile-user-img img-responsive img-circle" src="{{ gravatar(request, user.email, size=128) }}" alt="User profile picture">
 
             <h3 class="profile-username text-center">{{ user.username }}</h3>
 

--- a/warehouse/admin/templates/admin/users/list.html
+++ b/warehouse/admin/templates/admin/users/list.html
@@ -49,7 +49,7 @@
 
       {% for user in users %}
       <tr>
-        <td><img src="{{ gravatar(user.email, size=20) }}" class="img-circle" alt="User Image"></td>
+        <td><img src="{{ gravatar(request, user.email, size=20) }}" class="img-circle" alt="User Image"></td>
         <td>
           <a href="{{ request.route_path('admin.user.detail', user_id=user.id) }}">{{ user.username }}</a>
         </td>

--- a/warehouse/config.py
+++ b/warehouse/config.py
@@ -241,6 +241,9 @@ def configure(settings=None):
     # We'll want to use Jinja2 as our template system.
     config.include("pyramid_jinja2")
 
+    # Include our filters
+    config.include(".filters")
+
     # Including pyramid_mailer for sending emails through SMTP.
     config.include("pyramid_mailer")
 

--- a/warehouse/csp.py
+++ b/warehouse/csp.py
@@ -85,7 +85,6 @@ def includeme(config):
             "img-src": [
                 SELF,
                 config.registry.settings["camo.url"],
-                "https://secure.gravatar.com",
             ],
             "script-src": [SELF, "www.google-analytics.com"],
             "style-src": [SELF, "fonts.googleapis.com"],

--- a/warehouse/templates/accounts/profile.html
+++ b/warehouse/templates/accounts/profile.html
@@ -21,7 +21,7 @@
     <div class="left-layout__sidebar">
       <div class="author-profile">
         {% set alt = "Avatar for {} from gravatar.com".format(user.name|default(user.username, true)) %}
-        <img src="{{ gravatar(user.email, size=225) }}" alt="{{ alt }}" title="{{ alt }}">
+        <img src="{{ gravatar(request, user.email, size=225) }}" alt="{{ alt }}" title="{{ alt }}">
         <div class="author-profile__info">
           {% if user.name %}
           <h1 class="author-profile__name">{{ user.name }}</h1>

--- a/warehouse/templates/manage/account.html
+++ b/warehouse/templates/manage/account.html
@@ -119,7 +119,7 @@
   <h2 class="no-top-padding sub-title">Profile picture</h2>
   {% set alt = "Avatar for {} from gravatar.com".format(user.name|default(user.username, true)) %}
   <div class="gravatar-form">
-    <img src="{{ gravatar(user.email, size=140) }}" alt="{{ alt }}" title="{{ alt }}" class="gravatar-form__image">
+    <img src="{{ gravatar(request, user.email, size=140) }}" alt="{{ alt }}" title="{{ alt }}" class="gravatar-form__image">
     <div class="gravatar-form__content">
       <p>
       We use <a href="https://gravatar.com/">gravatar.com</a> to generate your profile picture based on your primary email address — <code class="break-on-mobile">{{ user.email }}</code>

--- a/warehouse/templates/manage/roles.html
+++ b/warehouse/templates/manage/roles.html
@@ -51,7 +51,7 @@
         <span class="table__user-details">
           <a href="{{ request.route_path('accounts.profile', username=role.user.username) }}" class="table__user-gravatar">
             {% set alt = "Avatar for {} from gravatar.com".format(role.user.username) %}
-            <img src="{{ gravatar(role.user.email, size=50) }}" height="50" width="50" alt="{{ alt }}" title="{{ alt }}">
+            <img src="{{ gravatar(request, role.user.email, size=50) }}" height="50" width="50" alt="{{ alt }}" title="{{ alt }}">
           </a>
           <a href="{{ request.route_path('accounts.profile', username=role.user.username) }}">
             <strong>{{ role.user.username }}</strong>

--- a/warehouse/templates/packaging/detail.html
+++ b/warehouse/templates/packaging/detail.html
@@ -210,7 +210,7 @@
             {% set alt = "Avatar for {} from gravatar.com".format(maintainer.username) %}
             <span class="sidebar-section__maintainer">
               <a href="{{ request.route_path('accounts.profile', username=maintainer.username) }}" aria-label="{{ maintainer.username}}" class="sidebar-section__user-gravatar">
-                <img src="{{ gravatar(maintainer.email, size=50) }}" height="50" width="50" alt="{{ alt }}" title="{{ alt }}">
+                <img src="{{ gravatar(request, maintainer.email, size=50) }}" height="50" width="50" alt="{{ alt }}" title="{{ alt }}">
               </a>
               <a href="{{ request.route_path('accounts.profile', username=maintainer.username) }}" class="sidebar-section__user-gravatar-text">
                 {{ maintainer.username}}

--- a/warehouse/utils/gravatar.py
+++ b/warehouse/utils/gravatar.py
@@ -15,8 +15,6 @@ import urllib.parse
 
 import pyramid.threadlocal
 
-from warehouse.filters import _camo_url
-
 
 def _hash(email):
     if email is None:
@@ -28,19 +26,12 @@ def _hash(email):
 def gravatar(email, size=80):
     request = pyramid.threadlocal.get_current_request()
 
-    camo_url = request.registry.settings["camo.url"].format(request=request)
-    camo_key = request.registry.settings["camo.key"]
-
     url = "https://secure.gravatar.com/avatar/{}".format(_hash(email))
     params = {
         "size": size,
     }
 
-    return _camo_url(
-        camo_url,
-        camo_key,
-        "?".join([url, urllib.parse.urlencode(params)])
-    )
+    return request.camo_url("?".join([url, urllib.parse.urlencode(params)]))
 
 
 def profile(email):

--- a/warehouse/utils/gravatar.py
+++ b/warehouse/utils/gravatar.py
@@ -13,8 +13,6 @@
 import hashlib
 import urllib.parse
 
-import pyramid.threadlocal
-
 
 def _hash(email):
     if email is None:
@@ -23,9 +21,7 @@ def _hash(email):
     return hashlib.md5(email.strip().lower().encode("utf8")).hexdigest()
 
 
-def gravatar(email, size=80):
-    request = pyramid.threadlocal.get_current_request()
-
+def gravatar(request, email, size=80):
     url = "https://secure.gravatar.com/avatar/{}".format(_hash(email))
     params = {
         "size": size,

--- a/warehouse/utils/gravatar.py
+++ b/warehouse/utils/gravatar.py
@@ -13,6 +13,10 @@
 import hashlib
 import urllib.parse
 
+import pyramid.threadlocal
+
+from warehouse.filters import _camo_url
+
 
 def _hash(email):
     if email is None:
@@ -22,12 +26,21 @@ def _hash(email):
 
 
 def gravatar(email, size=80):
+    request = pyramid.threadlocal.get_current_request()
+
+    camo_url = request.registry.settings["camo.url"].format(request=request)
+    camo_key = request.registry.settings["camo.key"]
+
     url = "https://secure.gravatar.com/avatar/{}".format(_hash(email))
     params = {
         "size": size,
     }
 
-    return "?".join([url, urllib.parse.urlencode(params)])
+    return _camo_url(
+        camo_url,
+        camo_key,
+        "?".join([url, urllib.parse.urlencode(params)])
+    )
 
 
 def profile(email):


### PR DESCRIPTION
Gravatar URLs are md5 hashes of user email addresses, which are trival to brute force.

Wrapping them with Camo allows us to guard user privacy and keep people from associating PyPI accounts with accounts on other services.