### PR TITLE
Disable users with breached passwords

### DIFF
--- a/dev/environment
+++ b/dev/environment
@@ -27,6 +27,8 @@ DOCS_BACKEND=warehouse.packaging.services.LocalDocsStorage path=/var/opt/warehou
 
 MAIL_BACKEND=warehouse.email.services.SMTPEmailSender host=smtp port=2525 ssl=false sender=noreply@pypi.org
 
+BREACHED_PASSWORDS=warehouse.accounts.NullPasswordBreachedService
+
 METRICS_BACKEND=warehouse.metrics.DataDogMetrics host=notdatadog
 
 STATUSPAGE_URL=https://2p66nmmycsj3.statuspage.io

--- a/tests/unit/accounts/test_core.py
+++ b/tests/unit/accounts/test_core.py
@@ -162,7 +162,7 @@ class TestLogin:
             disable_password=pretend.call_recorder(lambda user_id: None),
         )
         breach_service = pretend.stub(
-            failure_message="Bad Password!",
+            failure_message_plain="Bad Password!",
             check_password=pretend.call_recorder(lambda pw, tags=None: True),
         )
 

--- a/tests/unit/accounts/test_services.py
+++ b/tests/unit/accounts/test_services.py
@@ -299,6 +299,17 @@ class TestDatabaseUserService:
 
         assert found_user is None
 
+    def test_disable_password(self, user_service):
+        user = UserFactory.create()
+
+        # Need to give the user a good password first.
+        user_service.update_user(user.id, password="foo")
+        assert user.password != "!"
+
+        # Now we'll actually test our disble function.
+        user_service.disable_password(user.id)
+        assert user.password == "!"
+
 
 class TestTokenService:
     def test_verify_service(self):

--- a/tests/unit/accounts/test_services.py
+++ b/tests/unit/accounts/test_services.py
@@ -597,3 +597,36 @@ class TestHaveIBeenPwnedPasswordBreachedService:
         )
         svc = services.hibp_password_breach_factory(context, request)
         assert svc.failure_message == expected
+
+    @pytest.mark.parametrize(
+        ("help_url", "expected"),
+        [
+            (
+                None,
+                (
+                    "This password has appeared in a breach or has otherwise "
+                    "been compromised and cannot be used."
+                ),
+            ),
+            (
+                "http://localhost/help/#compromised-password",
+                (
+                    "This password has appeared in a breach or has otherwise "
+                    "been compromised and cannot be used. See "
+                    "the FAQ entry at http://localhost/help/#compromised-password for "
+                    "more information."
+                ),
+            ),
+        ],
+    )
+    def test_failure_message_plain(self, help_url, expected):
+        context = pretend.stub()
+        request = pretend.stub(
+            http=pretend.stub(),
+            find_service=lambda iface, context: {
+                (IMetricsService, None): NullMetrics()
+            }[(iface, context)],
+            help_url=lambda _anchor=None: help_url,
+        )
+        svc = services.hibp_password_breach_factory(context, request)
+        assert svc.failure_message_plain == expected

--- a/tests/unit/accounts/test_services.py
+++ b/tests/unit/accounts/test_services.py
@@ -25,6 +25,7 @@ from warehouse.accounts import services
 from warehouse.accounts.interfaces import (
     IUserService,
     ITokenService,
+    IPasswordBreachedService,
     TokenExpired,
     TokenInvalid,
     TokenMissing,
@@ -454,6 +455,11 @@ def test_token_service_factory_eq():
 
 
 class TestHaveIBeenPwnedPasswordBreachedService:
+    def test_verify_service(self):
+        assert verifyClass(
+            IPasswordBreachedService, services.HaveIBeenPwnedPasswordBreachedService
+        )
+
     @pytest.mark.parametrize(
         ("password", "prefix", "expected", "dataset"),
         [
@@ -559,7 +565,9 @@ class TestHaveIBeenPwnedPasswordBreachedService:
             }[(iface, context)],
             help_url=lambda _anchor=None: f"http://localhost/help/#{_anchor}",
         )
-        svc = services.hibp_password_breach_factory(context, request)
+        svc = services.HaveIBeenPwnedPasswordBreachedService.create_service(
+            context, request
+        )
 
         assert svc._http is request.http
         assert isinstance(svc._metrics, NullMetrics)
@@ -595,7 +603,9 @@ class TestHaveIBeenPwnedPasswordBreachedService:
             }[(iface, context)],
             help_url=lambda _anchor=None: help_url,
         )
