### PR TITLE
Add note to Getting Started docs about logos looking different locally

### DIFF
--- a/docs/development/getting-started.rst
+++ b/docs/development/getting-started.rst
@@ -218,6 +218,16 @@ This means that all the services are up, and web container is listening on port
     ``https://<docker-ip>:80/`` instead. You can get information about the
     docker container with ``docker-machine env``
 
+.. note::
+
+    In development mode, the official logos are replaced with placeholders due to
+    copyright.
+
+    On Firefox, the logos might show up as black rectangles due to  the
+    *Content Security Policy* used and an implementation bug in Firefox (see
+    `this bug report <https://bugzilla.mozilla.org/show_bug.cgi?id=1262842>`_
+    for more info).
+
 
 Logging in to Warehouse
 ^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Add a note to Getting Started docs that:
- logos are replaced with placeholders locally.
- on Firefox you might see black rectangles instead. 

I somewhat dug into the black rectangles issue - turns out it's a combination of the Content Security Policy used and a bug in Firefox. I didn't find a good way of getting around it (adding `'unsafe-inline'` to the `style-src` part of the CSP works but I don't think you want that), so I just added a note in docs.

What *might* be a better option wrt Firefox is optimizing the SVGs to get rid of the `style=` attributes which are causing the problem and using SVG attributes instead. I had a quick try with https://jakearchibald.github.io/svgomg/ and it seems to fix the problem, although the resulting SVG is now generated and might miss some info that you deem crucial. Let me if you'd prefer that approach and I can commit the optimized SVGs.

Please check the wording of the added text. Also note that there are now two _Note_ boxes after one another, not sure if that's ok if there's a better way.
