### PR TITLE
Email notification when user's role is changed/removed.

### DIFF
--- a/tests/unit/email/test_init.py
+++ b/tests/unit/email/test_init.py
@@ -462,3 +462,285 @@ class TestAddedAsCollaboratorEmail:
                 "Email Subject", "Email Body", recipient="username <email@example.com>"
             )
         ]
+
+
+class TestRemovedAsCollaboratorEmail:
+
+    def test_removed_as_collaborator_email(
+            self, pyramid_request, pyramid_config, monkeypatch):
+
+        stub_user = pretend.stub(
+            email='email',
+            username='username',
+        )
+        stub_submitter_user = pretend.stub(
+            email='submiteremail',
+            username='submitterusername'
+        )
+        stub_role = pretend.stub(
+            role_name="Owner",
+            user=stub_user,
+            project=pretend.stub(
+                name="test_project"
+            ),
+        )
+        pyramid_request.user = stub_submitter_user
+
+        subject_renderer = pyramid_config.testing_add_renderer(
+            'email/removed-as-collaborator.subject.txt'
+        )
+        subject_renderer.string_response = 'Email Subject'
+        body_renderer = pyramid_config.testing_add_renderer(
+            'email/removed-as-collaborator.body.txt'
+        )
+        body_renderer.string_response = 'Email Body'
+
+        send_email = pretend.stub(
+            delay=pretend.call_recorder(lambda *args, **kwargs: None)
+        )
+        pyramid_request.task = pretend.call_recorder(
+            lambda *args, **kwargs: send_email
+        )
+        monkeypatch.setattr(email, 'send_email', send_email)
+
+        result = email.send_removed_from_role_email(
+            pyramid_request,
+            role=stub_role,
+        )
+
+        assert result == {
+            'project': 'test_project',
+            'role': 'Owner',
+            'submitter': stub_submitter_user.username
+        }
+        subject_renderer.assert_()
+        body_renderer.assert_(submitter=stub_submitter_user.username)
+        body_renderer.assert_(project='test_project')
+        body_renderer.assert_(role='Owner')
+
+        assert pyramid_request.task.calls == [
+            pretend.call(send_email),
+        ]
+        assert send_email.delay.calls == [
+            pretend.call(
+                'Email Subject',
+                'Email Body',
+                recipient=stub_user.email,
+            ),
+        ]
+
+
+class TestUserRoleChangedEmail:
+
+    def test_user_role_changed_email(
+            self, pyramid_request, pyramid_config, monkeypatch):
+
+        stub_user = pretend.stub(
+            email='email',
+            username='username',
+        )
+        stub_submitter_user = pretend.stub(
+            email='submiteremail',
+            username='submitterusername'
+        )
+        stub_role = pretend.stub(
+            role_name="Owner",
+            user=stub_user,
+            project=pretend.stub(
+                name="test_project"
+            ),
+        )
+        pyramid_request.user = stub_submitter_user
+
+        subject_renderer = pyramid_config.testing_add_renderer(
+            'email/role-removed-from-user.subject.txt'
+        )
+        subject_renderer.string_response = 'Email Subject'
+        body_renderer = pyramid_config.testing_add_renderer(
+            'email/role-removed-from-user.body.txt'
+        )
+        body_renderer.string_response = 'Email Body'
+
+        send_email = pretend.stub(
+            delay=pretend.call_recorder(lambda *args, **kwargs: None)
+        )
+        pyramid_request.task = pretend.call_recorder(
+            lambda *args, **kwargs: send_email
+        )
+        monkeypatch.setattr(email, 'send_email', send_email)
+
+        result = email.send_role_removed_from_user_email(
+            pyramid_request,
+            role=stub_role,
+            email_recipients=[stub_user.email, stub_submitter_user.email]
+        )
+
+        assert result == {
+            'project': 'test_project',
+            'role': 'Owner',
+            'submitter': stub_submitter_user.username,
+            'username': stub_user.username,
+        }
+        subject_renderer.assert_()
+        body_renderer.assert_(submitter=stub_submitter_user.username)
+        body_renderer.assert_(project='test_project')
+        body_renderer.assert_(role='Owner')
+
+        assert pyramid_request.task.calls == [
+            pretend.call(send_email),
+            pretend.call(send_email),
+        ]
+
+        assert send_email.delay.calls == [
+            pretend.call(
+                'Email Subject',
+                'Email Body',
+                recipient=stub_user.email,
+            ),
+            pretend.call(
+                'Email Subject',
+                'Email Body',
+                recipient=stub_submitter_user.email,
+            ),
+        ]
+
+
+class TestUserRoleChangedEmailEmail:
+
+    def test_user_role_changed_email(
+            self, pyramid_request, pyramid_config, monkeypatch):
+
+        stub_user = pretend.stub(
+            email='email',
+            username='username',
+        )
+        stub_submitter_user = pretend.stub(
+            email='submiteremail',
+            username='submitterusername'
+        )
+        stub_role = pretend.stub(
+            role_name="Owner",
+            user=stub_user,
+            project=pretend.stub(
+                name="test_project"
+            ),
+        )
+        pyramid_request.user = stub_submitter_user
+
+        subject_renderer = pyramid_config.testing_add_renderer(
+            'email/user-role-changed.subject.txt'
+        )
+        subject_renderer.string_response = 'Email Subject'
+        body_renderer = pyramid_config.testing_add_renderer(
+            'email/user-role-changed.body.txt'
+        )
+        body_renderer.string_response = 'Email Body'
+
+        send_email = pretend.stub(
+            delay=pretend.call_recorder(lambda *args, **kwargs: None)
+        )
+        pyramid_request.task = pretend.call_recorder(
+            lambda *args, **kwargs: send_email
+        )
+        monkeypatch.setattr(email, 'send_email', send_email)
+
+        result = email.send_user_role_changed_email(
+            pyramid_request,
+            role=stub_role,
+        )
+
+        assert result == {
+            'project': 'test_project',
+            'role': 'Owner',
+            'submitter': stub_submitter_user.username
+        }
+        subject_renderer.assert_()
+        body_renderer.assert_(submitter=stub_submitter_user.username)
+        body_renderer.assert_(project='test_project')
+        body_renderer.assert_(role='Owner')
+
+        assert pyramid_request.task.calls == [
+            pretend.call(send_email),
+        ]
+        assert send_email.delay.calls == [
+            pretend.call(
+                'Email Subject',
+                'Email Body',
+                recipient=stub_user.email,
+            ),
+        ]
+
+
+class TestRoleChangedForUserEmail:
+
+    def test_role_changed_for_user_email(
+            self, pyramid_request, pyramid_config, monkeypatch):
+
+        stub_user = pretend.stub(
+            email='email',
+            username='username',
+        )
+        stub_submitter_user = pretend.stub(
+            email='submiteremail',
+            username='submitterusername'
+        )
+        stub_role = pretend.stub(
+            role_name="Owner",
+            user=stub_user,
+            project=pretend.stub(
+                name="test_project"
+            ),
+        )
+        pyramid_request.user = stub_submitter_user
+
+        subject_renderer = pyramid_config.testing_add_renderer(
+            'email/role-changed-for-user.subject.txt'
+        )
+        subject_renderer.string_response = 'Email Subject'
+        body_renderer = pyramid_config.testing_add_renderer(
+            'email/role-changed-for-user.body.txt'
+        )
+        body_renderer.string_response = 'Email Body'
+
+        send_email = pretend.stub(
+            delay=pretend.call_recorder(lambda *args, **kwargs: None)
+        )
+        pyramid_request.task = pretend.call_recorder(
+            lambda *args, **kwargs: send_email
+        )
+        monkeypatch.setattr(email, 'send_email', send_email)
+
+        result = email.send_role_changed_for_user_email(
+            pyramid_request,
+            role=stub_role,
+            email_recipients=[stub_user.email, stub_submitter_user.email]
+        )
+
+        assert result == {
+            'project': 'test_project',
+            'role': 'Owner',
+            'submitter': stub_submitter_user.username,
+            'username': stub_user.username,
+        }
+        subject_renderer.assert_()
+        body_renderer.assert_(submitter=stub_submitter_user.username)
+        body_renderer.assert_(project='test_project')
+        body_renderer.assert_(role='Owner')
+
+        assert pyramid_request.task.calls == [
+            pretend.call(send_email),
+            pretend.call(send_email),
+        ]
+
+        assert send_email.delay.calls == [
+            pretend.call(
+                'Email Subject',
+                'Email Body',
+                recipient=stub_user.email,
+            ),
+            pretend.call(
+                'Email Subject',
+                'Email Body',
+                recipient=stub_submitter_user.email,
+            ),
+        ]

