### PR TITLE
Without JS, show default navbar and notification that some things might be broken

### DIFF
--- a/warehouse/static/sass/noscript.scss
+++ b/warehouse/static/sass/noscript.scss
@@ -34,3 +34,8 @@
     display: inherit;
   }
 }
+
+.stick-to-top {
+  // Avoid hiding navigation bar with notification
+  position: relative;
+}

--- a/warehouse/templates/base.html
+++ b/warehouse/templates/base.html
@@ -150,6 +150,15 @@
         <span class="notification-bar__message">You are using TestPyPI – a separate instance of the Python Package Index that allows you to try distribution tools and processes without affecting the real index.</span>
       </div>
       {% endif %}
+      <noscript>
+      <div class="notification-bar notification-bar--danger">
+        <span class="notification-bar__icon">
+          <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
+          <span class="sr-only">Warning:</span>
+        </span>
+        <span class="notification-bar__message">Some features may not work without JavaScript. Please try enabling it if you encounter problems.</span>
+      </div>
+      </noscript>
     </section>
 
     {% block flash_messages %}

--- a/warehouse/templates/base.html
+++ b/warehouse/templates/base.html
@@ -32,6 +32,15 @@
 </p>
 {%- endmacro %}
 
+{% macro main_navigation_logged_out() -%}
+<nav id="user-indicator" class="horizontal-menu horizontal-menu--light horizontal-menu--tall" aria-label="Main navigation">
+  <a class="horizontal-menu__link horizontal-menu__link--remove-on-mobile" href="{{ request.route_path('help') }}">Help</a>
+  <a class="horizontal-menu__link horizontal-menu__link--remove-on-mobile" href="https://donate.pypi.org">Donate</a>
+  <a class="horizontal-menu__link" href="{{ request.route_path('accounts.login') }}">Log in</a>
+  <a class="horizontal-menu__link" href="{{ request.route_path('accounts.register') }}">Register</a>
+</nav>
+{%- endmacro %}
+
 <!DOCTYPE html>
 <html lang="en">
   <head>
@@ -182,6 +191,7 @@
           {% endblock %}
 
           {% csi request.route_path("includes.current-user-indicator") %}
+            {{ main_navigation_logged_out() }}
           {% endcsi %}
         </div>
       </div>

--- a/warehouse/templates/base.html
+++ b/warehouse/templates/base.html
@@ -152,6 +152,7 @@
       {% endif %}
       <noscript>
       <div class="notification-bar notification-bar--danger">
+        {# TODO: This should be removed once GH-3828 is fixed. #}
         <span class="notification-bar__icon">
           <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
           <span class="sr-only">Warning:</span>

--- a/warehouse/templates/includes/current-user-indicator.html
+++ b/warehouse/templates/includes/current-user-indicator.html
@@ -74,10 +74,6 @@
     </nav>
   </div>
   {% else %}
-  <nav id="user-indicator" class="horizontal-menu horizontal-menu--light horizontal-menu--tall" aria-label="Main navigation">
-    <a class="horizontal-menu__link horizontal-menu__link--remove-on-mobile" href="{{ request.route_path('help') }}">Help</a>
-    <a class="horizontal-menu__link horizontal-menu__link--remove-on-mobile" href="https://donate.pypi.org">Donate</a>
-    <a class="horizontal-menu__link" href="{{ request.route_path('accounts.login') }}">Log in</a>
-    <a class="horizontal-menu__link" href="{{ request.route_path('accounts.register') }}">Register</a>
-  </nav>
+    {% from 'base.html' import main_navigation_logged_out with context %}
+    {{ main_navigation_logged_out() }}
   {% endif %}


### PR DESCRIPTION
This PR does includes two things:
- Showing the logged-out version of the navbar in case CSI fails, so users can log in without JavaScript. 
- Show a notification at the top if JS is disabled, and disable the fixed positioning to avoid hiding the menu bar.

Let me know if this can be improved, in particular I'm not entirely sure if the way I've imported the macro is OK.