### PR TITLE
[WIP] Periodically prune unused users

### DIFF
--- a/warehouse/accounts/__init__.py
+++ b/warehouse/accounts/__init__.py
@@ -12,6 +12,7 @@
 
 import datetime
 
+from celery.schedules import crontab
 from pyramid.authorization import ACLAuthorizationPolicy
 from pyramid_multiauth import MultiAuthenticationPolicy
 
@@ -31,6 +32,7 @@ from warehouse.accounts.auth_policy import (
     BasicAuthAuthenticationPolicy,
     SessionAuthenticationPolicy,
 )
+from warehouse.accounts.tasks import prune_unused_users
 from warehouse.errors import BasicAuthBreachedPassword
 from warehouse.email import send_password_compromised_email
 from warehouse.rate_limiting import RateLimit, IRateLimiter
@@ -156,3 +158,6 @@ def includeme(config):
     config.register_service_factory(
         RateLimit("1000 per 5 minutes"), IRateLimiter, name="global.login"
     )
+
+    # Add our periodic user prune task
+    config.add_periodic_task(crontab(minute=0, hour=0), prune_unused_users)

--- a/warehouse/accounts/tasks.py
+++ b/warehouse/accounts/tasks.py
@@ -1,0 +1,49 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import datetime
+
+from warehouse import tasks
+from warehouse.accounts.models import User
+from warehouse.packaging.models import Role, JournalEntry
+
+
+@tasks.task(ignore_result=True, acks_late=True)
+def prune_unused_users(request):
+    # We're going to delete any user that matches the following criteria:
+    #
+    #   - Is not active (e.g. has never verified an email address)
+    #   - Joined more than 90 days ago.
+    #   - Has never been added to a project.
+    #   - Has never released any project.
+    #
+    # These users effectively add nothing to PyPI. They have never activated their
+    # account, they have never released anything to PyPI nor even been added to a
+    # project. The bulk of these are spam accounts that were registered or are emphereal
+    # auto generated accounts.
+    (
+        request.db.query(User)
+        .filter(User.is_active == False)  # noqa
+        .filter(
+            User.date_joined
+            < (datetime.datetime.utcnow() - datetime.timedelta(days=90))
+        )
+        .filter(
+            ~request.db.query(Role).filter(Role.user_name == User.username).exists()
+        )
+        .filter(
+            ~request.db.query(JournalEntry)
+            .filter(JournalEntry._submitted_by == User.username)
+            .exists()
+        )
+        .delete(synchronize_session=False)
+    )


### PR DESCRIPTION
This is just an idea, basically we get a fair amount of spam user signups who never go on to do anything meaningful with their account. I'm just throwing this PR up here for some discussion on whether this is a good idea or not.

This will currently delete about 102889 users on the production database, again to reiterate these are users who never activated, uploaded, or were added to a project.

If we did this, we would probably want to adjust the language of the verification email (at least for the first one) to say that if the user doesn't verify their email, they will be deleted after some period of time.

/cc @pypa/warehouse-committers 