### PR TITLE
admit defeat to leaky memory consumption

### DIFF
--- a/Procfile.cabotage
+++ b/Procfile.cabotage
@@ -1,7 +1,6 @@
 release: bin/release-cabotage
 web: bin/start-web-cabotage python -m gunicorn.app.wsgiapp -c gunicorn-cabotage.conf warehouse.wsgi:application
-web-alone: bin/start-web-cabotage python -m gunicorn.app.wsgiapp -c gunicorn-cabotage.conf warehouse.wsgi:application
 tcp: bin/start-web-cabotage python -m twisted web -n -p tcp:port=8001:backlog=2048 --wsgi warehouse.wsgi.application
 web-uploads: bin/start-web-cabotage python -m gunicorn.app.wsgiapp -c gunicorn-uploads-cabotage.conf warehouse.wsgi:application
-worker: bin/start-worker celery -A warehouse worker -l info
+worker: bin/start-worker celery -A warehouse worker -l info --max-tasks-per-child 128
 worker-beat: bin/start-worker celery -A warehouse beat -S redbeat.RedBeatScheduler -l info

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,7 +64,9 @@ services:
       context: .
       args:
         DEVEL: "yes"
-    command: celery -A warehouse worker -B -S redbeat.RedBeatScheduler -l info
+    command: hupper -m celery -A warehouse worker -B -S redbeat.RedBeatScheduler -l info
+    volumes:
+      - ./warehouse:/opt/warehouse/src/warehouse:z
     env_file: dev/environment
     environment:
       C_FORCE_ROOT: "1"

--- a/gunicorn-cabotage.conf
+++ b/gunicorn-cabotage.conf
@@ -1,6 +1,8 @@
 bind = 'unix:/var/run/cabotage/cabotage.sock'
 backlog = 2048
 preload_app = True
+max_requests = 2048
+max_requests_jitter = 128
 
 worker_connections = 1000
 timeout = 60

--- a/gunicorn-uploads-cabotage.conf
+++ b/gunicorn-uploads-cabotage.conf
@@ -1,6 +1,8 @@
 bind = 'unix:/var/run/cabotage/cabotage.sock'
 backlog = 512
 preload_app = True
+max_requests = 32
+max_requests_jitter = 8
 
 worker_connections = 256
 timeout = 240


### PR DESCRIPTION
Remove test process, limit impact of memory consumption on celery/gunicorn

Can't find a similar option for twisted web :/