### PR TITLE
Roadmap

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,7 @@ Everyone interacting in the Warehouse project's codebases, issue trackers, chat
 rooms, and mailing lists is expected to follow the `PyPA Code of Conduct`_.
 
 .. _`PyPI`: https://pypi.org/
-.. _`our development roadmap`: https://wiki.python.org/psf/WarehouseRoadmap
+.. _`our development roadmap`: https://warehouse.readthedocs.io/roadmap/
 .. _`architectural overview`: https://warehouse.readthedocs.io/application/
 .. _`documentation`: https://warehouse.readthedocs.io
 .. _`Getting started`: https://warehouse.readthedocs.io/development/getting-started/

--- a/docs/application.rst
+++ b/docs/application.rst
@@ -32,8 +32,9 @@ discussion of the differences between URL dispatch and traversal in Pyramid.
 Usage assumptions and concepts
 ------------------------------
 
-See `PyPI help <https://pypi.org/help/#packages>`_ to understand
-projects, releases, and packages.
+See `PyPI help <https://pypi.org/help/#packages>`_ and the glossary
+section of :doc:`ui-principles` to understand projects, releases,
+packages, maintainers, authors, and owners.
 
 Warehouse is specifically the codebase for the official Python Package
 Index, and thus focuses on architecture and features for PyPI and Test

--- a/docs/development/getting-started.rst
+++ b/docs/development/getting-started.rst
@@ -453,8 +453,7 @@ Learn about Warehouse and packaging
 
 Resources to help you learn Warehouse's context:
 
--  `the Warehouse
-   roadmap <https://wiki.python.org/psf/WarehouseRoadmap>`__
+-  :doc:`../roadmap`
 -  `blog posts, mailing list messages, and notes from our core developer
    meetings <https://wiki.python.org/psf/PackagingWG>`__
 - :doc:`../application`

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,6 +11,7 @@ Contents:
    api-reference/index
    ui-principles
    security
+   roadmap
 
 Warehouse is a `web application`_ that implements the canonical
 `Python package index (repository)`_; its production deployment is
@@ -24,8 +25,6 @@ The goal is to improve PyPI by making it:
 - remove legacy APIs
 - have more maintainable code with test coverage, docs, etc.
 
-See the `Warehouse roadmap`_.
-
 
 Indices and tables
 ==================
@@ -37,4 +36,3 @@ Indices and tables
 .. _`Python package index (repository)`: https://packaging.python.org/glossary/#term-package-index
 .. _`web application`: https://github.com/pypa/warehouse
 .. _PyPI: https://pypi.org
-.. _`Warehouse roadmap`: https://wiki.python.org/psf/WarehouseRoadmap

--- a/docs/roadmap.rst
+++ b/docs/roadmap.rst
@@ -1,0 +1,42 @@
+.. _roadmap:
+
+Warehouse feature roadmap
+=========================
+
+As we develop Warehouse, here are our plans along the way. To talk
+about them with us, please `contact us`_.
+
+PyCon 2018 sprints
+------------------
+
+At the `sprints`_ in mid-May, we will focus on interoperability with
+other tools and on the API redesign.
+
+See `sprint-tagged issues`_ on GitHub.
+
+Post Legacy Shutdown
+--------------------
+Issues that are unblocked now that legacy is dead (RIP).
+
+See `issues marked with the post-legacy shutdown milestone`_ on GitHub.
+
+Cool but not urgent
+-------------------
+
+Wishlist.
+
+See `issues marked with the cool-but-not-urgent milestone`_ on GitHub.
+
+History
+-------
+
+You can see `our past roadmap`_, focusing on replacing legacy PyPI, on
+the PSF wiki.
+
+
+.. _`sprints`: https://wiki.python.org/psf/PackagingSprints
+.. _`sprint-tagged issues`: https://github.com/pypa/warehouse/issues?q=is%3Aopen+is%3Aissue+label%3APyCon-2018-sprint
+.. _`issues marked with the post-legacy shutdown milestone`: https://github.com/pypa/warehouse/milestone/12
+.. _`issues marked with the cool-but-not-urgent milestone`: https://github.com/pypa/warehouse/milestone/11
+.. _`contact us`: https://github.com/pypa/warehouse/blob/master/README.rst#discussion
+.. _`our past roadmap`: https://wiki.python.org/psf/WarehouseRoadmap


### PR DESCRIPTION
I maintained the roadmap on the PSF wiki at https://wiki.python.org/psf/WarehouseRoadmap for ease of updating during the MOSS-funded project. Now that it'll change less frequently, let's move the roadmap to live alongside other Warehouse docs.

Once this is merged, I'll edit the top of https://wiki.python.org/psf/WarehouseRoadmap to point to https://warehouse.readthedocs.io/roadmap/ .