-        svc = services.hibp_password_breach_factory(context, request)
+        svc = services.HaveIBeenPwnedPasswordBreachedService.create_service(
+            context, request
+        )
         assert svc.failure_message == expected
 
     @pytest.mark.parametrize(
@@ -628,5 +638,26 @@ class TestHaveIBeenPwnedPasswordBreachedService:
             }[(iface, context)],
             help_url=lambda _anchor=None: help_url,
         )
-        svc = services.hibp_password_breach_factory(context, request)
+        svc = services.HaveIBeenPwnedPasswordBreachedService.create_service(
+            context, request
+        )
         assert svc.failure_message_plain == expected
+
+
+class TestNullPasswordBreachedService:
+    def test_verify_service(self):
+        assert verifyClass(
+            IPasswordBreachedService, services.NullPasswordBreachedService
+        )
+
+    def test_check_password(self):
+        svc = services.NullPasswordBreachedService()
+        assert not svc.check_password("password")
+
+    def test_factory(self):
+        context = pretend.stub()
+        request = pretend.stub()
+        svc = services.NullPasswordBreachedService.create_service(context, request)
+
+        assert isinstance(svc, services.NullPasswordBreachedService)
+        assert not svc.check_password("hunter2")

--- a/tests/unit/accounts/test_services.py
+++ b/tests/unit/accounts/test_services.py
@@ -307,7 +307,7 @@ class TestDatabaseUserService:
         user_service.update_user(user.id, password="foo")
         assert user.password != "!"
 
-        # Now we'll actually test our disble function.
+        # Now we'll actually test our disable function.
         user_service.disable_password(user.id)
         assert user.password == "!"
 

--- a/tests/unit/accounts/test_services.py
+++ b/tests/unit/accounts/test_services.py
@@ -579,15 +579,15 @@ class TestHaveIBeenPwnedPasswordBreachedService:
             (
                 None,
                 (
-                    "This password has appeared in a breach or has otherwise "
-                    "been compromised and cannot be used."
+                    "This password appears in a breach or has been compromised and "
+                    "cannot be used."
                 ),
             ),
             (
                 "http://localhost/help/#compromised-password",
                 (
-                    "This password has appeared in a breach or has otherwise "
-                    "been compromised and cannot be used. See "
+                    "This password appears in a breach or has been compromised and "
+                    "cannot be used. See "
                     '<a href="http://localhost/help/#compromised-password">'
                     "this FAQ entry</a> for more information."
                 ),
@@ -614,17 +614,16 @@ class TestHaveIBeenPwnedPasswordBreachedService:
             (
                 None,
                 (
-                    "This password has appeared in a breach or has otherwise "
-                    "been compromised and cannot be used."
+                    "This password appears in a breach or has been compromised and "
+                    "cannot be used."
                 ),
             ),
             (
                 "http://localhost/help/#compromised-password",
                 (
-                    "This password has appeared in a breach or has otherwise "
-                    "been compromised and cannot be used. See "
-                    "the FAQ entry at http://localhost/help/#compromised-password for "
-                    "more information."
+                    "This password appears in a breach or has been compromised and "
+                    "cannot be used. See the FAQ entry at "
+                    "http://localhost/help/#compromised-password for more information."
                 ),
             ),
         ],

--- a/tests/unit/accounts/test_views.py
+++ b/tests/unit/accounts/test_views.py
@@ -87,9 +87,7 @@ class TestLogin:
         )
 
         form_obj = pretend.stub()
-        form_class = pretend.call_recorder(
-            lambda d, user_service, check_password_metrics_tags: form_obj
-        )
+        form_class = pretend.call_recorder(lambda d, **kw: form_obj)
 
         if next_url is not None:
             pyramid_request.GET["next"] = next_url
@@ -104,6 +102,7 @@ class TestLogin:
             pretend.call(
                 pyramid_request.POST,
                 user_service=user_service,
+                breach_service=breach_service,
                 check_password_metrics_tags=["method:auth", "auth_method:login_form"],
             )
         ]
