### PR TITLE
Remove branch restriction to test feature branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,10 +59,3 @@ matrix:
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)
-
-notifications:
-  irc:
-    channels:
-      - "irc.freenode.org#pypa-dev"
-    use_notice: true
-    skip_join: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,10 +60,6 @@ matrix:
 after_success:
   - bash <(curl -s https://codecov.io/bash)
 
-branches:
-  only:
-    - master
-
 notifications:
   irc:
     channels:


### PR DESCRIPTION
Split out from PR https://github.com/pypa/warehouse/pull/3953.

Testing locally isn't easy. I've tried running tests locally, but it's erroring. It took a very long time to set up and I also don't think I have the disk space for the whole Docker image and all the downloads.

I only wanted to change some strings, it's quite heavy to do  https://warehouse.readthedocs.io/development/getting-started/#running-tests-and-linters and it downloaded several GB and taken about half an hour doing `make tests`. And then `make serve` is needed because `make tests` isn't working at the moment, which has downloaded several more GB before erroring:

```
ERROR: for warehouse_web_1  Cannot start service web: driver failed programming external connectivity on endpoint warehouse_web_1 (6704063cda248388329eecac5542769d636f0cb3dcf8bdCreating warehouse_worker_1        ... done

ERROR: for web  Cannot start service web: driver failed programming external connectivity on endpoint warehouse_web_1 (6704063cda248388329eecac5542769d636f0cb3dcf8bd3f5a5b3e3e21bda6bc): Error starting userland proxy: Bind for 0.0.0.0:80: unexpected error (Failure EADDRINUSE)
ERROR: Encountered errors while bringing up the project.
make: *** [serve] Error 1
```

An important point of a CI (for me) is to run all the tests in a known clean environment. Much effort has been put into setting up the CI to do all the tests, I'd much rather leave all that work to the CI server. It's also quicker.

It would be great if we could configure the CI so it can run for feature branches in forks without spamming IRC. One solution is to put the channel name as a secure variable: https://github.com/travis-ci/travis-ci/issues/5063.

Indeed, this is what pip does: https://github.com/pypa/pip/commit/4411d86f0408c3b65b87a20eb20e61dd18f6c803.