### PR TITLE
Update link to Material design writing guide

### DIFF
--- a/docs/ui-principles.rst
+++ b/docs/ui-principles.rst
@@ -61,7 +61,7 @@ help content).
 -------------------------------------------------------
 
 Warehouse follows the `Material design writing style guide
-<https://material.google.com/style/writing.html>`_.
+<https://material.io/design/usability/accessibility.html#writing>`_.
 
 When writing interfaces use direct, clear and simple language. This is
 especially important as Warehouse caters to an international audience with


### PR DESCRIPTION
The current link: https://material.google.com/style/writing.html redirects to https://material.io/design/. I believe the information it was pointing to is now present in this link: https://material.io/design/usability/accessibility.html#writing