### PR TITLE
Add a /stats endpoint

### DIFF
--- a/tests/unit/test_routes.py
+++ b/tests/unit/test_routes.py
@@ -111,6 +111,7 @@ def test_routes(warehouse):
         ),
         pretend.call("classifiers", "/classifiers/", domain=warehouse),
         pretend.call("search", "/search/", domain=warehouse),
+        pretend.call("stats", "/stats/", domain=warehouse),
         pretend.call(
             "accounts.profile",
             "/user/{username}/",

--- a/tests/unit/test_views.py
+++ b/tests/unit/test_views.py
@@ -548,7 +548,7 @@ def test_stats(db_request):
 
     assert stats(db_request) == {
         "total_packages_size": 69,
-        "top_packages": [(project.name, 69)]
+        "top_packages": [(project.name, 69)],
     }
 
 

--- a/tests/unit/test_views.py
+++ b/tests/unit/test_views.py
@@ -29,6 +29,7 @@ from warehouse.views import (
     robotstxt,
     opensearchxml,
     search,
+    stats,
     force_status,
     flash_messages,
     forbidden_include,
@@ -530,6 +531,24 @@ def test_classifiers(db_request):
 
     assert classifiers(db_request) == {
         "classifiers": [(classifier_a.classifier,), (classifier_b.classifier,)]
+    }
+
+
+def test_stats(db_request):
+
+    project = ProjectFactory.create()
+    release1 = ReleaseFactory.create(project=project)
+    release1.created = datetime.date(2011, 1, 1)
+    FileFactory.create(
+        release=release1,
+        filename="{}-{}.tar.gz".format(project.name, release1.version),
+        python_version="source",
+        size=69,
+    )
+
+    assert stats(db_request) == {
+        "total_packages_size": 69,
+        "top_packages": [(project.name, 69)]
     }
 
 

--- a/warehouse/routes.py
+++ b/warehouse/routes.py
@@ -83,6 +83,9 @@ def includeme(config):
     # Search Routes
     config.add_route("search", "/search/", domain=warehouse)
 
+    # Stats Routes
+    config.add_route("stats", "/stats/", domain=warehouse)
+
     # Accounts
     config.add_route(
         "accounts.profile",

--- a/warehouse/templates/pages/stats.html
+++ b/warehouse/templates/pages/stats.html
@@ -1,0 +1,49 @@
+{#
+ # Licensed under the Apache License, Version 2.0 (the "License");
+ # you may not use this file except in compliance with the License.
+ # You may obtain a copy of the License at
+ #
+ # http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+-#}
+{% extends "base.html" %}
+
+{% block title %}Stats{% endblock %}
+
+{% block content %}
+<section class="horizontal-section">
+  <div class="narrow-container">
+    <h1 class="page-title">PyPI Stats</h1>
+      <p>We all love stats, so here are some useful ones about PyPI.</p>
+
+      <h2>Top Storage Users</h2>
+      <p>Here is a list of the top 100 pacakges based on sum of their
+      packages sizes (in bytes).</p>
+
+      <table id="all_pypi">
+        <tr>
+          <td>All of PyPI: </td>
+          <td>{{ total_packages_size }}</td>
+        </tr>
+      </table>
+      <br />
+      <table id="top_packages">
+        <tr>
+          <th>Package Name</th>
+          <th>Sum of Release Files (bytes)</th>
+        <tr>
+        {% for package in top_packages %}
+          <tr>
+            <td>{{ package[0] }}</td>
+            <td>{{ package[1] }}</td>
+          <tr>
+        {% endfor %}
+      </table>
+  </div>
+</section>
+{% endblock %}

--- a/warehouse/templates/pages/stats.html
+++ b/warehouse/templates/pages/stats.html
@@ -31,7 +31,7 @@
           <td>{{ total_packages_size }}</td>
         </tr>
       </table>
-      <br />
+      <br>
       <table id="top_packages">
         <tr>
           <th>Package Name</th>

--- a/warehouse/views.py
+++ b/warehouse/views.py
@@ -317,6 +317,23 @@ def search(request):
     }
 
 
+@view_config(route_name="stats", renderer="pages/stats.html")
+def stats(request):
+    total_size_query = request.db.query(func.sum(File.size)).all()
+    top_100_packages = (
+        request.db.query(File.name, func.sum(File.size))
+        .group_by(File.name)
+        .order_by(func.sum(File.size).desc())
+        .limit(100)
+        .all()
+    )
+
+    return {
+        "total_packages_size": total_size_query[0][0],
+        "top_packages": top_100_packages,
+    }
+
+
 @view_config(
     route_name="includes.current-user-indicator",
     renderer="includes/current-user-indicator.html",


### PR DESCRIPTION
- Add /stats route + view
- Start with top 100 largest packages, multiple people and especailly bandersnatch users would love a way to know the X top packages that they could then blacklist
- Have kept the HTML very basic and tried to make it parsable friendly

Test:
- Ran warehouse locally and went to http://localhost/stats
- Ensured new unit test passes
- Ensure we kept 100% unit test coverage

Addresses #4288 