### PR TITLE
Revert erroring when readme content does not render

### DIFF
--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -919,6 +919,7 @@ class TestFileUpload:
             "for more information."
         ).format(name)
 
+    @pytest.mark.xfail(reason='https://github.com/pypa/warehouse/issues/4079')
     @pytest.mark.parametrize(
         ("description_content_type", "description", "message"),
         [

--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -919,7 +919,7 @@ class TestFileUpload:
             "for more information."
         ).format(name)
 
-    @pytest.mark.xfail(reason='https://github.com/pypa/warehouse/issues/4079')
+    @pytest.mark.xfail(reason="https://github.com/pypa/warehouse/issues/4079")
     @pytest.mark.parametrize(
         ("description_content_type", "description", "message"),
         [

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -899,24 +899,27 @@ def file_upload(request):
         rendered = readme.render(
             form.description.data, description_content_type, use_fallback=False
         )
-        if rendered is None:
-            if form.description_content_type.data:
-                message = (
-                    "The description failed to render "
-                    "for '{description_content_type}'."
-                ).format(description_content_type=description_content_type)
-            else:
-                message = (
-                    "The description failed to render "
-                    "in the default format of reStructuredText."
-                )
-            raise _exc_with_message(
-                HTTPBadRequest,
-                "{message} See {projecthelp} for more information.".format(
-                    message=message,
-                    projecthelp=request.help_url(_anchor="description-content-type"),
-                ),
-            ) from None
+
+        # Temporarily disabled, see
+        # https://github.com/pypa/warehouse/issues/4079
+        # if rendered is None:
+        #     if form.description_content_type.data:
+        #         message = (
+        #             "The description failed to render "
+        #             "for '{description_content_type}'."
+        #         ).format(description_content_type=description_content_type)
+        #     else:
+        #         message = (
+        #             "The description failed to render "
+        #             "in the default format of reStructuredText."
+        #         )
+        #     raise _exc_with_message(
+        #         HTTPBadRequest,
+        #         "{message} See {projecthelp} for more information.".format(
+        #             message=message,
+        #             projecthelp=request.help_url(_anchor="description-content-type"),
+        #         ),
+        #     ) from None
 
     try:
         canonical_version = packaging.utils.canonicalize_version(form.version.data)

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -892,34 +892,34 @@ def file_upload(request):
         )
 
     # Uploading should prevent broken rendered descriptions.
-    if form.description.data:
-        description_content_type = form.description_content_type.data
-        if not description_content_type:
-            description_content_type = "text/x-rst"
-        rendered = readme.render(
-            form.description.data, description_content_type, use_fallback=False
-        )
+    # Temporarily disabled, see
+    # https://github.com/pypa/warehouse/issues/4079
+    # if form.description.data:
+    #     description_content_type = form.description_content_type.data
+    #     if not description_content_type:
+    #         description_content_type = "text/x-rst"
+    #     rendered = readme.render(
+    #         form.description.data, description_content_type, use_fallback=False
+    #     )
 
-        # Temporarily disabled, see
-        # https://github.com/pypa/warehouse/issues/4079
-        # if rendered is None:
-        #     if form.description_content_type.data:
-        #         message = (
-        #             "The description failed to render "
-        #             "for '{description_content_type}'."
-        #         ).format(description_content_type=description_content_type)
-        #     else:
-        #         message = (
-        #             "The description failed to render "
-        #             "in the default format of reStructuredText."
-        #         )
-        #     raise _exc_with_message(
-        #         HTTPBadRequest,
-        #         "{message} See {projecthelp} for more information.".format(
-        #             message=message,
-        #             projecthelp=request.help_url(_anchor="description-content-type"),
-        #         ),
-        #     ) from None
+    #     if rendered is None:
+    #         if form.description_content_type.data:
+    #             message = (
+    #                 "The description failed to render "
+    #                 "for '{description_content_type}'."
+    #             ).format(description_content_type=description_content_type)
+    #         else:
+    #             message = (
+    #                 "The description failed to render "
+    #                 "in the default format of reStructuredText."
+    #             )
+    #         raise _exc_with_message(
+    #             HTTPBadRequest,
+    #             "{message} See {projecthelp} for more information.".format(
+    #                 message=message,
+    #                 projecthelp=request.help_url(_anchor="description-content-type"),
+    #             ),
+    #         ) from None
 
     try:
         canonical_version = packaging.utils.canonicalize_version(form.version.data)

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -52,7 +52,7 @@ from warehouse.packaging.models import (
     JournalEntry,
     BlacklistedProject,
 )
-from warehouse.utils import http, readme
+from warehouse.utils import http
 
 
 MAX_FILESIZE = 60 * 1024 * 1024  # 60M


### PR DESCRIPTION
This temporarily disables the validation added #3980 which is preventing several users from uploading packages (#4079).