### PR TITLE
Update docker-compose.yml to use concrete versions of redis and rabbitmq.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,10 +11,10 @@ services:
       - "5433:5432"
 
   redis:
-    image: redis:latest
+    image: redis:4.0
 
   rabbitmq:
-    image: rabbitmq:latest
+    image: rabbitmq:3.7
 
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:6.2.4


### PR DESCRIPTION
In docker-compose file two images were pulled from tag `latest`. As this may result in potential undetermined behavior when there are introduced breaking changes in given images I've changed it to corresponding minor version tag. 

There is also `warehouse-camo` but it only has `latest` tag