### PR TITLE
limit name length on registration

### DIFF
--- a/tests/unit/accounts/test_forms.py
+++ b/tests/unit/accounts/test_forms.py
@@ -287,6 +287,20 @@ class TestRegistrationForm:
             form.validate()
             assert (len(form.new_password.errors) == 0) == valid
 
+    def test_name_too_long(self):
+        form = forms.RegistrationForm(
+            data={"full_name": "hello " * 50},
+            user_service=pretend.stub(
+                find_userid=pretend.call_recorder(lambda _: None),
+            ),
+        )
+        assert not form.validate()
+        assert (
+            form.full_name.errors.pop() ==
+            "The name you have chosen is too long. Please choose "
+            "a name with under 100 characters."
+        )
+
 
 class TestRequestPasswordResetForm:
 

--- a/warehouse/accounts/forms.py
+++ b/warehouse/accounts/forms.py
@@ -166,7 +166,17 @@ class RegistrationForm(
         NewUsernameMixin, NewEmailMixin, NewPasswordMixin, HoneypotMixin,
         forms.Form):
 
-    full_name = wtforms.StringField()
+    full_name = wtforms.StringField(
+        validators=[
+            wtforms.validators.Length(
+                max=100,
+                message=(
+                    "The name you have chosen is too long. Please choose "
+                    "a name with under 100 characters."
+                )
+            ),
+        ]
+    )
 
     def __init__(self, *args, user_service, **kwargs):
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
This prevents name submissions that exceed the limit of the SQL table. We might actually want to make this shorter than 100.

Additionally, the `NewPasswordMixin` likely needs to be updated to use the same validator since it appears it allows you to submit any length `full_name`.

I don't know how to run the tests so it's possible this doesn't work. CI can tell us!