### PR TITLE
Allow for text-align to be explicitly set on tables

### DIFF
--- a/warehouse/static/sass/base/_tables.scss
+++ b/warehouse/static/sass/base/_tables.scss
@@ -19,4 +19,14 @@ table {
   td {
     text-align: left; // Required for ie11 where it is centered by default
   }
+
+  th[align="right"],
+  td[align="right"] {
+    text-align: right; // Override the above when explicitly set
+  }
+
+  th[align="center"],
+  td[align="center"] {
+    text-align: center; // Override the above when explicitly set
+  }
 }


### PR DESCRIPTION
Fixes an issue for markdown tables with alignment, the `<td align="right">` was being overridden by the fix for IE.

For example, the tables at the end of https://pypi.org/project/csvprint/0.3.3/