### PR TITLE
Make complete package boxes clickable

### DIFF
--- a/warehouse/static/sass/blocks/_package-snippet.scss
+++ b/warehouse/static/sass/blocks/_package-snippet.scss
@@ -14,14 +14,16 @@
 
 /*
   A card that contains information about a package. Often found in package lists.
+  The card can be an "a" or "div" element, but if it contains a link, choosing
+  a top-level "a" element is recommended for accessibility reasons.
 
-  <div class="package-snippet">
+  <a class="package-snippet" href="/link/to/target">
     <h3 class="package-snippet__title">
       // Package title
       <span class="package-snippet__version">// Version</span> // Optional!
     </h3>
     <p class="package-snippet__description">// Description</p>
-  </div>
+  </a>
 */
 
 .package-snippet {

--- a/warehouse/static/sass/blocks/_package-snippet.scss
+++ b/warehouse/static/sass/blocks/_package-snippet.scss
@@ -26,6 +26,7 @@
 
 .package-snippet {
   @include card;
+  display: block;
   padding: ($spacing-unit / 2) 20px ($spacing-unit / 2) 75px;
   margin: 0 0 20px;
   // Use png fallback
@@ -60,12 +61,14 @@
   }
 
   &__version {
+    color: $text-color;
     font-weight: $bold-font-weight;
   }
 
   &__description {
     @include add-ellipsis;
     clear: both;
+    color: $text-color;
     font-size: 1rem;
     font-style: italic;
   }

--- a/warehouse/static/sass/blocks/_release.scss
+++ b/warehouse/static/sass/blocks/_release.scss
@@ -23,10 +23,10 @@
       <div class="release__line"></div>
       <img class="release__node">
     </div>
-    <div class="release__card">
+    <a class="release__card" href="/link/to/version">
       <p class="release__version"></p>
       <p class="release__version-date"></p>
-    </div>
+    </a>
   </div>
 
   Modifiers:

--- a/warehouse/static/sass/blocks/_release.scss
+++ b/warehouse/static/sass/blocks/_release.scss
@@ -91,6 +91,7 @@
     border: 1px solid darken(#ececec, 5);
     background-color: $white;
     box-shadow: 1px 1px 2px 1px transparentize($black, 0.95);
+    display: block;
     padding: $spacing-unit / 2;
     margin: ($spacing-unit / 2) 0;
   }

--- a/warehouse/templates/accounts/profile.html
+++ b/warehouse/templates/accounts/profile.html
@@ -54,13 +54,13 @@
       <div class="package-list">
         {% if projects %}
         {% for project in projects %}
-        <div class="package-snippet">
-          <h3 class="package-snippet__title"><a href="{{ request.route_path('packaging.project', name=project.normalized_name) }}">{{ project.name }}</a></h3>
+        <a class="package-snippet" href="{{ request.route_path('packaging.project', name=project.normalized_name) }}">
+          <h3 class="package-snippet__title">{{ project.name }}</h3>
           <p class="package-snippet__meta">
             <em>Last released on {{ project.releases[0].created|format_date() }}</em>
           </p>
           <p class="package-snippet__description">{{ project.releases[0].summary }}</p>
-        </div>
+        </a>
         {% endfor %}
         {% else %}
           {% csi request.route_url("includes.current-user-profile-callout", username=user.username) %}

--- a/warehouse/templates/index.html
+++ b/warehouse/templates/index.html
@@ -16,13 +16,13 @@
 {% block title %}{% if testPyPI %}Test{% endif %}PyPI – the Python Package Index{% endblock %}
 
 {% macro project_snippet(release) -%}
-<div class="package-snippet">
+<a class="package-snippet" href="{{ request.route_path('packaging.project', name=release.project.normalized_name) }}">
   <h3 class="package-snippet__title">
-    <a href="{{ request.route_path('packaging.project', name=release.project.normalized_name) }}">{{ release.project.name }}</a>
+    <span class="package-snippet__name">{{ release.project.name }}</span>
     <span class="package-snippet__version">{{ release.version }}</span>
   </h3>
   <p class="package-snippet__description">{{ release.summary }}</p>
-</div>
+</a>
 {%- endmacro %}
 
 

--- a/warehouse/templates/manage/manage_project_base.html
+++ b/warehouse/templates/manage/manage_project_base.html
@@ -43,17 +43,15 @@
           </a>
         </nav>
         <div class="vertical-tabs__content">
-          <div class="package-snippet package-snippet--margin-bottom">
+          <a class="package-snippet package-snippet--margin-bottom" href="{{ request.route_path('packaging.project', name=project.normalized_name) }}">
             {% set release = project.releases[0] if project.releases else None %}
             {% if release %}
-            <h1 class="package-snippet__title package-snippet__title--page-title">
-              <a href="{{ request.route_path('packaging.project', name=project.normalized_name) }}">{{ project.name }}</a>
-            </h1>
+            <h1 class="package-snippet__title package-snippet__title--page-title">{{ project.name }}</h1>
             <p class="package-snippet__description">{{ release.summary }}</p>
             {% else %}
             <h1 class="package-snippet__title package-snippet__title--page-title">{{ project.name }}</h1>
             {% endif %}
-          </div>
+          </a>
           <!-- mobile nav -->
           {% with mode="mobile" %}
             {% include "warehouse:templates/includes/manage/manage-project-menu.html" %}

--- a/warehouse/templates/packaging/detail.html
+++ b/warehouse/templates/packaging/detail.html
@@ -43,13 +43,13 @@
 
 
 {% macro project_snippet(release) -%}
-<div class="package-snippet">
+<a class="package-snippet" href="{{ request.route_path('packaging.project', name=release.project.normalized_name) }}">
   <h3 class="package-snippet__title">
-    <a href="{{ request.route_path('packaging.project', name=release.project.normalized_name) }}">{{ release.project.name }}</a>
+    <span class="pacakge-snippet__name">{{ release.project.name }}</span>
     <span class="package-snippet__version">{{ release.version }}</span>
   </h3>
   <p class="package-snippet__description">{{ release.summary }}</p>
-</div>
+</a>
 {%- endmacro %}
 
 {% block title %}{{ release.project.name }}{% endblock %}
@@ -209,10 +209,10 @@
                 {% endif %}
               </div>
 
-              <div class="card release__card">
-                <p class="release__version"><a href="{{ request.route_path('packaging.release', name=release.project.name, version=hversion.version) }}">{{ hversion.version }}</a></p>
+              <a class="card release__card" href="{{ request.route_path('packaging.release', name=release.project.name, version=hversion.version) }}">
+                <p class="release__version">{{ hversion.version }}</p>
                 <p class="release__version-date">{{ humanize(hversion.created) }}</p>
-              </div>
+              </a>
             </div>
             {% endfor %}
           </section>

--- a/warehouse/templates/search/results.html
+++ b/warehouse/templates/search/results.html
@@ -17,13 +17,13 @@
 
 {% macro project_snippet(item) -%}
 
-<div class="package-snippet">
+<a class="package-snippet" href="{{ request.route_path('packaging.project', name=item.normalized_name) }}">
   <h3 class="package-snippet__title">
-    <a href="{{ request.route_path('packaging.project', name=item.normalized_name) }}">{{ item.name }}</a>
+    <span class="package-snippet__name">{{ item.name }}</span>
     <span class="package-snippet__version">{{ item.latest_version }}</span>
   </h3>
   <p class="package-snippet__description">{{ item.summary }}</p>
-</div>
+</a>
 {%- endmacro %}
 
 


### PR DESCRIPTION
Previously, only the package title was clickable. This change improves
accessibility, closing #3923. This change concerns the home page,
search results, the public user profile, and the version history page.
Visual appearance is unchanged. Only one ``package-snippet`` element
remains unchanged, because it contains buttons, so making it completely
clickable doesn't make sense.