### PR TITLE
Fix package_releases with a non-existent project

### DIFF
--- a/tests/unit/legacy/api/xmlrpc/test_xmlrpc.py
+++ b/tests/unit/legacy/api/xmlrpc/test_xmlrpc.py
@@ -472,6 +472,11 @@ def test_package_releases_hidden(db_request):
     ]
 
 
+def test_package_releases_no_project(db_request):
+    result = xmlrpc.package_releases(db_request, "foo")
+    assert result == []
+
+
 def test_release_data_no_project(db_request):
     assert xmlrpc.release_data(db_request, "foo", "1.0") == {}
 

--- a/warehouse/legacy/api/xmlrpc/views.py
+++ b/warehouse/legacy/api/xmlrpc/views.py
@@ -187,16 +187,20 @@ def top_packages(request, num=None):
 
 @xmlrpc_cache_by_project(method="package_releases")
 def package_releases(request, package_name, show_hidden=False):
+    try:
+        project = (
+            request.db.query(Project)
+                      .filter(Project.normalized_name ==
+                              func.normalize_pep426_name(package_name))
+                      .one()
+        )
+    except NoResultFound:
+        return []
+
     # This used to support the show_hidden parameter to determine if it should
     # show hidden releases or not. However, Warehouse doesn't support the
     # concept of hidden releases, so this parameter controls if the latest
     # version or all_versions are returned.
-    project = (
-        request.db.query(Project)
-                  .filter(Project.normalized_name ==
-                          func.normalize_pep426_name(package_name))
-                  .one()
-    )
     if show_hidden:
         return [v.version for v in project.all_versions]
     else:


### PR DESCRIPTION
Fixes this:

```python
import xmlrpc.client

c = xmlrpc.client.ServerProxy("https://pypi.org/pypi")
c.package_releases("this-doesnt-exist")
```

raising:

```
Traceback (most recent call last):
  File "<input>", line 1, in <module>
    c.package_releases("asdadsadsadasdasd")
  File "/Users/dstufft/.pyenv/versions/3.6.2/lib/python3.6/xmlrpc/client.py", line 1112, in __call__
    return self.__send(self.__name, args)
  File "/Users/dstufft/.pyenv/versions/3.6.2/lib/python3.6/xmlrpc/client.py", line 1452, in __request
    verbose=self.__verbose
  File "/Users/dstufft/.pyenv/versions/3.6.2/lib/python3.6/xmlrpc/client.py", line 1154, in request
    return self.single_request(host, handler, request_body, verbose)
  File "/Users/dstufft/.pyenv/versions/3.6.2/lib/python3.6/xmlrpc/client.py", line 1170, in single_request
    return self.parse_response(resp)
  File "/Users/dstufft/.pyenv/versions/3.6.2/lib/python3.6/xmlrpc/client.py", line 1342, in parse_response
    return u.close()
  File "/Users/dstufft/.pyenv/versions/3.6.2/lib/python3.6/xmlrpc/client.py", line 656, in close
    raise Fault(**self._stack[0])
xmlrpc.client.Fault: <Fault -32500: 'application error'>
```

Which is ultimately:

```
NoResultFound: No row was found for one()
  File "pyramid/tweens.py", line 39, in excview_tween
    response = handler(request)
  File "pyramid/router.py", line 156, in handle_request
    view_name
  File "pyramid/view.py", line 642, in _call_view
    response = view_callable(context, request)
  File "pyramid/config/views.py", line 181, in __call__
    return view(context, request)
  File "pyramid/viewderivers.py", line 390, in attr_view
    return view(context, request)
  File "pyramid/viewderivers.py", line 368, in predicate_wrapper
    return view(context, request)
  File "warehouse/sessions.py", line 302, in wrapped
    return view(context, request)
  File "warehouse/csrf.py", line 38, in wrapped
    return view(context, request)
  File "pyramid/viewderivers.py", line 439, in rendered_view
    result = view(context, request)
  File "warehouse/legacy/api/xmlrpc/cache/derivers.py", line 43, in wrapper_view
    view, (context, request), {}, key, _tag, expires
  File "warehouse/legacy/api/xmlrpc/cache/services.py", line 56, in fetch
    return self.redis_lru.fetch(func, args, kwargs, key, tag, expires)
  File "warehouse/legacy/api/xmlrpc/cache/fncache.py", line 94, in fetch
    func.__name__, key, func(*args, **kwargs), tag, expires
  File "pyramid_rpc/mapper.py", line 99, in _nonclass_view
    response = self.mapply(view, params, keywords)
  File "pyramid_rpc/mapper.py", line 133, in mapply
    return ob(*args)
  File "warehouse/legacy/api/xmlrpc/views.py", line 197, in package_releases
    func.normalize_pep426_name(package_name))
  File "sqlalchemy/orm/query.py", line 2854, in one
    raise orm_exc.NoResultFound("No row was found for one()")
```

This comes from https://sentry.io/python-software-foundation/warehouse-production/issues/528467317/