@@ -124,9 +123,7 @@ class TestLogin:
         if next_url is not None:
             pyramid_request.POST["next"] = next_url
         form_obj = pretend.stub(validate=pretend.call_recorder(lambda: False))
-        form_class = pretend.call_recorder(
-            lambda d, user_service, check_password_metrics_tags: form_obj
-        )
+        form_class = pretend.call_recorder(lambda d, **kw: form_obj)
 
         result = views.login(pyramid_request, _form_class=form_class)
         assert metrics.increment.calls == []
@@ -139,6 +136,7 @@ class TestLogin:
             pretend.call(
                 pyramid_request.POST,
                 user_service=user_service,
+                breach_service=breach_service,
                 check_password_metrics_tags=["method:auth", "auth_method:login_form"],
             )
         ]
@@ -183,9 +181,7 @@ class TestLogin:
             username=pretend.stub(data="theuser"),
             password=pretend.stub(data="password"),
         )
-        form_class = pretend.call_recorder(
-            lambda d, user_service, check_password_metrics_tags: form_obj
-        )
+        form_class = pretend.call_recorder(lambda d, **kw: form_obj)
 
         pyramid_request.route_path = pretend.call_recorder(lambda a: "/the-redirect")
 
@@ -205,6 +201,7 @@ class TestLogin:
             pretend.call(
                 pyramid_request.POST,
                 user_service=user_service,
+                breach_service=breach_service,
                 check_password_metrics_tags=["method:auth", "auth_method:login_form"],
             )
         ]
@@ -250,9 +247,7 @@ class TestLogin:
             username=pretend.stub(data="theuser"),
             password=pretend.stub(data="password"),
         )
-        form_class = pretend.call_recorder(
-            lambda d, user_service, check_password_metrics_tags: form_obj
-        )
+        form_class = pretend.call_recorder(lambda d, **kw: form_obj)
         pyramid_request.route_path = pretend.call_recorder(lambda a: "/the-redirect")
         result = views.login(pyramid_request, _form_class=form_class)
 

