### PR TITLE
Consistent Capitalization of TestPyPI

### DIFF
--- a/warehouse/templates/base.html
+++ b/warehouse/templates/base.html
@@ -119,7 +119,7 @@
           <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
           <span class="sr-only">Warning:</span>
         </span>
-        <span class="notification-bar__message">You are using testPyPI – a separate instance of the Python Package Index that allows you to try distribution tools and processes without affecting the real index.</span>
+        <span class="notification-bar__message">You are using TestPyPI – a separate instance of the Python Package Index that allows you to try distribution tools and processes without affecting the real index.</span>
       </div>
       {% endif %}
     </section>


### PR DESCRIPTION
The title of the page doesn't/didn't captalize the same way the banner on top did.

Modified to update the latter.