### PR TITLE
Raise 404 instead of return

### DIFF
--- a/tests/unit/packaging/test_views.py
+++ b/tests/unit/packaging/test_views.py
@@ -11,6 +11,7 @@
 # limitations under the License.
 
 import pretend
+import pytest
 
 from pyramid.httpexceptions import HTTPMovedPermanently, HTTPNotFound
 
@@ -48,8 +49,9 @@ class TestProjectDetail:
 
     def test_missing_release(self, db_request):
         project = ProjectFactory.create()
-        resp = views.project_detail(project, db_request)
-        assert isinstance(resp, HTTPNotFound)
+
+        with pytest.raises(HTTPNotFound):
+            views.project_detail(project, db_request)
 
     def test_calls_release_detail(self, monkeypatch, db_request):
         project = ProjectFactory.create()

--- a/tests/unit/test_views.py
+++ b/tests/unit/test_views.py
@@ -511,8 +511,8 @@ class TestSearch:
         url_maker_factory = pretend.call_recorder(lambda request: url_maker)
         monkeypatch.setattr(views, "paginate_url_factory", url_maker_factory)
 
-        resp = search(db_request)
-        assert isinstance(resp, HTTPNotFound)
+        with pytest.raises(HTTPNotFound):
+            search(db_request)
 
         assert page_cls.calls == [
             pretend.call(es_query, url_maker=url_maker, page=15 or 1)

--- a/warehouse/packaging/views.py
+++ b/warehouse/packaging/views.py
@@ -43,7 +43,7 @@ def project_detail(project, request):
             .one()
         )
     except NoResultFound:
-        return HTTPNotFound()
+        raise HTTPNotFound
 
     return release_detail(release, request)
 

--- a/warehouse/views.py
+++ b/warehouse/views.py
@@ -292,7 +292,7 @@ def search(request):
         raise HTTPServiceUnavailable
 
     if page.page_count and page_num > page.page_count:
-        return HTTPNotFound()
+        raise HTTPNotFound
 
     available_filters = collections.defaultdict(list)
 


### PR DESCRIPTION
Raise a `HTTPNotFound` instead of returning it so it can get caught by our exception handler and a nice 404 page will be rendered instead.