### PR TITLE
Releases and Files: Store User-Agent

### DIFF
--- a/tests/unit/admin/views/test_projects.py
+++ b/tests/unit/admin/views/test_projects.py
@@ -105,11 +105,22 @@ class TestProjectDetail:
 
 
 class TestReleaseDetail:
-    def test_gets_release(self):
-        release = pretend.stub()
-        request = pretend.stub()
+    def test_gets_release(self, db_request):
+        project = ProjectFactory.create()
+        release = ReleaseFactory.create(project=project)
+        journals = sorted(
+            [
+                JournalEntryFactory(name=project.name, version=release.version)
+                for _ in range(3)
+            ],
+            key=lambda x: (x.submitted_date, x.id),
+            reverse=True,
+        )
 
-        assert views.release_detail(release, request) == {"release": release}
+        assert views.release_detail(release, db_request) == {
+            "release": release,
+            "journals": journals,
+        }
 
 
 class TestProjectReleasesList:

--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -944,6 +944,7 @@ class TestFileUpload:
         EmailFactory.create(user=user)
         db_request.user = user
         db_request.remote_addr = "10.10.10.30"
+        db_request.user_agent = "warehouse-tests/6.6.6"
 
         db_request.POST = MultiDict(
             {
@@ -1212,6 +1213,7 @@ class TestFileUpload:
 
         db_request.user = user
         db_request.remote_addr = "10.10.10.40"
+        db_request.user_agent = "warehouse-tests/6.6.6"
 
         content = FieldStorage()
         content.filename = filename
@@ -2184,6 +2186,7 @@ class TestFileUpload:
 
         db_request.user = user
         db_request.remote_addr = "10.10.10.30"
+        db_request.user_agent = "warehouse-tests/6.6.6"
         db_request.POST = MultiDict(
             {
                 "metadata_version": "1.2",
@@ -2286,6 +2289,7 @@ class TestFileUpload:
 
         db_request.user = user
         db_request.remote_addr = "10.10.10.30"
+        db_request.user_agent = "warehouse-tests/6.6.6"
         db_request.POST = MultiDict(
             {
                 "metadata_version": "1.2",
@@ -2383,6 +2387,7 @@ class TestFileUpload:
 
         db_request.user = user
         db_request.remote_addr = "10.10.10.30"
+        db_request.user_agent = "warehouse-tests/6.6.6"
         db_request.POST = MultiDict(
             {
                 "metadata_version": "1.2",
@@ -2429,6 +2434,7 @@ class TestFileUpload:
 
         db_request.user = user
         db_request.remote_addr = "10.10.10.30"
+        db_request.user_agent = "warehouse-tests/6.6.6"
         db_request.POST = MultiDict(
             {
                 "metadata_version": "1.2",
@@ -2516,6 +2522,7 @@ class TestFileUpload:
 
         db_request.user = user
         db_request.remote_addr = "10.10.10.20"
+        db_request.user_agent = "warehouse-tests/6.6.6"
         db_request.POST = MultiDict(
             {
                 "metadata_version": "1.2",
@@ -2609,6 +2616,7 @@ class TestFileUpload:
 
         db_request.user = user
         db_request.remote_addr = "10.10.10.20"
+        db_request.user_agent = "warehouse-tests/6.6.6"
         db_request.POST = MultiDict(
             {
                 "metadata_version": "1.2",
@@ -2654,6 +2662,7 @@ class TestFileUpload:
 
         db_request.user = user
         db_request.remote_addr = "10.10.10.20"
+        db_request.user_agent = "warehouse-tests/6.6.6"
         db_request.POST = MultiDict(
             {
                 "metadata_version": "1.2",
@@ -2705,6 +2714,7 @@ class TestFileUpload:
         storage_service = pretend.stub(store=lambda path, filepath, meta: None)
         db_request.find_service = lambda svc, name=None: storage_service
         db_request.remote_addr = "10.10.10.10"
+        db_request.user_agent = "warehouse-tests/6.6.6"
 
         resp = legacy.file_upload(db_request)
 
@@ -2804,6 +2814,7 @@ class TestFileUpload:
         storage_service = pretend.stub(store=lambda path, filepath, meta: None)
         db_request.find_service = lambda svc, name=None: storage_service
         db_request.remote_addr = "10.10.10.10"
+        db_request.user_agent = "warehouse-tests/6.6.6"
 
         if expected_success:
             resp = legacy.file_upload(db_request)
@@ -2854,6 +2865,7 @@ class TestFileUpload:
         storage_service = pretend.stub(store=lambda path, filepath, meta: None)
         db_request.find_service = lambda svc, name=None: storage_service
         db_request.remote_addr = "10.10.10.10"
+        db_request.user_agent = "warehouse-tests/6.6.6"
 
         resp = legacy.file_upload(db_request)
 
@@ -2900,6 +2912,7 @@ class TestFileUpload:
 
         db_request.user = user
         db_request.remote_addr = "10.10.10.20"
+        db_request.user_agent = "warehouse-tests/6.6.6"
         db_request.POST = MultiDict(
             {
                 "metadata_version": "1.2",
@@ -2975,6 +2988,7 @@ class TestFileUpload:
 
         db_request.user = user
         db_request.remote_addr = "10.10.10.20"
+        db_request.user_agent = "warehouse-tests/6.6.6"
         db_request.POST = MultiDict(
             {
                 "metadata_version": "1.2",

--- a/warehouse/admin/templates/admin/projects/release_detail.html
+++ b/warehouse/admin/templates/admin/projects/release_detail.html
@@ -47,6 +47,10 @@
           <td>Uploader</td>
           <td><a href="{{ request.route_path('admin.user.detail', user_id=release.uploader.id) }}">{{ release.uploader.username }}</a></td>
         </tr>
+        <tr>
+          <td>Uploader User-Agent</td>
+          <td><code>{{ release.uploader_user_agent }}</code></td>
+        </tr>
       </table>
     </div>
   </div>
@@ -56,18 +60,18 @@
     </div>
     <div class="box-body table-responsive">
       <table class="table table-hover">
-        <thead>
-          <tr>
-            <th>Filename</th>
-            <th>Package Type</th>
-            <th>Python Version</th>
-          </tr>
-        </thead>
+        <tr>
+          <th>Filename</th>
+          <th>Package Type</th>
+          <th>Python Version</th>
+          <th>User-Agent</th>
+        </tr>
         {% for file in release.files %}
         <tr>
           <td><a href="{{ request.route_url('packaging.file', path=file.path) }}">{{ file.filename }}</a></td>
           <td>{{ file.packagetype }}</td>
           <td>{{ file.python_version }}</td>
+          <td><code>{{ file.uploader_user_agent }}</code></td>
         </tr>
         {% endfor %}
       </table>

--- a/warehouse/admin/templates/admin/projects/release_detail.html
+++ b/warehouse/admin/templates/admin/projects/release_detail.html
@@ -52,6 +52,50 @@
   </div>
   <div class="box">
     <div class="box-header with-border">
+      <h3>Files</h3>
+    </div>
+    <div class="box-body table-responsive">
+      <table class="table table-hover">
+        <thead>
+          <tr>
+            <th>Filename</th>
+            <th>Package Type</th>
+            <th>Python Version</th>
+          </tr>
+        </thead>
+        {% for file in release.files %}
+        <tr>
+          <td><a href="{{ request.route_url('packaging.file', path=file.path) }}">{{ file.filename }}</a></td>
+          <td>{{ file.packagetype }}</td>
+          <td>{{ file.python_version }}</td>
+        </tr>
+        {% endfor %}
+      </table>
+    </div>
+  </div>
+  <div class="box">
+    <div class="box-header with-border">
+      <h3>Journals</h3>
+    </div>
+    <div class="box-body table-responsive">
+      <table class="table table-hover">
+        <tr>
+          <th>Action</th>
+          <th>Date</th>
+          <th>User</th>
+        </tr>
+        {% for journal in journals %}
+        <tr>
+          <td>{{ journal.action }}</td>
+          <td>{{ journal.submitted_date|format_datetime() }}</td>
+          <td>{{ journal.submitted_by.username }} from {{ journal.submitted_from }}</td>
+        </tr>
+        {% endfor %}
+      </table>
+    </div>
+  </div>
+  <div class="box">
+    <div class="box-header with-border">
       <h3>Metadata</h3>
     </div>
     <div class="box-body table-responsive">

--- a/warehouse/admin/views/projects.py
+++ b/warehouse/admin/views/projects.py
@@ -171,7 +171,14 @@ def releases_list(project, request):
     uses_session=True,
 )
 def release_detail(release, request):
-    return {"release": release}
+    journals = (
+        request.db.query(JournalEntry)
+        .filter(JournalEntry.name == release.name)
+        .filter(JournalEntry.version == release.version)
+        .order_by(JournalEntry.submitted_date.desc(), JournalEntry.id.desc())
+        .all()
+    )
+    return {"release": release, "journals": journals}
 
 
 @view_config(

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -986,6 +986,7 @@ def file_upload(request):
                     "requires_python",
                 }
             },
+            uploader_user_agent=request.user_agent,
         )
         request.db.add(release)
         # TODO: This should be handled by some sort of database trigger or
@@ -1227,6 +1228,7 @@ def file_upload(request):
                     filename,
                 ]
             ),
+            uploader_user_agent=request.user_agent,
         )
         request.db.add(file_)
 

--- a/warehouse/migrations/versions/b00323b3efd8_uploader_user_agent_field_for_release_.py
+++ b/warehouse/migrations/versions/b00323b3efd8_uploader_user_agent_field_for_release_.py
@@ -1,0 +1,39 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+uploader_user_agent field for Release and Files
+
+Revision ID: b00323b3efd8
+Revises: f2a453c96ded
+Create Date: 2018-07-25 17:29:01.995083
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "b00323b3efd8"
+down_revision = "f2a453c96ded"
+
+
+def upgrade():
+    op.add_column(
+        "release_files", sa.Column("uploader_user_agent", sa.Text(), nullable=True)
+    )
+    op.add_column(
+        "releases", sa.Column("uploader_user_agent", sa.Text(), nullable=True)
+    )
+
+
+def downgrade():
+    op.drop_column("releases", "uploader_user_agent")
+    op.drop_column("release_files", "uploader_user_agent")

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -385,6 +385,8 @@ class Release(db.ModelBase):
         viewonly=True,
     )
 
+    uploader_user_agent = Column(Text)
+
     @property
     def urls(self):
         _urls = OrderedDict()
@@ -482,6 +484,8 @@ class File(db.Model):
     sha256_digest = Column(CIText, unique=True, nullable=False)
     blake2_256_digest = Column(CIText, unique=True, nullable=False)
     upload_time = Column(DateTime(timezone=False), server_default=func.now())
+    uploader_user_agent = Column(Text)
+
     # We need this column to allow us to handle the currently existing "double"
     # sdists that exist in our database. Eventually we should try to get rid
     # of all of them and then remove this column.


### PR DESCRIPTION
Stores the User-Agent of the client creating a given Release and uploading a given File for admin review.

Also adds Journals related to a given Release in the admin.

This can be helpful when providing support!

Exposed only via the admin UI at the moment, screenshot:

![screen shot 2018-07-25 at 2 13 16 pm](https://user-images.githubusercontent.com/1200832/43219308-e5dcfa90-9014-11e8-90d3-bdddef5b69cb.png)
