### PR TITLE
Additional email boilerplate reductions

### DIFF
--- a/tests/unit/accounts/test_views.py
+++ b/tests/unit/accounts/test_views.py
@@ -394,7 +394,7 @@ class TestRegister:
             pretend.call("username_value", "full_name", "MyStr0ng!shP455w0rd")
         ]
         assert add_email.calls == [pretend.call(user.id, "foo@bar.com", primary=True)]
-        assert send_email.calls == [pretend.call(db_request, user, email)]
+        assert send_email.calls == [pretend.call(db_request, (user, email))]
 
     def test_register_fails_with_admin_flag_set(self, db_request):
         # This flag was already set via migration, just need to enable it

--- a/tests/unit/email/test_init.py
+++ b/tests/unit/email/test_init.py
@@ -581,10 +581,7 @@ class TestPrimaryEmailChangeEmail:
 
         result = email.send_primary_email_change_email(
             pyramid_request,
-            (
-                stub_user,
-                pretend.stub(email="old_email@example.com", verified=True),
-            ),
+            (stub_user, pretend.stub(email="old_email@example.com", verified=True)),
         )
 
         assert result == {
@@ -637,10 +634,7 @@ class TestPrimaryEmailChangeEmail:
 
         result = email.send_primary_email_change_email(
             pyramid_request,
-            (
-                stub_user,
-                pretend.stub(email="old_email@example.com", verified=False),
-            ),
+            (stub_user, pretend.stub(email="old_email@example.com", verified=False)),
         )
 
         assert result == {

--- a/tests/unit/email/test_init.py
+++ b/tests/unit/email/test_init.py
@@ -274,7 +274,7 @@ class TestSendPasswordResetEmail:
         pyramid_request.task = pretend.call_recorder(lambda *args, **kwargs: send_email)
         monkeypatch.setattr(email, "send_email", send_email)
 
-        result = email.send_password_reset_email(pyramid_request, user=stub_user)
+        result = email.send_password_reset_email(pyramid_request, stub_user)
 
         assert result == {
             "token": "TOKEN",
@@ -345,8 +345,10 @@ class TestEmailVerificationEmail:
 
         result = email.send_email_verification_email(
             pyramid_request,
-            pretend.stub(username=None, name=None, email="foo@example.com"),
-            email=stub_email,
+            (
+                pretend.stub(username=None, name=None, email="foo@example.com"),
+                stub_email,
+            ),
         )
 
         assert result == {
@@ -405,7 +407,7 @@ class TestPasswordChangeEmail:
         pyramid_request.task = pretend.call_recorder(lambda *args, **kwargs: send_email)
         monkeypatch.setattr(email, "send_email", send_email)
 
-        result = email.send_password_change_email(pyramid_request, user=stub_user)
+        result = email.send_password_change_email(pyramid_request, stub_user)
 
         assert result == {"username": stub_user.username}
         subject_renderer.assert_()
@@ -453,7 +455,7 @@ class TestPasswordChangeEmail:
         pyramid_request.task = pretend.call_recorder(lambda *args, **kwargs: send_email)
         monkeypatch.setattr(email, "send_email", send_email)
 
-        result = email.send_password_change_email(pyramid_request, user=stub_user)
+        result = email.send_password_change_email(pyramid_request, stub_user)
 
         assert result == {"username": stub_user.username}
         subject_renderer.assert_()
@@ -491,7 +493,7 @@ class TestAccountDeletionEmail:
         pyramid_request.task = pretend.call_recorder(lambda *args, **kwargs: send_email)
         monkeypatch.setattr(email, "send_email", send_email)
 
-        result = email.send_account_deletion_email(pyramid_request, user=stub_user)
+        result = email.send_account_deletion_email(pyramid_request, stub_user)
 
         assert result == {"username": stub_user.username}
         subject_renderer.assert_()
@@ -540,7 +542,7 @@ class TestAccountDeletionEmail:
         pyramid_request.task = pretend.call_recorder(lambda *args, **kwargs: send_email)
         monkeypatch.setattr(email, "send_email", send_email)
 
-        result = email.send_account_deletion_email(pyramid_request, user=stub_user)
+        result = email.send_account_deletion_email(pyramid_request, stub_user)
 
         assert result == {"username": stub_user.username}
         subject_renderer.assert_()
@@ -579,8 +581,10 @@ class TestPrimaryEmailChangeEmail:
 
         result = email.send_primary_email_change_email(
             pyramid_request,
-            stub_user,
-            pretend.stub(email="old_email@example.com", verified=True),
+            (
+                stub_user,
+                pretend.stub(email="old_email@example.com", verified=True),
+            ),
         )
 
         assert result == {
@@ -633,8 +637,10 @@ class TestPrimaryEmailChangeEmail:
 
         result = email.send_primary_email_change_email(
             pyramid_request,
-            stub_user,
-            pretend.stub(email="old_email@example.com", verified=False),
+            (
+                stub_user,
+                pretend.stub(email="old_email@example.com", verified=False),
+            ),
         )
 
         assert result == {
@@ -689,11 +695,11 @@ class TestCollaboratorAddedEmail:
 
         result = email.send_collaborator_added_email(
             pyramid_request,
+            [stub_user, stub_submitter_user],
             user=stub_user,
             submitter=stub_submitter_user,
             project_name="test_project",
             role="Owner",
-            email_recipients=[stub_user, stub_submitter_user],
         )
 
         assert result == {
@@ -778,11 +784,11 @@ class TestCollaboratorAddedEmail:
 
         result = email.send_collaborator_added_email(
             pyramid_request,
+            [stub_user, stub_submitter_user],
             user=stub_user,
             submitter=stub_submitter_user,
             project_name="test_project",
             role="Owner",
-            email_recipients=[stub_user, stub_submitter_user],
         )
 
         assert result == {
@@ -851,10 +857,10 @@ class TestAddedAsCollaboratorEmail:
 
         result = email.send_added_as_collaborator_email(
             pyramid_request,
+            stub_user,
             submitter=stub_submitter_user,
             project_name="test_project",
             role="Owner",
-            user=stub_user,
         )
 
         assert result == {
@@ -918,10 +924,10 @@ class TestAddedAsCollaboratorEmail:
 
         result = email.send_added_as_collaborator_email(
             pyramid_request,
+            stub_user,
             submitter=stub_submitter_user,
             project_name="test_project",
             role="Owner",
-            user=stub_user,
         )
 
         assert result == {

--- a/tests/unit/manage/test_views.py
+++ b/tests/unit/manage/test_views.py
@@ -1189,12 +1189,12 @@ class TestManageProjectRoles:
             flash=pretend.call_recorder(lambda *a, **kw: None)
         )
 
-        send_collaborator_added_email = pretend.call_recorder(lambda *a: None)
+        send_collaborator_added_email = pretend.call_recorder(lambda r, u, **k: None)
         monkeypatch.setattr(
             views, "send_collaborator_added_email", send_collaborator_added_email
         )
 
-        send_added_as_collaborator_email = pretend.call_recorder(lambda *a: None)
+        send_added_as_collaborator_email = pretend.call_recorder(lambda r, u, **k: None)
         monkeypatch.setattr(
             views, "send_added_as_collaborator_email", send_added_as_collaborator_email
         )
@@ -1217,10 +1217,10 @@ class TestManageProjectRoles:
             pretend.call(
                 db_request,
                 {owner_2},
-                new_user,
-                db_request.user,
-                project.name,
-                form_obj.role_name.data,
+                user=new_user,
+                submitter=db_request.user,
+                project_name=project.name,
+                role=form_obj.role_name.data,
             )
         ]
 
@@ -1228,9 +1228,9 @@ class TestManageProjectRoles:
             pretend.call(
                 db_request,
                 new_user,
-                db_request.user,
-                project.name,
-                form_obj.role_name.data,
+                submitter=db_request.user,
+                project_name=project.name,
+                role=form_obj.role_name.data,
             )
         ]
 

--- a/tests/unit/manage/test_views.py
+++ b/tests/unit/manage/test_views.py
@@ -213,7 +213,7 @@ class TestManageAccount:
                 queue="success",
             )
         ]
-        assert send_email.calls == [pretend.call(request, request.user, email)]
+        assert send_email.calls == [pretend.call(request, (request.user, email))]
 
     def test_add_email_validation_fails(self, monkeypatch):
         email_address = "test@example.com"
@@ -346,7 +346,7 @@ class TestManageAccount:
         monkeypatch.setattr(views, "send_primary_email_change_email", send_email)
         assert view.change_primary_email() == view.default_response
         assert send_email.calls == [
-            pretend.call(db_request, db_request.user, old_primary)
+            pretend.call(db_request, (db_request.user, old_primary))
         ]
         assert db_request.session.flash.calls == [
             pretend.call(
@@ -401,7 +401,7 @@ class TestManageAccount:
         assert request.session.flash.calls == [
             pretend.call("Verification email for email_address resent", queue="success")
         ]
-        assert send_email.calls == [pretend.call(request, request.user, email)]
+        assert send_email.calls == [pretend.call(request, (request.user, email))]
 
     def test_reverify_email_not_found(self, monkeypatch):
         def raise_no_result():
@@ -1216,21 +1216,21 @@ class TestManageProjectRoles:
         assert send_collaborator_added_email.calls == [
             pretend.call(
                 db_request,
+                {owner_2},
                 new_user,
                 db_request.user,
                 project.name,
                 form_obj.role_name.data,
-                {owner_2},
             )
         ]
 
         assert send_added_as_collaborator_email.calls == [
             pretend.call(
                 db_request,
+                new_user,
                 db_request.user,
                 project.name,
                 form_obj.role_name.data,
-                new_user,
             )
         ]
 

--- a/warehouse/accounts/views.py
+++ b/warehouse/accounts/views.py
@@ -260,7 +260,7 @@ def register(request, _form_class=RegistrationForm):
         )
         email = user_service.add_email(user.id, form.email.data, primary=True)
 
-        send_email_verification_email(request, user, email)
+        send_email_verification_email(request, (user, email))
 
         return HTTPSeeOther(
             request.route_path("index"), headers=dict(_login_user(request, user.id))

--- a/warehouse/email/__init__.py
+++ b/warehouse/email/__init__.py
@@ -75,7 +75,7 @@ def _email(name, *, allow_unverified=False):
     Functions that are decorated by this need to accept two positional arguments, the
     first argument is the Pyramid request object, and the second argument is either
     a single User, or a list of Users. These users represent the recipients of this
-    email. Additional parameters are supported, but are not otherwise restricted.
+    email. Additional keyword arguments are supported, but are not otherwise restricted.
 
     Functions decorated by this must return a mapping of context variables that will
     ultimately be returned, but which will also be used to render the templates for
@@ -92,15 +92,16 @@ def _email(name, *, allow_unverified=False):
     email address, instead of a User object, a tuple of (User, Email) objects may be
     used in place of a User object.
     """
+
     def inner(fn):
         @functools.wraps(fn)
-        def wrapper(request, user_or_users, *args, **kwargs):
+        def wrapper(request, user_or_users, **kwargs):
             if isinstance(user_or_users, list):
                 recipients = user_or_users
             else:
                 recipients = [user_or_users]
 
-            context = fn(request, user_or_users, *args, **kwargs)
+            context = fn(request, user_or_users, **kwargs)
             msg = EmailMessage.from_template(name, context, request=request)
 
             for recipient in recipients:
@@ -174,7 +175,7 @@ def send_primary_email_change_email(request, user_and_email):
 
 @_email("collaborator-added")
 def send_collaborator_added_email(
-    request, email_recipients, user, submitter, project_name, role,
+    request, email_recipients, *, user, submitter, project_name, role
 ):
     return {
         "username": user.username,
@@ -185,7 +186,7 @@ def send_collaborator_added_email(
 
 
 @_email("added-as-collaborator")
-def send_added_as_collaborator_email(request, user, submitter, project_name, role):
+def send_added_as_collaborator_email(request, user, *, submitter, project_name, role):
     return {"project": project_name, "submitter": submitter.username, "role": role}
 
 

--- a/warehouse/email/__init__.py
+++ b/warehouse/email/__init__.py
@@ -10,6 +10,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import functools
+
 from email.headerregistry import Address
 
 import attr
@@ -59,6 +61,66 @@ def _send_email_to_user(request, user, msg, *, email=None, allow_unverified=Fals
     )
 
 
+def _email(name, *, allow_unverified=False):
+    """
+    This decorator is used to turn an e function into an email sending function!
+
+    The name parameter is the name of the email we're going to be sending (used to
+    locate the templates on the file system).
+
+    The allow_unverified kwarg flags whether we will send this email to an unverified
+    email or not. We generally do not want to do this, but some emails are important
+    enough or have special requirements that require it.
+
+    Functions that are decorated by this need to accept two positional arguments, the
+    first argument is the Pyramid request object, and the second argument is either
+    a single User, or a list of Users. These users represent the recipients of this
+    email. Additional parameters are supported, but are not otherwise restricted.
+
+    Functions decorated by this must return a mapping of context variables that will
+    ultimately be returned, but which will also be used to render the templates for
+    the emails.
+
+    Thus this function can decorate functions with a signature like so:
+
+        def foo(
+            request: Request, user_or_users: Union[User, List[User]]
+        ) -> Mapping[str, Any]:
+            ...
+
+    Finally, if the email needs to be sent to an address *other* than the user's primary
+    email address, instead of a User object, a tuple of (User, Email) objects may be
+    used in place of a User object.
+    """
+    def inner(fn):
+        @functools.wraps(fn)
+        def wrapper(request, user_or_users, *args, **kwargs):
+            if isinstance(user_or_users, list):
+                recipients = user_or_users
+            else:
+                recipients = [user_or_users]
+
+            context = fn(request, user_or_users, *args, **kwargs)
+            msg = EmailMessage.from_template(name, context, request=request)
+
+            for recipient in recipients:
+                if isinstance(recipient, tuple):
+                    user, email = recipient
+                else:
+                    user, email = recipient, None
+
+                _send_email_to_user(
+                    request, user, msg, email=email, allow_unverified=allow_unverified
+                )
+
+            return context
+
+        return wrapper
+
+    return inner
+
+
+@_email("password-reset", allow_unverified=True)
 def send_password_reset_email(request, user):
     token_service = request.find_service(ITokenService, name="password")
     token = token_service.dumps(
@@ -70,96 +132,61 @@ def send_password_reset_email(request, user):
         }
     )
 
-    fields = {
+    return {
         "token": token,
         "username": user.username,
         "n_hours": token_service.max_age // 60 // 60,
     }
 
-    msg = EmailMessage.from_template("password-reset", fields, request=request)
 
-    _send_email_to_user(request, user, msg, allow_unverified=True)
-
-    # Return the fields we used, in case we need to show any of them to the
-    # user
-    return fields
-
-
-def send_email_verification_email(request, user, email):
+@_email("verify-email", allow_unverified=True)
+def send_email_verification_email(request, user_and_email):
+    user, email = user_and_email
     token_service = request.find_service(ITokenService, name="email")
-
     token = token_service.dumps({"action": "email-verify", "email.id": email.id})
 
-    fields = {
+    return {
         "token": token,
         "email_address": email.email,
         "n_hours": token_service.max_age // 60 // 60,
     }
 
-    msg = EmailMessage.from_template("verify-email", fields, request=request)
 
-    _send_email_to_user(request, user, msg, email=email, allow_unverified=True)
-
-    return fields
-
-
+@_email("password-change")
 def send_password_change_email(request, user):
-    fields = {"username": user.username}
-    msg = EmailMessage.from_template("password-change", fields, request=request)
-
-    _send_email_to_user(request, user, msg)
-
-    return fields
+    return {"username": user.username}
 
 
+@_email("account-deleted")
 def send_account_deletion_email(request, user):
-    fields = {"username": user.username}
-    msg = EmailMessage.from_template("account-deleted", fields, request=request)
-
-    _send_email_to_user(request, user, msg)
-
-    return fields
+    return {"username": user.username}
 
 
-def send_primary_email_change_email(request, user, email):
-    fields = {
+@_email("primary-email-change")
+def send_primary_email_change_email(request, user_and_email):
+    user, email = user_and_email
+    return {
         "username": user.username,
         "old_email": email.email,
         "new_email": user.email,
     }
 
-    msg = EmailMessage.from_template("primary-email-change", fields, request=request)
 
-    _send_email_to_user(request, user, msg, email=email)
-
-    return fields
-
-
+@_email("collaborator-added")
 def send_collaborator_added_email(
-    request, user, submitter, project_name, role, email_recipients
+    request, email_recipients, user, submitter, project_name, role,
 ):
-    fields = {
+    return {
         "username": user.username,
         "project": project_name,
         "submitter": submitter.username,
         "role": role,
     }
 
-    msg = EmailMessage.from_template("collaborator-added", fields, request=request)
 
-    for recipient in email_recipients:
-        _send_email_to_user(request, recipient, msg)
-
-    return fields
-
-
-def send_added_as_collaborator_email(request, submitter, project_name, role, user):
-    fields = {"project": project_name, "submitter": submitter.username, "role": role}
-    msg = EmailMessage.from_template("added-as-collaborator", fields, request=request)
-
-    _send_email_to_user(request, user, msg)
-
-    return fields
+@_email("added-as-collaborator")
+def send_added_as_collaborator_email(request, user, submitter, project_name, role):
+    return {"project": project_name, "submitter": submitter.username, "role": role}
 
 
 def includeme(config):

--- a/warehouse/manage/views.py
+++ b/warehouse/manage/views.py
@@ -113,7 +113,7 @@ class ManageAccountViews:
         if form.validate():
             email = self.user_service.add_email(self.request.user.id, form.email.data)
 
-            send_email_verification_email(self.request, self.request.user, email)
+            send_email_verification_email(self.request, (self.request.user, email))
 
             self.request.session.flash(
                 f"Email {email.email} added - check your email for "
@@ -178,7 +178,7 @@ class ManageAccountViews:
         )
 
         send_primary_email_change_email(
-            self.request, self.request.user, previous_primary_email
+            self.request, (self.request.user, previous_primary_email),
         )
         return self.default_response
 
@@ -200,7 +200,7 @@ class ManageAccountViews:
         if email.verified:
             self.request.session.flash("Email is already verified", queue="error")
         else:
-            send_email_verification_email(self.request, self.request.user, email)
+            send_email_verification_email(self.request, (self.request.user, email))
 
             self.request.session.flash(
                 f"Verification email for {email.email} resent", queue="success"
@@ -551,15 +551,15 @@ def manage_project_roles(project, request, _form_class=CreateRoleForm):
 
             send_collaborator_added_email(
                 request,
+                owner_users,
                 user,
                 request.user,
                 project.name,
                 form.role_name.data,
-                owner_users,
             )
 
             send_added_as_collaborator_email(
-                request, request.user, project.name, form.role_name.data, user
+                request, user, request.user, project.name, form.role_name.data,
             )
 
             request.session.flash(

--- a/warehouse/manage/views.py
+++ b/warehouse/manage/views.py
@@ -178,7 +178,7 @@ class ManageAccountViews:
         )
 
         send_primary_email_change_email(
-            self.request, (self.request.user, previous_primary_email),
+            self.request, (self.request.user, previous_primary_email)
         )
         return self.default_response
 
@@ -552,14 +552,18 @@ def manage_project_roles(project, request, _form_class=CreateRoleForm):
             send_collaborator_added_email(
                 request,
                 owner_users,
-                user,
-                request.user,
-                project.name,
-                form.role_name.data,
+                user=user,
+                submitter=request.user,
+                project_name=project.name,
+                role=form.role_name.data,
             )
 
             send_added_as_collaborator_email(
-                request, user, request.user, project.name, form.role_name.data,
+                request,
+                user,
+                submitter=request.user,
+                project_name=project.name,
+                role=form.role_name.data,
             )
 
             request.session.flash(


### PR DESCRIPTION
* Implements a ``@_email(email_name, *, allow_unverified=False)`` decorator which implements the boilerplate parts of sending email.
* Email functions now require passing two position parameters: A Pyramid ``Request``, and either the ``User`` to send email to, a tuple of ``(User, Email)`` to send email too or a list of either of those to send email to.
* Additional parameters may be passed to email functions using keyword arguments.
* Email functions must return the context that they want to have the email templates rendered with.