--- a/tests/unit/email/test_init.py
+++ b/tests/unit/email/test_init.py
@@ -467,124 +467,97 @@ class TestAddedAsCollaboratorEmail:
 class TestRemovedAsCollaboratorEmail:
 
     def test_removed_as_collaborator_email(
-            self, pyramid_request, pyramid_config, monkeypatch):
+        self, pyramid_request, pyramid_config, monkeypatch
+    ):
 
-        stub_user = pretend.stub(
-            email='email',
-            username='username',
-        )
+        stub_user = pretend.stub(email="email", username="username")
         stub_submitter_user = pretend.stub(
-            email='submiteremail',
-            username='submitterusername'
+            email="submiteremail", username="submitterusername"
         )
         stub_role = pretend.stub(
-            role_name="Owner",
-            user=stub_user,
-            project=pretend.stub(
-                name="test_project"
-            ),
+            role_name="Owner", user=stub_user, project=pretend.stub(name="test_project")
         )
         pyramid_request.user = stub_submitter_user
 
         subject_renderer = pyramid_config.testing_add_renderer(
-            'email/removed-as-collaborator.subject.txt'
+            "email/removed-as-collaborator.subject.txt"
         )
-        subject_renderer.string_response = 'Email Subject'
+        subject_renderer.string_response = "Email Subject"
         body_renderer = pyramid_config.testing_add_renderer(
-            'email/removed-as-collaborator.body.txt'
+            "email/removed-as-collaborator.body.txt"
         )
-        body_renderer.string_response = 'Email Body'
+        body_renderer.string_response = "Email Body"
 
         send_email = pretend.stub(
             delay=pretend.call_recorder(lambda *args, **kwargs: None)
         )
-        pyramid_request.task = pretend.call_recorder(
-            lambda *args, **kwargs: send_email
-        )
-        monkeypatch.setattr(email, 'send_email', send_email)
+        pyramid_request.task = pretend.call_recorder(lambda *args, **kwargs: send_email)
+        monkeypatch.setattr(email, "send_email", send_email)
 
-        result = email.send_removed_from_role_email(
-            pyramid_request,
-            role=stub_role,
-        )
+        result = email.send_removed_from_role_email(pyramid_request, role=stub_role)
 
         assert result == {
-            'project': 'test_project',
-            'role': 'Owner',
-            'submitter': stub_submitter_user.username
+            "project": "test_project",
+            "role": "Owner",
+            "submitter": stub_submitter_user.username,
         }
         subject_renderer.assert_()
         body_renderer.assert_(submitter=stub_submitter_user.username)
-        body_renderer.assert_(project='test_project')
-        body_renderer.assert_(role='Owner')
+        body_renderer.assert_(project="test_project")
+        body_renderer.assert_(role="Owner")
 
-        assert pyramid_request.task.calls == [
-            pretend.call(send_email),
-        ]
+        assert pyramid_request.task.calls == [pretend.call(send_email)]
         assert send_email.delay.calls == [
-            pretend.call(
-                'Email Subject',
-                'Email Body',
-                recipient=stub_user.email,
-            ),
+            pretend.call("Email Subject", "Email Body", recipient=stub_user.email)
         ]
 
 
 class TestUserRoleChangedEmail:
 
     def test_user_role_changed_email(
-            self, pyramid_request, pyramid_config, monkeypatch):
+        self, pyramid_request, pyramid_config, monkeypatch
+    ):
 
-        stub_user = pretend.stub(
-            email='email',
-            username='username',
-        )
+        stub_user = pretend.stub(email="email", username="username")
         stub_submitter_user = pretend.stub(
-            email='submiteremail',
-            username='submitterusername'
+            email="submiteremail", username="submitterusername"
         )
         stub_role = pretend.stub(
-            role_name="Owner",
-            user=stub_user,
-            project=pretend.stub(
-                name="test_project"
-            ),
+            role_name="Owner", user=stub_user, project=pretend.stub(name="test_project")
         )
         pyramid_request.user = stub_submitter_user
 
         subject_renderer = pyramid_config.testing_add_renderer(
-            'email/role-removed-from-user.subject.txt'
+            "email/role-removed-from-user.subject.txt"
         )
-        subject_renderer.string_response = 'Email Subject'
+        subject_renderer.string_response = "Email Subject"
         body_renderer = pyramid_config.testing_add_renderer(
-            'email/role-removed-from-user.body.txt'
+            "email/role-removed-from-user.body.txt"
         )
-        body_renderer.string_response = 'Email Body'
+        body_renderer.string_response = "Email Body"
 
         send_email = pretend.stub(
             delay=pretend.call_recorder(lambda *args, **kwargs: None)
         )
