### PR TITLE
Don't validate emails in Admin UI

### DIFF
--- a/warehouse/admin/views/users.py
+++ b/warehouse/admin/views/users.py
@@ -72,7 +72,6 @@ class EmailField(forms.Form):
     email = wtforms.fields.html5.EmailField(
         validators=[
             wtforms.validators.DataRequired(),
-            wtforms.validators.Email(),
         ],
     )
     primary = wtforms.fields.BooleanField()


### PR DESCRIPTION
This allows admins to add "invalid" email addresses to work around https://github.com/pypa/warehouse/issues/3733 until it's resolved.