### PR TITLE
Show project_urls in metadata order

### DIFF
--- a/tests/unit/packaging/test_models.py
+++ b/tests/unit/packaging/test_models.py
@@ -245,6 +245,20 @@ class TestRelease:
                     ("Download", "https://example.com/download2/"),
                 ]),
             ),
+            (
+                None,
+                None,
+                [
+                    "Getting Started,https://docs.example.com/quickstart",
+                    "Full Documentation,https://docs.example.com/index",
+                    "Discontinued Versions,https://legacy.example.com/",
+                ],
+                OrderedDict([
+                    ("Getting Started", "https://docs.example.com/quickstart"),
+                    ("Full Documentation", "https://docs.example.com/index"),
+                    ("Discontinued Versions", "https://legacy.example.com/"),
+                ]),
+            ),
         ],
     )
     def test_urls(self, db_session, home_page, download_url, project_urls,

--- a/tests/unit/packaging/test_models.py
+++ b/tests/unit/packaging/test_models.py
@@ -264,8 +264,7 @@ class TestRelease:
                 )
             )
 
-        # TODO: It'd be nice to test for the actual ordering here.
-        assert dict(release.urls) == dict(expected)
+        assert release.urls == expected
 
     def test_acl(self, db_session):
         project = DBProjectFactory.create()

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -232,7 +232,7 @@ class DependencyKind(enum.IntEnum):
     requires_external = 7
 
     # TODO: Move project URLs into their own table, since they are not actually
-    #       a "dependency".
+    #       a "dependency". (And add position column: see Release.urls.)
     project_url = 8
 
 
@@ -424,7 +424,11 @@ class Release(db.ModelBase):
         if self.home_page:
             _urls["Homepage"] = self.home_page
 
-        for urlspec in self.project_urls:
+        # TODO: We have `reversed` here to show project URLs in metadata order
+        #       (which is db insertion order, which is reverse of query order).
+        #       Remove this when moving project URLs to own table (see note in
+        #       DependencyKind), by instead ordering with a position column.
+        for urlspec in reversed(self.project_urls):
             name, url = [x.strip() for x in urlspec.split(",", 1)]
             _urls[name] = url
 


### PR DESCRIPTION
Make minimal change to display project URLs in same order they appear
in package metadata. Add specific test case.

Also note more robust fix available with future schema change.

Fixes #3097.
