### PR TITLE
Bugfix/license check for scss

### DIFF
--- a/Gulpfile.babel.js
+++ b/Gulpfile.babel.js
@@ -1,3 +1,18 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 import brotli from "gulp-brotli";
 import composer from "gulp-uglify/composer";
 import del from "del";

--- a/bin/licenses
+++ b/bin/licenses
@@ -3,9 +3,9 @@
 EXIT_CODE=0
 
 # Search all .py files
-for fn in $(find . -type f \( -name "*.py" -o -name "*.html" \) ! -path "./.state*" ! -path "./node_modules*" ! -path "./htmlcov*" ! -path "./warehouse/static*" ! -path "./warehouse/datadog/pyramid_datadog.py"); do
-    # Check for license in first 3 lines (allows for shebang and encoding)
-    if [[ ! "$(head -3 $fn | grep "^ *# Licensed")" ]]; then
+for fn in $(find . -type f \( -name "*.py" -o -name "*.html" -o -name "*.scss" -o ! -name "*.min.js" -name "*.js" \) ! -path "./.state*" ! -path "./node_modules*" ! -path "./htmlcov*" ! -path "./warehouse/static/html*" ! -path "./warehouse/static/js/vendor*" ! -path "./warehouse/datadog/pyramid_datadog.py"); do
+    # Check for license in first 5 lines (allows for shebang, encoding and handles comment character in various languages)
+    if [[ ! "$(head -5 $fn | grep "^ *\(#\|\*\|\/\/\) .* License\(d*\)")" ]]; then
         echo $fn is missing a license
         EXIT_CODE=1
     fi

--- a/bin/licenses
+++ b/bin/licenses
@@ -3,7 +3,18 @@
 EXIT_CODE=0
 
 # Search all .py files
-for fn in $(find . -type f \( -name "*.py" -o -name "*.html" -o -name "*.scss" -o ! -name "*.min.js" -name "*.js" \) ! -path "./.state*" ! -path "./node_modules*" ! -path "./htmlcov*" ! -path "./warehouse/static/html*" ! -path "./warehouse/static/js/vendor*" ! -path "./warehouse/datadog/pyramid_datadog.py"); do
+for fn in $(find . -type f \( \
+            -name "*.py" -o \
+            -name "*.html" -o \
+            -name "*.scss" -o \
+          ! -name "*.min.js" \
+            -name "*.js" \) \
+          ! -path "./.state*" \
+          ! -path "./node_modules*" \
+          ! -path "./htmlcov*" \
+          ! -path "./warehouse/static/html*" \
+          ! -path "./warehouse/static/js/vendor*" \
+          ! -path "./warehouse/datadog/pyramid_datadog.py"); do
     # Check for license in first 5 lines (allows for shebang, encoding and handles comment character in various languages)
     if [[ ! "$(head -5 $fn | grep "^ *\(#\|\*\|\/\/\) .* License\(d*\)")" ]]; then
         echo $fn is missing a license

--- a/warehouse/admin/static/js/controllers/child_classifier_controller.js
+++ b/warehouse/admin/static/js/controllers/child_classifier_controller.js
@@ -1,3 +1,18 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 import { Controller } from "stimulus";
 
 export default class extends Controller {

--- a/warehouse/admin/static/js/controllers/parent_classifier_controller.js
+++ b/warehouse/admin/static/js/controllers/parent_classifier_controller.js
@@ -1,3 +1,18 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 import { Controller } from "stimulus";
 
 export default class extends Controller {

--- a/warehouse/static/js/warehouse/controllers/confirm_controller.js
+++ b/warehouse/static/js/warehouse/controllers/confirm_controller.js
@@ -1,3 +1,18 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 import { Controller } from "stimulus";
 
 export default class extends Controller {

--- a/warehouse/static/sass/resets/_boxsizing.scss
+++ b/warehouse/static/sass/resets/_boxsizing.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 /*------------------------------------*\
     #BOX-SIZING
 \*------------------------------------*/

--- a/warehouse/static/sass/resets/_normalize.scss
+++ b/warehouse/static/sass/resets/_normalize.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 /*! normalize.css v3.0.2 | MIT License | git.io/normalize */
 
 /**

--- a/warehouse/static/sass/resets/_reset.scss
+++ b/warehouse/static/sass/resets/_reset.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 // GENERIC - RESET
 
 /*

--- a/warehouse/static/sass/settings/_neat.scss
+++ b/warehouse/static/sass/settings/_neat.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 // SETTINGS - NEAT
 
 /*

--- a/warehouse/static/sass/tools/bourbon/_bourbon-deprecated-upcoming.scss
+++ b/warehouse/static/sass/tools/bourbon/_bourbon-deprecated-upcoming.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 // The following features have been deprecated and will be removed in the next MAJOR version release
 
 @mixin inline-block {

--- a/warehouse/static/sass/tools/bourbon/addons/_border-color.scss
+++ b/warehouse/static/sass/tools/bourbon/addons/_border-color.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 @charset "UTF-8";
 
 /// Provides a quick method for targeting `border-color` on specific sides of a box. Use a `null` value to “skip” a side.

--- a/warehouse/static/sass/tools/bourbon/addons/_border-radius.scss
+++ b/warehouse/static/sass/tools/bourbon/addons/_border-radius.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 @charset "UTF-8";
 
 /// Provides a quick method for targeting `border-radius` on both corners on the side of a box.

--- a/warehouse/static/sass/tools/bourbon/addons/_border-style.scss
+++ b/warehouse/static/sass/tools/bourbon/addons/_border-style.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 @charset "UTF-8";
 
 /// Provides a quick method for targeting `border-style` on specific sides of a box. Use a `null` value to “skip” a side.

--- a/warehouse/static/sass/tools/bourbon/addons/_border-width.scss
+++ b/warehouse/static/sass/tools/bourbon/addons/_border-width.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 @charset "UTF-8";
 
 /// Provides a quick method for targeting `border-width` on specific sides of a box. Use a `null` value to “skip” a side.

--- a/warehouse/static/sass/tools/bourbon/addons/_buttons.scss
+++ b/warehouse/static/sass/tools/bourbon/addons/_buttons.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 @charset "UTF-8";
 
 /// Generates variables for all buttons. Please note that you must use interpolation on the variable: `#{$all-buttons}`.

--- a/warehouse/static/sass/tools/bourbon/addons/_clearfix.scss
+++ b/warehouse/static/sass/tools/bourbon/addons/_clearfix.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 @charset "UTF-8";
 
 /// Provides an easy way to include a clearfix for containing floats.

--- a/warehouse/static/sass/tools/bourbon/addons/_ellipsis.scss
+++ b/warehouse/static/sass/tools/bourbon/addons/_ellipsis.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 @charset "UTF-8";
 
 /// Truncates text and adds an ellipsis to represent overflow.

--- a/warehouse/static/sass/tools/bourbon/addons/_font-stacks.scss
+++ b/warehouse/static/sass/tools/bourbon/addons/_font-stacks.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 @charset "UTF-8";
 
 /// Georgia font stack.

--- a/warehouse/static/sass/tools/bourbon/addons/_hide-text.scss
+++ b/warehouse/static/sass/tools/bourbon/addons/_hide-text.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 /// Hides the text in an element, commonly used to show an image. Some elements will need block-level styles applied.
 ///
 /// @link http://zeldman.com/2012/03/01/replacing-the-9999px-hack-new-image-replacement

--- a/warehouse/static/sass/tools/bourbon/addons/_margin.scss
+++ b/warehouse/static/sass/tools/bourbon/addons/_margin.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 @charset "UTF-8";
 
 /// Provides a quick method for targeting `margin` on specific sides of a box. Use a `null` value to “skip” a side.

--- a/warehouse/static/sass/tools/bourbon/addons/_padding.scss
+++ b/warehouse/static/sass/tools/bourbon/addons/_padding.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 @charset "UTF-8";
 
 /// Provides a quick method for targeting `padding` on specific sides of a box. Use a `null` value to “skip” a side.

--- a/warehouse/static/sass/tools/bourbon/addons/_position.scss
+++ b/warehouse/static/sass/tools/bourbon/addons/_position.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 @charset "UTF-8";
 
 /// Provides a quick method for setting an element’s position. Use a `null` value to “skip” a side.

--- a/warehouse/static/sass/tools/bourbon/addons/_prefixer.scss
+++ b/warehouse/static/sass/tools/bourbon/addons/_prefixer.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 @charset "UTF-8";
 
 /// A mixin for generating vendor prefixes on non-standardized properties.

--- a/warehouse/static/sass/tools/bourbon/addons/_retina-image.scss
+++ b/warehouse/static/sass/tools/bourbon/addons/_retina-image.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 @mixin retina-image($filename, $background-size, $extension: png, $retina-filename: null, $retina-suffix: _2x, $asset-pipeline: $asset-pipeline) {
   @if $asset-pipeline {
     background-image: image-url("#{$filename}.#{$extension}");

--- a/warehouse/static/sass/tools/bourbon/addons/_size.scss
+++ b/warehouse/static/sass/tools/bourbon/addons/_size.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 @charset "UTF-8";
 
 /// Sets the `width` and `height` of the element.

--- a/warehouse/static/sass/tools/bourbon/addons/_text-inputs.scss
+++ b/warehouse/static/sass/tools/bourbon/addons/_text-inputs.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 @charset "UTF-8";
 
 /// Generates variables for all text-based inputs. Please note that you must use interpolation on the variable: `#{$all-text-inputs}`.

--- a/warehouse/static/sass/tools/bourbon/addons/_timing-functions.scss
+++ b/warehouse/static/sass/tools/bourbon/addons/_timing-functions.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 @charset "UTF-8";
 
 /// CSS cubic-bezier timing functions. Timing functions courtesy of jquery.easie (github.com/jaukia/easie)

--- a/warehouse/static/sass/tools/bourbon/addons/_triangle.scss
+++ b/warehouse/static/sass/tools/bourbon/addons/_triangle.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 @mixin triangle($size, $color, $direction) {
   $width: nth($size, 1);
   $height: nth($size, length($size));

--- a/warehouse/static/sass/tools/bourbon/addons/_word-wrap.scss
+++ b/warehouse/static/sass/tools/bourbon/addons/_word-wrap.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 @charset "UTF-8";
 
 /// Provides an easy way to change the `word-wrap` property.

--- a/warehouse/static/sass/tools/bourbon/css3/_animation.scss
+++ b/warehouse/static/sass/tools/bourbon/css3/_animation.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 // http://www.w3.org/TR/css3-animations/#the-animation-name-property-
 // Each of these mixins support comma separated lists of values, which allows different transitions for individual properties to be described in a single style rule. Each value in the list corresponds to the value at that same position in the other properties.
 

--- a/warehouse/static/sass/tools/bourbon/css3/_appearance.scss
+++ b/warehouse/static/sass/tools/bourbon/css3/_appearance.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 @mixin appearance($value) {
   @include prefixer(appearance, $value, webkit moz ms o spec);
 }

--- a/warehouse/static/sass/tools/bourbon/css3/_backface-visibility.scss
+++ b/warehouse/static/sass/tools/bourbon/css3/_backface-visibility.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 @mixin backface-visibility($visibility) {
   @include prefixer(backface-visibility, $visibility, webkit spec);
 }

--- a/warehouse/static/sass/tools/bourbon/css3/_background-image.scss
+++ b/warehouse/static/sass/tools/bourbon/css3/_background-image.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 //************************************************************************//
 // Background-image property for adding multiple background images with
 // gradients, or for stringing multiple gradients together.

--- a/warehouse/static/sass/tools/bourbon/css3/_background.scss
+++ b/warehouse/static/sass/tools/bourbon/css3/_background.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 //************************************************************************//
 // Background property for adding multiple backgrounds using shorthand
 // notation.

--- a/warehouse/static/sass/tools/bourbon/css3/_border-image.scss
+++ b/warehouse/static/sass/tools/bourbon/css3/_border-image.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 @mixin border-image($borders...) {
   $webkit-borders: ();
   $spec-borders: ();

--- a/warehouse/static/sass/tools/bourbon/css3/_calc.scss
+++ b/warehouse/static/sass/tools/bourbon/css3/_calc.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 @mixin calc($property, $value) {
   #{$property}: -webkit-calc(#{$value});
   #{$property}: calc(#{$value});

--- a/warehouse/static/sass/tools/bourbon/css3/_columns.scss
+++ b/warehouse/static/sass/tools/bourbon/css3/_columns.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 @mixin columns($arg: auto) {
   // <column-count> || <column-width>
   @include prefixer(columns, $arg, webkit moz spec);

--- a/warehouse/static/sass/tools/bourbon/css3/_filter.scss
+++ b/warehouse/static/sass/tools/bourbon/css3/_filter.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 @mixin filter($function: none) {
   // <filter-function> [<filter-function]* | none
   @include prefixer(filter, $function, webkit spec);

--- a/warehouse/static/sass/tools/bourbon/css3/_flex-box.scss
+++ b/warehouse/static/sass/tools/bourbon/css3/_flex-box.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 // CSS3 Flexible Box Model and property defaults
 
 // Custom shorthand notation for flexbox

--- a/warehouse/static/sass/tools/bourbon/css3/_font-face.scss
+++ b/warehouse/static/sass/tools/bourbon/css3/_font-face.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 @mixin font-face(
   $font-family,
   $file-path,

--- a/warehouse/static/sass/tools/bourbon/css3/_font-feature-settings.scss
+++ b/warehouse/static/sass/tools/bourbon/css3/_font-feature-settings.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 @mixin font-feature-settings($settings...) {
   @if length($settings) == 0 { $settings: none; }
   @include prefixer(font-feature-settings, $settings, webkit moz ms spec);

--- a/warehouse/static/sass/tools/bourbon/css3/_hidpi-media-query.scss
+++ b/warehouse/static/sass/tools/bourbon/css3/_hidpi-media-query.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 // HiDPI mixin. Default value set to 1.3 to target Google Nexus 7 (http://bjango.com/articles/min-device-pixel-ratio/)
 @mixin hidpi($ratio: 1.3) {
   @media only screen and (-webkit-min-device-pixel-ratio: $ratio),

--- a/warehouse/static/sass/tools/bourbon/css3/_hyphens.scss
+++ b/warehouse/static/sass/tools/bourbon/css3/_hyphens.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 @mixin hyphens($hyphenation: none) {
   // none | manual | auto
   @include prefixer(hyphens, $hyphenation, webkit moz ms spec);

--- a/warehouse/static/sass/tools/bourbon/css3/_image-rendering.scss
+++ b/warehouse/static/sass/tools/bourbon/css3/_image-rendering.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 @mixin image-rendering ($mode:auto) {
 
   @if ($mode == crisp-edges) {

--- a/warehouse/static/sass/tools/bourbon/css3/_keyframes.scss
+++ b/warehouse/static/sass/tools/bourbon/css3/_keyframes.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 // Adds keyframes blocks for supported prefixes, removing redundant prefixes in the block's content
 @mixin keyframes($name) {
   $original-prefix-for-webkit:    $prefix-for-webkit;

--- a/warehouse/static/sass/tools/bourbon/css3/_linear-gradient.scss
+++ b/warehouse/static/sass/tools/bourbon/css3/_linear-gradient.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 @mixin linear-gradient($pos, $g1, $g2: null,
                        $g3: null, $g4: null,
                        $g5: null, $g6: null,

--- a/warehouse/static/sass/tools/bourbon/css3/_perspective.scss
+++ b/warehouse/static/sass/tools/bourbon/css3/_perspective.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 @mixin perspective($depth: none) {
   // none | <length>
   @include prefixer(perspective, $depth, webkit moz spec);

--- a/warehouse/static/sass/tools/bourbon/css3/_placeholder.scss
+++ b/warehouse/static/sass/tools/bourbon/css3/_placeholder.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 @mixin placeholder {
   $placeholders: ":-webkit-input" ":-moz" "-moz" "-ms-input";
   @each $placeholder in $placeholders {

--- a/warehouse/static/sass/tools/bourbon/css3/_radial-gradient.scss
+++ b/warehouse/static/sass/tools/bourbon/css3/_radial-gradient.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 // Requires Sass 3.1+
 @mixin radial-gradient($g1, $g2,
                        $g3: null, $g4: null,

--- a/warehouse/static/sass/tools/bourbon/css3/_selection.scss
+++ b/warehouse/static/sass/tools/bourbon/css3/_selection.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 @charset "UTF-8";
 
 /// Outputs the spec and prefixed versions of the `::selection` pseudo-element.

--- a/warehouse/static/sass/tools/bourbon/css3/_text-decoration.scss
+++ b/warehouse/static/sass/tools/bourbon/css3/_text-decoration.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 @mixin text-decoration($value) {
 // <text-decoration-line> || <text-decoration-style> || <text-decoration-color>
   @include prefixer(text-decoration, $value, moz);

--- a/warehouse/static/sass/tools/bourbon/css3/_transform.scss
+++ b/warehouse/static/sass/tools/bourbon/css3/_transform.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 @mixin transform($property: none) {
   // none | <transform-function>
   @include prefixer(transform, $property, webkit moz ms o spec);

--- a/warehouse/static/sass/tools/bourbon/css3/_transition.scss
+++ b/warehouse/static/sass/tools/bourbon/css3/_transition.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 // Shorthand mixin. Supports multiple parentheses-deliminated values for each variable.
 // Example: @include transition (all 2s ease-in-out);
 //          @include transition (opacity 1s ease-in 2s, width 2s ease-out);

--- a/warehouse/static/sass/tools/bourbon/css3/_user-select.scss
+++ b/warehouse/static/sass/tools/bourbon/css3/_user-select.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 @mixin user-select($value: none) {
   @include prefixer(user-select, $value, webkit moz ms spec);
 }

--- a/warehouse/static/sass/tools/bourbon/functions/_assign-inputs.scss
+++ b/warehouse/static/sass/tools/bourbon/functions/_assign-inputs.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 @function assign-inputs($inputs, $pseudo: null) {
   $list: ();
 

--- a/warehouse/static/sass/tools/bourbon/functions/_contains-falsy.scss
+++ b/warehouse/static/sass/tools/bourbon/functions/_contains-falsy.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 @charset "UTF-8";
 
 /// Checks if a list does not contains a value.

--- a/warehouse/static/sass/tools/bourbon/functions/_contains.scss
+++ b/warehouse/static/sass/tools/bourbon/functions/_contains.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 @charset "UTF-8";
 
 /// Checks if a list contains a value(s).

--- a/warehouse/static/sass/tools/bourbon/functions/_is-length.scss
+++ b/warehouse/static/sass/tools/bourbon/functions/_is-length.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 @charset "UTF-8";
 
 /// Checks for a valid CSS length.

--- a/warehouse/static/sass/tools/bourbon/functions/_is-light.scss
+++ b/warehouse/static/sass/tools/bourbon/functions/_is-light.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 @charset "UTF-8";
 
 /// Programatically determines whether a color is light or dark.

--- a/warehouse/static/sass/tools/bourbon/functions/_is-number.scss
+++ b/warehouse/static/sass/tools/bourbon/functions/_is-number.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 @charset "UTF-8";
 
 /// Checks for a valid number.

--- a/warehouse/static/sass/tools/bourbon/functions/_is-size.scss
+++ b/warehouse/static/sass/tools/bourbon/functions/_is-size.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 @charset "UTF-8";
 
 /// Checks for a valid CSS size.

--- a/warehouse/static/sass/tools/bourbon/functions/_modular-scale.scss
+++ b/warehouse/static/sass/tools/bourbon/functions/_modular-scale.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 // Scaling Variables
 $golden:           1.618;
 $minor-second:     1.067;

--- a/warehouse/static/sass/tools/bourbon/functions/_px-to-em.scss
+++ b/warehouse/static/sass/tools/bourbon/functions/_px-to-em.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 // Convert pixels to ems
 // eg. for a relational value of 12px write em(12) when the parent is 16px
 // if the parent is another value say 24px write em(12, 24)

--- a/warehouse/static/sass/tools/bourbon/functions/_px-to-rem.scss
+++ b/warehouse/static/sass/tools/bourbon/functions/_px-to-rem.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 // Convert pixels to rems
 // eg. for a relational value of 12px write rem(12)
 // Assumes $em-base is the font-size of <html>

--- a/warehouse/static/sass/tools/bourbon/functions/_shade.scss
+++ b/warehouse/static/sass/tools/bourbon/functions/_shade.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 @charset "UTF-8";
 
 /// Mixes a color with black.

--- a/warehouse/static/sass/tools/bourbon/functions/_strip-units.scss
+++ b/warehouse/static/sass/tools/bourbon/functions/_strip-units.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 @charset "UTF-8";
 
 /// Strips the unit from a number.

--- a/warehouse/static/sass/tools/bourbon/functions/_tint.scss
+++ b/warehouse/static/sass/tools/bourbon/functions/_tint.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 @charset "UTF-8";
 
 /// Mixes a color with white.

--- a/warehouse/static/sass/tools/bourbon/functions/_transition-property-name.scss
+++ b/warehouse/static/sass/tools/bourbon/functions/_transition-property-name.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 // Return vendor-prefixed property names if appropriate
 // Example: transition-property-names((transform, color, background), moz) -> -moz-transform, color, background
 //************************************************************************//

--- a/warehouse/static/sass/tools/bourbon/functions/_unpack.scss
+++ b/warehouse/static/sass/tools/bourbon/functions/_unpack.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 @charset "UTF-8";
 
 /// Converts shorthand to the 4-value syntax.

--- a/warehouse/static/sass/tools/bourbon/helpers/_convert-units.scss
+++ b/warehouse/static/sass/tools/bourbon/helpers/_convert-units.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 //************************************************************************//
 // Helper function for str-to-num fn.
 // Source: http://sassmeister.com/gist/9647408

--- a/warehouse/static/sass/tools/bourbon/helpers/_directional-values.scss
+++ b/warehouse/static/sass/tools/bourbon/helpers/_directional-values.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 @charset "UTF-8";
 
 /// Directional-property mixins are shorthands for writing properties like the following

--- a/warehouse/static/sass/tools/bourbon/helpers/_font-source-declaration.scss
+++ b/warehouse/static/sass/tools/bourbon/helpers/_font-source-declaration.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 // Used for creating the source string for fonts using @font-face
 // Reference: http://goo.gl/Ru1bKP
 

--- a/warehouse/static/sass/tools/bourbon/helpers/_gradient-positions-parser.scss
+++ b/warehouse/static/sass/tools/bourbon/helpers/_gradient-positions-parser.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 @function _gradient-positions-parser($gradient-type, $gradient-positions) {
   @if $gradient-positions
   and ($gradient-type == linear)

--- a/warehouse/static/sass/tools/bourbon/helpers/_linear-angle-parser.scss
+++ b/warehouse/static/sass/tools/bourbon/helpers/_linear-angle-parser.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 // Private function for linear-gradient-parser
 @function _linear-angle-parser($image, $first-val, $prefix, $suffix) {
   $offset: null;

--- a/warehouse/static/sass/tools/bourbon/helpers/_linear-gradient-parser.scss
+++ b/warehouse/static/sass/tools/bourbon/helpers/_linear-gradient-parser.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 @function _linear-gradient-parser($image) {
   $image: unquote($image);
   $gradients: ();

--- a/warehouse/static/sass/tools/bourbon/helpers/_linear-positions-parser.scss
+++ b/warehouse/static/sass/tools/bourbon/helpers/_linear-positions-parser.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 @function _linear-positions-parser($pos) {
   $type: type-of(nth($pos, 1));
   $spec: null;

--- a/warehouse/static/sass/tools/bourbon/helpers/_linear-side-corner-parser.scss
+++ b/warehouse/static/sass/tools/bourbon/helpers/_linear-side-corner-parser.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 // Private function for linear-gradient-parser
 @function _linear-side-corner-parser($image, $first-val, $prefix, $suffix, $has-multiple-vals) {
   $val-1: str-slice($first-val, 1, $has-multiple-vals - 1);

--- a/warehouse/static/sass/tools/bourbon/helpers/_radial-arg-parser.scss
+++ b/warehouse/static/sass/tools/bourbon/helpers/_radial-arg-parser.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 @function _radial-arg-parser($g1, $g2, $pos, $shape-size) {
   @each $value in $g1, $g2 {
     $first-val: nth($value, 1);

--- a/warehouse/static/sass/tools/bourbon/helpers/_radial-gradient-parser.scss
+++ b/warehouse/static/sass/tools/bourbon/helpers/_radial-gradient-parser.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 @function _radial-gradient-parser($image) {
   $image: unquote($image);
   $gradients: ();

--- a/warehouse/static/sass/tools/bourbon/helpers/_radial-positions-parser.scss
+++ b/warehouse/static/sass/tools/bourbon/helpers/_radial-positions-parser.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 @function _radial-positions-parser($gradient-pos) {
   $shape-size: nth($gradient-pos, 1);
   $pos:        nth($gradient-pos, 2);

--- a/warehouse/static/sass/tools/bourbon/helpers/_render-gradients.scss
+++ b/warehouse/static/sass/tools/bourbon/helpers/_render-gradients.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 // User for linear and radial gradients within background-image or border-image properties
 
 @function _render-gradients($gradient-positions, $gradients, $gradient-type, $vendor: false) {

--- a/warehouse/static/sass/tools/bourbon/helpers/_shape-size-stripper.scss
+++ b/warehouse/static/sass/tools/bourbon/helpers/_shape-size-stripper.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 @function _shape-size-stripper($shape-size) {
   $shape-size-spec: null;
   @each $value in $shape-size {

--- a/warehouse/static/sass/tools/bourbon/helpers/_str-to-num.scss
+++ b/warehouse/static/sass/tools/bourbon/helpers/_str-to-num.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 //************************************************************************//
 // Helper function for linear/radial-gradient-parsers.
 // Source: http://sassmeister.com/gist/9647408

--- a/warehouse/static/sass/tools/bourbon/settings/_asset-pipeline.scss
+++ b/warehouse/static/sass/tools/bourbon/settings/_asset-pipeline.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 @charset "UTF-8";
 
 /// A global setting to enable or disable the `$asset-pipeline` variable for all functions that accept it.

--- a/warehouse/static/sass/tools/bourbon/settings/_prefixer.scss
+++ b/warehouse/static/sass/tools/bourbon/settings/_prefixer.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 @charset "UTF-8";
 
 /// Global variables to enable or disable vendor prefixes

--- a/warehouse/static/sass/tools/bourbon/settings/_px-to-em.scss
+++ b/warehouse/static/sass/tools/bourbon/settings/_px-to-em.scss
@@ -1,1 +1,16 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 $em-base: 16px !default;

--- a/warehouse/static/sass/tools/neat/_neat-helpers.scss
+++ b/warehouse/static/sass/tools/neat/_neat-helpers.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 // Functions
 @import "functions/private";
 @import "functions/new-breakpoint";

--- a/warehouse/static/sass/tools/neat/functions/_new-breakpoint.scss
+++ b/warehouse/static/sass/tools/neat/functions/_new-breakpoint.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 @charset "UTF-8";
 
 /// Returns a media context (media query / grid context) that can be stored in a variable and passed to `media()` as a single-keyword argument. Media contexts defined using `new-breakpoint` are used by the visual grid, as long as they are defined before importing Neat.

--- a/warehouse/static/sass/tools/neat/functions/_private.scss
+++ b/warehouse/static/sass/tools/neat/functions/_private.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 // Not function for Libsass compatibility
 // https://github.com/sass/libsass/issues/368
 @function is-not($value) {

--- a/warehouse/static/sass/tools/neat/grid/_box-sizing.scss
+++ b/warehouse/static/sass/tools/neat/grid/_box-sizing.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 @charset "UTF-8";
 
 @if $border-box-sizing == true {

--- a/warehouse/static/sass/tools/neat/grid/_direction-context.scss
+++ b/warehouse/static/sass/tools/neat/grid/_direction-context.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 @charset "UTF-8";
 
 /// Changes the direction property used by other mixins called in the code block argument.

--- a/warehouse/static/sass/tools/neat/grid/_display-context.scss
+++ b/warehouse/static/sass/tools/neat/grid/_display-context.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 @charset "UTF-8";
 
 /// Changes the display property used by other mixins called in the code block argument.

--- a/warehouse/static/sass/tools/neat/grid/_fill-parent.scss
+++ b/warehouse/static/sass/tools/neat/grid/_fill-parent.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 @charset "UTF-8";
 
 /// Forces the element to fill its parent container.

--- a/warehouse/static/sass/tools/neat/grid/_media.scss
+++ b/warehouse/static/sass/tools/neat/grid/_media.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 @charset "UTF-8";
 
 /// Outputs a media-query block with an optional grid context (the total number of columns used in the grid).

--- a/warehouse/static/sass/tools/neat/grid/_omega.scss
+++ b/warehouse/static/sass/tools/neat/grid/_omega.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 @charset "UTF-8";
 
 /// Removes the element's gutter margin, regardless of its position in the grid hierarchy or display property. It can target a specific element, or every `nth-child` occurrence. Works only with `block` layouts.

--- a/warehouse/static/sass/tools/neat/grid/_outer-container.scss
+++ b/warehouse/static/sass/tools/neat/grid/_outer-container.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 @charset "UTF-8";
 
 /// Makes an element a outer container by centring it in the viewport, clearing its floats, and setting its `max-width`.

--- a/warehouse/static/sass/tools/neat/grid/_pad.scss
+++ b/warehouse/static/sass/tools/neat/grid/_pad.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 @charset "UTF-8";
 
 /// Adds padding to the element.

--- a/warehouse/static/sass/tools/neat/grid/_private.scss
+++ b/warehouse/static/sass/tools/neat/grid/_private.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 $parent-columns: $grid-columns !default;
 $fg-column: $column;
 $fg-gutter: $gutter;

--- a/warehouse/static/sass/tools/neat/grid/_row.scss
+++ b/warehouse/static/sass/tools/neat/grid/_row.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 @charset "UTF-8";
 
 /// Designates the element as a row of columns in the grid layout. It clears the floats on the element and sets its display property. Rows can't be nested, but there can be more than one row element—with different display properties—per layout.

--- a/warehouse/static/sass/tools/neat/grid/_shift.scss
+++ b/warehouse/static/sass/tools/neat/grid/_shift.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 @charset "UTF-8";
 
 /// Translates an element horizontally by a number of columns. Positive arguments shift the element to the active layout direction, while negative ones shift it to the opposite direction.

--- a/warehouse/static/sass/tools/neat/grid/_span-columns.scss
+++ b/warehouse/static/sass/tools/neat/grid/_span-columns.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 @charset "UTF-8";
 
 /// Specifies the number of columns an element should span. If the selector is nested the number of columns of its parent element should be passed as an argument as well.

--- a/warehouse/static/sass/tools/neat/grid/_to-deprecate.scss
+++ b/warehouse/static/sass/tools/neat/grid/_to-deprecate.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 @charset "UTF-8";
 
 @mixin breakpoint($query:$feature $value $columns, $total-columns: $grid-columns) {

--- a/warehouse/static/sass/tools/neat/grid/_visual-grid.scss
+++ b/warehouse/static/sass/tools/neat/grid/_visual-grid.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 @charset "UTF-8";
 
 @mixin grid-column-gradient($values...) {

--- a/warehouse/static/sass/tools/neat/settings/_disable-warnings.scss
+++ b/warehouse/static/sass/tools/neat/settings/_disable-warnings.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 @charset "UTF-8";
 
 /// Disable all deprecation warnings. Defaults to `false`. Set with a `!global` flag.

--- a/warehouse/static/sass/tools/neat/settings/_grid.scss
+++ b/warehouse/static/sass/tools/neat/settings/_grid.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 @charset "UTF-8";
 
 /// Sets the relative width of a single grid column. The unit used should be the same one used to define `$gutter`. To learn more about modular-scale() see [Bourbon docs](http://bourbon.io/docs/#modular-scale). Set with a `!global` flag.

--- a/warehouse/static/sass/tools/neat/settings/_visual-grid.scss
+++ b/warehouse/static/sass/tools/neat/settings/_visual-grid.scss
@@ -1,3 +1,18 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 @charset "UTF-8";
 
 /// Displays the visual grid when set to true. The overlaid grid may be few pixels off depending on the browser's rendering engine and pixel rounding algorithm. Set with the `!global` flag.


### PR DESCRIPTION
This PR provides following changes to `bin/licenses` script:
  * checks first 5 lines for license (handles `./warehouse/static/sass/tools/neat/_neat.scss` case)
  * greps for `#` (*.py files), `*` (*.scss and *.js files) or `//` (also *.scss ?)
  * checks `*.scss` and `*.js` files