### PR TITLE
Prevent compromised/breached passwords

### DIFF
--- a/tests/unit/accounts/test_core.py
+++ b/tests/unit/accounts/test_core.py
@@ -17,8 +17,16 @@ import pretend
 import pytest
 
 from warehouse import accounts
-from warehouse.accounts.interfaces import IUserService, ITokenService
-from warehouse.accounts.services import TokenServiceFactory, database_login_factory
+from warehouse.accounts.interfaces import (
+    IUserService,
+    ITokenService,
+    IPasswordBreachedService,
+)
+from warehouse.accounts.services import (
+    TokenServiceFactory,
+    database_login_factory,
+    hibp_password_breach_factory,
+)
 from warehouse.rate_limiting import RateLimit, IRateLimiter
 
 
@@ -151,6 +159,7 @@ def test_includeme(monkeypatch):
             TokenServiceFactory(name="password"), ITokenService, name="password"
         ),
         pretend.call(TokenServiceFactory(name="email"), ITokenService, name="email"),
+        pretend.call(hibp_password_breach_factory, IPasswordBreachedService),
         pretend.call(RateLimit("10 per 5 minutes"), IRateLimiter, name="user.login"),
         pretend.call(
             RateLimit("1000 per 5 minutes"), IRateLimiter, name="global.login"

--- a/tests/unit/manage/test_forms.py
+++ b/tests/unit/manage/test_forms.py
@@ -77,6 +77,11 @@ class TestAddEmailForm:
 class TestChangePasswordForm:
     def test_creation(self):
         user_service = pretend.stub()
-        form = forms.ChangePasswordForm(user_service=user_service)
+        breach_service = pretend.stub()
+
+        form = forms.ChangePasswordForm(
+            user_service=user_service, breach_service=breach_service
+        )
 
         assert form.user_service is user_service
+        assert form._breach_service is breach_service

--- a/warehouse/accounts/__init__.py
+++ b/warehouse/accounts/__init__.py
@@ -15,8 +15,16 @@ import datetime
 from pyramid.authorization import ACLAuthorizationPolicy
 from pyramid_multiauth import MultiAuthenticationPolicy
 
-from warehouse.accounts.interfaces import IUserService, ITokenService
-from warehouse.accounts.services import database_login_factory, TokenServiceFactory
+from warehouse.accounts.interfaces import (
+    IUserService,
+    ITokenService,
+    IPasswordBreachedService,
+)
+from warehouse.accounts.services import (
+    TokenServiceFactory,
+    database_login_factory,
+    hibp_password_breach_factory,
+)
 from warehouse.accounts.auth_policy import (
     BasicAuthAuthenticationPolicy,
     SessionAuthenticationPolicy,
@@ -71,6 +79,11 @@ def includeme(config):
     )
     config.register_service_factory(
         TokenServiceFactory(name="email"), ITokenService, name="email"
+    )
+
+    # Register our password breach detection service.
+    config.register_service_factory(
+        hibp_password_breach_factory, IPasswordBreachedService
     )
 
     # Register our authentication and authorization policies

--- a/warehouse/accounts/forms.py
+++ b/warehouse/accounts/forms.py
@@ -106,6 +106,17 @@ class NewPasswordMixin:
     username = wtforms.StringField(validators=[wtforms.validators.DataRequired()])
     email = wtforms.StringField(validators=[wtforms.validators.DataRequired()])
 
+    def __init__(self, *args, breach_service, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._breach_service = breach_service
+
+    def validate_new_password(self, field):
+        if self._breach_service.check_password(field.data):
+            raise wtforms.validators.ValidationError(
+                "This password has appeared in a breach or has otherwise been "
+                "compromised."
+            )
+
 
 class NewEmailMixin:
 

--- a/warehouse/accounts/interfaces.py
+++ b/warehouse/accounts/interfaces.py
@@ -94,3 +94,11 @@ class ITokenService(Interface):
         """
         Gets the data corresponding to the token provided
         """
+
+
+class IPasswordBreachedService(Interface):
+    def check_password(password):
+        """
+        Returns a boolean indicating if the given password has been involved in a breach or is
+        otherwise insecure.
+        """

--- a/warehouse/accounts/services.py
+++ b/warehouse/accounts/services.py
@@ -12,8 +12,11 @@
 
 import collections
 import functools
+import hashlib
 import hmac
 import logging
+import posixpath
+import urllib.parse
 import uuid
 
 from passlib.context import CryptContext
@@ -23,6 +26,7 @@ from zope.interface import implementer
 from warehouse.accounts.interfaces import (
     IUserService,
     ITokenService,
+    IPasswordBreachedService,
     TokenExpired,
     TokenInvalid,
     TokenMissing,
@@ -238,3 +242,54 @@ class TokenServiceFactory:
             return NotImplemented
 
         return (self.name, self.service_class) == (other.name, other.service_class)
+
+
+@implementer(IPasswordBreachedService)
+class HaveIBeenPwnedPasswordBreachedService:
+    def __init__(self, *, session, api_base="https://api.pwnedpasswords.com"):
+        self._http = session
+        self._api_base = api_base
+
+    def _get_url(self, prefix):
+        return urllib.parse.urljoin(self._api_base, posixpath.join("/range/", prefix))
+
+    def check_password(self, password):
+        # The HIBP API impements a k-Anonymity scheme, by which you can take a given
+        # password, hash it using sha1, and then send only the first 5 characters of the
+        # hex encoded digest. This avoids leaking data to the HIBP API, because without
+        # the rest of the hash, the HIBP service cannot even begin to brute force or do
+        # a reverse lookup to determine what password has just been sent to it. For More
+        # information see:
+        #       https://www.troyhunt.com/ive-just-launched-pwned-passwords-version-2/
+
+        # To work with the HIBP API, we need the sha1 of the UTF8 encoded passsword.
+        hashed_password = hashlib.sha1(password.encode("utf8")).hexdigest().lower()
+
+        # Fetch the passwords from the HIBP data set.
+        resp = self._http.get(self._get_url(hashed_password[:5]))
+        resp.raise_for_status()
+
+        # The dataset that comes back from HIBP looks like:
+        #
+        #   0018A45C4D1DEF81644B54AB7F969B88D65:1
+        #   00D4F6E8FA6EECAD2A3AA415EEC418D38EC:2
+        #   011053FD0102E94D6AE2F8B83D76FAF94F6:1
+        #   012A7CA357541F0AC487871FEEC1891C49C:2
+        #   0136E006E24E7D152139815FB0FC6A50B15:2
+        #   ...
+        #
+        # THat is, it is a line delimited textual data, where each line is a hash, a
+        # colon, and then the number of times that password has appeared in a breach.
+        # For our uses, we're going to consider any password that has ever appeared in
+        # a breach to be insecure, even if only once.
+        for line in resp.text.splitlines():
+            possible, _ = line.split(":")
+            if hashed_password[5:] == possible.lower():
+                return True
+
+        # If we made it to this point, then the password is safe.
+        return False
+
+
+def hibp_password_breach_factory(context, request):
+    return HaveIBeenPwnedPasswordBreachedService(session=request.http)

--- a/warehouse/accounts/views.py
+++ b/warehouse/accounts/views.py
@@ -33,6 +33,7 @@ from warehouse.accounts.forms import (
 from warehouse.accounts.interfaces import (
     IUserService,
     ITokenService,
+    IPasswordBreachedService,
     TokenExpired,
     TokenInvalid,
     TokenMissing,
@@ -239,8 +240,11 @@ def register(request, _form_class=RegistrationForm):
         return HTTPSeeOther(request.route_path("index"))
 
     user_service = request.find_service(IUserService, context=None)
+    breach_service = request.find_service(IPasswordBreachedService, context=None)
 
-    form = _form_class(data=request.POST, user_service=user_service)
+    form = _form_class(
+        data=request.POST, user_service=user_service, breach_service=breach_service
+    )
 
     if request.method == "POST" and form.validate():
         user = user_service.create_user(
@@ -296,6 +300,7 @@ def reset_password(request, _form_class=ResetPasswordForm):
         return HTTPSeeOther(request.route_path("index"))
 
     user_service = request.find_service(IUserService, context=None)
+    breach_service = request.find_service(IPasswordBreachedService, context=None)
     token_service = request.find_service(ITokenService, name="password")
 
     def _error(message):
@@ -343,6 +348,7 @@ def reset_password(request, _form_class=ResetPasswordForm):
         full_name=user.name,
         email=user.email,
         user_service=user_service,
+        breach_service=breach_service,
     )
 
     if request.method == "POST" and form.validate():

--- a/warehouse/manage/views.py
+++ b/warehouse/manage/views.py
@@ -17,7 +17,7 @@ from pyramid.view import view_config, view_defaults
 from sqlalchemy import func
 from sqlalchemy.orm.exc import NoResultFound
 
-from warehouse.accounts.interfaces import IUserService
+from warehouse.accounts.interfaces import IUserService, IPasswordBreachedService
 from warehouse.accounts.models import User, Email
 from warehouse.accounts.views import logout
 from warehouse.email import (
@@ -51,6 +51,9 @@ class ManageAccountViews:
     def __init__(self, request):
         self.request = request
         self.user_service = request.find_service(IUserService, context=None)
+        self.breach_service = request.find_service(
+            IPasswordBreachedService, context=None
+        )
 
     @property
     def active_projects(self):
@@ -83,7 +86,9 @@ class ManageAccountViews:
         return {
             "save_account_form": SaveAccountForm(name=self.request.user.name),
             "add_email_form": AddEmailForm(user_service=self.user_service),
-            "change_password_form": ChangePasswordForm(user_service=self.user_service),
+            "change_password_form": ChangePasswordForm(
+                user_service=self.user_service, breach_service=self.breach_service
+            ),
             "active_projects": self.active_projects,
         }
 
@@ -211,6 +216,7 @@ class ManageAccountViews:
             full_name=self.request.user.name,
             email=self.request.user.email,
             user_service=self.user_service,
+            breach_service=self.breach_service,
         )
 
         if form.validate():


### PR DESCRIPTION
This uses the HaveIBeenPwned password API to determine if a given password has ever appeared in a breached list of passwords or not. If a password appears in the list of breached/compromised passwords, it will reject the password during registration, password reset, and changing passwords.

This does *NOT* send the password to HIBP, instead of does a sha1 hash of the password, and sends the first 5 characters of the hex digest to HIBP and HIBP will return a list of all of the sha1 hashes that begin with that prefix. This is not enough for HIBP to determine the password, or whether the user's password existed in the returned set. For more information see https://www.troyhunt.com/ive-just-launched-pwned-passwords-version-2/.