### PR TITLE
Add rel="noopener" guidance to developer documentation

### DIFF
--- a/docs/development/frontend.rst
+++ b/docs/development/frontend.rst
@@ -75,6 +75,9 @@ More information on how BEM works can be found in `this article from
 CSS Wizardry
 <https://csswizardry.com/2013/01/mindbemding-getting-your-head-round-bem-syntax/>`_.
 
+When using ``target="_blank_"`` for a hyperlink (usually to an external site),
+we should always set ``rel="noopener"``.
+
 
 SCSS Style and Structure
 ------------------------

--- a/docs/development/reviewing-patches.rst
+++ b/docs/development/reviewing-patches.rst
@@ -36,6 +36,9 @@ These are small things that are not caught by the automated style checkers.
 * Does a variable need a better name?
 * Should this be a keyword argument?
 
+When using ``target="_blank_"`` for a hyperlink (usually to an external site),
+we should always set ``rel="noopener"``.
+
 Testing branches on your local machine
 --------------------------------------
 


### PR DESCRIPTION
Fixes #3877 
Added guidance for `rel="noopener"` for external hyperlinks having `target="_blank_"` to developer documentation files, `warehouse/docs/development/frontend.rst` and `warehouse/docs/development/reviewing-patches.rst` 