### PR TITLE
show forklift endpoint page on test.pypi.org (fixes #4087)

### DIFF
--- a/dev/environment
+++ b/dev/environment
@@ -37,3 +37,4 @@ TOKEN_PASSWORD_SECRET="an insecure password reset secret key"
 TOKEN_EMAIL_SECRET="an insecure email verification secret key"
 
 WAREHOUSE_LEGACY_DOMAIN=pypi.python.org
+TEST_DOMAIN=test.pypi.org

--- a/tests/unit/forklift/test_init.py
+++ b/tests/unit/forklift/test_init.py
@@ -16,11 +16,14 @@ import pytest
 from warehouse import forklift
 
 
-@pytest.mark.parametrize("forklift_domain", [None, "upload.pypi.io"])
-def test_includeme(forklift_domain, monkeypatch):
+@pytest.mark.parametrize(
+    "forklift_domain,test_domain", [(None, None), ("upload.pypi.io", "test.pypi.org")]
+)
+def test_includeme(forklift_domain, test_domain, monkeypatch):
     settings = {}
     if forklift_domain:
         settings["forklift.domain"] = forklift_domain
+        settings["test.domain"] = test_domain
 
     _help_url = pretend.stub()
     monkeypatch.setattr(forklift, "_help_url", _help_url)
@@ -58,10 +61,16 @@ def test_includeme(forklift_domain, monkeypatch):
                 route_kw={"domain": forklift_domain},
             ),
             pretend.call(
+                "forklift.test",
+                "/legacy/",
+                "upload.html",
+                route_kw={"domain": test_domain},
+            ),
+            pretend.call(
                 "forklift.legacy.invalid_request",
                 "/legacy/",
                 "upload.html",
-                route_kw={"domain": "upload.pypi.io"},
+                route_kw={"domain": forklift_domain},
             ),
         ]
     else:

--- a/warehouse/config.py
+++ b/warehouse/config.py
@@ -146,6 +146,7 @@ def configure(settings=None):
     maybe_set(settings, "warehouse.theme", "WAREHOUSE_THEME")
     maybe_set(settings, "warehouse.domain", "WAREHOUSE_DOMAIN")
     maybe_set(settings, "forklift.domain", "FORKLIFT_DOMAIN")
+    maybe_set(settings, "test.domain", "TEST_DOMAIN")
     maybe_set(settings, "warehouse.legacy_domain", "WAREHOUSE_LEGACY_DOMAIN")
     maybe_set(settings, "site.name", "SITE_NAME", default="Warehouse")
     maybe_set(settings, "aws.key_id", "AWS_ACCESS_KEY_ID")

--- a/warehouse/forklift/__init__.py
+++ b/warehouse/forklift/__init__.py
@@ -25,6 +25,7 @@ def includeme(config):
     # these to segregate the Warehouse routes from the Forklift routes until
     # Forklift is properly split out into it's own project.
     forklift = config.get_settings().get("forklift.domain")
+    test_domain = config.get_settings().get("test.domain")
 
     # Include our legacy action routing
     config.include(".action_routing")
@@ -45,6 +46,10 @@ def includeme(config):
     if forklift:
         config.add_template_view(
             "forklift.index", "/", "upload.html", route_kw={"domain": forklift}
+        )
+
+        config.add_template_view(
+            "forklift.test", "/legacy/", "upload.html", route_kw={"domain": test_domain}
         )
 
         # Any call to /legacy/ not handled by another route (e.g. no :action

--- a/warehouse/templates/base.html
+++ b/warehouse/templates/base.html
@@ -51,7 +51,7 @@
     <meta name="defaultLanguage" content="en">
     <meta name="availableLanguages" content="en">
 
-    {% if request.registry.settings.get("warehouse.domain") == "test.pypi.org" %}
+    {% if request.registry.settings.get("warehouse.domain") == request.registry.settings.get("test.domain") %}
       {% set testPyPI = true %}
     {% endif %}
 


### PR DESCRIPTION
Fixes #4087 

This displays the API endpoint page when visiting [https://test.pypi.org/legacy/](https://test.pypi.org/legacy/).

With this change, `test.pypi.org` was beginning to be hard-coded several places, so I added it to `dev/environment` and brought it into the the code via `warehouse/config.py`.

If there's a different/better way to do this, just let me know and I'd be happy to push the change.