### PR TITLE
Fix user detail booleans for Admin view

### DIFF
--- a/tests/unit/admin/views/test_users.py
+++ b/tests/unit/admin/views/test_users.py
@@ -15,7 +15,7 @@ import pytest
 import uuid
 
 from pyramid.httpexceptions import HTTPBadRequest, HTTPNotFound
-from webob.multidict import MultiDict
+from webob.multidict import MultiDict, NoVars
 
 from warehouse.admin.views import users as views
 from warehouse.packaging.models import Project
@@ -115,15 +115,17 @@ class TestUserDetail:
             views.user_detail(db_request)
 
     def test_gets_user(self, db_request):
-        user = UserFactory.create()
+        email = EmailFactory.create(primary=True)
+        user = UserFactory.create(emails=[email])
         project = ProjectFactory.create()
         roles = sorted([RoleFactory(project=project, user=user, role_name="Owner")])
         db_request.matchdict["user_id"] = str(user.id)
-        db_request.POST = MultiDict(db_request.POST)
+        db_request.POST = NoVars()
         result = views.user_detail(db_request)
 
         assert result["user"] == user
         assert result["roles"] == roles
+        assert result["form"].emails[0].primary.data
 
     def test_updates_user(self, db_request):
         user = UserFactory.create()

--- a/warehouse/admin/views/users.py
+++ b/warehouse/admin/views/users.py
@@ -112,7 +112,7 @@ def user_detail(request):
         .all()
     )
 
-    form = UserForm(request.POST, user)
+    form = UserForm(request.POST if request.method == "POST" else None, user)
 
     if request.method == "POST" and form.validate():
         form.populate_obj(user)


### PR DESCRIPTION
This fixes a bug introduced in #4141, where any checkboxes in the user detail page of the admin UI were always displayed as unchecked.

This is due to https://github.com/wtforms/wtforms/issues/414 -- essentially WTForms is interpreting any value here other than `None` as valid formdata, and any missing boolean values are assumed to be `False`.

There may be other instances of this in our codebase, I took a quick glance but didn't find any. We'd need to be:

a) providing `request.POST` to the form in a GET request
b) using checkboxes in the form.