### PR TITLE
Add 1 day caching decorators to /stats endpoint

### DIFF
--- a/warehouse/templates/pages/stats.html
+++ b/warehouse/templates/pages/stats.html
@@ -19,7 +19,11 @@
 <section class="horizontal-section">
   <div class="narrow-container">
     <h1 class="page-title">PyPI Stats</h1>
-      <p>We all love stats, so here are some useful ones about PyPI.</p>
+      <p>
+        We all love stats, so here are some useful statistics about PyPI.
+        The statistics page is cached for 24 hours, so don't expect the
+        numbers to be realtime.
+      </p>
 
       <h2>Top Storage Users</h2>
       <p>Here is a list of the top 100 pacakges based on sum of their

--- a/warehouse/views.py
+++ b/warehouse/views.py
@@ -317,7 +317,14 @@ def search(request):
     }
 
 
-@view_config(route_name="stats", renderer="pages/stats.html")
+@view_config(
+    route_name="stats",
+    renderer="pages/stats.html",
+    decorator=[
+        cache_control(1 * 24 * 60 * 60),  # 1 day
+        origin_cache(1 * 24 * 60 * 60),  # 1 day
+    ],
+)
 def stats(request):
     total_size_query = request.db.query(func.sum(File.size)).all()
     top_100_packages = (


### PR DESCRIPTION
Lets ensure the CDN and users cache this page for a day. It's not designed to be realtime as the DB queries are quite costly.