### PR TITLE
Don't fail on `xz` when unzipped file exists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ endif
 initdb:
 	docker-compose run --rm web psql -h db -d postgres -U postgres -c "DROP DATABASE IF EXISTS warehouse"
 	docker-compose run --rm web psql -h db -d postgres -U postgres -c "CREATE DATABASE warehouse ENCODING 'UTF8'"
-	xz -d -k dev/$(DB).sql.xz
+	xz -d -f -k dev/$(DB).sql.xz
 	docker-compose run --rm web psql -h db -d warehouse -U postgres -v ON_ERROR_STOP=1 -1 -f dev/$(DB).sql
 	rm dev/$(DB).sql
 	docker-compose run --rm web python -m warehouse db upgrade head


### PR DESCRIPTION
This would be a bad thing if anybody ever puts local modifications in their local `dev/<db>.sql` file before running `initdb`.  Is that a thing that anybody does?