### PR TITLE
Several style guideline related issues #3167

### DIFF
--- a/docs/ui-principles.rst
+++ b/docs/ui-principles.rst
@@ -61,7 +61,7 @@ help content).
 -------------------------------------------------------
 
 Warehouse follows the `Material design writing style guide
-<https://material.io/design/usability/accessibility.html#writing>`_.
+<https://web.archive.org/web/20180410101124/https://material.io/guidelines/style/writing.html#>`_.
 
 When writing interfaces use direct, clear and simple language. This is
 especially important as Warehouse caters to an international audience with

--- a/docs/ui-principles.rst
+++ b/docs/ui-principles.rst
@@ -61,7 +61,7 @@ help content).
 -------------------------------------------------------
 
 Warehouse follows the `Material design writing style guide
-<https://web.archive.org/web/20180410101124/https://material.io/guidelines/style/writing.html#>`_.
+<https://web.archive.org/web/20180410101124/https://material.io/guidelines/style/writing.html>`_.
 
 When writing interfaces use direct, clear and simple language. This is
 especially important as Warehouse caters to an international audience with

--- a/warehouse/templates/base.html
+++ b/warehouse/templates/base.html
@@ -250,7 +250,7 @@
             <h2>Using PyPI</h2>
           </li>
           <li><a href="https://www.pypa.io/en/latest/code-of-conduct/">Code of conduct</a></li>
-          <li><a href="{{ request.route_path('security') }}">Security policy</a></li>
+          <li><a href="{{ request.route_path('security') }}">Report security issue</a></li>
           <li><a href="https://www.python.org/privacy/">Privacy policy</a></li>
           <li><a href="{{ request.route_path('policy.terms-of-use') }}">Terms of use</a></li>
         </ul>

--- a/warehouse/templates/base.html
+++ b/warehouse/templates/base.html
@@ -241,7 +241,7 @@
           <li>
             <h2>Contributing to PyPI</h2>
           </li>
-          <li><a href="{{ request.route_path('help')}}#feedback">Bugs &amp; feedback</a></li>
+          <li><a href="{{ request.route_path('help')}}#feedback">Bugs and feedback</a></li>
           <li><a href="https://github.com/pypa/warehouse">Contribute on GitHub</a></li>
           <li><a href="https://github.com/pypa/warehouse/graphs/contributors">Development credits</a></li>
         </ul>

--- a/warehouse/templates/search/results.html
+++ b/warehouse/templates/search/results.html
@@ -117,7 +117,7 @@
         {% set applied_filters_str = applied_filters|join(' ') %}
         {% for top_level, classifiers in available_filters %}
           <div class="accordion{{ ' accordion--closed' if top_level not in applied_filters_str else '' }}">
-            <button type="button" class="accordion__link -js-accordion-trigger">By {{ top_level }}</button>
+            <button type="button" class="accordion__link -js-accordion-trigger">{{ top_level }}</button>
             <div class="accordion__content">
               <div class="checkbox-tree">
               {% for classifier in classifiers %}


### PR DESCRIPTION
https://github.com/pypa/warehouse/issues/3167

Rename "Security policy" to "Report security issue"
Remove all ampersands in the codebase
Change filter list titles to 'By licence', 'By environment', etc.
Change the link in the documentation to https://web.archive.org/web/20180410101124/https://material.io/guidelines/style/writing.html