### PR TITLE
Remove Unused and Duplicate Indexes

### DIFF
--- a/warehouse/accounts/models.py
+++ b/warehouse/accounts/models.py
@@ -114,7 +114,6 @@ class Email(db.ModelBase):
     __tablename__ = "accounts_email"
     __table_args__ = (
         UniqueConstraint("email", name="accounts_email_email_key"),
-        Index("accounts_email_email_like", "email"),
         Index("accounts_email_user_id", "user_id"),
     )
 

--- a/warehouse/classifiers/models.py
+++ b/warehouse/classifiers/models.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from sqlalchemy import Boolean, Column, Index, Integer, Text, sql
+from sqlalchemy import Boolean, Column, Integer, Text, sql
 
 from warehouse import db
 from warehouse.utils.attrs import make_repr
@@ -19,10 +19,6 @@ from warehouse.utils.attrs import make_repr
 class Classifier(db.ModelBase):
 
     __tablename__ = "trove_classifiers"
-    __table_args__ = (
-        Index("trove_class_class_idx", "classifier"),
-        Index("trove_class_id_idx", "id"),
-    )
 
     __repr__ = make_repr("classifier")
 

--- a/warehouse/email/ses/models.py
+++ b/warehouse/email/ses/models.py
@@ -230,7 +230,6 @@ class EmailMessage(db.Model):
         Enum(EmailStatuses, values_callable=lambda x: [e.value for e in x]),
         nullable=False,
         server_default=EmailStatuses.Accepted.value,
-        index=True,
     )
 
     message_id = Column(Text, nullable=False, unique=True, index=True)

