### PR TITLE
Correctly label open issues/PRs

### DIFF
--- a/warehouse/templates/packaging/detail.html
+++ b/warehouse/templates/packaging/detail.html
@@ -161,7 +161,7 @@
           </a>
           <a class="vertical-tabs__tab vertical-tabs__tab--with-icon vertical-tabs__tab--condensed github-repo-info__item" data-key="html_url" data-attr="href" data-supplement="/issues" rel="noopener" target="_blank">
             <i class="fa fa-exclamation-circle" aria-hidden="true"></i>
-            <strong>Open issues: </strong>
+            <strong>Open Issues/PRs: </strong>
             <span class="github-repo-info__item" data-key="open_issues_count"></span>
           </a>
         </div>


### PR DESCRIPTION
Works around #3673


Opted to change the label vs changing the data collection type

The GitHub REST API doesn't nicely give the separation of Issues/PRs without having to do a deep count

There are ways in the GraphQL API, but that would require a complete change to how we collect data. A solution like https://github.com/isaacs/github/issues/536 would work for this particular datapoint. 

Before/After: 
<img width="253" alt="after" src="https://user-images.githubusercontent.com/813732/38790327-c4242eee-4183-11e8-8d18-ff1171780c58.png"> <img width="253" alt="before" src="https://user-images.githubusercontent.com/813732/38790326-c3f22c3c-4183-11e8-89c0-666d6cd19687.png"> 

Mockup of a project with a lot of issues
<img width="276" alt="Mockup" src="https://user-images.githubusercontent.com/813732/38790240-27798efe-4183-11e8-8c51-4ae3eee6c72e.png">

I was worried that the length of the label would mean a limit to how much data we could display, but it looks like there's still plenty of space. 

While the labels no longer have a consistent length, it now displays accurate data.


([ding contributor 100?](https://twitter.com/EWDurbin/status/985686173879332865))
