### PR TITLE
Fix invalid boundary

### DIFF
--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -16,77 +16,11 @@ import pretend
 import pytest
 
 from pyramid import renderers
-from pyramid.request import Request
 from pyramid.tweens import EXCVIEW
 
 from warehouse import config
 from warehouse.errors import BasicAuthBreachedPassword
 from warehouse.utils.wsgi import ProxyFixer, VhmRootRemover, HostRewrite
-
-
-class TestJunkEncodingTween:
-    def test_valid(self):
-        response = pretend.stub()
-        handler = pretend.call_recorder(lambda request: response)
-
-        tween = config.junk_encoding_tween_factory(handler, pretend.stub())
-
-        request = Request({"QUERY_STRING": ":action=browse", "PATH_INFO": "/pypi"})
-        resp = tween(request)
-
-        assert resp is response
-
-    def test_invalid_qsl(self):
-        response = pretend.stub()
-        handler = pretend.call_recorder(lambda request: response)
-
-        tween = config.junk_encoding_tween_factory(handler, pretend.stub())
-
-        request = Request({"QUERY_STRING": "%Aaction=browse"})
-        resp = tween(request)
-
-        assert resp is not response
-        assert resp.status_code == 400
-        assert resp.detail == "Invalid bytes in query string."
-
-    def test_invalid_path(self):
-        response = pretend.stub()
-        handler = pretend.call_recorder(lambda request: response)
-
-        tween = config.junk_encoding_tween_factory(handler, pretend.stub())
-
-        request = Request({"PATH_INFO": "/projects/abouÅt"})
-        resp = tween(request)
-
-        assert resp is not response
-        assert resp.status_code == 400
-        assert resp.detail == "Invalid bytes in URL."
-
-
-class TestUnicodeRedirectTween:
-    def test_basic_redirect(self):
-        response = pretend.stub(location="/a/path/to/nowhere")
-        handler = pretend.call_recorder(lambda request: response)
-        registry = pretend.stub()
-        tween = config.unicode_redirect_tween_factory(handler, registry)
-        request = pretend.stub(path="/A/pAtH/tO/nOwHeRe/")
-        assert tween(request) == response
-
-    def test_unicode_basic_redirect(self):
-        response = pretend.stub(location="/pypi/\u2603/json/")
-        handler = pretend.call_recorder(lambda request: response)
-        registry = pretend.stub()
-        tween = config.unicode_redirect_tween_factory(handler, registry)
-        request = pretend.stub(path="/pypi/snowman/json/")
-        assert tween(request).location == "/pypi/%E2%98%83/json/"
-
-    def test_not_redirect(self):
-        response = pretend.stub(location=None)
-        handler = pretend.call_recorder(lambda request: response)
-        registry = pretend.stub()
-        tween = config.unicode_redirect_tween_factory(handler, registry)
-        request = pretend.stub(path="/wu/tang/")
-        assert tween(request) == response
 
 
 class TestRequireHTTPSTween:
@@ -393,6 +327,7 @@ def test_configure(monkeypatch, settings, environment, other_settings):
             pretend.call(".http"),
         ]
         + [pretend.call(x) for x in [configurator_settings.get("warehouse.theme")] if x]
