### PR TITLE
Add data to mobile view

### DIFF
--- a/warehouse/templates/includes/packaging/project-data.html
+++ b/warehouse/templates/includes/packaging/project-data.html
@@ -1,0 +1,107 @@
+{% if release.urls.values() | contains_valid_uris %}
+<div class="sidebar-section">
+  <h3 class="sidebar-section__title">Project links</h3>
+  {% for name, url in release.urls.items() %}
+  {% if is_valid_uri(url) %}
+  <a class="vertical-tabs__tab vertical-tabs__tab--with-icon vertical-tabs__tab--condensed" href="{{ url }}" rel="nofollow">
+    {# TODO: We need to figure out a way to get better icons here, like fa-github, fa-book, etc. #}
+    {{ url_icon(name, url) }}{{ name }}
+  </a>
+  {% endif %}
+  {% endfor %}
+</div>
+{% endif %}
+
+{% if release.github_repo_info_url %}
+<div class="sidebar-section github-repo-info hidden" data-url="{{release.github_repo_info_url}}">
+  <h3 class="sidebar-section__title">GitHub statistics</h3>
+  <a class="vertical-tabs__tab vertical-tabs__tab--with-icon vertical-tabs__tab--condensed github-repo-info__item" data-key="html_url" data-attr="href" data-supplement="/stargazers" rel="noopener" target="_blank">
+    <i class="fa fa-star" aria-hidden="true"></i>
+    <strong>Stars: </strong>
+    <span class="github-repo-info__item" data-key="stargazers_count"></span>
+  </a>
+  <a class="vertical-tabs__tab vertical-tabs__tab--with-icon vertical-tabs__tab--condensed github-repo-info__item" data-key="html_url" data-attr="href" data-supplement="/network" rel="noopener" target="_blank">
+    <i class="fa fa-code-fork" aria-hidden="true"></i>
+    <strong>Forks: </strong>
+    <span class="github-repo-info__item" data-key="forks"></span>
+  </a>
+  <a class="vertical-tabs__tab vertical-tabs__tab--with-icon vertical-tabs__tab--condensed github-repo-info__item" data-key="html_url" data-attr="href" data-supplement="/issues" rel="noopener" target="_blank">
+    <i class="fa fa-exclamation-circle" aria-hidden="true"></i>
+    <strong>Open issues/PRs: </strong>
+    <span class="github-repo-info__item" data-key="open_issues_count"></span>
+  </a>
+</div>
+{% endif %}
+
+{% if release.has_meta %}
+<div class="sidebar-section">
+  <h3 class="sidebar-section__title">Meta</h3>
+  {% if license %}
+  <p><strong>License:</strong> {{ license }}</p>
+  {% endif %}
+  {% if release.author_email %}
+    <p><strong>Author:</strong> <a href="mailto:{{ release.author_email }}">{{ release.author or release.author_email }}</a></p>
+  {% elif release.author %}
+    <p><strong>Author:</strong> {{ release.author }}</p>
+  {% endif %}
+  {% if release.maintainer_email %}
+    <p><strong>Maintainer:</strong> <a href="mailto:{{ release.maintainer_email }}">{{ release.maintainer or release.maintainer_email }}</a></p>
+  {% elif release.maintainer %}
+    <p><strong>Maintainer:</strong> {{ release.maintainer }}</p>
+  {% endif %}
+  {% if release.keywords %}
+  <p class="tags">
+    <i class="fa fa-tags"aria-hidden="true"></i>
+    <span class="sr-only">Tags:</span>
+    {% for keyword in release.keywords | format_tags %}
+    <span class="package-keyword">
+      {{ keyword }}{% if not loop.last %},{% endif %}
+    </span>
+    {% endfor %}
+  </p>
+  {% endif %}
+  {% if release.requires_python %}
+  <p>
+    <strong>Requires:</strong> Python {{ release.requires_python }}
+  </p>
+  {% endif %}
+</div>
+{% endif %}
+
+<div class="sidebar-section">
+  <h3 class="sidebar-section__title">Maintainers</h3>
+  {% for maintainer in maintainers %}
+    {% set alt = "Avatar for {} from gravatar.com".format(maintainer.username) %}
+    <span class="sidebar-section__maintainer">
+      <a href="{{ request.route_path('accounts.profile', username=maintainer.username) }}" aria-label="{{ maintainer.username}}" class="sidebar-section__user-gravatar">
+        <img src="{{ gravatar(request, maintainer.email, size=50) }}" height="50" width="50" alt="{{ alt }}" title="{{ alt }}">
+      </a>
+      <a href="{{ request.route_path('accounts.profile', username=maintainer.username) }}" class="sidebar-section__user-gravatar-text">
+        {{ maintainer.username}}
+      </a>
+    </span>
+  {% endfor %}
+</div>
+
+<div class="sidebar-section">
+  <h3 class="sidebar-section__title">Statistics</h3>
+  <p>View statistics for this project via <a href="https://libraries.io/pypi/{{ release.project.name }}">Libraries.io</a>, or by using <a href="https://packaging.python.org/guides/analyzing-pypi-package-downloads/">Google BigQuery</a></p>
+</div>
+
+{% if release.classifiers %}
+<div class="sidebar-section classifiers">
+  <h3>Classifiers</h3>
+  <dl>
+    {% for classifier_head, classifier_tail in (release.classifiers|format_classifiers()).items() %}
+    <dt>{{ classifier_head }}</dt>
+    {% for classifier in classifier_tail %}
+    <dd>
+    <a href="{{ request.route_path('search', _query={'c': ' :: '.join((classifier_head, classifier))}) }}">
+      {{ classifier }}
+    </a>
+    </dd>
+    {% endfor %}
+    {% endfor %}
+  </dl>
+</div>
+{% endif %}

--- a/warehouse/templates/packaging/detail.html
+++ b/warehouse/templates/packaging/detail.html
@@ -131,114 +131,8 @@
               {% endif %}
             </nav>
         </div>
+        {% include "warehouse:templates/includes/packaging/project-data.html" %}
 
-        {% if release.urls.values() | contains_valid_uris %}
-        <div class="sidebar-section">
-          <h3 class="sidebar-section__title">Project links</h3>
-          {% for name, url in release.urls.items() %}
-          {% if is_valid_uri(url) %}
-          <a class="vertical-tabs__tab vertical-tabs__tab--with-icon vertical-tabs__tab--condensed" href="{{ url }}" rel="nofollow">
-            {# TODO: We need to figure out a way to get better icons here, like fa-github, fa-book, etc. #}
-            {{ url_icon(name, url) }}{{ name }}
-          </a>
-          {% endif %}
-          {% endfor %}
-        </div>
-        {% endif %}
-
-        {% if release.github_repo_info_url %}
-        <div class="sidebar-section github-repo-info hidden" data-url="{{release.github_repo_info_url}}">
-          <h3 class="sidebar-section__title">GitHub statistics</h3>
-          <a class="vertical-tabs__tab vertical-tabs__tab--with-icon vertical-tabs__tab--condensed github-repo-info__item" data-key="html_url" data-attr="href" data-supplement="/stargazers" rel="noopener" target="_blank">
-            <i class="fa fa-star" aria-hidden="true"></i>
-            <strong>Stars: </strong>
-            <span class="github-repo-info__item" data-key="stargazers_count"></span>
-          </a>
-          <a class="vertical-tabs__tab vertical-tabs__tab--with-icon vertical-tabs__tab--condensed github-repo-info__item" data-key="html_url" data-attr="href" data-supplement="/network" rel="noopener" target="_blank">
-            <i class="fa fa-code-fork" aria-hidden="true"></i>
-            <strong>Forks: </strong>
-            <span class="github-repo-info__item" data-key="forks"></span>
-          </a>
-          <a class="vertical-tabs__tab vertical-tabs__tab--with-icon vertical-tabs__tab--condensed github-repo-info__item" data-key="html_url" data-attr="href" data-supplement="/issues" rel="noopener" target="_blank">
-            <i class="fa fa-exclamation-circle" aria-hidden="true"></i>
-            <strong>Open issues/PRs: </strong>
-            <span class="github-repo-info__item" data-key="open_issues_count"></span>
-          </a>
-        </div>
-        {% endif %}
-
-        {% if release.has_meta %}
-        <div class="sidebar-section">
-          <h3 class="sidebar-section__title">Meta</h3>
-          {% if license %}
-          <p><strong>License:</strong> {{ license }}</p>
-          {% endif %}
-          {% if release.author_email %}
-            <p><strong>Author:</strong> <a href="mailto:{{ release.author_email }}">{{ release.author or release.author_email }}</a></p>
-          {% elif release.author %}
-            <p><strong>Author:</strong> {{ release.author }}</p>
-          {% endif %}
-          {% if release.maintainer_email %}
-            <p><strong>Maintainer:</strong> <a href="mailto:{{ release.maintainer_email }}">{{ release.maintainer or release.maintainer_email }}</a></p>
-          {% elif release.maintainer %}
-            <p><strong>Maintainer:</strong> {{ release.maintainer }}</p>
-          {% endif %}
-          {% if release.keywords %}
-          <p class="tags">
-            <i class="fa fa-tags"aria-hidden="true"></i>
-            <span class="sr-only">Tags:</span>
-            {% for keyword in release.keywords | format_tags %}
-            <span class="package-keyword">
-              {{ keyword }}{% if not loop.last %},{% endif %}
-            </span>
-            {% endfor %}
-          </p>
-          {% endif %}
-          {% if release.requires_python %}
-          <p>
-            <strong>Requires:</strong> Python {{ release.requires_python }}
-          </p>
-          {% endif %}
-        </div>
-        {% endif %}
-
-        <div class="sidebar-section">
-          <h3 class="sidebar-section__title">Maintainers</h3>
-          {% for maintainer in maintainers %}
-            {% set alt = "Avatar for {} from gravatar.com".format(maintainer.username) %}
-            <span class="sidebar-section__maintainer">
-              <a href="{{ request.route_path('accounts.profile', username=maintainer.username) }}" aria-label="{{ maintainer.username}}" class="sidebar-section__user-gravatar">
-                <img src="{{ gravatar(request, maintainer.email, size=50) }}" height="50" width="50" alt="{{ alt }}" title="{{ alt }}">
-              </a>
-              <a href="{{ request.route_path('accounts.profile', username=maintainer.username) }}" class="sidebar-section__user-gravatar-text">
-                {{ maintainer.username}}
-              </a>
-            </span>
-          {% endfor %}
-        </div>
-
-        <div class="sidebar-section">
-          <h3 class="sidebar-section__title">Statistics</h3>
-          <p>View statistics for this project via <a href="https://libraries.io/pypi/{{ release.project.name }}">Libraries.io</a>, or by using <a href="https://packaging.python.org/guides/analyzing-pypi-package-downloads/">Google BigQuery</a></p>
-        </div>
-
-        {% if release.classifiers %}
-        <div class="sidebar-section classifiers">
-          <h3>Classifiers</h3>
-          <dl>
-            {% for classifier_head, classifier_tail in (release.classifiers|format_classifiers()).items() %}
-            <dt>{{ classifier_head }}</dt>
-            {% for classifier in classifier_tail %}
-            <dd>
-            <a href="{{ request.route_path('search', _query={'c': ' :: '.join((classifier_head, classifier))}) }}">
-              {{ classifier }}
-            </a>
-            </dd>
-            {% endfor %}
-            {% endfor %}
-          </dl>
-        </div>
-        {% endif %}
       </div>
       <div class="vertical-tabs__panel">
         <!-- mobile menu -->
@@ -246,6 +140,10 @@
           <a id="mobile-description-tab" class="-js-vertical-tab-mobile-heading vertical-tabs__tab vertical-tabs__tab--with-icon vertical-tabs__tab--mobile vertical-tabs__tab--no-top-border vertical-tabs__tab--is-active" href="#description">
             <i class="fa fa-align-left" aria-hidden="true"></i>
             Project description
+          </a>
+          <a id="mobile-data-tab" class="-js-vertical-tab-mobile-heading vertical-tabs__tab vertical-tabs__tab--with-icon vertical-tabs__tab--mobile" href="#data">
+            <i class="fa fa-info-circle" aria-hidden="true"></i>
+            Project data
           </a>
           <a id="mobile-history-tab" class="-js-vertical-tab-mobile-heading vertical-tabs__tab vertical-tabs__tab--with-icon vertical-tabs__tab--mobile" href="#history">
             <i class="fa fa-history" aria-hidden="true"></i>
@@ -258,9 +156,10 @@
           </a>
           {% endif %}
         </nav>
+
         {# Tab: Project description #}
         <div id="description" class="-js-vertical-tab-content vertical-tabs__content" role="tabpanel" aria-labelledby="description-tab mobile-description-tab">
-          <h2 class="page-title">Project Description</h2>
+          <h2 class="page-title">Project description</h2>
           {% if release.description %}
           <div class="project-description">
             {{ release.description|readme(description_content_type=release.description_content_type) }}
@@ -270,6 +169,13 @@
             <p>The author of this package has not provided a project description</p>
           </div>
           {% endif %}
+        </div>
+
+        {# Tab: project data #}
+        <div id="data" class="-js-vertical-tab-content vertical-tabs__content" role="tabpanel" aria-labelledby="mobile-data-tab">
+          <h2 class="page-title">Project data</h2>
+          {% include "warehouse:templates/includes/packaging/project-data.html" %}
+          <br>
         </div>
 
         {# Tab: Release history #}


### PR DESCRIPTION
Closes #3546

Behaviour:

- 800px and under, adds a 'data' item into the mobile tabs menu.
- 801px and above, the data tab is removed, and the data is displayed in the sidebar

This PR only adds the HTML needed to make this change.  We also need to adjust the JS so that:

1. The tabs work on desktop (currently broken)
2. Users who are on the 'data' tab when <800px, *then* resize their browser to be > 800px, are "switched" to the project description tab

![screenshot from 2018-04-26 08-31-34](https://user-images.githubusercontent.com/3323703/39326486-0d6d00a6-498d-11e8-828f-6324da67dea0.png)

@yeraydiazdiaz would this be something you might be able to help me with?

