### PR TITLE
WIP: Show popup with hash instead of copying directly to clipboard

### DIFF
--- a/warehouse/templates/packaging/detail.html
+++ b/warehouse/templates/packaging/detail.html
@@ -247,11 +247,44 @@
                       {{ file.filename }}
                     </a>
                     {% if file.size %} ({{ file.size|filesizeformat() }}){% endif %}
-                    <a class="-js-copy-hash table__sha256-link tooltipped tooltipped-s" aria-label="Copy to clipboard" data-original-label="Copy to clipboard" data-clipboard-text="{{ file.sha256_digest }}">
-                      <i class="fa fa-copy" aria-hidden="true"></i>
-                      <span class="sr-only">Copy SHA256 hash</span>
+                    <a href="#copy-hash-modal-{{ loop.index }}" class="tooltipped tooltipped-s" aria-label="View hash" data-original-label="View hash" >
+                      <i class="fa fa-hashtag" aria-hidden="true"></i>
                       SHA256
                     </a>
+                    <div id="copy-hash-modal-{{ loop.index }}" class="modal modal--wide">
+                      <div class="modal__content" role="dialog">
+                        <a href="#modal-close" title="Close" class="modal__close">
+                          <i class="fa fa-times" aria-hidden="true"></i>
+                          <span class="sr-only">close</span>
+                        </a>
+                        <div class="modal__body">
+                          <h3 class="modal__title">Hashes for {{ file.filename }}</h3>
+                          <table class="table table--light table--hashes">
+                            <thead>
+                              <tr>
+                                <th class="table__algorithm">Algorithm</th>
+                                <th class="table__hash">Hash digest</th>
+                                <th class="table__copy"></th>
+                              </tr>
+                            </thead>
+                            <tbody>
+                              <tr>
+                                <td class="table__algorithm">SHA256</td>
+                                <td class="table__hash"><code>{{ file.sha256_digest }}</code></td>
+                                <td class="table__copy">
+                                  <button class="button button--primary -js-copy-hash tooltipped tooltipped-w" aria-label="Copy to clipboard" data-original-label="Copy to clipboard" data-clipboard-text="{{ file.sha256_digest }}">
+                                    Copy
+                                  </button>
+                                </td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </div>
+                        <div class="modal__footer">
+                          <a href="#modal-close" class="button button--primary modal__action">OK</a>
+                        </div>
+                      </div>
+                    </div>
                   </td>
                   <td>
                     {{ file.packagetype|format_package_type }}


### PR DESCRIPTION
Also for #3828 .

Note that closing the popup via Esc is broken. 
On the manage release page, it works by accident as there are two other possible popups that set the data-controller attribute and thus work with https://github.com/pypa/warehouse/blob/master/warehouse/static/js/warehouse/index.js#L129 (it still throws some TypeErrors). 

Any ideas on how to properly fix the key handler? Or should everything use the data-controller?