+        + [pretend.call(".sanity")]
     )
     assert configurator_obj.add_jinja2_renderer.calls == [
         pretend.call(".html"),
@@ -420,22 +355,6 @@ def test_configure(monkeypatch, settings, environment, other_settings):
     add_settings_dict = configurator_obj.add_settings.calls[2].args[0]
     assert add_settings_dict["tm.manager_hook"](pretend.stub()) is transaction_manager
     assert configurator_obj.add_tween.calls == [
-        pretend.call(
-            "warehouse.config.junk_encoding_tween_factory",
-            over=[
-                "warehouse.referrer_policy.referrer_policy_tween_factory",
-                "warehouse.config.require_https_tween_factory",
-                "warehouse.config.unicode_redirect_tween_factory",
-                "warehouse.csp.content_security_policy_tween_factory",
-                "warehouse.static.whitenoise_tween_factory",
-                "warehouse.utils.compression.compression_tween_factory",
-                "warehouse.raven.raven_tween_factory",
-                "pyramid_tm.tm_tween_factory",
-                "pyramid.tweens.excview_tween_factory",
-                "warehouse.cache.http.conditional_http_tween_factory",
-            ],
-        ),
-        pretend.call("warehouse.config.unicode_redirect_tween_factory"),
         pretend.call("warehouse.config.require_https_tween_factory"),
         pretend.call(
             "warehouse.utils.compression.compression_tween_factory",

--- a/tests/unit/test_sanity.py
+++ b/tests/unit/test_sanity.py
@@ -1,0 +1,108 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pretend
+import pytest
+
+from pyramid.httpexceptions import HTTPMovedPermanently, HTTPBadRequest
+from pyramid.request import Request
+from pyramid.response import Response
+
+from warehouse import sanity
+
+
+class TestJunkEncoding:
+    def test_valid(self):
+        request = Request({"QUERY_STRING": ":action=browse", "PATH_INFO": "/pypi"})
+        sanity.junk_encoding(request)
+
+    def test_invalid_qsl(self):
+        request = Request({"QUERY_STRING": "%Aaction=browse"})
+
+        with pytest.raises(HTTPBadRequest, match="Invalid bytes in query string."):
+            sanity.junk_encoding(request)
+
+    def test_invalid_path(self):
+        request = Request({"PATH_INFO": "/projects/abouÅt"})
+
+        with pytest.raises(HTTPBadRequest, match="Invalid bytes in URL."):
+            sanity.junk_encoding(request)
+
+
+@pytest.mark.parametrize(("original_location", "expected_location"), [
+    ("/a/path/to/nowhere", "/a/path/to/nowhere"),
+    ("/project/☃/", "/project/%E2%98%83/"),
+    (None, None),
+])
+def test_unicode_redirects(original_location, expected_location):
+    if original_location:
+        resp_in = HTTPMovedPermanently(original_location)
+    else:
+        resp_in = Response()
+
+    resp_out = sanity.unicode_redirects(resp_in)
+
+    assert resp_out.location == expected_location
+
+
+class TestSanityTween:
+    def test_ingress_valid(self, monkeypatch):
+        junk_encoding = pretend.call_recorder(lambda request: None)
+        monkeypatch.setattr(sanity, "junk_encoding", junk_encoding)
+
+        response = pretend.stub()
+        handler = pretend.call_recorder(lambda request: response)
+        registry = pretend.stub()
+
+        request = pretend.stub()
+
+        tween = sanity.sanity_tween_factory_ingress(handler, registry)
+
+        assert tween(request) is response
+        assert junk_encoding.calls == [pretend.call(request)]
+        assert handler.calls == [pretend.call(request)]
+
+    def test_ingress_invalid(self, monkeypatch):
+        response = HTTPBadRequest()
+
+        @pretend.call_recorder
+        def junk_encoding(request):
+            raise response
+
+        monkeypatch.setattr(sanity, "junk_encoding", junk_encoding)
+
+        handler = pretend.call_recorder(lambda request: response)
+        registry = pretend.stub()
+
+        request = pretend.stub()
+
+        tween = sanity.sanity_tween_factory_ingress(handler, registry)
+
+        assert tween(request) is response
+        assert junk_encoding.calls == [pretend.call(request)]
+        assert handler.calls == []
+
+    def test_egress(self, monkeypatch):
+        unicode_redirects = pretend.call_recorder(lambda resp: resp)
+        monkeypatch.setattr(sanity, "unicode_redirects", unicode_redirects)
+
+        response = pretend.stub()
+        handler = pretend.call_recorder(lambda request: response)
+        registry = pretend.stub()
+
+        request = pretend.stub()
+
+        tween = sanity.sanity_tween_factory_egress(handler, registry)
+
+        assert tween(request) is response
+        assert handler.calls == [pretend.call(request)]
+        assert unicode_redirects.calls == [pretend.call(response)]

--- a/tests/unit/test_sanity.py
+++ b/tests/unit/test_sanity.py
@@ -42,31 +42,32 @@ class TestJunkEncoding:
 
 class TestInvalidForms:
     def test_valid(self):
-        request = Request({
-            "REQUEST_METHOD": "POST",
-            "CONTENT_TYPE": (
-                "multipart/form-data; boundary=c397e2aa2980f1a53dee37c05b8fb45a"
-            ),
-            "wsgi.input": io.BytesIO(
-                b"--------------------------c397e2aa2980f1a53dee37c05b8fb45a\r\n"
-                b'Content-Disposition: form-data; name="person"\r\n'
-                b"anonymous"
-            )
-        })
+        request = Request(
+            {
+                "REQUEST_METHOD": "POST",
+                "CONTENT_TYPE": (
+                    "multipart/form-data; boundary=c397e2aa2980f1a53dee37c05b8fb45a"
+                ),
+                "wsgi.input": io.BytesIO(
+                    b"--------------------------c397e2aa2980f1a53dee37c05b8fb45a\r\n"
+                    b'Content-Disposition: form-data; name="person"\r\n'
+                    b"anonymous"
+                ),
+            }
+        )
 
         sanity.invalid_forms(request)
 
     def test_invalid_form(self):
-        request = Request({
-            "REQUEST_METHOD": "POST",
-            "CONTENT_TYPE": (
-                "multipart/form-data"
-            ),
-            "wsgi.input": io.BytesIO(
-                b'Content-Disposition: form-data; name="person"\r\n'
-                b"anonymous"
-            )
-        })
+        request = Request(
+            {
+                "REQUEST_METHOD": "POST",
+                "CONTENT_TYPE": ("multipart/form-data"),
+                "wsgi.input": io.BytesIO(
+                    b'Content-Disposition: form-data; name="person"\r\n' b"anonymous"
+                ),
+            }
+        )
 
         with pytest.raises(HTTPBadRequest, match="Invalid Form Data."):
             sanity.invalid_forms(request)
@@ -76,11 +77,14 @@ class TestInvalidForms:
         sanity.invalid_forms(request)
 
 
-@pytest.mark.parametrize(("original_location", "expected_location"), [
-    ("/a/path/to/nowhere", "/a/path/to/nowhere"),
-    ("/project/☃/", "/project/%E2%98%83/"),
-    (None, None),
-])
+@pytest.mark.parametrize(
+    ("original_location", "expected_location"),
+    [
+        ("/a/path/to/nowhere", "/a/path/to/nowhere"),
+        ("/project/☃/", "/project/%E2%98%83/"),
+        (None, None),
+    ],
+)
 def test_unicode_redirects(original_location, expected_location):
     if original_location:
         resp_in = HTTPMovedPermanently(original_location)

--- a/warehouse/sanity.py
+++ b/warehouse/sanity.py
@@ -81,14 +81,12 @@ def sanity_tween_factory_egress(handler, registry):
 def _add_tween(config):
     tweens = config.registry.queryUtility(ITweens)
     tweens.add_explicit(
-        "warehouse.sanity.sanity_tween_factory_ingress",
-        sanity_tween_factory_ingress,
+        "warehouse.sanity.sanity_tween_factory_ingress", sanity_tween_factory_ingress
     )
     for tween_name, tween_factory in tweens.implicit():
         tweens.add_explicit(tween_name, tween_factory)
     tweens.add_explicit(
-        "warehouse.sanity.sanity_tween_factory_egress",
-        sanity_tween_factory_egress,
+        "warehouse.sanity.sanity_tween_factory_egress", sanity_tween_factory_egress
     )
 
 
@@ -96,7 +94,7 @@ def includeme(config):
     # I'm doing bad things, I'm sorry. - dstufft
     config.action(
         ("tween", "warehouse.sanity.sanity_tween_factory", True),
-        _add_tween ,
+        _add_tween,
         args=(config,),
         order=PHASE3_CONFIG,
     )

--- a/warehouse/sanity.py
+++ b/warehouse/sanity.py
@@ -1,0 +1,91 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import urllib.parse
+
+from pyramid.config import PHASE3_CONFIG
+from pyramid.httpexceptions import HTTPException, HTTPBadRequest
+from pyramid.interfaces import ITweens
+
+
+def junk_encoding(request):
+    # We're going to test our request a bit, before we pass it into the
+    # handler. This will let us return a better error than a 500 if we
+    # can't decode these.
+
+    # Ref: https://github.com/Pylons/webob/issues/161
+    # Ref: https://github.com/Pylons/webob/issues/115
+    try:
+        request.GET.get("", None)
+    except UnicodeDecodeError:
+        raise HTTPBadRequest("Invalid bytes in query string.")
+
+    # Look for invalid bytes in a path.
+    try:
+        request.path_info
+    except UnicodeDecodeError:
+        raise HTTPBadRequest("Invalid bytes in URL.")
+
+
+def unicode_redirects(response):
+    if response.location:
+        try:
+            response.location.encode("ascii")
+        except UnicodeEncodeError:
+            response.location = "/".join(
+                [urllib.parse.quote_plus(x) for x in response.location.split("/")]
+            )
+
+    return response
+
+
+def sanity_tween_factory_ingress(handler, registry):
+    def sanity_tween_ingress(request):
+        try:
+            junk_encoding(request)
+        except HTTPException as exc:
+            return exc
+
+        return handler(request)
+
+    return sanity_tween_ingress
+
+
+def sanity_tween_factory_egress(handler, registry):
+    def sanity_tween_egress(request):
+        return unicode_redirects(handler(request))
+
+    return sanity_tween_egress
+
+
+def _add_tween(config):
+    tweens = config.registry.queryUtility(ITweens)
+    tweens.add_explicit(
+        "warehouse.sanity.sanity_tween_factory_ingress",
+        sanity_tween_factory_ingress,
+    )
+    for tween_name, tween_factory in tweens.implicit():
+        tweens.add_explicit(tween_name, tween_factory)
+    tweens.add_explicit(
+        "warehouse.sanity.sanity_tween_factory_egress",
+        sanity_tween_factory_egress,
+    )
+
+
+def includeme(config):
+    # I'm doing bad things, I'm sorry. - dstufft
+    config.action(
+        ("tween", "warehouse.sanity.sanity_tween_factory", True),
+        _add_tween ,
+        args=(config,),
+        order=PHASE3_CONFIG,
+    )

--- a/warehouse/sanity.py
+++ b/warehouse/sanity.py
@@ -36,6 +36,16 @@ def junk_encoding(request):
         raise HTTPBadRequest("Invalid bytes in URL.")
 
 
+def invalid_forms(request):
+    # People send invalid forms that we can't actually decode, so we'll want to return
+    # a BadRequest here instead of a 500 error.
+    if request.method == "POST":
+        try:
+            request.POST.get("", None)
+        except ValueError:
+            raise HTTPBadRequest("Invalid Form Data.")
+
+
 def unicode_redirects(response):
     if response.location:
         try:
@@ -52,6 +62,7 @@ def sanity_tween_factory_ingress(handler, registry):
     def sanity_tween_ingress(request):
         try:
             junk_encoding(request)
+            invalid_forms(request)
         except HTTPException as exc:
             return exc
 


### PR DESCRIPTION
* Refactors our sanity checking into its own module and does some really janky shit to absolutely ensure our ingress/egress sanity checking is being done in the correct place.
* Fixes unhandled exceptions when someone ``POST`` an invalid form.