### PR TITLE
Fix edge case w/ identical canonical versions

### DIFF
--- a/tests/unit/packaging/test_models.py
+++ b/tests/unit/packaging/test_models.py
@@ -92,6 +92,14 @@ class TestProject:
         with pytest.raises(KeyError):
             project["1.0"]
 
+    def test_traversal_cant_find_if_multiple(self, db_request):
+        project = DBProjectFactory.create()
+        DBReleaseFactory.create(version='1.0.0', project=project)
+        DBReleaseFactory.create(version='1.0', project=project)
+
+        with pytest.raises(KeyError):
+            project["1"]
+
     def test_doc_url_doesnt_exist(self, db_request):
         project = DBProjectFactory.create()
         assert project.documentation_url is None

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -156,13 +156,20 @@ class Project(SitemapMixin, db.ModelBase):
             # There are multiple releases of this project which have the same
             # canonical version that were uploaded before we checked for
             # canonical version equivalence, so return the exact match instead
-            return (
-                session.query(Release)
-                .filter(
-                    (Release.project == self) & (Release.version == version)
+            try:
+                return (
+                    session.query(Release)
+                    .filter(
+                        (Release.project == self) &
+                        (Release.version == version)
+                    )
+                    .one()
                 )
-                .one()
-            )
+            except NoResultFound:
+                # There are multiple releases of this project which have the
+                # same canonical version, but none that have the exact version
+                # specified, so just 404
+                raise KeyError from None
         except NoResultFound:
             raise KeyError from None
 


### PR DESCRIPTION
This PR fixes an edge case where a version for a release would be requested that, when canonicalized, would match multiple releases, but wouldn't match the exact version for _any_ release.