### PR TITLE
Issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,24 @@
+---
+name: Bug report
+about: Let us know if something is broken on PyPI
+
+---
+
+**Describe the bug**
+<!-- A clear and concise description the bug -->
+
+**Expected behavior**
+<!-- A clear and concise description of what you expected to happen -->
+
+**To Reproduce**
+<!-- Steps to reproduce the bug, or a link to PyPI where the bug is visible -->
+
+**My Platform**
+<!--
+Any details about your specific platform:
+* If the problem is in the browser, what browser, version, and OS?
+* If the problem is with a command-line tool, what version of that tool?
+-->
+
+**Additional context**
+<!-- Add any other context, links, etc. about the feature here. -->

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -10,9 +10,9 @@ about: Let us know if something is broken on PyPI
     * test.pypi.org
     * files.pythonhosted.org
 
-    This issue should NOT be for a project hosted on PyPI.  If you are having
-    an issue with a specific package, you should reach out to the maintainers
-    of that project directly instead.
+    This issue should NOT be for a project installed from PyPI. If you are
+    having an issue with a specific package, you should reach out to the
+    maintainers of that project directly instead.
 
     Furthermore, this issue should NOT be for any non-PyPI properties (like
     python.org, docs.python.org, etc.)

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -21,9 +21,12 @@ about: Let us know if something is broken on PyPI
 
 **My Platform**
 <!--
-Any details about your specific platform:
-* If the problem is in the browser, what browser, version, and OS?
-* If the problem is with a command-line tool, what version of that tool?
+    Any details about your specific platform:
+    * If the problem is in the browser, what browser, version, and OS?
+    * If the problem is with a command-line tool, what version of that tool?
+    * If the problem is with connecting to PyPI, include some details about
+      your network, including SSL/TLS implementation in use, internet service
+      provider, and if there are any firewalls or proxies in use.
 -->
 
 **Additional context**

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -5,9 +5,17 @@ about: Let us know if something is broken on PyPI
 ---
 
 <!--
-    NOTE: this is for problems with PyPI itself, not with the projects hosted
-    there. If you are having an issue with a specific package, you should
-    reach out to the maintainers of that project directly instead.
+    NOTE: This issue should be for problems with PyPI itself, including:
+    * pypi.org
+    * test.pypi.org
+    * files.pythonhosted.org
+
+    This issue should NOT be for a project hosted on PyPI.  If you are having
+    an issue with a specific package, you should reach out to the maintainers
+    of that project directly instead.
+
+    Furthermore, this issue should NOT be for any non-PyPI properties (like
+    python.org, docs.python.org, etc.)
 -->
 
 **Describe the bug**

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -4,6 +4,12 @@ about: Let us know if something is broken on PyPI
 
 ---
 
+<!--
+    NOTE: this is for problems with PyPI itself, not with the projects hosted
+    there. If you are having an issue with a specific package, you should
+    reach out to the maintainers of that project directly instead.
+-->
+
 **Describe the bug**
 <!-- A clear and concise description the bug -->
 

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,14 @@
+---
+name: Feature request
+about: Suggest a new feature for PyPI
+
+---
+
+**What's the problem this feature will solve?**
+<!-- A clear and concise description of what the problem is. -->
+
+**Describe the solution you'd like**
+<!-- A clear and concise description of what you want to happen. -->
+
+**Additional context**
+<!-- Add any other context, links, etc. about the feature here. -->

--- a/.github/ISSUE_TEMPLATE/new-trove-classifier.md
+++ b/.github/ISSUE_TEMPLATE/new-trove-classifier.md
@@ -1,3 +1,9 @@
+---
+name: Trove Classifier Request
+about: Request a new trove classifier
+
+---
+
 Request to add a new Trove classifier.
 
 ## The name of the classifier you would like to add

--- a/.github/ISSUE_TEMPLATE/~good-first-issue.md
+++ b/.github/ISSUE_TEMPLATE/~good-first-issue.md
@@ -1,3 +1,9 @@
+---
+name: (Maintainers Only) Good First Issue
+about: For maintainers to create an issue that is good for new contributors
+
+---
+
 <!-- Issue text below -->
 
 <!-- End issue text, leave the following intact -->

--- a/.github/ISSUE_TEMPLATE/~visual-design.md
+++ b/.github/ISSUE_TEMPLATE/~visual-design.md
@@ -1,3 +1,9 @@
+---
+name: (Maintainers Only) Visual Design Issue
+about: For maintainers to create an issue that requires a screenshot
+
+---
+
 <!-- Issue text below -->
 
 <!-- End issue text, leave the following intact -->

--- a/README.rst
+++ b/README.rst
@@ -19,13 +19,6 @@ Discussion
 
 If you run into bugs, you can file them in our `issue tracker`_.
 
-You can also file specific types of issues:
-
-- `Good First Issue`_: An easy issue reserved for people who haven't
-  contributed before
-- `Visual Design Issue`_: An issue related to the visual design of the site
-- `Trove Classifier Issue`_: A request for a new trove classifier
-
 You can also join the chat channels ``#pypa`` (general packaging
 discussion and user support) and ``#pypa-dev`` (discussion about
 development of packaging tools) `on Freenode`_, or the `pypa-dev
@@ -55,9 +48,6 @@ rooms, and mailing lists is expected to follow the `PyPA Code of Conduct`_.
 .. _`Getting started`: https://warehouse.readthedocs.io/development/getting-started/
 .. _`issue tracker`: https://github.com/pypa/warehouse/issues
 .. _`pypi.org`: https://pypi.org/
-.. _`Good First Issue`: https://github.com/pypa/warehouse/issues/new?template=good-first-issue.md
-.. _`Visual Design Issue`: https://github.com/pypa/warehouse/issues/new?template=visual-design.md
-.. _`Trove Classifier Issue`: https://github.com/pypa/warehouse/issues/new?title=Request+trove+classifier&template=new-trove-classifier.md
 .. _`on Freenode`: https://webchat.freenode.net/?channels=%23pypa-dev,pypa
 .. _`pypa-dev mailing list`: https://groups.google.com/forum/#!forum/pypa-dev
 .. _`Running tests and linters section`: https://warehouse.readthedocs.io/development/getting-started/#running-tests-and-linters


### PR DESCRIPTION
This PR updates our existing issue templates to be compatible with the [latest changes to Github issue templates](https://blog.github.com/2018-05-02-issue-template-improvements/).

It also adds two new templates, for bug reports and feature requests.

Creating a new issue will look like this:

<img width="832" alt="screen shot 2018-05-02 at 7 08 17 pm" src="https://user-images.githubusercontent.com/294415/39555094-3eceb582-4e3c-11e8-9638-db6eeb8eb66c.png">