-        pyramid_request.task = pretend.call_recorder(
-            lambda *args, **kwargs: send_email
-        )
-        monkeypatch.setattr(email, 'send_email', send_email)
+        pyramid_request.task = pretend.call_recorder(lambda *args, **kwargs: send_email)
+        monkeypatch.setattr(email, "send_email", send_email)
 
         result = email.send_role_removed_from_user_email(
             pyramid_request,
             role=stub_role,
-            email_recipients=[stub_user.email, stub_submitter_user.email]
+            email_recipients=[stub_user.email, stub_submitter_user.email],
         )
 
         assert result == {
-            'project': 'test_project',
-            'role': 'Owner',
-            'submitter': stub_submitter_user.username,
-            'username': stub_user.username,
+            "project": "test_project",
+            "role": "Owner",
+            "submitter": stub_submitter_user.username,
+            "username": stub_user.username,
         }
         subject_renderer.assert_()
         body_renderer.assert_(submitter=stub_submitter_user.username)
-        body_renderer.assert_(project='test_project')
-        body_renderer.assert_(role='Owner')
+        body_renderer.assert_(project="test_project")
+        body_renderer.assert_(role="Owner")
 
         assert pyramid_request.task.calls == [
             pretend.call(send_email),
@@ -592,15 +565,9 @@ class TestUserRoleChangedEmail:
         ]
 
         assert send_email.delay.calls == [
+            pretend.call("Email Subject", "Email Body", recipient=stub_user.email),
             pretend.call(
-                'Email Subject',
-                'Email Body',
-                recipient=stub_user.email,
-            ),
-            pretend.call(
-                'Email Subject',
-                'Email Body',
-                recipient=stub_submitter_user.email,
+                "Email Subject", "Email Body", recipient=stub_submitter_user.email
             ),
         ]
 
@@ -608,124 +575,97 @@ class TestUserRoleChangedEmail:
 class TestUserRoleChangedEmailEmail:
 
     def test_user_role_changed_email(
-            self, pyramid_request, pyramid_config, monkeypatch):
+        self, pyramid_request, pyramid_config, monkeypatch
+    ):
 
-        stub_user = pretend.stub(
-            email='email',
-            username='username',
-        )
+        stub_user = pretend.stub(email="email", username="username")
         stub_submitter_user = pretend.stub(
-            email='submiteremail',
-            username='submitterusername'
+            email="submiteremail", username="submitterusername"
         )
         stub_role = pretend.stub(
-            role_name="Owner",
-            user=stub_user,
-            project=pretend.stub(
-                name="test_project"
-            ),
+            role_name="Owner", user=stub_user, project=pretend.stub(name="test_project")
         )
         pyramid_request.user = stub_submitter_user
 
         subject_renderer = pyramid_config.testing_add_renderer(
-            'email/user-role-changed.subject.txt'
+            "email/user-role-changed.subject.txt"
         )
-        subject_renderer.string_response = 'Email Subject'
+        subject_renderer.string_response = "Email Subject"
         body_renderer = pyramid_config.testing_add_renderer(
-            'email/user-role-changed.body.txt'
+            "email/user-role-changed.body.txt"
         )
-        body_renderer.string_response = 'Email Body'
+        body_renderer.string_response = "Email Body"
 
         send_email = pretend.stub(
             delay=pretend.call_recorder(lambda *args, **kwargs: None)
         )
-        pyramid_request.task = pretend.call_recorder(
-            lambda *args, **kwargs: send_email
-        )
-        monkeypatch.setattr(email, 'send_email', send_email)
+        pyramid_request.task = pretend.call_recorder(lambda *args, **kwargs: send_email)
+        monkeypatch.setattr(email, "send_email", send_email)
 
-        result = email.send_user_role_changed_email(
-            pyramid_request,
-            role=stub_role,
-        )
+        result = email.send_user_role_changed_email(pyramid_request, role=stub_role)
 
         assert result == {
-            'project': 'test_project',
-            'role': 'Owner',
-            'submitter': stub_submitter_user.username
+            "project": "test_project",
+            "role": "Owner",
+            "submitter": stub_submitter_user.username,
         }
         subject_renderer.assert_()
         body_renderer.assert_(submitter=stub_submitter_user.username)
-        body_renderer.assert_(project='test_project')
-        body_renderer.assert_(role='Owner')
+        body_renderer.assert_(project="test_project")
+        body_renderer.assert_(role="Owner")
 
-        assert pyramid_request.task.calls == [
-            pretend.call(send_email),
-        ]
+        assert pyramid_request.task.calls == [pretend.call(send_email)]
         assert send_email.delay.calls == [
-            pretend.call(
-                'Email Subject',
-                'Email Body',
-                recipient=stub_user.email,
-            ),
+            pretend.call("Email Subject", "Email Body", recipient=stub_user.email)
         ]
 
 
 class TestRoleChangedForUserEmail:
 
     def test_role_changed_for_user_email(
-            self, pyramid_request, pyramid_config, monkeypatch):
+        self, pyramid_request, pyramid_config, monkeypatch
+    ):
 
-        stub_user = pretend.stub(
-            email='email',
-            username='username',
-        )
+        stub_user = pretend.stub(email="email", username="username")
         stub_submitter_user = pretend.stub(
-            email='submiteremail',
-            username='submitterusername'
+            email="submiteremail", username="submitterusername"
         )
         stub_role = pretend.stub(
-            role_name="Owner",
-            user=stub_user,
-            project=pretend.stub(
-                name="test_project"
-            ),
+            role_name="Owner", user=stub_user, project=pretend.stub(name="test_project")
         )
         pyramid_request.user = stub_submitter_user
 
         subject_renderer = pyramid_config.testing_add_renderer(
-            'email/role-changed-for-user.subject.txt'
+            "email/role-changed-for-user.subject.txt"
         )
-        subject_renderer.string_response = 'Email Subject'
+        subject_renderer.string_response = "Email Subject"
         body_renderer = pyramid_config.testing_add_renderer(
-            'email/role-changed-for-user.body.txt'
+            "email/role-changed-for-user.body.txt"
         )
-        body_renderer.string_response = 'Email Body'
+        body_renderer.string_response = "Email Body"
 
         send_email = pretend.stub(
             delay=pretend.call_recorder(lambda *args, **kwargs: None)
         )
-        pyramid_request.task = pretend.call_recorder(
-            lambda *args, **kwargs: send_email
-        )
-        monkeypatch.setattr(email, 'send_email', send_email)
+        pyramid_request.task = pretend.call_recorder(lambda *args, **kwargs: send_email)
+        monkeypatch.setattr(email, "send_email", send_email)
 
         result = email.send_role_changed_for_user_email(
             pyramid_request,
             role=stub_role,
-            email_recipients=[stub_user.email, stub_submitter_user.email]
+            email_recipients=[stub_user.email, stub_submitter_user.email],
         )
 
         assert result == {
-            'project': 'test_project',
-            'role': 'Owner',
-            'submitter': stub_submitter_user.username,
-            'username': stub_user.username,
+            "project": "test_project",
+            "role": "Owner",
+            "submitter": stub_submitter_user.username,
+            "username": stub_user.username,
         }
         subject_renderer.assert_()
         body_renderer.assert_(submitter=stub_submitter_user.username)
