### PR TITLE
Fix XMLRPC when called with too few arguments

### DIFF
--- a/tests/functional/legacy_api/test_xmlrpc.py
+++ b/tests/functional/legacy_api/test_xmlrpc.py
@@ -29,3 +29,10 @@ def test_xmlrpc_nomethod(app_config, webtest, metrics):
 
 def test_xmlrpc_succeeds(app_config, webtest, metrics):
     webtest.xmlrpc("/pypi", "changelog_last_serial")
+
+
+def test_invalid_arguments(app_config, webtest):
+    with pytest.raises(
+        xmlrpc.client.Fault, match="server error; invalid method params"
+    ):
+        webtest.xmlrpc("/pypi", "package_releases")

--- a/warehouse/legacy/api/xmlrpc/cache/derivers.py
+++ b/warehouse/legacy/api/xmlrpc/cache/derivers.py
@@ -36,7 +36,7 @@ def cached_return_view(view, info):
                 if arg_index is not None:
                     _tag = tag % (tag_processor(request.rpc_args[arg_index]),)
                 return service.fetch(view, (context, request), {}, key, _tag, expires)
-            except interfaces.CacheError:
+            except (interfaces.CacheError, IndexError):
                 return view(context, request)
 
         return wrapper_view


### PR DESCRIPTION
Previously XMLRPC would fail with an IndexError if the user provided too few arguments to flesh out the cache key when caching was enabled. Fix that so in that case we just fall back to no caching.

Can reproduce original error with:

```python
import xmlrpc.client

c = xmlrpc.client.Server("http://localhost/pypi")
c.package_releases()
```

Fixes https://sentry.io/python-software-foundation/warehouse-production/issues/605060014/.