### PR TITLE
Add sprint documentation

### DIFF
--- a/docs/roadmap.rst
+++ b/docs/roadmap.rst
@@ -1,42 +1,63 @@
 .. _roadmap:
 
-Warehouse feature roadmap
-=========================
+Roadmap and Sprints
+===================
+
+Roadmap
+-------
 
 As we develop Warehouse, here are our plans along the way. To talk
 about them with us, please `contact us`_.
 
-PyCon 2018 sprints
-------------------
-
-At the `sprints`_ in mid-May, we will focus on interoperability with
-other tools and on the API redesign.
-
-See `sprint-tagged issues`_ on GitHub.
-
 Post legacy shutdown
---------------------
+~~~~~~~~~~~~~~~~~~~~
 Issues that are unblocked now that legacy is dead (RIP).
 
 See `issues marked with the post-legacy shutdown milestone`_ on GitHub.
 
 Cool but not urgent
--------------------
+~~~~~~~~~~~~~~~~~~~
 
 Wishlist.
 
 See `issues marked with the cool-but-not-urgent milestone`_ on GitHub.
 
 History
--------
+~~~~~~~
 
 You can see `our past roadmap`_, focusing on replacing legacy PyPI, on
 the PSF wiki.
 
+Sprints
+-------
 
-.. _`sprints`: https://wiki.python.org/psf/PackagingSprints
-.. _`sprint-tagged issues`: https://github.com/pypa/warehouse/issues?q=is%3Aopen+is%3Aissue+label%3APyCon-2018-sprint
+Please check the Python Wiki for a list of upcoming `sprints`_.
+
+Sprint planners should consider the following checklist for organising events:
+
+- Prior to the sprint, tag issues that you identify as appropriate for the
+  attendees. Ensure you have a mix of short acheivable tickets, and more
+  complex issues. Do not tag issues that are still under discussion or require
+  specification, unless core team members will be in attendance
+- Prior to the sprint, organise with the Working Group to print stickers and/or
+  other swag to give to participants
+- If not provided by the venue, bring along snacks. Everybody loves snacks.
+- If not provided by the venue, bring nametags. If possible, organise the
+  facilitators to wear the same colored shirt, lanyard or hat, to be easily
+  identified by the group.
+- If possible, ask participants to install the codebase *prior* to the event.
+  This will save on delays caused by many people downloading docker images at
+  once.
+- Use a whiteboard or large sheets of paper to direct participants towards the
+  codebase, issue tracker and installation documentation. Keep track of merged
+  PRs in the same location.
+- Ask participants to comment on the issues they want to work on. This avoids a
+  situation where two people are unknowingly working towards the same goal.
+- Where possible, pair people to work on issues together. This is particularly
+  useful for large issues, or for newer developers.
+
 .. _`issues marked with the post-legacy shutdown milestone`: https://github.com/pypa/warehouse/milestone/12
 .. _`issues marked with the cool-but-not-urgent milestone`: https://github.com/pypa/warehouse/milestone/11
 .. _`contact us`: https://github.com/pypa/warehouse/blob/master/README.rst#discussion
 .. _`our past roadmap`: https://wiki.python.org/psf/WarehouseRoadmap
+.. _`sprints`: https://wiki.python.org/psf/PackagingSprints


### PR DESCRIPTION
Add docs for sprints.  Not sure if this is the best location?

Also, I couldn't get this to build, as when I ran `make docs` I kept getting:

```
make -C docs/ doctest SPHINXOPTS="-W" SPHINXBUILD="/home/nlh/Code/personal_projects/warehouse/.state/env/bin/sphinx-build"
make[1]: Entering directory '/home/nlh/Code/personal_projects/warehouse/docs'
Makefile:12: *** The 'pathtoproject/.state/env/bin/sphinx-build' command was not found. Make sure you have Sphinx installed, then set the SPHINXBUILD environment variable to point to the full path of the '/pathtoproject/.state/env/bin/sphinx-build' executable. Alternatively you can add the directory with the executable to your PATH. If you don't have Sphinx installed, grab it from http://sphinx-doc.org/. Stop.
make[1]: Leaving directory 'pathtoproject/docs'
Makefile:125: recipe for target 'docs' failed
make: *** [docs] Error 2
```