### PR TITLE
Refactor the stale-while-revalidate header

### DIFF
--- a/warehouse/accounts/views.py
+++ b/warehouse/accounts/views.py
@@ -69,9 +69,7 @@ def failed_logins(exc, request):
     context=User,
     renderer="accounts/profile.html",
     decorator=[
-        origin_cache(
-            1 * 24 * 60 * 60, stale_if_error=1 * 24 * 60 * 60  # 1 day each.
-        )
+        origin_cache(1 * 24 * 60 * 60, stale_if_error=1 * 24 * 60 * 60)  # 1 day each.
     ],
 )
 def profile(user, request):

--- a/warehouse/accounts/views.py
+++ b/warehouse/accounts/views.py
@@ -70,9 +70,7 @@ def failed_logins(exc, request):
     renderer="accounts/profile.html",
     decorator=[
         origin_cache(
-            1 * 24 * 60 * 60,  # 1 day
-            stale_while_revalidate=5 * 60,  # 5 minutes
-            stale_if_error=1 * 24 * 60 * 60,  # 1 day
+            1 * 24 * 60 * 60, stale_if_error=1 * 24 * 60 * 60  # 1 day each.
         )
     ],
 )

--- a/warehouse/packaging/views.py
+++ b/warehouse/packaging/views.py
@@ -26,9 +26,7 @@ from warehouse.packaging.models import Project, Release, Role
     renderer="packaging/detail.html",
     decorator=[
         origin_cache(
-            1 * 24 * 60 * 60,  # 1 day
-            stale_while_revalidate=1 * 24 * 60 * 60,  # 1 day
-            stale_if_error=5 * 24 * 60 * 60,  # 5 days
+            1 * 24 * 60 * 60, stale_if_error=5 * 24 * 60 * 60  # 1 day, 5 days stale
         )
     ],
 )
@@ -56,9 +54,7 @@ def project_detail(project, request):
     renderer="packaging/detail.html",
     decorator=[
         origin_cache(
-            1 * 24 * 60 * 60,  # 1 day
-            stale_while_revalidate=1 * 24 * 60 * 60,  # 1 day
-            stale_if_error=5 * 24 * 60 * 60,  # 5 days
+            1 * 24 * 60 * 60, stale_if_error=5 * 24 * 60 * 60  # 1 day, 5 days stale
         )
     ],
 )

--- a/warehouse/views.py
+++ b/warehouse/views.py
@@ -235,7 +235,6 @@ def classifiers(request):
     decorator=[
         origin_cache(
             1 * 60 * 60,  # 1 hour
-            stale_while_revalidate=10 * 60,  # 10 minutes
             stale_if_error=1 * 24 * 60 * 60,  # 1 day
             keys=["all-projects"],
         )
@@ -323,7 +322,11 @@ def search(request):
     decorator=[
         add_vary("Accept"),
         cache_control(1 * 24 * 60 * 60),  # 1 day
-        origin_cache(1 * 24 * 60 * 60),  # 1 day
+        origin_cache(
+            1 * 24 * 60 * 60,  # 1 day
+            stale_while_revalidate=1 * 24 * 60 * 60,  # 1 day
+            stale_if_error=1 * 24 * 60 * 60,  # 1 day
+        ),
     ],
 )
 @view_config(
@@ -332,7 +335,11 @@ def search(request):
     decorator=[
         add_vary("Accept"),
         cache_control(1 * 24 * 60 * 60),  # 1 day
-        origin_cache(1 * 24 * 60 * 60),  # 1 day
+        origin_cache(
+            1 * 24 * 60 * 60,  # 1 day
+            stale_while_revalidate=1 * 24 * 60 * 60,  # 1 day
+            stale_if_error=1 * 24 * 60 * 60,  # 1 day
+        ),
     ],
     accept="application/json",
 )


### PR DESCRIPTION
Removes the stale-while-revalidate setting on:

* User profile pages (``/user/<user>/``).
* Project detail page (``/project/<foo>/``, and ``/project/<foo>/``).
* Search result page (``/search/``).

Add the stale-while-revalidate setting on:

* States page (``/stats/``).

This should remove the bulk of the noticeable cases where users feel like they have to reload the page. The remaining pages are either API pages, or are pages like the front page where users generally aren't going to notice if the page is stale.