### PR TITLE
Use alpine equivalent of Docker Compose services to reduce size and startup time

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,16 +5,16 @@ volumes:
 
 services:
   db:
-    image: postgres:10.1
+    image: postgres:10.1-alpine
     ports:
       # 5432 may already in use by another PostgreSQL on host
       - "5433:5432"
 
   redis:
-    image: redis:latest
+    image: redis:4.0-alpine
 
   rabbitmq:
-    image: rabbitmq:latest
+    image: rabbitmq:3.7-alpine
 
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:6.2.4


### PR DESCRIPTION
Hi all,

This is my first PR against `warehouse`! Let me know if anything is out of order.

To reduce the size of dependencies pulled in for Docker Compose services I've changed the image's to be their Alpine equivalent. This should save something like ~400MB when downloading the images:

```
$ docker images | grep -E "postgres|redis|rabbitmq" | grep -Ev "<none>|latest" | sort
postgres                                        10.1-alpine          e6c5e6a76255        6 months ago        38.2MB
postgres                                        10.1                 ec61d13c8566        7 months ago        287MB
rabbitmq                                        3.7-alpine           23917a8e0e82        9 days ago          48MB
rabbitmq                                        3.7                  dc1744b237f9        3 days ago          125MB
redis                                           4.0-alpine           80581db8c700        9 days ago          28.6MB
redis                                           4.0                  f06a5773f01e        3 days ago          83.4MB
```

One thing I noticed, though, is a couple of tests fail after the move from `postgres:10.1` -> `postgres:10.1-alpine`. Perhaps this is just an oddity with my dev environment, so I'll be curious to see if the TravisCI tests fail. Here are the failures in question:

```
============================================== FAILURES ===============================================
____________________________________ TestProjectList.test_no_query ____________________________________

self = <tests.unit.admin.views.test_projects.TestProjectList object at 0x7f4697e716a0>
db_request = <pyramid.testing.DummyRequest object at 0x7f4694c8f1d0>

    def test_no_query(self, db_request):
        projects = sorted(
            [ProjectFactory.create() for _ in range(30)],
            key=lambda p: p.normalized_name,
        )
        result = views.project_list(db_request)
    
>       assert result == {"projects": projects[:25], "query": None}
E       AssertionError: assert {'projects': ...'query': None} == {'projects': [...'query': None}
E         Common items:
E         {'query': None}
E         Differing items:
E         {'projects': <paginate.Page: Page 1/2>} != {'projects': [Project(name='buGkrZztOVdJ'), Project(name='CUSRSHwyrWYS'), Project(name='DQYmKgwGbDWN'), Project(name='EZSwnoLaZDBP'), Project(name='fGYqTjDlvGzs'), Project(name='fhRNAXlQsSPb'), ...]}
E         Full diff:
E         - {'projects': <paginate.Page: Page 1/2>, 'query': None}
E         + {'projects': [Project(name='buGkrZztOVdJ'),
E         +               Project(name='CUSRSHwyrWYS'),
E         +               Project(name='DQYmKgwGbDWN'),
E         +               Project(name='EZSwnoLaZDBP'),
E         +               Project(name='fGYqTjDlvGzs'),
E         +               Project(name='fhRNAXlQsSPb'),
E         +               Project(name='GLinWsOkojkz'),
E         +               Project(name='gOrRfJDhcYfq'),
E         +               Project(name='HEFdmcDNAyrG'),
E         +               Project(name='hGINavLJVZma'),
E         +               Project(name='hIenNBvaBTCF'),
E         +               Project(name='lioPBgmNzTGj'),
E         +               Project(name='mglUjgSIumKu'),
E         +               Project(name='MNwUhtYjNBTX'),
E         +               Project(name='MPPpqZvLqrwG'),
E         +               Project(name='mPVlJqlpJXWO'),
E         +               Project(name='mzpiabwWpmkw'),
E         +               Project(name='oMDIktqhGEqJ'),
E         +               Project(name='OTEYViBAKZfk'),
E         +               Project(name='PzpfZMoMsAgf'),
E         +               Project(name='QWKRstFHveKi'),
E         +               Project(name='SelaTfofhpsB'),
E         +               Project(name='tKRYkXvtVlDW'),
E         +               Project(name='tXgrnOXiYWKc'),
E         +               Project(name='tYlRgnNjegiv')],
E         +  'query': None}

tests/unit/admin/views/test_projects.py:38
___________________________________ TestProjectList.test_with_page ____________________________________

self = <tests.unit.admin.views.test_projects.TestProjectList object at 0x7f468f899ac8>
db_request = <pyramid.testing.DummyRequest object at 0x7f468f899d68>

    def test_with_page(self, db_request):
        projects = sorted(
            [ProjectFactory.create() for _ in range(30)],
            key=lambda p: p.normalized_name,
        )
        db_request.GET["page"] = "2"
        result = views.project_list(db_request)
    
>       assert result == {"projects": projects[25:], "query": None}
E       AssertionError: assert {'projects': ...'query': None} == {'projects': [...'query': None}
E         Common items:
E         {'query': None}
E         Differing items:
E         {'projects': <paginate.Page: Page 2/2>} != {'projects': [Project(name='UYEuGqrPAsdI'), Project(name='VGjnNowaWLFS'), Project(name='VJSpPMJWvdha'), Project(name='wBPbUpitYyCJ'), Project(name='WSuUehNTmuFp')]}
E         Full diff:
E         - {'projects': <paginate.Page: Page 2/2>, 'query': None}
E         + {'projects': [Project(name='UYEuGqrPAsdI'),
E         +               Project(name='VGjnNowaWLFS'),
E         +               Project(name='VJSpPMJWvdha'),
E         +               Project(name='wBPbUpitYyCJ'),
E         +               Project(name='WSuUehNTmuFp')],
E         +  'query': None}

tests/unit/admin/views/test_projects.py:48: AssertionError
================================= 2 failed, 27 passed in 7.38 seconds =================================
```

I'm especially confused because `tests/unit/admin/views/test_users.py` has very similar tests, but those pass.

Thoughts?