### PR TITLE
make default target now shows list of available make commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,4 +173,4 @@ purge: stop clean
 stop:
 	docker-compose down -v
 
-.PHONY: default build serve initdb shell tests docs deps travis-deps clean purge debug stop list
+.PHONY: default build serve initdb shell tests docs deps travis-deps clean purge debug stop

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,13 @@ if extra_in_left or extra_in_right:
 endef
 
 default:
-	@echo "Call a specific subcommand"
+	@echo "Call a specific subcommand:"
+	@echo
+	@$(MAKE) -pRrq -f $(lastword $(MAKEFILE_LIST)) : 2>/dev/null\
+	| awk -v RS= -F: '/^# File/,/^# Finished Make data base/ {if ($$1 !~ "^[#.]") {print $$1}}'\
+	| sort\
+	| egrep -v -e '^[^[:alnum:]]' -e '^$@$$'
+	@echo
 	@exit 1
 
 .state/env/pyvenv.cfg: requirements/dev.txt requirements/docs.txt requirements/lint.txt requirements/ipython.txt
@@ -167,4 +173,4 @@ purge: stop clean
 stop:
 	docker-compose down -v
 
-.PHONY: default build serve initdb shell tests docs deps travis-deps clean purge debug stop
+.PHONY: default build serve initdb shell tests docs deps travis-deps clean purge debug stop list

--- a/docs/development/getting-started.rst
+++ b/docs/development/getting-started.rst
@@ -33,11 +33,14 @@ Detailed installation instructions
 
 Getting the Warehouse source code
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Clone the Warehouse repository from `GitHub`_:
+`Fork <https://help.github.com/articles/fork-a-repo/>`_ the repository
+on `GitHub`_ and
+`clone <https://help.github.com/articles/cloning-a-repository/>`_ it to
+your local machine:
 
 .. code-block:: console
 
-    git clone git@github.com:pypa/warehouse.git
+    git clone git@github.com:YOUR-USERNAME/warehouse.git
 
 
 Configure the development environment


### PR DESCRIPTION
I took the solution from https://stackoverflow.com/questions/4219255/how-do-you-get-the-list-of-targets-in-a-makefile/#answer-26339924

```bash
$ make
Call a specific subcommand:

build
clean
debug
deps
docs
initdb
licenses
lint
list
purge
reformat
reindex
serve
shell
stop
tests
travis-deps

make: *** [default] Error 1
```