### PR TITLE
Make the xz decompress to stdout and psql to eat the SQL from stdin, so that no unnecessary temporary disk space is required.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,9 +149,7 @@ endif
 initdb:
 	docker-compose run --rm web psql -h db -d postgres -U postgres -c "DROP DATABASE IF EXISTS warehouse"
 	docker-compose run --rm web psql -h db -d postgres -U postgres -c "CREATE DATABASE warehouse ENCODING 'UTF8'"
-	xz -d -f -k dev/$(DB).sql.xz
-	docker-compose run --rm web psql -h db -d warehouse -U postgres -v ON_ERROR_STOP=1 -1 -f dev/$(DB).sql
-	rm dev/$(DB).sql
+	xz -d -f -k dev/$(DB).sql.xz --stdout | docker-compose run --rm web psql -h db -d warehouse -U postgres -v ON_ERROR_STOP=1 -1 -f -
 	docker-compose run --rm web python -m warehouse db upgrade head
 	$(MAKE) reindex
 


### PR DESCRIPTION
I ran out of disk space in the middle of `make initdb` in my home directory. `psql` should be able to eat the source straight from standard input and this works for *me* with my docker-compose and Linux; I am not so sure about other platforms.

This change avoids writing to a temporary file; it would also make sure that no uncompressed file would be left to linger on disk, should `psql` fail for some reason.