--- a/tests/unit/accounts/test_views.py
+++ b/tests/unit/accounts/test_views.py
@@ -101,6 +101,7 @@ class TestLogin:
         assert form_class.calls == [
             pretend.call(
                 pyramid_request.POST,
+                request=pyramid_request,
                 user_service=user_service,
                 breach_service=breach_service,
                 check_password_metrics_tags=["method:auth", "auth_method:login_form"],
@@ -135,6 +136,7 @@ class TestLogin:
         assert form_class.calls == [
             pretend.call(
                 pyramid_request.POST,
+                request=pyramid_request,
                 user_service=user_service,
                 breach_service=breach_service,
                 check_password_metrics_tags=["method:auth", "auth_method:login_form"],
@@ -200,6 +202,7 @@ class TestLogin:
         assert form_class.calls == [
             pretend.call(
                 pyramid_request.POST,
+                request=pyramid_request,
                 user_service=user_service,
                 breach_service=breach_service,
                 check_password_metrics_tags=["method:auth", "auth_method:login_form"],

--- a/tests/unit/email/test_init.py
+++ b/tests/unit/email/test_init.py
@@ -474,6 +474,57 @@ class TestPasswordChangeEmail:
         assert send_email.delay.calls == []
 
 
+class TestPasswordCompromisedEmail:
+    @pytest.mark.parametrize("verified", [True, False])
+    def test_password_compromised_email(
+        self, pyramid_request, pyramid_config, monkeypatch, verified
+    ):
+        stub_user = pretend.stub(
+            username="username",
+            name="",
+            email="email@example.com",
+            primary_email=pretend.stub(email="email@example.com", verified=verified),
+        )
+        subject_renderer = pyramid_config.testing_add_renderer(
+            "email/password-compromised/subject.txt"
+        )
+        subject_renderer.string_response = "Email Subject"
+        body_renderer = pyramid_config.testing_add_renderer(
+            "email/password-compromised/body.txt"
+        )
+        body_renderer.string_response = "Email Body"
+        html_renderer = pyramid_config.testing_add_renderer(
+            "email/password-compromised/body.html"
+        )
+        html_renderer.string_response = "Email HTML Body"
+
+        send_email = pretend.stub(
+            delay=pretend.call_recorder(lambda *args, **kwargs: None)
+        )
+        pyramid_request.task = pretend.call_recorder(lambda *args, **kwargs: send_email)
+        monkeypatch.setattr(email, "send_email", send_email)
+
+        result = email.send_password_compromised_email(pyramid_request, stub_user)
+
+        assert result == {}
+        assert pyramid_request.task.calls == [pretend.call(send_email)]
+        assert send_email.delay.calls == [
+            pretend.call(
+                f"{stub_user.username} <{stub_user.email}>",
+                attr.asdict(
+                    EmailMessage(
+                        subject="Email Subject",
+                        body_text="Email Body",
+                        body_html=(
+                            "<html>\n<head></head>\n"
+                            "<body><p>Email HTML Body</p></body>\n</html>\n"
+                        ),
+                    )
+                ),
+            )
+        ]
+
+
 class TestAccountDeletionEmail:
     def test_account_deletion_email(self, pyramid_request, pyramid_config, monkeypatch):
 

--- a/warehouse/accounts/__init__.py
+++ b/warehouse/accounts/__init__.py
@@ -79,7 +79,7 @@ def _login_via_basic_auth(username, password, request):
             # it won't screw up the fall through to other authentication mechanisms
             # (since we wouldn't have fell through to them anyways).
             resp = HTTPUnauthorized()
-            resp.status = f"{resp.status_code} {breach_service.failure_message}"
+            resp.status = f"{resp.status_code} {breach_service.failure_message_plain}"
             raise resp
 
     return result

--- a/warehouse/accounts/interfaces.py
+++ b/warehouse/accounts/interfaces.py
@@ -107,6 +107,9 @@ class ITokenService(Interface):
 
 class IPasswordBreachedService(Interface):
     failure_message = Attribute("The message to describe the failure that occured")
+    failure_message_plain = Attribute(
+        "The message to describe the failure that occured in plain text"
+    )
 
     def check_password(password, *, tags=None):
         """

--- a/warehouse/accounts/interfaces.py
+++ b/warehouse/accounts/interfaces.py
@@ -86,6 +86,12 @@ class IUserService(Interface):
         Updates the user object
         """
 
+    def disable_password(user_id):
+        """
+        Disables the given user's password, preventing further login until the user
+        resets their password.
+        """
+
 
 class ITokenService(Interface):
     def dumps(data):

--- a/warehouse/accounts/services.py
+++ b/warehouse/accounts/services.py
@@ -288,8 +288,7 @@ class TokenServiceFactory:
 class HaveIBeenPwnedPasswordBreachedService:
 
     _failure_message_preamble = (
-        "This password has appeared in a breach or has otherwise been compromised and "
-        "cannot be used."
+        "This password appears in a breach or has been compromised and cannot be used."
     )
 
     def __init__(
@@ -393,8 +392,8 @@ class HaveIBeenPwnedPasswordBreachedService:
 
 @implementer(IPasswordBreachedService)
 class NullPasswordBreachedService:
-    failure_message = "This password has appeared in a breach."
-    failure_message_plain = "This password has appeared in a breach."
+    failure_message = "This password appears in a breach."
+    failure_message_plain = "This password appears in a breach."
 
     @classmethod
     def create_service(cls, context, request):

--- a/warehouse/accounts/services.py
+++ b/warehouse/accounts/services.py
@@ -286,6 +286,12 @@ class TokenServiceFactory:
 
 @implementer(IPasswordBreachedService)
 class HaveIBeenPwnedPasswordBreachedService:
+
+    _failure_message_preamble = (
+        "This password has appeared in a breach or has otherwise been compromised and "
+        "cannot be used."
+    )
+
     def __init__(
         self,
         *,
@@ -301,9 +307,21 @@ class HaveIBeenPwnedPasswordBreachedService:
 
     @property
     def failure_message(self):
-        message = "This password has appeared in a breach or has otherwise been compromised and cannot be used."
+        message = self._failure_message_preamble
         if self._help_url:
-            message += f' See <a href="{self._help_url}">this FAQ entry</a> for more information.'
+            message += (
+                f' See <a href="{self._help_url}">this FAQ entry</a> for more '
+                "information."
+            )
+        return message
+
+    @property
+    def failure_message_plain(self):
+        message = self._failure_message_preamble
+        if self._help_url:
+            message += (
+                f" See the FAQ entry at {self._help_url} for more information."
+            )
         return message
 
     def _metrics_increment(self, *args, **kwargs):

--- a/warehouse/accounts/services.py
+++ b/warehouse/accounts/services.py
@@ -221,6 +221,10 @@ class DatabaseUserService:
             setattr(user, attr, value)
         return user
 
+    def disable_password(self, user_id):
+        user = self.get_user(user_id)
+        user.password = self.hasher.disable()
+
 
 @implementer(ITokenService)
 class TokenService:

--- a/warehouse/accounts/views.py
+++ b/warehouse/accounts/views.py
@@ -111,6 +111,7 @@ def login(request, redirect_field_name=REDIRECT_FIELD_NAME, _form_class=LoginFor
     form = _form_class(
         request.POST,
         user_service=user_service,
+        breach_service=breach_service,
         check_password_metrics_tags=["method:auth", "auth_method:login_form"],
     )
 
@@ -119,13 +120,6 @@ def login(request, redirect_field_name=REDIRECT_FIELD_NAME, _form_class=LoginFor
             # Get the user id for the given username.
             username = form.username.data
             userid = user_service.find_userid(username)
-
-            # Run our password through our breach validation. We don't currently do
-            # anything with this information, but for now it will provide metrics into
-            # how many authentications are using compromised credentials.
-            breach_service.check_password(
-                form.password.data, tags=["method:auth", "auth_method:login_form"]
-            )
 
             # If the user-originating redirection url is not safe, then
             # redirect to the index instead.

--- a/warehouse/accounts/views.py
+++ b/warehouse/accounts/views.py
@@ -110,6 +110,7 @@ def login(request, redirect_field_name=REDIRECT_FIELD_NAME, _form_class=LoginFor
 
     form = _form_class(
         request.POST,
+        request=request,
         user_service=user_service,
         breach_service=breach_service,
         check_password_metrics_tags=["method:auth", "auth_method:login_form"],

--- a/warehouse/config.py
+++ b/warehouse/config.py
@@ -220,6 +220,7 @@ def configure(settings=None):
     maybe_set_compound(settings, "origin_cache", "backend", "ORIGIN_CACHE")
     maybe_set_compound(settings, "mail", "backend", "MAIL_BACKEND")
     maybe_set_compound(settings, "metrics", "backend", "METRICS_BACKEND")
+    maybe_set_compound(settings, "breached_passwords", "backend", "BREACHED_PASSWORDS")
 
     # Add the settings we use when the environment is set to development.
     if settings["warehouse.env"] == Environment.development:

--- a/warehouse/email/__init__.py
+++ b/warehouse/email/__init__.py
@@ -158,6 +158,11 @@ def send_password_change_email(request, user):
     return {"username": user.username}
 
 
+@_email("password-compromised", allow_unverified=True)
+def send_password_compromised_email(request, user):
+    return {}
+
+
 @_email("account-deleted")
 def send_account_deletion_email(request, user):
     return {"username": user.username}

--- a/warehouse/templates/email/password-compromised/body.html
+++ b/warehouse/templates/email/password-compromised/body.html
@@ -32,7 +32,7 @@
 <h3>What should I do?</h3>
 <p>
   To regain access to your account,
-  <a href="{{ request.route_url('accounts.reset-password') }}">reset your password</a>
+  <a href="{{ request.route_url('accounts.request-password-reset') }}">reset your password</a>
   on PyPI. We also recommend that you go to
   <a href="https://haveibeenpwned.com/">HaveIBeenPwned</a> and check your other
   passwords and get yourself familiar with good password practices.

--- a/warehouse/templates/email/password-compromised/body.html
+++ b/warehouse/templates/email/password-compromised/body.html
@@ -1,0 +1,55 @@
+{#
+ # Licensed under the Apache License, Version 2.0 (the "License");
+ # you may not use this file except in compliance with the License.
+ # You may obtain a copy of the License at
+ #
+ # http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+-#}
+{% extends "email/_base/body.html" %}
+
+
+{% block content %}
+<h3>What?</h3>
+<p>
+  During your recent attempt to log in or upload to PyPI, we noticed that your password
+  has appeared in public data breaches. To protect you and other users, we have
+  preemptively reset your password and you will no longer be able to log in or upload to
+  PyPI with your existing password.
+</p>
+<p>
+  PyPI itself has not suffered a breach. This is a protective measure to reduce the
+  risk of <a href="https://www.owasp.org/index.php/Credential_stuffing">credential stuffing</a>
+  attacks against PyPI and its users.
+</p>
+
+
+<h3>What should I do?</h3>
+<p>
+  To regain access to your account, you will need to
+  <a href="{{ request.route_url('accounts.reset-password') }}">reset your password</a>
+  on PyPI. We also recommend that you go to
+  <a href="https://haveibeenpwned.com/">HaveIBeenPwned</a> and check your other
+  passwords and get yourself familiar with good password practices.
+</p>
+
+
+<h3>How do you know this?</h3>
+<p>
+  We utilize a free security service from
+  <a href="https://haveibeenpwned.com/">HaveIBeenPwned</a>. When registering,
+  authenticating, or updating your password, we generate a SHA1 hash of your password
+  and use the first five (5) characters of the hash to determine if the password has
+  been previously compromised. The plaintext password is never stored by PyPI or
+  submitted to the HaveIBeenPwned API.
+</p>
+<p>
+  For more information, see our
+  <a href="{{ request.help_url(_anchor='compromised-password') }}">FAQ</a>.
+</p>
+{% endblock %}

--- a/warehouse/templates/email/password-compromised/body.html
+++ b/warehouse/templates/email/password-compromised/body.html
@@ -17,10 +17,10 @@
 {% block content %}
 <h3>What?</h3>
 <p>
-  During your recent attempt to log in or upload to PyPI, we noticed that your password
-  has appeared in public data breaches. To protect you and other users, we have
-  preemptively reset your password and you will no longer be able to log in or upload to
-  PyPI with your existing password.
+  During your recent attempt to log in or upload to PyPI, we noticed your password appears
+  in public data breaches. To protect you and other users, we have preemptively reset your
+  password and you will no longer be able to log in or upload to PyPI with your existing
+  password.
 </p>
 <p>
   PyPI itself has not suffered a breach. This is a protective measure to reduce the
@@ -31,7 +31,7 @@
 
 <h3>What should I do?</h3>
 <p>
-  To regain access to your account, you will need to
+  To regain access to your account,
   <a href="{{ request.route_url('accounts.reset-password') }}">reset your password</a>
   on PyPI. We also recommend that you go to
   <a href="https://haveibeenpwned.com/">HaveIBeenPwned</a> and check your other
@@ -41,12 +41,11 @@
 
 <h3>How do you know this?</h3>
 <p>
-  We utilize a free security service from
+  We use a free security service from
   <a href="https://haveibeenpwned.com/">HaveIBeenPwned</a>. When registering,
   authenticating, or updating your password, we generate a SHA1 hash of your password
-  and use the first five (5) characters of the hash to determine if the password has
-  been previously compromised. The plaintext password is never stored by PyPI or
-  submitted to the HaveIBeenPwned API.
+  and use the first 5 characters of the hash to decide if the password is compromised.
+  The plaintext password is never stored by PyPI or sent to HaveIBeenPwned.
 </p>
 <p>
   For more information, see our

--- a/warehouse/templates/email/password-compromised/body.txt
+++ b/warehouse/templates/email/password-compromised/body.txt
@@ -30,7 +30,7 @@ against PyPI and its users.
 # What should I do?
 
 To regain access to your account, reset your password on PyPI
-({{ request.route_url('accounts.reset-password') }}). We also recommend that you go to
+({{ request.route_url('accounts.request-password-reset') }}). We also recommend that you go to
 HaveIBeenPwned (https://haveibeenpwned.com/) and check your other passwords and get
 yourself familiar with good password practices.
 

--- a/warehouse/templates/email/password-compromised/body.txt
+++ b/warehouse/templates/email/password-compromised/body.txt
@@ -1,0 +1,47 @@
+{#
+ # Licensed under the Apache License, Version 2.0 (the "License");
+ # you may not use this file except in compliance with the License.
+ # You may obtain a copy of the License at
+ #
+ # http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+-#}
+{% extends "email/_base/body.txt" %}
+
+
+{% block content %}
+# What?
+
+During your recent attempt to log in or upload to PyPI, we noticed that your password
+has appeared in public data breaches. To protect you and other users, we have
+preemptively reset your password and you will no longer be able to log in or upload to
+PyPI with your existing password.
+
+PyPI itself has not suffered a breach. This is a protective measure to reduce the risk
+of credential stuffing (https://www.owasp.org/index.php/Credential_stuffing) attacks
+against PyPI and its users.
+
+
+# What should I do?
+
+To regain access to your account, you will need to reset your password on PyPI
+({{ request.route_url('accounts.reset-password') }}). We also recommend that you go to
+HaveIBeenPwned (https://haveibeenpwned.com/) and check your other passwords and get
+yourself familiar with good password practices.
+
+
+# How do you know this?
+
+We utilize a free security service from HaveIBeenPwned. When registering,
+authenticating, or updating your password, we generate a SHA1 hash of your password and
+use the first five (5) characters of the hash to determine if the password has been
+previously compromised. The plaintext password is never stored by PyPI or submitted to
+the HaveIBeenPwned API.
+
+For more information, see {{ request.help_url(_anchor='compromised-password') }}.
+{% endblock %}

--- a/warehouse/templates/email/password-compromised/body.txt
+++ b/warehouse/templates/email/password-compromised/body.txt
@@ -17,10 +17,10 @@
 {% block content %}
 # What?
 
-During your recent attempt to log in or upload to PyPI, we noticed that your password
-has appeared in public data breaches. To protect you and other users, we have
-preemptively reset your password and you will no longer be able to log in or upload to
-PyPI with your existing password.
+During your recent attempt to log in or upload to PyPI, we noticed your password appears
+in public data breaches. To protect you and other users, we have preemptively reset your
+password and you will no longer be able to log in or upload to PyPI with your existing
+password.
 
 PyPI itself has not suffered a breach. This is a protective measure to reduce the risk
 of credential stuffing (https://www.owasp.org/index.php/Credential_stuffing) attacks
@@ -29,7 +29,7 @@ against PyPI and its users.
 
 # What should I do?
 
-To regain access to your account, you will need to reset your password on PyPI
+To regain access to your account, reset your password on PyPI
 ({{ request.route_url('accounts.reset-password') }}). We also recommend that you go to
 HaveIBeenPwned (https://haveibeenpwned.com/) and check your other passwords and get
 yourself familiar with good password practices.
@@ -37,11 +37,10 @@ yourself familiar with good password practices.
 
 # How do you know this?
 
-We utilize a free security service from HaveIBeenPwned. When registering,
-authenticating, or updating your password, we generate a SHA1 hash of your password and
-use the first five (5) characters of the hash to determine if the password has been
-previously compromised. The plaintext password is never stored by PyPI or submitted to
-the HaveIBeenPwned API.
+We use a free security service from HaveIBeenPwned. When registering, authenticating, or
+updating your password, we generate a SHA1 hash of your password and use the first 5
+characters of the hash to decide if the password is compromised. The plaintext password
+is never stored by PyPI or sent to HaveIBeenPwned.
 
 For more information, see {{ request.help_url(_anchor='compromised-password') }}.
 {% endblock %}

--- a/warehouse/templates/email/password-compromised/subject.txt
+++ b/warehouse/templates/email/password-compromised/subject.txt
@@ -1,0 +1,17 @@
+{#
+ # Licensed under the Apache License, Version 2.0 (the "License");
+ # you may not use this file except in compliance with the License.
+ # You may obtain a copy of the License at
+ #
+ # http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+-#}
+
+{% extends "email/_base/subject.txt" %}
+
+{% block subject %}Your {{ request.registry.settings["site.name"] }} password has been reset{% endblock %}

--- a/warehouse/templates/pages/help.html
+++ b/warehouse/templates/pages/help.html
@@ -178,6 +178,9 @@
           <p>
             If you receive an error message saying that "This password has appeared in a breach or has otherwise been compromised and cannot be used", you should change it all other places that you use it as soon as possible.
           </p>
+          <p>
+            If you've received this error while attempting to log in to or upload to PyPI, then your password has been reset and you will no longer be able to log into PyPI until you <a href="{{ request.route_url('accounts.reset-password') }}">reset your password</a>.
+          </p>
       </section>
 
       <section class="faq-group" id="integrating">

--- a/warehouse/templates/pages/help.html
+++ b/warehouse/templates/pages/help.html
@@ -179,7 +179,7 @@
             If you receive an error message saying that "This password appears in a breach or has been compromised and cannot be used", you should change it all other places that you use it as soon as possible.
           </p>
           <p>
-            If you have received this error while attempting to log in or upload to PyPI, then your password has been reset and you cannot log in to PyPI until you <a href="{{ request.route_url('accounts.reset-password') }}">reset your password</a>.
+            If you have received this error while attempting to log in or upload to PyPI, then your password has been reset and you cannot log in to PyPI until you <a href="{{ request.route_url('accounts.request-password-reset') }}">reset your password</a>.
           </p>
       </section>
 

--- a/warehouse/templates/pages/help.html
+++ b/warehouse/templates/pages/help.html
@@ -179,7 +179,7 @@
             If you receive an error message saying that "This password has appeared in a breach or has otherwise been compromised and cannot be used", you should change it all other places that you use it as soon as possible.
           </p>
           <p>
-            If you've received this error while attempting to log in to or upload to PyPI, then your password has been reset and you will no longer be able to log into PyPI until you <a href="{{ request.route_url('accounts.reset-password') }}">reset your password</a>.
+            If you have received this error while attempting to log in or upload to PyPI, then your password has been reset and you cannot log in to PyPI until you <a href="{{ request.route_url('accounts.reset-password') }}">reset your password</a>.
           </p>
       </section>
 

--- a/warehouse/templates/pages/help.html
+++ b/warehouse/templates/pages/help.html
@@ -176,7 +176,7 @@
             PyPI will not allow such passwords to be used when setting a password at registration or updating your password.
           </p>
           <p>
-            If you receive an error message saying that "This password has appeared in a breach or has otherwise been compromised and cannot be used", you should change it all other places that you use it as soon as possible.
+            If you receive an error message saying that "This password appears in a breach or has been compromised and cannot be used", you should change it all other places that you use it as soon as possible.
           </p>
           <p>
             If you have received this error while attempting to log in or upload to PyPI, then your password has been reset and you cannot log in to PyPI until you <a href="{{ request.route_url('accounts.reset-password') }}">reset your password</a>.


### PR DESCRIPTION
This pull request effectively disables a user if their password appears in the HIBP data until they reset their password. Whenever the user attempts to authenticate, we will check their password using the HIBP breached password service, and if it comes back as a positive hit we will disable their password, preventing any future attempts to authenticate, send them an email with information, and finally return an error ultimately preventing them from authenticating.

While we can't iterate over our database and look for any users that have compromised credentials, this will effectively do the same thing since once a password has appeared in the HIBP data, it will no longer be usable to log into PyPI.

This will be in effect both for users authenticating using the log in form in the UI and for users uploading files to PyPI.

This is a fairly abrupt interruption to the user's flow-- they are attempting to do something and we forcibly prevent them and require them to do something else first. However this is considered to be an acceptable trade off in this case, because these password are known to the general public, and can be used in [credential stuffing](https://www.owasp.org/index.php/Credential_stuffing) attacks on PyPI. This was recently the cause of a fairly large security issue on NPM, where reused credentials by one of the users for a popular package were used to upload malicious packages ([more information](https://eslint.org/blog/2018/07/postmortem-for-malicious-package-publishes)).

This branch is currently working, however it still needs:

- [x] A plaintext (non HTML) error message when authenticating via Basic Auth.
- [x] Tests
- [x] A solution for local development. We currently have all users set to have the password, ``password``, which doesn't work because it has been compromised. Likely we should just have a no-op breached password service in local development.
- [ ] ~~Maybe give a different error when we're failing during authentication versus when changing the password? Consistency in error message makes it easier to google the problem, but the error message is more generic and harder to know exactly what just happened.~~

I'm submitting this PR now, so that people can start to review the messaging that we're sending to users. Particularly the emails that i've written (plain text and HTML) and the additional information I've added to the FAQ.

Fixes #4471.