### PR TITLE
Refactor permissions

### DIFF
--- a/warehouse/accounts/views.py
+++ b/warehouse/accounts/views.py
@@ -361,9 +361,7 @@ def reset_password(request, _form_class=ResetPasswordForm):
 
 
 @view_config(
-    route_name="accounts.verify-email",
-    uses_session=True,
-    permission="manage:user",
+    route_name="accounts.verify-email", uses_session=True, permission="manage:user"
 )
 def verify_email(request):
     token_service = request.find_service(ITokenService, name="email")

--- a/warehouse/accounts/views.py
+++ b/warehouse/accounts/views.py
@@ -363,7 +363,7 @@ def reset_password(request, _form_class=ResetPasswordForm):
 @view_config(
     route_name="accounts.verify-email",
     uses_session=True,
-    effective_principals=Authenticated,
+    permission="manage:user",
 )
 def verify_email(request):
     token_service = request.find_service(ITokenService, name="email")

--- a/warehouse/accounts/views.py
+++ b/warehouse/accounts/views.py
@@ -19,7 +19,7 @@ from pyramid.httpexceptions import (
     HTTPSeeOther,
     HTTPTooManyRequests,
 )
-from pyramid.security import Authenticated, remember, forget
+from pyramid.security import remember, forget
 from pyramid.view import view_config
 from sqlalchemy.orm.exc import NoResultFound
 

--- a/warehouse/config.py
+++ b/warehouse/config.py
@@ -21,7 +21,7 @@ from pyramid import renderers
 from pyramid.config import Configurator as _Configurator
 from pyramid.httpexceptions import HTTPBadRequest
 from pyramid.response import Response
-from pyramid.security import Allow
+from pyramid.security import Allow, Authenticated
 from pyramid.tweens import EXCVIEW
 from pyramid_rpc.xmlrpc import XMLRPCRenderer
 
@@ -57,7 +57,7 @@ class RootFactory:
     __parent__ = None
     __name__ = None
 
-    __acl__ = [(Allow, "group:admins", "admin")]
+    __acl__ = [(Allow, "group:admins", "admin"), (Allow, Authenticated, "manage:user")]
 
     def __init__(self, request):
         pass

--- a/warehouse/manage/views.py
+++ b/warehouse/manage/views.py
@@ -301,8 +301,7 @@ def manage_projects(request):
     context=Project,
     renderer="manage/settings.html",
     uses_session=True,
-    permission="manage",
-    effective_principals=Authenticated,
+    permission="manage:project",
 )
 def manage_project_settings(project, request):
     return {"project": project}
@@ -313,7 +312,7 @@ def manage_project_settings(project, request):
     context=Project,
     uses_session=True,
     require_methods=["POST"],
-    permission="manage",
+    permission="manage:project",
 )
 def delete_project(project, request):
     confirm_project(project, request, fail_route="manage.project.settings")
@@ -327,7 +326,7 @@ def delete_project(project, request):
     context=Project,
     uses_session=True,
     require_methods=["POST"],
-    permission="manage",
+    permission="manage:project",
 )
 def destroy_project_docs(project, request):
     confirm_project(project, request, fail_route="manage.project.documentation")
@@ -345,8 +344,7 @@ def destroy_project_docs(project, request):
     context=Project,
     renderer="manage/releases.html",
     uses_session=True,
-    permission="manage",
-    effective_principals=Authenticated,
+    permission="manage:project",
 )
 def manage_project_releases(project, request):
     return {"project": project}
@@ -359,8 +357,7 @@ def manage_project_releases(project, request):
     uses_session=True,
     require_csrf=True,
     require_methods=False,
-    permission="manage",
-    effective_principals=Authenticated,
+    permission="manage:project",
 )
 class ManageProjectRelease:
     def __init__(self, release, request):
@@ -492,7 +489,7 @@ class ManageProjectRelease:
     renderer="manage/roles.html",
     uses_session=True,
     require_methods=False,
-    permission="manage",
+    permission="manage:project",
 )
 def manage_project_roles(project, request, _form_class=CreateRoleForm):
     user_service = request.find_service(IUserService, context=None)
@@ -575,7 +572,7 @@ def manage_project_roles(project, request, _form_class=CreateRoleForm):
     context=Project,
     uses_session=True,
     require_methods=["POST"],
-    permission="manage",
+    permission="manage:project",
 )
 def change_project_role(project, request, _form_class=ChangeRoleForm):
     # TODO: This view was modified to handle deleting multiple roles for a
@@ -658,7 +655,7 @@ def change_project_role(project, request, _form_class=ChangeRoleForm):
     context=Project,
     uses_session=True,
     require_methods=["POST"],
-    permission="manage",
+    permission="manage:project",
 )
 def delete_project_role(project, request):
     # TODO: This view was modified to handle deleting multiple roles for a
@@ -700,7 +697,7 @@ def delete_project_role(project, request):
     context=Project,
     renderer="manage/history.html",
     uses_session=True,
