### PR TITLE
DX Improvement: recover from failed DB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ endif
 initdb:
 	docker-compose run --rm web psql -h db -d postgres -U postgres -c "DROP DATABASE IF EXISTS warehouse"
 	docker-compose run --rm web psql -h db -d postgres -U postgres -c "CREATE DATABASE warehouse ENCODING 'UTF8'"
-	xz -d -k dev/$(DB).sql.xz
+	xz -d -k -f dev/$(DB).sql.xz
 	docker-compose run --rm web psql -h db -d warehouse -U postgres -v ON_ERROR_STOP=1 -1 -f dev/$(DB).sql
 	rm dev/$(DB).sql
 	docker-compose run --rm web python -m warehouse db upgrade head
@@ -151,6 +151,7 @@ shell:
 clean:
 	rm -rf warehouse/static/components
 	rm -rf warehouse/static/dist
+	rm -rf dev/*.sql
 
 purge: stop clean
 	rm -rf .state

--- a/docs/development/getting-started.rst
+++ b/docs/development/getting-started.rst
@@ -297,7 +297,7 @@ https://github.com/chadoe/docker-cleanup-volumes)
 
 This typically occur when Docker is not allocated enough memory to perform the
 migrations. Try modifying your Docker configuration to allow more RAM for each
-container and run ``make initdb`` again.
+container, temporarily stop ``make_serve`` and run ``make initdb`` again.
 
 Docker and Windows Subsystem for Linux Quirks
 ---------------------------------------------


### PR DESCRIPTION
Hello maintainers.

I followed the guide in `development/getting-started.rst` but had some issues.
I did not have enough resources allocated, and followed the section:
`make initdb is slow or appears to make no progress`
without success.

This patch fixes three issues in recovery from a failed DB setup:
1. if xz has decompressed a file already, it fails to work on a second attempt, and stops make initdb
2. `make clean` does not remove files previously created by `make initdb`
3. The documentation states to run `make serve` and then kick off `make initdb`. This will not work if `make serve` has gotten far enough to open a web session. I changed the documentation to something that worked for me.

Please accept these changes.

