### PR TITLE
Customise confirmation message when verifying the user's primary email address

### DIFF
--- a/warehouse/accounts/views.py
+++ b/warehouse/accounts/views.py
@@ -411,11 +411,15 @@ def verify_email(request):
     email.unverify_reason = None
     email.transient_bounces = 0
 
+    if not email.primary:
+        confirm_message = 'You can now set this email as your primary address.'
+    else:
+        confirm_message = 'This is your primary address.'
+
     request.user.is_active = True
 
     request.session.flash(
-        f'Email address {email.email} verified. ' +
-        'You can now set this email as your primary address.',
+        f'Email address {email.email} verified. {confirm_message}',
         queue='success'
     )
     return HTTPSeeOther(request.route_path("manage.account"))


### PR DESCRIPTION
Congratulations on last week migration, it's amazing to see the new PyPI website! 🎉 

I just verified my email address from my existing account and the confirmation message prompted a small confusing moment when it was saying _"You can now set this email as your primary address"_  although it was already my primary (I only had one email address). 

I would suggest tweaking a bit the message in that case, so here is my tiny contribution to make this happen.

PS: The new message is only my own suggestion, and english isn't my first language. Suggestions for improvements are welcome!