### PR TITLE
Time ago: remove fullstop from readable text for consistency

### DIFF
--- a/warehouse/static/js/warehouse/utils/timeago.js
+++ b/warehouse/static/js/warehouse/utils/timeago.js
@@ -28,12 +28,12 @@ const convertToReadableText = (time) => {
   let { numDays, numMinutes, numHours } = time;
 
   if (numDays >= 1) {
-    return numDays == 1 ? "Yesterday." : `About ${numDays} days ago`;
+    return numDays == 1 ? "Yesterday" : `About ${numDays} days ago`;
   }
 
   if (numHours > 0) {
     numHours = numHours != 1 ? `${numHours} hours` : "an hour";
-    return `About ${numHours} ago.`;
+    return `About ${numHours} ago`;
   } else if (numMinutes > 0) {
     numMinutes = numMinutes > 1 ? `${numMinutes} minutes` : "a minute";
     return `About ${numMinutes} ago`;


### PR DESCRIPTION
For example, "Yesterday." should be "Yesterday":

![image](https://user-images.githubusercontent.com/1324225/42340021-78ad5dac-8097-11e8-80fb-1472d5e3f23e.png)

https://pypi.org/project/botocore/#history

Sorry, I missed these in https://github.com/pypa/warehouse/pull/3584!