### PR TITLE
Gracefully handle redis errors while rate limiting

### DIFF
--- a/tests/unit/rate_limiting/test_core.py
+++ b/tests/unit/rate_limiting/test_core.py
@@ -12,6 +12,7 @@
 
 import datetime
 
+import redis
 import pretend
 
 from limits import storage
@@ -21,9 +22,12 @@ from warehouse.rate_limiting import RateLimiter, DummyRateLimiter, RateLimit
 
 
 class TestRateLimiter:
-    def test_basic(self):
+    def test_basic(self, metrics):
         limiter = RateLimiter(
-            storage.MemoryStorage(), "1 per minute", identifiers=["foo"]
+            storage.MemoryStorage(),
+            "1 per minute",
+            identifiers=["foo"],
+            metrics=metrics,
         )
 
         assert limiter.test("foo")
@@ -35,10 +39,35 @@ class TestRateLimiter:
         assert limiter.test("foo")
         assert not limiter.test("bar")
 
-    def test_namespacing(self):
+    def test_error(self, metrics):
+        limiter = RateLimiter(
+            storage.MemoryStorage(),
+            "1 per minute",
+            identifiers=["foo"],
+            metrics=metrics,
+        )
+
+        def raiser(*args, **kwargs):
+            raise redis.ConnectionError()
+
+        limiter._window = pretend.stub(hit=raiser, test=raiser, get_window_stats=raiser)
+
+        assert limiter.test("foo")
+        assert limiter.hit("foo")
+        assert limiter.resets_in("foo") is None
+
+        assert metrics.increment.calls == [
+            pretend.call("warehouse.ratelimiter.error", tags=["call:test"]),
+            pretend.call("warehouse.ratelimiter.error", tags=["call:hit"]),
+            pretend.call("warehouse.ratelimiter.error", tags=["call:resets_in"]),
+        ]
+
+    def test_namespacing(self, metrics):
         storage_ = storage.MemoryStorage()
-        limiter1 = RateLimiter(storage_, "1 per minute", identifiers=["foo"])
-        limiter2 = RateLimiter(storage_, "1 per minute")
+        limiter1 = RateLimiter(
+            storage_, "1 per minute", identifiers=["foo"], metrics=metrics
+        )
+        limiter2 = RateLimiter(storage_, "1 per minute", metrics=metrics)
 
         assert limiter1.test("bar")
         assert limiter2.test("bar")
@@ -49,8 +78,8 @@ class TestRateLimiter:
         assert limiter2.test("bar")
         assert not limiter1.test("bar")
 
-    def test_results_in(self):
-        limiter = RateLimiter(storage.MemoryStorage(), "1 per minute")
+    def test_results_in(self, metrics):
+        limiter = RateLimiter(storage.MemoryStorage(), "1 per minute", metrics=metrics)
 
         assert limiter.resets_in("foo") is None
 
@@ -60,9 +89,11 @@ class TestRateLimiter:
         assert limiter.resets_in("foo") > datetime.timedelta(seconds=0)
         assert limiter.resets_in("foo") < datetime.timedelta(seconds=60)
 
-    def test_results_in_expired(self):
+    def test_results_in_expired(self, metrics):
         limiter = RateLimiter(
-            storage.MemoryStorage(), "1 per minute; 1 per hour; 1 per day"
+            storage.MemoryStorage(),
+            "1 per minute; 1 per hour; 1 per day",
+            metrics=metrics,
         )
 
         current = datetime.datetime.now(tz=datetime.timezone.utc)
@@ -92,23 +123,24 @@ class TestDummyRateLimiter:
 
 
 class TestRateLimit:
-    def test_basic(self):
+    def test_basic(self, pyramid_request, metrics):
         limiter_obj = pretend.stub()
         limiter_class = pretend.call_recorder(lambda *a, **kw: limiter_obj)
 
         context = pretend.stub()
-        request = pretend.stub(registry={"ratelimiter.storage": pretend.stub()})
+        pyramid_request.registry["ratelimiter.storage"] = pretend.stub()
 
         result = RateLimit(
             "1 per 5 minutes", identifiers=["foo"], limiter_class=limiter_class
-        )(context, request)
+        )(context, pyramid_request)
 
         assert result is limiter_obj
         assert limiter_class.calls == [
             pretend.call(
-                request.registry["ratelimiter.storage"],
+                pyramid_request.registry["ratelimiter.storage"],
                 limit="1 per 5 minutes",
                 identifiers=["foo"],
+                metrics=metrics,
             )
         ]
 

--- a/warehouse/rate_limiting/__init__.py
+++ b/warehouse/rate_limiting/__init__.py
@@ -10,7 +10,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import functools
+import logging
+
 from datetime import datetime, timezone
+
+import redis
 
 from first import first
 from limits import parse_many
@@ -18,22 +23,46 @@ from limits.strategies import MovingWindowRateLimiter
 from limits.storage import storage_from_string
 from zope.interface import implementer
 
+from warehouse.metrics import IMetricsService
 from warehouse.rate_limiting.interfaces import IRateLimiter
+
+
+logger = logging.getLogger(__name__)
+
+
+def _return_on_exception(rvalue, *exceptions):
+    def deco(fn):
+        @functools.wraps(fn)
+        def wrapper(self, *args, **kwargs):
+            try:
+                return fn(self, *args, **kwargs)
+            except exceptions as exc:
+                logging.warning("Error computing rate limits: %r", exc)
+                self._metrics.increment(
+                    "warehouse.ratelimiter.error", tags=[f"call:{fn.__name__}"]
+                )
+                return rvalue
+
+        return wrapper
+
+    return deco
 
 
 @implementer(IRateLimiter)
 class RateLimiter:
-    def __init__(self, storage, limit, identifiers=None):
+    def __init__(self, storage, limit, *, identifiers=None, metrics):
         if identifiers is None:
             identifiers = []
 
         self._window = MovingWindowRateLimiter(storage)
         self._limits = parse_many(limit)
         self._identifiers = identifiers
+        self._metrics = metrics
 
     def _get_identifiers(self, identifiers):
         return [str(i) for i in list(self._identifiers) + list(identifiers)]
 
+    @_return_on_exception(True, redis.RedisError)
     def test(self, *identifiers):
         return all(
             [
@@ -42,6 +71,7 @@ class RateLimiter:
             ]
         )
 
+    @_return_on_exception(True, redis.RedisError)
     def hit(self, *identifiers):
         return all(
             [
@@ -50,6 +80,7 @@ class RateLimiter:
             ]
         )
 
+    @_return_on_exception(None, redis.RedisError)
     def resets_in(self, *identifiers):
         resets = []
         for limit in self._limits:
@@ -103,6 +134,7 @@ class RateLimit:
             request.registry["ratelimiter.storage"],
             limit=self.limit,
             identifiers=self.identifiers,
+            metrics=request.find_service(IMetricsService, context=None),
         )
 
     def __eq__(self, other):


### PR DESCRIPTION
Instead of hard failing when there is a redis issue while rate limiting, we will instead just assume that the rate limit is *not* being hit, and allow the user to do what they were trying to do.

We will submit a metric anytime we have an error in the rate limiter.