### PR TITLE
Set search filter focus

### DIFF
--- a/warehouse/static/js/warehouse/utils/search-filter-toggle.js
+++ b/warehouse/static/js/warehouse/utils/search-filter-toggle.js
@@ -14,17 +14,19 @@
 export default () => {
   var showPanel = document.querySelector(".-js-add-filter");
   var hidePanel = document.querySelector(".-js-close-panel");
+  var firstFilter = document.querySelector('#classifiers > .accordion > button');
 
-  const togglePanelDisplay = (display, event) => {
+  const togglePanelDisplay = (display, focusOn, event) => {
     event.preventDefault();
     var elements = document.querySelectorAll(".-js-dark-overlay, .-js-filter-panel");
     for (var el of elements) {
       el.style.display = display;
     }
+    focusOn.focus();
   };
 
-  const toggleEvent = (element, display) => {
-    element.addEventListener("click", togglePanelDisplay.bind(null, display), false);
+  const toggleEvent = (element, display, focusOn) => {
+    element.addEventListener("click", togglePanelDisplay.bind(null, display, focusOn), false);
   };
 
   const toggleAccordion = (event) => {
@@ -36,6 +38,6 @@ export default () => {
     trigger.addEventListener("click", toggleAccordion, false);
   }
 
-  toggleEvent(showPanel, "block");
-  toggleEvent(hidePanel, "");
+  toggleEvent(showPanel, "block", firstFilter);
+  toggleEvent(hidePanel, "", showPanel);
 };


### PR DESCRIPTION
Added focus switching for the search filter when under <1000px:
- When the `Add Filter` button is pressed, focus is now shifted to the first filter in the tray
- When then filter closer close button is pressed, focus is shifted back to the `Add Filter` button

This is a fairly basic fix. Let me know if this is sufficient.

Fixes #3559 

Screenshot of the UI right after the Add Filter button is pressed:
![selected](https://user-images.githubusercontent.com/1919554/41385991-d4d9a1aa-6f33-11e8-9687-82ff43f4158d.png)
