### PR TITLE
Disallow adding a user with an unverified primary email to a project

### DIFF
--- a/warehouse/manage/views.py
+++ b/warehouse/manage/views.py
@@ -511,6 +511,12 @@ def manage_project_roles(project, request, _form_class=CreateRoleForm):
                 f"User '{username}' already has {role_name} role for project",
                 queue="error",
             )
+        elif user.primary_email is None or not user.primary_email.verified:
+            request.session.flash(
+                f"User '{username}' does not have a verified primary email "
+                f"adddress and cannot be added as a {role_name} for project.",
+                queue="error",
+            )
         else:
             request.db.add(
                 Role(user=user, project=project, role_name=form.role_name.data)


### PR DESCRIPTION
As specified in https://github.com/pypa/warehouse/issues/3632#issuecomment-406094189, this removes the ability to add a user as a maintainer or a owner to a project unless they have a verified, primary email address.

It does not have any effect to the users who are already added as a owner or maintainer on a project (although they cannot upload without a verified primary email address either).