-        body_renderer.assert_(project='test_project')
-        body_renderer.assert_(role='Owner')
+        body_renderer.assert_(project="test_project")
+        body_renderer.assert_(role="Owner")
 
         assert pyramid_request.task.calls == [
             pretend.call(send_email),
@@ -733,14 +673,8 @@ class TestRoleChangedForUserEmail:
         ]
 
         assert send_email.delay.calls == [
+            pretend.call("Email Subject", "Email Body", recipient=stub_user.email),
             pretend.call(
-                'Email Subject',
-                'Email Body',
-                recipient=stub_user.email,
-            ),
-            pretend.call(
-                'Email Subject',
-                'Email Body',
-                recipient=stub_submitter_user.email,
+                "Email Subject", "Email Body", recipient=stub_submitter_user.email
             ),
         ]

--- a/tests/unit/manage/test_views.py
+++ b/tests/unit/manage/test_views.py
@@ -1168,6 +1168,8 @@ class TestManageProjectRoles:
         owner_2_role = RoleFactory.create(
             user=owner_2, project=project, role_name="Owner"
         )
+        user = UserFactory.create(username="testuser")
+        EmailFactory.create(user=user, email="useremail")
 
         user_service = pretend.stub(
             find_userid=lambda username: new_user.id, get_user=lambda userid: new_user
@@ -1254,6 +1256,90 @@ class TestManageProjectRoles:
         assert entry.submitted_by == db_request.user
         assert entry.submitted_from == db_request.remote_addr
 
+    def test_post_new_role_notify_all_owners(self, monkeypatch, db_request):
+        project = ProjectFactory.create(name="foobar")
+        user = UserFactory.create(username="testuser")
+        EmailFactory.create(user=user, email="useremail")
+
+        owner = UserFactory.create(username="owneruser")
+        EmailFactory.create(user=owner, email="owneremail")
+        other_owner = UserFactory.create(username="otherowner")
+        EmailFactory.create(
+            user=other_owner,
+            email="otherowneremail",
+        )
+
+        RoleFactory.create(
+            user=owner, project=project, role_name="Owner"
+        )
+        RoleFactory.create(
+            user=other_owner, project=project, role_name="Owner"
+        )
+
+        user_service = pretend.stub(
+            find_userid=lambda username: user.id,
+            get_user=lambda userid: user,
+        )
+        db_request.find_service = pretend.call_recorder(
+            lambda iface, context: user_service
+        )
+        db_request.method = "POST"
+        db_request.POST = pretend.stub()
+        db_request.remote_addr = "10.10.10.10"
+        db_request.user = owner
+        form_obj = pretend.stub(
+            validate=pretend.call_recorder(lambda: True),
+            username=pretend.stub(data=user.username),
+            role_name=pretend.stub(data="Owner"),
+        )
+        form_class = pretend.call_recorder(lambda *a, **kw: form_obj)
+        db_request.session = pretend.stub(
+            flash=pretend.call_recorder(lambda *a, **kw: None),
+        )
+
+        send_collaborator_added_email = pretend.call_recorder(lambda *a: None)
+        monkeypatch.setattr(
+            views,
+            'send_collaborator_added_email',
+            send_collaborator_added_email,
+        )
+
+        send_added_as_collaborator_email = pretend.call_recorder(
+            lambda *a: None)
+        monkeypatch.setattr(
+            views,
+            'send_added_as_collaborator_email',
+            send_added_as_collaborator_email,
+        )
+
+        views.manage_project_roles(
+            project, db_request, _form_class=form_class
+        )
+
+        assert db_request.session.flash.calls == [
+            pretend.call("Added collaborator 'testuser'", queue="success"),
+        ]
+
+        assert send_collaborator_added_email.calls == [
+            pretend.call(
+                db_request,
+                user,
+                db_request.user,
+                project.name,
+                form_obj.role_name.data,
+                {other_owner}
+            )
+        ]
+
+        assert send_added_as_collaborator_email.calls == [
+            pretend.call(
+                db_request,
+                db_request.user,
+                project.name,
+                form_obj.role_name.data,
+                user)
+        ]
+
     def test_post_duplicate_role(self, db_request):
         project = ProjectFactory.create(name="foobar")
         user = UserFactory.create(username="testuser")
@@ -1305,20 +1391,45 @@ class TestManageProjectRoles:
 
 class TestChangeProjectRoles:
 
-    def test_change_role(self, db_request):
+    def test_change_role(self, db_request, monkeypatch):
         project = ProjectFactory.create(name="foobar")
         user = UserFactory.create(username="testuser")
-        role = RoleFactory.create(user=user, project=project, role_name="Owner")
+        role = RoleFactory.create(
+            user=user, project=project, role_name="Owner"
+        )
+        EmailFactory.create(user=user, email="useremail")
+
+        otherowner = UserFactory.create(username="otherowner")
+        RoleFactory.create(
+            user=otherowner, project=project, role_name="Owner"
+        )
+        EmailFactory.create(user=otherowner, email="otherowneremail")
         new_role_name = "Maintainer"
 
         db_request.method = "POST"
-        db_request.user = UserFactory.create()
+        db_request.user = otherowner
         db_request.remote_addr = "10.10.10.10"
         db_request.POST = MultiDict({"role_id": role.id, "role_name": new_role_name})
         db_request.session = pretend.stub(
             flash=pretend.call_recorder(lambda *a, **kw: None)
         )
         db_request.route_path = pretend.call_recorder(lambda *a, **kw: "/the-redirect")
+
+        send_user_role_changed_email = pretend.call_recorder(
+            lambda *a: None)
+        monkeypatch.setattr(
+            views,
+            'send_user_role_changed_email',
+            send_user_role_changed_email
+        )
+
+        send_role_changed_for_user_email = pretend.call_recorder(
+            lambda *a: None)
+        monkeypatch.setattr(
+            views,
+            'send_role_changed_for_user_email',
+            send_role_changed_for_user_email
+        )
 
         result = views.change_project_role(project, db_request)
 
@@ -1332,12 +1443,98 @@ class TestChangeProjectRoles:
         assert isinstance(result, HTTPSeeOther)
         assert result.headers["Location"] == "/the-redirect"
 
+        assert send_user_role_changed_email.calls == [
+            pretend.call(
+                db_request,
+                role,
+            ),
+        ]
+
+        assert send_role_changed_for_user_email.calls == [
+            pretend.call(
+                db_request,
+                role,
+                [otherowner.email],
+            ),
+        ]
+
         entry = db_request.db.query(JournalEntry).one()
 
         assert entry.name == project.name
         assert entry.action == "change Owner testuser to Maintainer"
         assert entry.submitted_by == db_request.user
         assert entry.submitted_from == db_request.remote_addr
+
+    def test_change_role_email_notify_all_owners(self, db_request,
+                                                 monkeypatch):
+        project = ProjectFactory.create(name="foobar")
+        user = UserFactory.create(username="testuser")
+        role = RoleFactory.create(
+            user=user, project=project, role_name="Owner"
+        )
+        EmailFactory.create(user=user, email="useremail")
+        owner = UserFactory.create(username="owneruser")
+        EmailFactory.create(user=owner, email="owneremail")
+        other_owner = UserFactory.create(username="otherowner")
+        EmailFactory.create(
+            user=other_owner,
+            email="otherowneremail",
+        )
+
+        RoleFactory.create(
+            user=owner, project=project, role_name="Owner"
+        )
+        RoleFactory.create(
+            user=other_owner, project=project, role_name="Owner"
+        )
+        new_role_name = "Maintainer"
+
+        db_request.method = "POST"
+        db_request.user = owner
+        db_request.remote_addr = "10.10.10.10"
+        db_request.POST = MultiDict({
+            "role_id": role.id,
+            "role_name": new_role_name,
+        })
+        db_request.session = pretend.stub(
+            flash=pretend.call_recorder(lambda *a, **kw: None),
+        )
+        db_request.route_path = pretend.call_recorder(
+            lambda *a, **kw: "/the-redirect"
+        )
+
+        send_user_role_changed_email = pretend.call_recorder(
+            lambda *a: None)
+        monkeypatch.setattr(
+            views,
+            'send_user_role_changed_email',
+            send_user_role_changed_email
+        )
+
+        send_role_changed_for_user_email = pretend.call_recorder(
+            lambda *a: None)
+        monkeypatch.setattr(
+            views,
+            'send_role_changed_for_user_email',
+            send_role_changed_for_user_email
+        )
+
+        views.change_project_role(project, db_request)
+
+        assert send_user_role_changed_email.calls == [
+            pretend.call(
+                db_request,
+                role,
+            )
+        ]
+
+        assert send_role_changed_for_user_email.calls == [
+            pretend.call(
+                db_request,
+                role,
+                sorted([other_owner.email, owner.email]),
+            )
+        ]
 
     def test_change_role_invalid_role_name(self, pyramid_request):
         project = pretend.stub(name="foobar")
@@ -1475,13 +1672,21 @@ class TestChangeProjectRoles:
 
 class TestDeleteProjectRoles:
 
-    def test_delete_role(self, db_request):
+    def test_delete_role(self, db_request, monkeypatch):
         project = ProjectFactory.create(name="foobar")
         user = UserFactory.create(username="testuser")
-        role = RoleFactory.create(user=user, project=project, role_name="Owner")
+        role = RoleFactory.create(
+            user=user, project=project, role_name="Owner"
+        )
+        EmailFactory.create(user=user, email="useremail")
+        otherowner = UserFactory.create(username="otherowner")
+        otherowner_role = RoleFactory.create(
+            user=otherowner, project=project, role_name="Owner"
+        )
+        EmailFactory.create(user=otherowner, email="otherowneremail")
 
         db_request.method = "POST"
-        db_request.user = UserFactory.create()
+        db_request.user = otherowner
         db_request.remote_addr = "10.10.10.10"
         db_request.POST = MultiDict({"role_id": role.id})
         db_request.session = pretend.stub(
@@ -1489,17 +1694,47 @@ class TestDeleteProjectRoles:
         )
         db_request.route_path = pretend.call_recorder(lambda *a, **kw: "/the-redirect")
 
-        result = views.delete_project_role(project, db_request)
+        send_removed_from_role_email = pretend.call_recorder(
+            lambda *a: None)
+        monkeypatch.setattr(
+            views,
+            'send_removed_from_role_email',
+            send_removed_from_role_email
+        )
 
+        send_role_removed_from_user_email = pretend.call_recorder(
+            lambda *a: None)
+        monkeypatch.setattr(
+            views,
+            'send_role_removed_from_user_email',
+            send_role_removed_from_user_email
+        )
+
+        result = views.delete_project_role(project, db_request)
         assert db_request.route_path.calls == [
             pretend.call("manage.project.roles", project_name=project.name)
         ]
-        assert db_request.db.query(Role).all() == []
+        assert db_request.db.query(Role).all() == [otherowner_role]
         assert db_request.session.flash.calls == [
             pretend.call("Removed role", queue="success")
         ]
         assert isinstance(result, HTTPSeeOther)
         assert result.headers["Location"] == "/the-redirect"
+
+        assert send_removed_from_role_email.calls == [
+            pretend.call(
+                db_request,
+                role,
+            )
+        ]
+
+        assert send_role_removed_from_user_email.calls == [
+            pretend.call(
+                db_request,
+                role,
+                [otherowner.email],
+            ),
+        ]
 
         entry = db_request.db.query(JournalEntry).one()
 
@@ -1507,6 +1742,71 @@ class TestDeleteProjectRoles:
         assert entry.action == "remove Owner testuser"
         assert entry.submitted_by == db_request.user
         assert entry.submitted_from == db_request.remote_addr
+
+    def test_delete_role_notify_all_owners(self, db_request, monkeypatch):
+        project = ProjectFactory.create(name="foobar")
+        user = UserFactory.create(username="testuser")
+        role = RoleFactory.create(
+            user=user, project=project, role_name="Owner"
+        )
+        owner = UserFactory.create(username="owneruser")
+        EmailFactory.create(user=owner, email="owneremail")
+        other_owner = UserFactory.create(username="otherowner")
+        EmailFactory.create(
+            user=other_owner,
+            email="otherowneremail",
+        )
+
+        RoleFactory.create(
+            user=owner, project=project, role_name="Owner"
+        )
+        RoleFactory.create(
+            user=other_owner, project=project, role_name="Owner"
+        )
+
+        db_request.method = "POST"
+        db_request.user = owner
+        db_request.remote_addr = "10.10.10.10"
+        db_request.POST = MultiDict({"role_id": role.id})
+        db_request.session = pretend.stub(
+            flash=pretend.call_recorder(lambda *a, **kw: None),
+        )
+        db_request.route_path = pretend.call_recorder(
+            lambda *a, **kw: "/the-redirect"
+        )
+
+        send_removed_from_role_email = pretend.call_recorder(
+            lambda *a: None)
+        monkeypatch.setattr(
+            views,
+            'send_removed_from_role_email',
+            send_removed_from_role_email
+        )
+
+        send_role_removed_from_user_email = pretend.call_recorder(
+            lambda *a: None)
+        monkeypatch.setattr(
+            views,
+            'send_role_removed_from_user_email',
+            send_role_removed_from_user_email
+        )
+
+        views.delete_project_role(project, db_request)
+
+        assert send_removed_from_role_email.calls == [
+            pretend.call(
+                db_request,
+                role,
+            )
+        ]
+
+        assert send_role_removed_from_user_email.calls == [
+            pretend.call(
+                db_request,
+                role,
+                sorted([other_owner.email, owner.email]),
+            )
+        ]
 
     def test_delete_missing_role(self, db_request):
         project = ProjectFactory.create(name="foobar")

--- a/warehouse/email/__init__.py
+++ b/warehouse/email/__init__.py
@@ -184,18 +184,16 @@ def includeme(config):
 
 def send_removed_from_role_email(request, role):
     fields = {
-        'project': role.project.name,
-        'submitter': request.user.username,
-        'role': role.role_name
+        "project": role.project.name,
+        "submitter": request.user.username,
+        "role": role.role_name,
     }
 
     subject = render(
-        'email/removed-as-collaborator.subject.txt', fields, request=request
+        "email/removed-as-collaborator.subject.txt", fields, request=request
     )
 
-    body = render(
-        'email/removed-as-collaborator.body.txt', fields, request=request
-    )
+    body = render("email/removed-as-collaborator.body.txt", fields, request=request)
 
     request.task(send_email).delay(subject, body, recipient=role.user.email)
 
@@ -204,43 +202,33 @@ def send_removed_from_role_email(request, role):
 
 def send_role_removed_from_user_email(request, role, email_recipients):
     fields = {
-        'project': role.project.name,
-        'submitter': request.user.username,
-        'role': role.role_name,
-        'username': role.user.username,
+        "project": role.project.name,
+        "submitter": request.user.username,
+        "role": role.role_name,
+        "username": role.user.username,
     }
 
     subject = render(
-        'email/role-removed-from-user.subject.txt', fields, request=request
+        "email/role-removed-from-user.subject.txt", fields, request=request
     )
 
-    body = render(
-        'email/role-removed-from-user.body.txt', fields, request=request
-    )
+    body = render("email/role-removed-from-user.body.txt", fields, request=request)
 
     for recipient in email_recipients:
-        request.task(send_email).delay(
-            subject,
-            body,
-            recipient=recipient,
-        )
+        request.task(send_email).delay(subject, body, recipient=recipient)
     return fields
 
 
 def send_user_role_changed_email(request, role):
     fields = {
-        'project': role.project.name,
-        'submitter': request.user.username,
-        'role': role.role_name
+        "project": role.project.name,
+        "submitter": request.user.username,
+        "role": role.role_name,
     }
 
-    subject = render(
-        'email/user-role-changed.subject.txt', fields, request=request
-    )
+    subject = render("email/user-role-changed.subject.txt", fields, request=request)
 
-    body = render(
-        'email/user-role-changed.body.txt', fields, request=request
-    )
+    body = render("email/user-role-changed.body.txt", fields, request=request)
 
     request.task(send_email).delay(subject, body, recipient=role.user.email)
 
@@ -249,25 +237,17 @@ def send_user_role_changed_email(request, role):
 
 def send_role_changed_for_user_email(request, role, email_recipients):
     fields = {
-        'project': role.project.name,
-        'submitter': request.user.username,
-        'role': role.role_name,
-        'username': role.user.username,
+        "project": role.project.name,
+        "submitter": request.user.username,
+        "role": role.role_name,
+        "username": role.user.username,
     }
 
-    subject = render(
-        'email/role-changed-for-user.subject.txt', fields, request=request
-    )
+    subject = render("email/role-changed-for-user.subject.txt", fields, request=request)
 
-    body = render(
-        'email/role-changed-for-user.body.txt', fields, request=request
-    )
+    body = render("email/role-changed-for-user.body.txt", fields, request=request)
 
     for recipient in email_recipients:
-        request.task(send_email).delay(
-            subject,
-            body,
-            recipient=recipient,
-        )
+        request.task(send_email).delay(subject, body, recipient=recipient)
 
     return fields

--- a/warehouse/email/__init__.py
+++ b/warehouse/email/__init__.py
@@ -180,3 +180,94 @@ def includeme(config):
     # or not, because even if we stop using SES, we'll want to remove any
     # emails that had been sent, and the cost of doing this is very low.
     config.add_periodic_task(crontab(minute=0, hour=0), ses_cleanup)
+
+
+def send_removed_from_role_email(request, role):
+    fields = {
+        'project': role.project.name,
+        'submitter': request.user.username,
+        'role': role.role_name
+    }
+
+    subject = render(
+        'email/removed-as-collaborator.subject.txt', fields, request=request
+    )
+
+    body = render(
+        'email/removed-as-collaborator.body.txt', fields, request=request
+    )
+
+    request.task(send_email).delay(subject, body, recipient=role.user.email)
+
+    return fields
+
+
+def send_role_removed_from_user_email(request, role, email_recipients):
+    fields = {
+        'project': role.project.name,
+        'submitter': request.user.username,
+        'role': role.role_name,
+        'username': role.user.username,
+    }
+
+    subject = render(
+        'email/role-removed-from-user.subject.txt', fields, request=request
+    )
+
+    body = render(
+        'email/role-removed-from-user.body.txt', fields, request=request
+    )
+
+    for recipient in email_recipients:
+        request.task(send_email).delay(
+            subject,
+            body,
+            recipient=recipient,
+        )
+    return fields
+
+
+def send_user_role_changed_email(request, role):
+    fields = {
+        'project': role.project.name,
+        'submitter': request.user.username,
+        'role': role.role_name
+    }
+
+    subject = render(
+        'email/user-role-changed.subject.txt', fields, request=request
+    )
+
+    body = render(
+        'email/user-role-changed.body.txt', fields, request=request
+    )
+
+    request.task(send_email).delay(subject, body, recipient=role.user.email)
+
+    return fields
+
+
+def send_role_changed_for_user_email(request, role, email_recipients):
+    fields = {
+        'project': role.project.name,
+        'submitter': request.user.username,
+        'role': role.role_name,
+        'username': role.user.username,
+    }
+
+    subject = render(
+        'email/role-changed-for-user.subject.txt', fields, request=request
+    )
+
+    body = render(
+        'email/role-changed-for-user.body.txt', fields, request=request
+    )
+
+    for recipient in email_recipients:
+        request.task(send_email).delay(
+            subject,
+            body,
+            recipient=recipient,
+        )
+
+    return fields

--- a/warehouse/manage/views.py
+++ b/warehouse/manage/views.py
@@ -22,20 +22,16 @@ from warehouse.accounts.interfaces import IUserService
 from warehouse.accounts.models import User, Email
 from warehouse.accounts.views import logout
 from warehouse.email import (
-<<<<<<< 40a982e23b95d76c6249d0b8beaedaf193808ae2
     send_account_deletion_email,
     send_added_as_collaborator_email,
     send_collaborator_added_email,
     send_email_verification_email,
     send_password_change_email,
     send_primary_email_change_email,
-=======
-    send_account_deletion_email, send_added_as_collaborator_email,
-    send_collaborator_added_email, send_email_verification_email,
-    send_password_change_email, send_primary_email_change_email,
-    send_removed_from_role_email, send_role_changed_for_user_email,
-    send_role_removed_from_user_email, send_user_role_changed_email,
->>>>>>> Email notification when user's role is changed/removed.
+    send_removed_from_role_email,
+    send_role_changed_for_user_email,
+    send_role_removed_from_user_email,
+    send_user_role_changed_email,
 )
 from warehouse.manage.forms import (
     AddEmailForm,
@@ -559,7 +555,7 @@ def manage_project_roles(project, request, _form_class=CreateRoleForm):
                 request.user,
                 project.name,
                 form.role_name.data,
-                owner_users
+                owner_users,
             )
 
             send_added_as_collaborator_email(
@@ -658,24 +654,20 @@ def change_project_role(project, request, _form_class=ChangeRoleForm):
                     owners = (
                         request.db.query(Role)
                         .join(Role.user)
-                        .filter(
-                            Role.role_name == 'Owner',
-                            Role.project == role.project,
-                        )
+                        .filter(Role.role_name == "Owner", Role.project == role.project)
                     )
-                    owner_emails = [owner.user.email for owner in owners
-                                    if owner.user.email != role.user.email]
+                    owner_emails = [
+                        owner.user.email
+                        for owner in owners
+                        if owner.user.email != role.user.email
+                    ]
 
                     role.role_name = form.role_name.data
                     send_user_role_changed_email(request, role)
                     send_role_changed_for_user_email(
-                        request,
-                        role,
-                        sorted(owner_emails),
+                        request, role, sorted(owner_emails)
                     )
-                    request.session.flash(
-                        'Changed role', queue="success"
-                    )
+                    request.session.flash("Changed role", queue="success")
             except NoResultFound:
                 request.session.flash("Could not find role", queue="error")
 
@@ -722,18 +714,13 @@ def delete_project_role(project, request):
             owners = (
                 request.db.query(Role)
                 .join(Role.user)
-                .filter(
-                    Role.role_name == 'Owner',
-                    Role.project == role.project,
-                )
+                .filter(Role.role_name == "Owner", Role.project == role.project)
             )
             owner_emails = [owner.user.email for owner in owners]
 
             send_removed_from_role_email(request, role)
-            send_role_removed_from_user_email(
-                request, role, sorted(owner_emails)
-            )
-        request.session.flash("Successfully removed role", queue="success")
+            send_role_removed_from_user_email(request, role, sorted(owner_emails))
+        request.session.flash("Removed role", queue="success")
 
     return HTTPSeeOther(
         request.route_path("manage.project.roles", project_name=project.name)

--- a/warehouse/manage/views.py
+++ b/warehouse/manage/views.py
@@ -22,12 +22,20 @@ from warehouse.accounts.interfaces import IUserService
 from warehouse.accounts.models import User, Email
 from warehouse.accounts.views import logout
 from warehouse.email import (
+<<<<<<< 40a982e23b95d76c6249d0b8beaedaf193808ae2
     send_account_deletion_email,
     send_added_as_collaborator_email,
     send_collaborator_added_email,
     send_email_verification_email,
     send_password_change_email,
     send_primary_email_change_email,
+=======
+    send_account_deletion_email, send_added_as_collaborator_email,
+    send_collaborator_added_email, send_email_verification_email,
+    send_password_change_email, send_primary_email_change_email,
+    send_removed_from_role_email, send_role_changed_for_user_email,
+    send_role_removed_from_user_email, send_user_role_changed_email,
+>>>>>>> Email notification when user's role is changed/removed.
 )
 from warehouse.manage.forms import (
     AddEmailForm,
@@ -551,7 +559,7 @@ def manage_project_roles(project, request, _form_class=CreateRoleForm):
                 request.user,
                 project.name,
                 form.role_name.data,
-                owner_users,
+                owner_users
             )
 
             send_added_as_collaborator_email(
@@ -647,8 +655,27 @@ def change_project_role(project, request, _form_class=ChangeRoleForm):
                             submitted_from=request.remote_addr,
                         )
                     )
+                    owners = (
+                        request.db.query(Role)
+                        .join(Role.user)
+                        .filter(
+                            Role.role_name == 'Owner',
+                            Role.project == role.project,
+                        )
+                    )
+                    owner_emails = [owner.user.email for owner in owners
+                                    if owner.user.email != role.user.email]
+
                     role.role_name = form.role_name.data
-                    request.session.flash("Changed role", queue="success")
+                    send_user_role_changed_email(request, role)
+                    send_role_changed_for_user_email(
+                        request,
+                        role,
+                        sorted(owner_emails),
+                    )
+                    request.session.flash(
+                        'Changed role', queue="success"
+                    )
             except NoResultFound:
                 request.session.flash("Could not find role", queue="error")
 
@@ -692,7 +719,21 @@ def delete_project_role(project, request):
                     submitted_from=request.remote_addr,
                 )
             )
