### PR TITLE
Link IP address in journal list

### DIFF
--- a/warehouse/admin/templates/admin/journals/list.html
+++ b/warehouse/admin/templates/admin/journals/list.html
@@ -53,7 +53,11 @@
         <td>{{ journal.version }}</td>
         <td>{{ journal.submitted_date }}</td>
         <td><a href="{{ request.route_path('admin.user.detail', user_id=journal.submitted_by.id) }}">{{ journal.submitted_by.username }}</a></td>
-        <td>{{ journal.submitted_from }}</td>
+        <td>
+          <a href="{{ request.route_path('admin.journals.list', _query={'q': 'ip:' + journal.submitted_from}) }}">
+            {{ journal.submitted_from }}
+          </a>
+        </td>
         <td>{{ journal.action }}</td>
       </tr>
       {% endfor %}


### PR DESCRIPTION
This makes it a little bit easier to drill down on a single IP when viewing the list of journal entries.