### PR TITLE
Updated profile pages to show username if not viewing own profile

### DIFF
--- a/warehouse/static/sass/blocks/_sidebar-section.scss
+++ b/warehouse/static/sass/blocks/_sidebar-section.scss
@@ -33,6 +33,10 @@
     font-size: 18px;
   }
 
+  .sidebar-section__spacer {
+    height: 20px;
+  }
+
   .sidebar-section__user-gravatar {
     text-decoration: none;
   }

--- a/warehouse/templates/accounts/profile.html
+++ b/warehouse/templates/accounts/profile.html
@@ -36,10 +36,6 @@
           {% endcsi %}
         </div>
 
-        <div class="sidebar-section">
-          <h3 class="sidebar-section__title">Statistics</h3>
-          <p>View statistics for your projects via <a href="https://libraries.io/">Libraries.io</a>, or by using <a href="https://packaging.python.org/guides/analyzing-pypi-package-downloads/">Google BigQuery</a></p>
-        </div>
       </div>
     </div>
 

--- a/warehouse/templates/includes/accounts/edit-profile-button.html
+++ b/warehouse/templates/includes/accounts/edit-profile-button.html
@@ -14,4 +14,16 @@
 
 {% if request.user == user %}
   <a href="{{ request.route_path('manage.account') }}" class="button button--primary author-profile__edit-button">Edit profile</a>
+
+  <div class="sidebar-section">
+    <div style="height:20px"></div>
+    <h3 class="sidebar-section__title">Statistics</h3>
+    <p>View statistics for your projects via <a href="https://libraries.io/">Libraries.io</a>, or by using <a href="https://packaging.python.org/guides/analyzing-pypi-package-downloads/">Google BigQuery</a></p>
+  </div>
+{% else %}
+<div class="sidebar-section">
+  <div style="height:20px"></div>
+  <h3 class="sidebar-section__title">Statistics</h3>
+  <p>View statistics for {{ user.username }}'s projects via <a href="https://libraries.io/">Libraries.io</a>, or by using <a href="https://packaging.python.org/guides/analyzing-pypi-package-downloads/">Google BigQuery</a></p>
+</div>
 {% endif %}

--- a/warehouse/templates/includes/accounts/edit-profile-button.html
+++ b/warehouse/templates/includes/accounts/edit-profile-button.html
@@ -16,13 +16,13 @@
   <a href="{{ request.route_path('manage.account') }}" class="button button--primary author-profile__edit-button">Edit profile</a>
 
   <div class="sidebar-section">
-    <div style="height:20px"></div>
+    <div class="sidebar-section__spacer"></div>
     <h3 class="sidebar-section__title">Statistics</h3>
     <p>View statistics for your projects via <a href="https://libraries.io/">Libraries.io</a>, or by using <a href="https://packaging.python.org/guides/analyzing-pypi-package-downloads/">Google BigQuery</a></p>
   </div>
 {% else %}
 <div class="sidebar-section">
-  <div style="height:20px"></div>
+  <div class="sidebar-section__spacer"></div>
   <h3 class="sidebar-section__title">Statistics</h3>
   <p>View statistics for {{ user.username }}'s projects via <a href="https://libraries.io/">Libraries.io</a>, or by using <a href="https://packaging.python.org/guides/analyzing-pypi-package-downloads/">Google BigQuery</a></p>
 </div>


### PR DESCRIPTION
Closes #3591

### When signed in and viewing own profile
<img width="238" alt="screen shot 2018-04-26 at 8 20 28 pm" src="https://user-images.githubusercontent.com/4074644/39338196-6c4690c2-498f-11e8-8711-4b7cad776136.png">

---

### When signed out or viewing someone else's profile
<img width="204" alt="screen shot 2018-04-26 at 8 20 50 pm" src="https://user-images.githubusercontent.com/4074644/39338197-6c65d1e4-498f-11e8-84f9-204bb07e512a.png">
