### PR TITLE
Handle errors connecting to PostgreSQL better

### DIFF
--- a/tests/unit/test_db.py
+++ b/tests/unit/test_db.py
@@ -25,6 +25,7 @@ from sqlalchemy import event
 from warehouse import db
 from warehouse.db import (
     DEFAULT_ISOLATION,
+    DatabaseNotAvailable,
     ModelBase,
     includeme,
     _configure_alembic,
@@ -145,6 +146,25 @@ def test_creates_engine(monkeypatch):
     assert listen.calls == [pretend.call(engine, "reset", _reset)]
 
 
+def test_raises_db_available_error(pyramid_services, metrics):
+    def raiser():
+        raise psycopg2.OperationalError()
+
+    engine = pretend.stub(connect=raiser)
+    request = pretend.stub(
+        find_service=pyramid_services.find_service,
+        registry={"sqlalchemy.engine": engine},
+    )
+
+    with pytest.raises(DatabaseNotAvailable):
+        _create_session(request)
+
+    assert metrics.increment.calls == [
+        pretend.call("warehouse.db.session.start"),
+        pretend.call("warehouse.db.session.error", tags=["error_in:connecting"]),
+    ]
+
+
 @pytest.mark.parametrize(
     ("read_only", "tx_status"),
     [
@@ -154,7 +174,7 @@ def test_creates_engine(monkeypatch):
         (False, psycopg2.extensions.TRANSACTION_STATUS_INTRANS),
     ],
 )
-def test_create_session(monkeypatch, read_only, tx_status):
+def test_create_session(monkeypatch, pyramid_services, read_only, tx_status):
     session_obj = pretend.stub(
         close=pretend.call_recorder(lambda: None),
         query=lambda *a: pretend.stub(get=lambda *a: None),
@@ -173,6 +193,7 @@ def test_create_session(monkeypatch, read_only, tx_status):
     )
     engine = pretend.stub(connect=pretend.call_recorder(lambda: connection))
     request = pretend.stub(
+        find_service=pyramid_services.find_service,
         registry={"sqlalchemy.engine": engine},
         tm=pretend.stub(),
         read_only=read_only,
@@ -219,7 +240,7 @@ def test_create_session(monkeypatch, read_only, tx_status):
     ],
 )
 def test_create_session_read_only_mode(
-    admin_flag, is_superuser, doom_calls, monkeypatch
+    admin_flag, is_superuser, doom_calls, monkeypatch, pyramid_services
 ):
     get = pretend.call_recorder(lambda *a: admin_flag)
     session_obj = pretend.stub(
@@ -242,6 +263,7 @@ def test_create_session_read_only_mode(
     )
     engine = pretend.stub(connect=pretend.call_recorder(lambda: connection))
     request = pretend.stub(
+        find_service=pyramid_services.find_service,
         registry={"sqlalchemy.engine": engine},
         tm=pretend.stub(doom=pretend.call_recorder(lambda: None)),
         read_only=False,

--- a/tests/unit/test_views.py
+++ b/tests/unit/test_views.py
@@ -33,6 +33,7 @@ from warehouse.views import (
     force_status,
     flash_messages,
     forbidden_include,
+    service_unavailable,
 )
 
 from ..common.db.accounts import UserFactory
@@ -148,6 +149,18 @@ class TestForbiddenIncludeView:
         assert resp.status_code == 403
         assert resp.content_type == "text/html"
         assert resp.content_length == 0
+
+
+class TestServiceUnavailableView:
+    def test_renders_503(self, pyramid_config, pyramid_request):
+        renderer = pyramid_config.testing_add_renderer("503.html")
+        renderer.string_response = "A 503 Error"
+
+        resp = service_unavailable(pretend.stub(), pyramid_request)
+
+        assert resp.status_code == 503
+        assert resp.content_type == "text/html"
+        assert resp.body == b"A 503 Error"
 
 
 def test_robotstxt(pyramid_request):

--- a/warehouse/views.py
+++ b/warehouse/views.py
@@ -19,6 +19,7 @@ from pyramid.httpexceptions import (
     HTTPMovedPermanently,
     HTTPNotFound,
     HTTPBadRequest,
+    HTTPServiceUnavailable,
     exception_response,
 )
 from pyramid.exceptions import PredicateMismatch
@@ -35,6 +36,7 @@ from sqlalchemy import func
 from sqlalchemy.orm import aliased, joinedload
 from sqlalchemy.sql import exists
 
+from warehouse.db import DatabaseNotAvailable
 from warehouse.accounts import REDIRECT_FIELD_NAME
 from warehouse.accounts.models import User
 from warehouse.cache.origin import origin_cache
@@ -108,6 +110,11 @@ def forbidden_include(exc, request):
     # If the forbidden error is for a client-side-include, just return an empty
     # response instead of redirecting
     return Response(status=403)
+
+
+@view_config(context=DatabaseNotAvailable)
+def service_unavailable(exc, request):
+    return httpexception_view(HTTPServiceUnavailable(), request)
 
 
 @view_config(


### PR DESCRIPTION
Instead of just exploding when we can't connect to PostgreSQL, we will instead raise a different error (``DatabaseNotAvailable``) so we can differentiate it from other causes of this error. Then we'll add an exception view that will turn the ``DatabaseNotAvailable`` error into a generic 503 error.

This will keep these errors from getting caught by sentry, but to provide insight into if they're happening or not metrics and logging have been added.

Fixes: https://sentry.io/python-software-foundation/warehouse-production/issues/534930428/.
Fixes: https://sentry.io/python-software-foundation/warehouse-production/issues/570776802/.