-    permission="manage",
+    permission="manage:project",
 )
 def manage_project_history(project, request):
     journals = (
@@ -717,7 +714,7 @@ def manage_project_history(project, request):
     context=Project,
     renderer="manage/documentation.html",
     uses_session=True,
-    permission="manage",
+    permission="manage:project",
 )
 def manage_project_documentation(project, request):
     return {"project": project}

--- a/warehouse/manage/views.py
+++ b/warehouse/manage/views.py
@@ -46,7 +46,7 @@ from warehouse.utils.project import confirm_project, destroy_docs, remove_projec
     uses_session=True,
     require_csrf=True,
     require_methods=False,
-    effective_principals=Authenticated,
+    permission="manage:user",
 )
 class ManageAccountViews:
     def __init__(self, request):
@@ -272,7 +272,7 @@ class ManageAccountViews:
     route_name="manage.projects",
     renderer="manage/projects.html",
     uses_session=True,
-    effective_principals=Authenticated,
+    permission="manage:user",
 )
 def manage_projects(request):
     def _key(project):

--- a/warehouse/manage/views.py
+++ b/warehouse/manage/views.py
@@ -13,7 +13,6 @@
 from collections import defaultdict
 
 from pyramid.httpexceptions import HTTPSeeOther
-from pyramid.security import Authenticated
 from pyramid.view import view_config, view_defaults
 from sqlalchemy import func
 from sqlalchemy.orm.exc import NoResultFound

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -178,7 +178,7 @@ class Project(SitemapMixin, db.ModelBase):
             query.all(), key=lambda x: ["Owner", "Maintainer"].index(x.role_name)
         ):
             if role.role_name == "Owner":
-                acls.append((Allow, str(role.user.id), ["manage", "upload"]))
+                acls.append((Allow, str(role.user.id), ["manage:project", "upload"]))
             else:
                 acls.append((Allow, str(role.user.id), ["upload"]))
         return acls
@@ -394,7 +394,7 @@ class Release(db.ModelBase):
             query.all(), key=lambda x: ["Owner", "Maintainer"].index(x.role_name)
         ):
             if role.role_name == "Owner":
-                acls.append((Allow, str(role.user.id), ["manage", "upload"]))
+                acls.append((Allow, str(role.user.id), ["manage:project", "upload"]))
             else:
                 acls.append((Allow, str(role.user.id), ["upload"]))
         return acls

--- a/warehouse/packaging/views.py
+++ b/warehouse/packaging/views.py
@@ -128,7 +128,7 @@ def release_detail(release, request):
     context=Project,
     renderer="includes/manage-project-button.html",
     uses_session=True,
-    permission="manage",
+    permission="manage:project",
 )
 def edit_project_button(project, request):
     return {"project": project}

--- a/warehouse/utils/__init__.py
+++ b/warehouse/utils/__init__.py
@@ -15,3 +15,12 @@ import datetime
 
 def now():
     return datetime.datetime.utcnow()
+
+
+def dotted_navigator(path):
+    def method(self):
+        obj = self
+        for item in path.split("."):
+            obj = getattr(obj, item)
+        return obj
+    return property(method)

--- a/warehouse/utils/__init__.py
+++ b/warehouse/utils/__init__.py
@@ -23,4 +23,5 @@ def dotted_navigator(path):
         for item in path.split("."):
             obj = getattr(obj, item)
         return obj
+
     return property(method)


### PR DESCRIPTION
Currently in Warehouse, we have an adhoc mechanism for introducing permissions and verifying that a user has permission to complete a particular request. In general we're using the Pyramid AuthZ policy, but in a few cases we are instead directly checking principals instead of allowing the AuthZ policy to do it's work. In addition, the permission names don't always make sense divorced from the object they are designated on (or if they do, they're overly generic).

So this PR attempts to reconcile this by sending *all* permission checking through the Pyramid AuthZ framework. It also refactors our permission names so that they make more sense in the abstract rather than being context sensitive.

Originally, Our Permissions looked like this:

- admin: Able to be specified on any object.
- manage: Able to be specified on *only* Project/Release
- upload: Able to be specified on *only* Project/Release

Along with a number of account management pages without any permissions, but thatonly check for an authenticated user.

This PR ends up with the following permissions:

- admin
- manage:project
- manage:user
- upload

The admin permission can be defined on any object in the system, and is designedto grant permission for PyPI administrators.

The "manage" permission on Project/Release has been renamed to manage:project,to indicate the scoping that it should generally have.

The implicit permission granted to modify the current user's account by beinglogged in, has been named "manage:user".

The "upload" permission has stayed the same.

Finally, this PR also makes the ``Release`` model location aware, which meansthat when looking for the ACL, Pyramid will traverse upwards until it finds an explicit ``Deny`` or ``Allow`` for the current user, or until it runs out of objects to traverse upwards to.
