### PR TITLE
Try to make sure our junk encoding tween is first

### DIFF
--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -404,7 +404,18 @@ def test_configure(monkeypatch, settings, environment, other_settings):
     assert configurator_obj.add_tween.calls == [
         pretend.call(
             "warehouse.config.junk_encoding_tween_factory",
-            over="warehouse.csp.content_security_policy_tween_factory",
+            over=[
+                "warehouse.referrer_policy.referrer_policy_tween_factory",
+                "warehouse.config.require_https_tween_factory",
+                "warehouse.config.unicode_redirect_tween_factory",
+                "warehouse.csp.content_security_policy_tween_factory",
+                "warehouse.static.whitenoise_tween_factory",
+                "warehouse.utils.compression.compression_tween_factory",
+                "warehouse.raven.raven_tween_factory",
+                "pyramid_tm.tm_tween_factory",
+                "pyramid.tweens.excview_tween_factory",
+                "warehouse.cache.http.conditional_http_tween_factory",
+            ],
         ),
         pretend.call("warehouse.config.unicode_redirect_tween_factory"),
         pretend.call("warehouse.config.require_https_tween_factory"),

--- a/warehouse/config.py
+++ b/warehouse/config.py
@@ -256,7 +256,18 @@ def configure(settings=None):
     # Add some fixups for some encoding/decoding issues
     config.add_tween(
         "warehouse.config.junk_encoding_tween_factory",
-        over="warehouse.csp.content_security_policy_tween_factory",
+        over=[
+            "warehouse.referrer_policy.referrer_policy_tween_factory",
+            "warehouse.config.require_https_tween_factory",
+            "warehouse.config.unicode_redirect_tween_factory",
+            "warehouse.csp.content_security_policy_tween_factory",
+            "warehouse.static.whitenoise_tween_factory",
+            "warehouse.utils.compression.compression_tween_factory",
+            "warehouse.raven.raven_tween_factory",
+            "pyramid_tm.tm_tween_factory",
+            "pyramid.tweens.excview_tween_factory",
+            "warehouse.cache.http.conditional_http_tween_factory",
+        ],
     )
     config.add_tween("warehouse.config.unicode_redirect_tween_factory")
 


### PR DESCRIPTION
Explicitly mention all other tweens for the junk encoding tween to be over. This should hopefully mean that it will always come first in our tween order.

Thanks to @mcdonc for pointing out that ``add_tween(over=..)`` takes a list.

Fixes https://sentry.io/python-software-foundation/warehouse-production/issues/536078743/.