-        request.session.flash("Removed role", queue="success")
+            owners = (
+                request.db.query(Role)
+                .join(Role.user)
+                .filter(
+                    Role.role_name == 'Owner',
+                    Role.project == role.project,
+                )
+            )
+            owner_emails = [owner.user.email for owner in owners]
+
+            send_removed_from_role_email(request, role)
+            send_role_removed_from_user_email(
+                request, role, sorted(owner_emails)
+            )
+        request.session.flash("Successfully removed role", queue="success")
 
     return HTTPSeeOther(
         request.route_path("manage.project.roles", project_name=project.name)

--- a/warehouse/templates/email/added-as-collaborator.body.txt
+++ b/warehouse/templates/email/added-as-collaborator.body.txt
@@ -1,4 +1,4 @@
-You have been added as a collaborator to the PyPI project {{ project }}
+You have been added as a collaborator to the project {{ project }}
 by {{ submitter }}.
 
 {% if role == 'Owner' -%}

--- a/warehouse/templates/email/collaborator-added.body.txt
+++ b/warehouse/templates/email/collaborator-added.body.txt
@@ -1,4 +1,4 @@
-A new collaborator has been added to a project you own on PyPI:
+A new collaborator has been added to a project you own:
 
   Username: {{ username }}
   Role: {{ role }}

--- a/warehouse/templates/email/removed-as-collaborator.body.txt
+++ b/warehouse/templates/email/removed-as-collaborator.body.txt
@@ -1,0 +1,14 @@
+Your role in the {{ project }} project has been removed by {{ submitter }}.
+
+{% if role == 'Owner' -%}
+You are no longer a project owner. This means that you can no longer add other
+collaborators, upload releases for the project, delete files and releases, or
+delete the entire project.
+{%- elif role == 'Maintainer' -%}
+You are no longer a project maintainer. This means that you can no longer add
+other collaborators, upload releases for the project, delete files and releases,
+or delete the entire project.
+{%- endif %}
+
+If this was a mistake, you can email admin@mail.pypi.org to communicate with
+the PyPI administrators.

--- a/warehouse/templates/email/removed-as-collaborator.subject.txt
+++ b/warehouse/templates/email/removed-as-collaborator.subject.txt
@@ -1,0 +1,1 @@
+Role removed for project {{ project }}

--- a/warehouse/templates/email/role-changed-for-user.body.txt
+++ b/warehouse/templates/email/role-changed-for-user.body.txt
@@ -1,9 +1,9 @@
-A collaborator's role has been changed in a project you own on PyPI:
+A collaborator's role has been changed in a project you own:
 
   Username: {{ username }}
   New role: {{ role }}
   Collaborator for: {{ project }}
   Changed by: {{ submitter }}
 
-If this was a mistake, you can reply to this email directly to communicate with
+If this was a mistake, you can email admin@mail.pypi.org to communicate with
 the PyPI administrators.

--- a/warehouse/templates/email/role-changed-for-user.body.txt
+++ b/warehouse/templates/email/role-changed-for-user.body.txt
@@ -1,0 +1,9 @@
+A collaborator's role has been changed in a project you own on PyPI:
+
+  Username: {{ username }}
+  New role: {{ role }}
+  Collaborator for: {{ project }}
+  Changed by: {{ submitter }}
+
+If this was a mistake, you can reply to this email directly to communicate with
+the PyPI administrators.

--- a/warehouse/templates/email/role-changed-for-user.subject.txt
+++ b/warehouse/templates/email/role-changed-for-user.subject.txt
@@ -1,0 +1,1 @@
+Role changed on PyPI for project {{ project }}

--- a/warehouse/templates/email/role-changed-for-user.subject.txt
+++ b/warehouse/templates/email/role-changed-for-user.subject.txt
@@ -1,1 +1,1 @@
-Role changed on PyPI for project {{ project }}
+Role changed for project {{ project }}

--- a/warehouse/templates/email/role-removed-from-user.body.txt
+++ b/warehouse/templates/email/role-removed-from-user.body.txt
@@ -1,9 +1,9 @@
-A collaborator's role has been removed from a project you own on PyPI:
+A collaborator's role has been removed from a project you own:
 
   Username: {{ username }}
   Role was previously: {{ role }}
   Collaborator for: {{ project }}
   Changed by: {{ submitter }}
 
-If this was a mistake, you can reply to this email directly to communicate with
+If this was a mistake, you can email admin@mail.pypi.org to communicate with
 the PyPI administrators.

--- a/warehouse/templates/email/role-removed-from-user.body.txt
+++ b/warehouse/templates/email/role-removed-from-user.body.txt
@@ -1,0 +1,9 @@
+A collaborator's role has been removed from a project you own on PyPI:
+
+  Username: {{ username }}
+  Role was previously: {{ role }}
+  Collaborator for: {{ project }}
+  Changed by: {{ submitter }}
+
+If this was a mistake, you can reply to this email directly to communicate with
+the PyPI administrators.

--- a/warehouse/templates/email/role-removed-from-user.subject.txt
+++ b/warehouse/templates/email/role-removed-from-user.subject.txt
@@ -1,0 +1,1 @@
+Role removed on PyPI for project {{ project }}

--- a/warehouse/templates/email/role-removed-from-user.subject.txt
+++ b/warehouse/templates/email/role-removed-from-user.subject.txt
@@ -1,1 +1,1 @@
-Role removed on PyPI for project {{ project }}
+Role removed for project {{ project }}

--- a/warehouse/templates/email/user-role-changed.body.txt
+++ b/warehouse/templates/email/user-role-changed.body.txt
@@ -1,16 +1,14 @@
 Your role in the {{ project }} project has been changed by {{ submitter }}.
 
-{% if role == 'Owner' %}
+{% if role == 'Owner' -%}
 You are now a project owner. This means that you may add other collaborators,
 upload releases for the project, delete files and releases, or delete the entire
 project.
-{% endif %}
-
-{% if role == 'Maintainer' %}
+{%- elif role == 'Maintainer' -%}
 You are now a project maintainer. This means that you may upload releases for
 the project. You cannot add collaborators, delete files, delete releases, or
 delete the project.
-{% endif %}
+{%- endif %}
 
-If this was a mistake, you can reply to this email directly to communicate with
+If this was a mistake, you can email admin@mail.pypi.org to communicate with
 the PyPI administrators.

--- a/warehouse/templates/email/user-role-changed.body.txt
+++ b/warehouse/templates/email/user-role-changed.body.txt
@@ -1,17 +1,16 @@
-You have been added as a collaborator to the PyPI project {{ project }}
-by {{ submitter }}.
+Your role in the {{ project }} project has been changed by {{ submitter }}.
 
-{% if role == 'Owner' -%}
+{% if role == 'Owner' %}
 You are now a project owner. This means that you may add other collaborators,
 upload releases for the project, delete files and releases, or delete the entire
 project.
-{%- elif role == 'Maintainer' -%}
+{% endif %}
+
+{% if role == 'Maintainer' %}
 You are now a project maintainer. This means that you may upload releases for
 the project. You cannot add collaborators, delete files, delete releases, or
 delete the project.
-{%- endif %}
+{% endif %}
 
-Congratulations!
-
-If this was a mistake, you can email admin@mail.pypi.org to communicate with
+If this was a mistake, you can reply to this email directly to communicate with
 the PyPI administrators.

--- a/warehouse/templates/email/user-role-changed.subject.txt
+++ b/warehouse/templates/email/user-role-changed.subject.txt
@@ -1,0 +1,1 @@
+Role changed on PyPI for project {{ project }}

--- a/warehouse/templates/email/user-role-changed.subject.txt
+++ b/warehouse/templates/email/user-role-changed.subject.txt
@@ -1,1 +1,1 @@
-Role changed on PyPI for project {{ project }}
+Role changed for project {{ project }}


### PR DESCRIPTION
PR which addresses issues on #3306 
- Send email to the user whose role has been changed/removed.
- Send email to other owners of the project.
- The person who made the change will not receive the email.

Closes https://github.com/pypa/warehouse/issues/3264