### PR TITLE
Revert "Warehouse API currently redirects pypi.org/pypi/{project}/json/ (#3971)"

### DIFF
--- a/tests/unit/test_routes.py
+++ b/tests/unit/test_routes.py
@@ -288,16 +288,6 @@ def test_routes(warehouse):
         pretend.call("/p/{name}/", "/project/{name}/", domain=warehouse),
         pretend.call("/pypi/{name}/", "/project/{name}/", domain=warehouse),
         pretend.call(
-            "/pypi/{name}/{version}/json/",
-            "/pypi/{name}/{version}/json",
-            domain=warehouse,
-        ),
-        pretend.call(
-            "/pypi/{name}/json/",
-            "/pypi/{name}/json",
-            domain=warehouse,
-        ),
-        pretend.call(
             "/pypi/{name}/{version}/",
             "/project/{name}/{version}/",
             domain=warehouse,

--- a/warehouse/routes.py
+++ b/warehouse/routes.py
@@ -326,17 +326,6 @@ def includeme(config):
     # Legacy Redirects
     config.add_redirect("/pypi/{name}/", "/project/{name}/", domain=warehouse)
     config.add_redirect(
-        "/pypi/{name}/{version}/json/",
-        "/pypi/{name}/{version}/json",
-        domain=warehouse,
-    )
-    config.add_redirect(
-        "/pypi/{name}/json/",
-        "/pypi/{name}/json",
-        domain=warehouse,
-    )
-
-    config.add_redirect(
         "/pypi/{name}/{version}/",
         "/project/{name}/{version}/",
         domain=warehouse,


### PR DESCRIPTION
This reverts commit 464271b9676819e97348dd72646bad5dfe41d873.

Fixes #4012.