### PR TITLE
Purge the database of inactive users with no email or projects

### DIFF
--- a/warehouse/migrations/versions/f71770e7d9b3_remove_users_without_an_email_or_a_.py
+++ b/warehouse/migrations/versions/f71770e7d9b3_remove_users_without_an_email_or_a_.py
@@ -1,0 +1,46 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Remove users without an email or a project
+
+Revision ID: f71770e7d9b3
+Revises: 42e76a605cac
+Create Date: 2018-08-11 04:04:50.931746
+"""
+
+from alembic import op
+
+
+revision = "f71770e7d9b3"
+down_revision = "42e76a605cac"
+
+
+def upgrade():
+    op.execute(
+        """
+        DELETE FROM accounts_user
+        WHERE NOT EXISTS
+            (SELECT 1
+             FROM accounts_email
+             WHERE accounts_email.user_id = accounts_user.id)
+          AND (accounts_user.last_login < CURRENT_TIMESTAMP - interval '1' year
+                OR accounts_user.last_login IS NULL)
+          AND NOT EXISTS
+            (SELECT 1
+             FROM ROLES
+             WHERE roles.user_name = accounts_user.username)
+        """
+    )
+
+
+def downgrade():
+    raise RuntimeError("Order No. 227 - Ни шагу назад!")


### PR DESCRIPTION
Deletes any user who matches the follow constraints:

* Does not have any emails associated with their account.
* Has not logged in for over a year (or last login is null, to deal with *really* old data).
* Does not have a role on any projects in PyPI.

I'm making this a migration because I figure it's the easiest way to execute some SQL and get it reviewed etc.

I'm going to leave this to @ewdurbin to merge, because as is usual, we probably want to snapshot the database before executing just in case. I was not able to really test this locally because the dev database doesn't contain any users that match, though there is a single user who matches if we drop the last login restriction. I did test it with that single user and it worked fine, but it may be a smart idea to grab a copy of the database and make sure that it only deletes 34790 users, and there are no roles, emails, or projects gone once those users are deleted.

Refs #4481.