### PR TITLE
Add sudo to lsof command

### DIFF
--- a/docs/development/getting-started.rst
+++ b/docs/development/getting-started.rst
@@ -109,7 +109,7 @@ For example, checking port ``80``:
 
 .. code-block:: console
 
-    lsof -i:80 | grep LISTEN
+    sudo lsof -i:80 | grep LISTEN
 
 If the port is in use, the command will produce output, and you will need to
 determine what is occupying the port and shut down the corresponding service.


### PR DESCRIPTION
If this is not run as root it will silently fail. Not all users will have `sudo`, but those who don't are probably more advanced users that can figure out the alternative.