### PR TITLE
Admin: admin.project.releases template urls

### DIFF
--- a/warehouse/admin/templates/admin/projects/releases_list.html
+++ b/warehouse/admin/templates/admin/projects/releases_list.html
@@ -50,7 +50,7 @@
 
       {% for release in releases %}
       <tr>
-        <td><a href="{{ request.route_path('packaging.release', name=release.project.normalized_name, version=release.version) }}">{{ release.name }}-{{ release.version }}</a></td>
+        <td><a href="{{ request.route_path('admin.project.release', project_name=release.project.normalized_name, version=release.version) }}">{{ release.name }}-{{ release.version }}</a></td>
         <td>{{ release.created }}</td>
         <td>{{ release._pypi_hidden }}</td>
         <td><a href="{{ request.route_path('admin.user.detail', user_id=release.uploader.id) }}">{{ release.uploader.username }}</a></td>


### PR DESCRIPTION
Update the urls in the admin.project.releases view to link to the admin url rather than public url.

Matches behavior in the `admin.project.detail` view when clicking through to All Releases.