### PR TITLE
[Bugfix] fix wrong docker Compose file format version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '2'
 
 services:
   db:


### PR DESCRIPTION
Error message when I use ``` docker-compose build```:
```
ERROR: Version in "./docker-compose.yml" is unsupported. You might be seeing this error because you're using the wrong Compose file version. 
```
specify a version of  "2",solved it