--- a/warehouse/migrations/versions/0864352e2168_drop_duplicate_indexes.py
+++ b/warehouse/migrations/versions/0864352e2168_drop_duplicate_indexes.py
@@ -1,0 +1,50 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Drop duplicate indexes
+
+Revision ID: 0864352e2168
+Revises: 6a6eb0a95603
+Create Date: 2018-08-15 20:27:08.429077
+"""
+
+from alembic import op
+
+
+revision = "0864352e2168"
+down_revision = "6a6eb0a95603"
+
+
+def upgrade():
+    # This is an exact duplicate of the accounts_email_email_key index, minus the unique
+    # constraint.
+    op.drop_index("accounts_email_email_like", table_name="accounts_email")
+    # This is an exact duplicate of the journals_pkey index, minus the primary key
+    # constraint.
+    op.drop_index("journals_id_idx", table_name="journals")
+    # This is an exact duplicate of the trove_classifiers_classifier_key index, minus
+    # the unique constraint.
+    op.drop_index("trove_class_class_idx", table_name="trove_classifiers")
+    # This is an exact duplicate of the trove_classifiers_pkey index, minus the primary
+    # key constraint.
+    op.drop_index("trove_class_id_idx", table_name="trove_classifiers")
+
+
+def downgrade():
+    op.create_index("trove_class_id_idx", "trove_classifiers", ["id"], unique=False)
+    op.create_index(
+        "trove_class_class_idx", "trove_classifiers", ["classifier"], unique=False
+    )
+    op.create_index("journals_id_idx", "journals", ["id"], unique=False)
+    op.create_index(
+        "accounts_email_email_like", "accounts_email", ["email"], unique=False
+    )

--- a/warehouse/migrations/versions/6a6eb0a95603_drop_unused_indexes.py
+++ b/warehouse/migrations/versions/6a6eb0a95603_drop_unused_indexes.py
@@ -1,0 +1,69 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Drop unused indexes
+
+Revision ID: 6a6eb0a95603
+Revises: 4e7d5154cb0c
+Create Date: 2018-08-15 20:01:42.232010
+"""
+
+from alembic import op
+
+
+revision = "6a6eb0a95603"
+down_revision = "4e7d5154cb0c"
+
+
+def upgrade():
+    op.drop_index("journals_latest_releases", table_name="journals")
+    op.drop_index("rel_class_name_idx", table_name="release_classifiers")
+    op.drop_index("rel_dep_name_idx", table_name="release_dependencies")
+    op.drop_index("release_files_packagetype_idx", table_name="release_files")
+    op.drop_index("release_pypi_hidden_idx", table_name="releases")
+    op.drop_index("releases_name_ts_idx", table_name="releases")
+    op.drop_index("releases_summary_ts_idx", table_name="releases")
+    op.drop_index("ix_ses_emails_status", table_name="ses_emails")
+
+
+def downgrade():
+    op.create_index("ix_ses_emails_status", "ses_emails", ["status"], unique=False)
+    op.create_index(
+        "release_pypi_hidden_idx", "releases", ["_pypi_hidden"], unique=False
+    )
+    op.create_index(
+        "release_files_packagetype_idx", "release_files", ["packagetype"], unique=False
+    )
+    op.create_index("rel_dep_name_idx", "release_dependencies", ["name"], unique=False)
+    op.create_index("rel_class_name_idx", "release_classifiers", ["name"], unique=False)
+    op.create_index(
+        "journals_latest_releases",
+        "journals",
+        ["submitted_date", "name", "version"],
+        unique=False,
+    )
+
+    op.execute(
+        """ CREATE INDEX releases_name_ts_idx
+            ON releases
+            USING gin
+            (to_tsvector('english'::regconfig, name))
+        """
+    )
+
+    op.execute(
+        """ CREATE INDEX releases_summary_ts_idx
+            ON releases
+            USING gin
+            (to_tsvector('english'::regconfig, summary));
+        """
+    )

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -539,7 +539,6 @@ class JournalEntry(db.ModelBase):
     def __table_args__(cls):  # noqa
         return (
             Index("journals_changelog", "submitted_date", "name", "version", "action"),
-            Index("journals_id_idx", "id"),
             Index("journals_name_idx", "name"),
             Index("journals_version_idx", "version"),
             Index("journals_submitted_by_idx", "submitted_by"),

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -236,7 +236,6 @@ class Dependency(db.Model):
 
     __tablename__ = "release_dependencies"
     __table_args__ = (
-        Index("rel_dep_name_idx", "name"),
         Index("rel_dep_name_version_idx", "name", "version"),
         Index("rel_dep_name_version_kind_idx", "name", "version", "kind"),
         ForeignKeyConstraint(
@@ -276,7 +275,6 @@ class Release(db.ModelBase):
             Index("release_created_idx", cls.created.desc()),
             Index("release_name_created_idx", cls.name, cls.created.desc()),
             Index("release_name_idx", cls.name),
-            Index("release_pypi_hidden_idx", cls._pypi_hidden),
             Index("release_version_idx", cls.version),
         )
 
@@ -444,7 +442,6 @@ class File(db.Model):
             CheckConstraint("sha256_digest ~* '^[A-F0-9]{64}$'"),
             CheckConstraint("blake2_256_digest ~* '^[A-F0-9]{64}$'"),
             Index("release_files_name_version_idx", "name", "version"),
-            Index("release_files_packagetype_idx", "packagetype"),
             Index("release_files_version_idx", "version"),
             Index(
                 "release_files_single_sdist",
@@ -528,7 +525,6 @@ release_classifiers = Table(
         onupdate="CASCADE",
         ondelete="CASCADE",
     ),
-    Index("rel_class_name_idx", "name"),
     Index("rel_class_name_version_idx", "name", "version"),
     Index("rel_class_trove_id_idx", "trove_id"),
     Index("rel_class_version_id_idx", "version"),
@@ -547,15 +543,6 @@ class JournalEntry(db.ModelBase):
             Index("journals_name_idx", "name"),
             Index("journals_version_idx", "version"),
             Index("journals_submitted_by_idx", "submitted_by"),
-            Index(
-                "journals_latest_releases",
-                "submitted_date",
-                "name",
-                "version",
-                postgresql_where=(
-                    (cls.version != None) & (cls.action == "new release")  # noqa
-                ),
-            ),
         )
 
     id = Column(Integer, primary_key=True, nullable=False)


### PR DESCRIPTION
I split this into two migrations/commits to make it a bit easier to see.

The first one removes any index which has *never* actually been used. I found these using:

```
warehouse=> SELECT idstat.relname AS table_name,
    indexrelname AS index_name,
    idstat.idx_scan AS times_used,
pg_size_pretty(pg_relation_size(idstat.relname::regclass)) AS table_size, pg_size_pretty(pg_relation_size(indexrelname::regclass)) AS index_size,
    n_tup_upd + n_tup_ins + n_tup_del as num_writes
FROM pg_stat_user_indexes AS idstat JOIN pg_indexes ON indexrelname = indexname
    JOIN pg_stat_user_tables AS tabstat ON idstat.relname = tabstat.relname
WHERE idstat.idx_scan < 200
    AND indexdef !~* 'unique'
ORDER BY idstat.relname, indexrelname;

      table_name      |          index_name           | times_used | table_size | index_size | num_writes
----------------------+-------------------------------+------------+------------+------------+------------
 blacklist            | ix_blacklist_blacklisted_by   |          0 | 16 kB      | 16 kB      |         33
 journals             | journals_latest_releases      |          0 | 505 MB     | 59 MB      |     253465
 release_classifiers  | rel_class_name_idx            |          0 | 354 MB     | 229 MB     |     522851
 release_dependencies | rel_dep_name_idx              |          0 | 128 MB     | 50 MB      |     243821
 release_files        | release_files_packagetype_idx |          0 | 645 MB     | 34 MB      |     436673
 releases             | release_pypi_hidden_idx       |          0 | 730 MB     | 31 MB      |     307195
 releases             | releases_name_ts_idx          |          0 | 730 MB     | 21 MB      |     307195
 releases             | releases_summary_ts_idx       |          0 | 730 MB     | 33 MB      |     307195
 ses_emails           | ix_ses_emails_status          |          0 | 14 MB      | 1400 kB    |    1550088
 ses_emails           | ix_ses_emails_to              |         14 | 14 MB      | 2528 kB    |    1550088
(10 rows)
```

I did not however, remove the ``ix_blacklist_blacklisted_by``, even though it had never been used, because it will make querying that particular foreign key faster if we ever want to do it, and it is a very small index with very minimal impact. However if we are going to try to remove *all* unneeded indexes, then it would be a candidate for removal.

I also did not remove the ``ix_ses_emails_to`` index, it has barely ever been used, but it would be used when searching via the admin interface for a particular email, and I felt that it was worth while to keep that around to make that search faster.

The second migration/commit looks for queries that are exactly the same, regardless of how often they're being used. I found that with:

```
warehouse=> SELECT pg_size_pretty(SUM(pg_relation_size(idx))::BIGINT) AS SIZE,
       (array_agg(idx))[1] AS idx1, (array_agg(idx))[2] AS idx2,
       (array_agg(idx))[3] AS idx3, (array_agg(idx))[4] AS idx4
FROM (
    SELECT indexrelid::regclass AS idx, (indrelid::text ||E'\n'|| indclass::text ||E'\n'|| indkey::text ||E'\n'||
                                         COALESCE(indexprs::text,'')||E'\n' || COALESCE(indpred::text,'')) AS KEY
    FROM pg_index) sub
GROUP BY KEY HAVING COUNT(*)>1
ORDER BY SUM(pg_relation_size(idx)) DESC;

  size  |               idx1               |           idx2            | idx3 | idx4
--------+----------------------------------+---------------------------+------+------
 174 MB | journals_pkey                    | journals_id_idx           |      |
 28 MB  | accounts_email_email_key         | accounts_email_email_like |      |
 128 kB | trove_classifiers_classifier_key | trove_class_class_idx     |      |
 64 kB  | trove_classifiers_pkey           | trove_class_id_idx        |      |
(4 rows)
```

I double checked the definition of all of these, and in every case they were an index that was heavily being used, but which were duplicates of another index minus either a primary key or a unique-ness constraint. While these indexes are being heavily used, since they are exact duplicates dropping them will just have the other index take over instead and we cannot drop the *other* index, because it is enforcing either a unique or a primary key constraint.
