### PR TITLE
Add Dependabot to list of release monitoring services

### DIFF
--- a/warehouse/templates/pages/help.html
+++ b/warehouse/templates/pages/help.html
@@ -171,7 +171,7 @@
         </p>
         <h3 id="project-release-notifications">{{ project_release_notifications() }}</h3>
         <p>
-          PyPI itself does not offer a way to get notified when a project uploads new releases. However, there are several third-party services that offer comprehensive monitoring and notifications for project releases and vulnerabilities such as <a href="https://pyup.io" target="_blank" rel="noopener">pyup.io</a> and <a href="https://libraries.io/" target="_blank" rel="noopener">libraries.io</a>.
+          PyPI itself does not offer a way to get notified when a project uploads new releases. However, there are several third-party services that offer comprehensive monitoring and notifications for project releases and vulnerabilities such as <a href="https://pyup.io" target="_blank" rel="noopener">pyup.io</a>, <a href="https://libraries.io/" target="_blank" rel="noopener">libraries.io</a> and <a href="https://dependabot.com/" target="_blank" rel="noopener">dependabot.com</a>.
         </p>
       <h3 id="statistics">{{ statistics() }}</h3>
         <p>You can <a href="https://packaging.python.org/guides/analyzing-pypi-package-downloads/">analyze PyPI download usage statistics via Google BigQuery</a>.</p>


### PR DESCRIPTION
Hi team,

I noticed libraries.io and pyup.io listed as ways to receive notifications of new releases, and wondered if you'd be happy to list [Dependabot](https://dependabot.com), too. It offers Pipfile and requirements.txt support (although it's better at Pipfile), is free for open source and personal accounts, and we try to be good open source citizens by contributing back whenever we can. (We've helped fixed a few bugs in Pipenv recently, and will continue doing so whenever we encounter any.)