### PR TITLE
Partial search updates

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,10 +64,12 @@ services:
       context: .
       args:
         DEVEL: "yes"
-    command: celery -A warehouse worker -B -S redbeat.RedBeatScheduler -l info
+    command: hupper -m celery -A warehouse worker -B -S redbeat.RedBeatScheduler -l info
     env_file: dev/environment
     environment:
       C_FORCE_ROOT: "1"
+    volumes:
+      - ./warehouse:/opt/warehouse/src/warehouse:z
     links:
       - db
       - redis

--- a/tests/unit/search/test_init.py
+++ b/tests/unit/search/test_init.py
@@ -35,6 +35,28 @@ def test_store_projects(db_request):
         project0,
         project1,
     }
+    assert session.info["warehouse.search.project_deletes"] == set()
+
+
+def test_store_projects_unindex(db_request):
+    project0 = ProjectFactory.create()
+    project1 = ProjectFactory.create()
+    config = pretend.stub()
+    session = pretend.stub(
+        info={},
+        new={project0},
+        dirty=set(),
+        deleted={project1},
+    )
+
+    search.store_projects_for_project_reindex(config, session, pretend.stub())
+
+    assert session.info["warehouse.search.project_updates"] == {
+        project0,
+    }
+    assert session.info["warehouse.search.project_deletes"] == {
+        project1,
+    }
 
 
 def test_execute_reindex_success(app_config):
@@ -52,6 +74,23 @@ def test_execute_reindex_success(app_config):
 
     assert _delay.calls == [pretend.call("foo")]
     assert "warehouse.search.project_updates" not in session.info
+
+
+def test_execute_unindex_success(app_config):
+    _delay = pretend.call_recorder(lambda x: None)
+    app_config.task = lambda x: pretend.stub(delay=_delay)
+    session = pretend.stub(
+        info={
+            "warehouse.search.project_deletes": {
+                pretend.stub(normalized_name="foo"),
+            },
+        },
+    )
+
+    search.execute_project_reindex(app_config, session)
+
+    assert _delay.calls == [pretend.call("foo")]
+    assert "warehouse.search.project_deletes" not in session.info
 
 
 def test_es(monkeypatch):

--- a/tests/unit/search/test_init.py
+++ b/tests/unit/search/test_init.py
@@ -14,6 +14,45 @@ import pretend
 
 from warehouse import search
 
+from ...common.db.packaging import ProjectFactory, ReleaseFactory
+
+
+def test_store_projects(db_request):
+    project0 = ProjectFactory.create()
+    project1 = ProjectFactory.create()
+    release1 = ReleaseFactory.create(project=project1)
+    config = pretend.stub()
+    session = pretend.stub(
+        info={},
+        new={project0},
+        dirty=set(),
+        deleted={release1},
+    )
+
+    search.store_projects_for_project_reindex(config, session, pretend.stub())
+
+    assert session.info["warehouse.search.project_updates"] == {
+        project0,
+        project1,
+    }
+
+
+def test_execute_reindex_success(app_config):
+    _delay = pretend.call_recorder(lambda x: None)
+    app_config.task = lambda x: pretend.stub(delay=_delay)
+    session = pretend.stub(
+        info={
+            "warehouse.search.project_updates": {
+                pretend.stub(normalized_name="foo"),
+            },
+        },
+    )
+
+    search.execute_project_reindex(app_config, session)
+
+    assert _delay.calls == [pretend.call("foo")]
+    assert "warehouse.search.project_updates" not in session.info
+
 
 def test_es(monkeypatch):
     search_obj = pretend.stub()

--- a/tests/unit/search/test_tasks.py
+++ b/tests/unit/search/test_tasks.py
@@ -19,7 +19,7 @@ import pytest
 from first import first
 
 import warehouse.search.tasks
-from warehouse.search.tasks import reindex, _project_docs
+from warehouse.search.tasks import reindex, reindex_project, _project_docs
 
 from ...common.db.packaging import ProjectFactory, ReleaseFactory
 
@@ -51,6 +51,37 @@ def test_project_docs(db_session):
             },
         }
         for p, prs in sorted(releases.items(), key=lambda x: x[0].name.lower())
+    ]
+
+
+def test_single_project_doc(db_session):
+    projects = [ProjectFactory.create() for _ in range(2)]
+    releases = {
+        p: sorted(
+            [ReleaseFactory.create(project=p) for _ in range(3)],
+            key=lambda r: packaging.version.parse(r.version),
+            reverse=True,
+        )
+        for p in projects
+    }
+
+    assert list(_project_docs(db_session, project_name=projects[1].name)) == [
+        {
+            "_id": p.normalized_name,
+            "_type": "project",
+            "_source": {
+                "created": p.created,
+                "name": p.name,
+                "normalized_name": p.normalized_name,
+                "version": [r.version for r in prs],
+                "latest_version": first(
+                    prs,
+                    key=lambda r: not r.is_prerelease,
+                ).version,
+            },
+        }
+        for p, prs in sorted(releases.items(), key=lambda x: x[0].name.lower())
+        if p.name == projects[1].name
     ]
 
 
@@ -273,3 +304,85 @@ class TestReindex:
         assert es_client.indices.forcemerge.calls == [
             pretend.call(index='warehouse-cbcbcbcbcb')
         ]
