### PR TITLE
xmlrpc search: return latest_version of projects

### DIFF
--- a/tests/unit/legacy/api/xmlrpc/test_xmlrpc.py
+++ b/tests/unit/legacy/api/xmlrpc/test_xmlrpc.py
@@ -297,7 +297,6 @@ class TestSearch:
             {"name": "foo-bar", "summary": "other summary", "version": "1.0"},
         ]
 
-
     def test_version_search_returns_latest(self):
         class FakeQuery:
             def __init__(self, type, must):

--- a/warehouse/legacy/api/xmlrpc/views.py
+++ b/warehouse/legacy/api/xmlrpc/views.py
@@ -115,11 +115,16 @@ def search(request, spec, operator="and"):
 
     results = query[:1000].execute()
 
+    if "version" in spec.keys():
+        return [
+            {"name": r.name, "summary": r.summary, "version": v}
+            for r in results
+            for v in r.version
+            if v in spec.get("version", [v])
+        ]
     return [
-        {"name": r.name, "summary": r.summary, "version": v}
+        {"name": r.name, "summary": r.summary, "version": r.latest_version}
         for r in results
-        for v in r.version
-        if v in spec.get("version", [v])
     ]
 
 


### PR DESCRIPTION
matches the legacy behavior of returning only a single version per matching project

part of #3656 