### PR TITLE
Remove reminder that pypi-legacy and warehouse shared user accounts

### DIFF
--- a/warehouse/templates/accounts/login.html
+++ b/warehouse/templates/accounts/login.html
@@ -42,12 +42,6 @@
         {% endif %}
 
         <div class="form-group">
-          <p>
-            Accounts from {{ request.registry.settings.get("warehouse.legacy_domain") }} work too!
-          </p>
-        </div>
-
-        <div class="form-group">
           <label for="username" class="form-group__label">Username</label>
           {{ form.username(placeholder="Your username", autocorrect="off", autocapitalize="off", autocomplete="username", spellcheck="false", required="required", class_="form-group__input", tabindex="1", autofocus=true) }}
           {% if form.username.errors %}


### PR DESCRIPTION
This was useful during the transition, but is no longer needed.

Resolves #4050