+
+
+class TestPartialReindex:
+
+    def test_fails_when_raising(self, db_request, monkeypatch):
+        docs = pretend.stub()
+
+        def project_docs(db, project_name=None):
+            return docs
+
+        monkeypatch.setattr(
+            warehouse.search.tasks,
+            "_project_docs",
+            project_docs,
+        )
+
+        es_client = FakeESClient()
+
+        db_request.registry.update(
+            {
+                "elasticsearch.client": es_client,
+                "elasticsearch.index": "warehouse",
+            },
+        )
+
+        class TestException(Exception):
+            pass
+
+        def parallel_bulk(client, iterable):
+            assert client is es_client
+            assert iterable is docs
+            raise TestException
+
+        monkeypatch.setattr(
+            warehouse.search.tasks, "parallel_bulk", parallel_bulk)
+
+        with pytest.raises(TestException):
+            reindex_project(db_request, 'foo')
+
+        assert es_client.indices.put_settings.calls == []
+        assert es_client.indices.forcemerge.calls == []
+
+    def test_successfully_indexes(self, db_request, monkeypatch):
+        docs = pretend.stub()
+
+        def project_docs(db, project_name=None):
+            return docs
+
+        monkeypatch.setattr(
+            warehouse.search.tasks,
+            "_project_docs",
+            project_docs,
+        )
+
+        es_client = FakeESClient()
+        es_client.indices.indices["warehouse-aaaaaaaaaa"] = None
+        es_client.indices.aliases["warehouse"] = ["warehouse-aaaaaaaaaa"]
+        db_engine = pretend.stub()
+
+        db_request.registry.update(
+            {
+                "elasticsearch.client": es_client,
+                "elasticsearch.index": "warehouse",
+                "elasticsearch.shards": 42,
+                "sqlalchemy.engine": db_engine,
+            },
+        )
+
+        parallel_bulk = pretend.call_recorder(lambda client, iterable: [None])
+        monkeypatch.setattr(
+            warehouse.search.tasks, "parallel_bulk", parallel_bulk)
+
+        reindex_project(db_request, 'foo')
+
+        assert parallel_bulk.calls == [pretend.call(es_client, docs)]
+        assert es_client.indices.create.calls == []
+        assert es_client.indices.delete.calls == []
+        assert es_client.indices.aliases == {
+            "warehouse": ["warehouse-aaaaaaaaaa"],
+        }
+        assert es_client.indices.put_settings.calls == []
+        assert es_client.indices.forcemerge.calls == []

--- a/warehouse/search/__init__.py
+++ b/warehouse/search/__init__.py
@@ -27,23 +27,40 @@ from warehouse.packaging.models import Project, Release
 def store_projects_for_project_reindex(config, session, flush_context):
     # We'll (ab)use the session.info dictionary to store a list of pending
     # Project updates to the session.
-    purges = session.info.setdefault("warehouse.search.project_updates", set())
+    projects_to_update = session.info.setdefault(
+        "warehouse.search.project_updates", set())
+    projects_to_delete = session.info.setdefault(
+        "warehouse.search.project_deletes", set())
 
     # Go through each new, changed, and deleted object and attempt to store
     # a Project to reindex for when the session has been committed.
-    for obj in (session.new | session.dirty | session.deleted):
+    for obj in (session.new | session.dirty):
         if obj.__class__ == Project:
-            purges.add(obj)
+            projects_to_update.add(obj)
         if obj.__class__ == Release:
-            purges.add(obj.project)
+            projects_to_update.add(obj.project)
+
+    for obj in (session.deleted):
+        if obj.__class__ == Project:
+            projects_to_delete.add(obj)
+        if obj.__class__ == Release:
+            projects_to_update.add(obj.project)
 
 
 @db.listens_for(db.Session, "after_commit")
 def execute_project_reindex(config, session):
-    purges = session.info.pop("warehouse.search.project_updates", set())
-    from warehouse.search.tasks import reindex_project
-    for project in purges:
+    projects_to_update = session.info.pop(
+        "warehouse.search.project_updates", set())
+    projects_to_delete = session.info.pop(
+        "warehouse.search.project_deletes", set())
+
+    from warehouse.search.tasks import reindex_project, unindex_project
+
+    for project in projects_to_update:
         config.task(reindex_project).delay(project.normalized_name)
+
+    for project in projects_to_delete:
+        config.task(unindex_project).delay(project.normalized_name)
 
 
 def es(request):

--- a/warehouse/search/tasks.py
+++ b/warehouse/search/tasks.py
@@ -37,8 +37,12 @@ def _project_docs(db, project_name=None):
             Release._pypi_ordering.desc(),
         )
         .distinct(Release.name)
-        .subquery("release_list")
     )
+
+    if project_name:
+        releases_list = releases_list.filter(Release.name == project_name)
+
+    releases_list = releases_list.subquery()
 
     r = aliased(Release, name="r")
 
@@ -88,9 +92,6 @@ def _project_docs(db, project_name=None):
         .outerjoin(Release.project)
         .order_by(Release.name)
     )
-
-    if project_name:
-        release_data = release_data.filter(Release.name == project_name)
 
     for release in windowed_query(release_data, Release.name, 50000):
         p = ProjectDocType.from_db(release)


### PR DESCRIPTION
A fools attempt at #701 

Incrementally reindexes new documents or unindexes whenever a Project or Release is created, updated, or deleted.