### PR TITLE
Add "missing" indexes for Foreign Keys

### DIFF
--- a/warehouse/email/ses/models.py
+++ b/warehouse/email/ses/models.py
@@ -268,6 +268,7 @@ class Event(db.Model):
             "ses_emails.id", deferrable=True, initially="DEFERRED", ondelete="CASCADE"
         ),
         nullable=False,
+        index=True,
     )
 
     event_id = Column(Text, nullable=False, unique=True, index=True)

--- a/warehouse/migrations/versions/68a00c174ba5_add_missing_indexes_for_foreign_keys.py
+++ b/warehouse/migrations/versions/68a00c174ba5_add_missing_indexes_for_foreign_keys.py
@@ -1,0 +1,52 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+add missing indexes for foreign keys
+
+Revision ID: 68a00c174ba5
+Revises: 42e76a605cac
+Create Date: 2018-08-13 16:49:12.920887
+"""
+
+from alembic import op
+
+
+revision = "68a00c174ba5"
+down_revision = "42e76a605cac"
+
+
+def upgrade():
+    op.create_index(
+        op.f("ix_blacklist_blacklisted_by"),
+        "blacklist",
+        ["blacklisted_by"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_ses_events_email_id"), "ses_events", ["email_id"], unique=False
+    )
+    # CREATE INDEX CONCURRENTLY cannot happen inside a transaction. We'll close
+    # our transaction here and issue the statement.
+    op.execute("COMMIT")
+    op.create_index(
+        "journals_submitted_by_idx",
+        "journals",
+        ["submitted_by"],
+        unique=False,
+        postgresql_concurrently=True,
+    )
+
+
+def downgrade():
+    op.drop_index("journals_submitted_by_idx", table_name="journals")
+    op.drop_index(op.f("ix_ses_events_email_id"), table_name="ses_events")
+    op.drop_index(op.f("ix_blacklist_blacklisted_by"), table_name="blacklist")

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -546,6 +546,7 @@ class JournalEntry(db.ModelBase):
             Index("journals_id_idx", "id"),
             Index("journals_name_idx", "name"),
             Index("journals_version_idx", "version"),
+            Index("journals_submitted_by_idx", "submitted_by"),
             Index(
                 "journals_latest_releases",
                 "submitted_date",
@@ -588,7 +589,7 @@ class BlacklistedProject(db.Model):
     )
     name = Column(Text, unique=True, nullable=False)
     _blacklisted_by = Column(
-        "blacklisted_by", UUID(as_uuid=True), ForeignKey("accounts_user.id")
+        "blacklisted_by", UUID(as_uuid=True), ForeignKey("accounts_user.id"), index=True
     )
     blacklisted_by = orm.relationship(User)
     comment = Column(Text, nullable=False, server_default="")


### PR DESCRIPTION
In attempting to apply #4537 we found that the cascading deletes caused the execution to crawl due to missing indexes for the Foreign Key relationships involved.

This adds indexes for all Foreign Keys which don't currently have them.

Note that the index creation on `journals` is performed using Postgres's `CREATE INDEX CONCURRENTLY` and cannot run inside of a transaction.