### PR TITLE
Add code highlighting demo project to fronted.rst

### DIFF
--- a/docs/development/frontend.rst
+++ b/docs/development/frontend.rst
@@ -93,4 +93,7 @@ The majority of the SCSS styles are found within the 'blocks' layer,
 with each BEM block in its own file. All blocks are documented at the top of
 the file to provide guidelines for use and modification.
 
-One of these blocks provides code syntax highlighting, which can be tested on reference project provided at `<http://localhost/project/pypi-code-highlighting-demo/>`_ when using dev database dump. Source rst file is available `here <https://github.com/evemorgen/pypi-code-highlighting-demo>`_.
+One of these blocks provides code syntax highlighting, which can be tested with
+reference project provided at `<http://localhost/project/pypi-code-highlighting-demo/>`_ 
+when using development database. Source reStructuredText file is available 
+`here <https://github.com/evemorgen/pypi-code-highlighting-demo>`_.

--- a/docs/development/frontend.rst
+++ b/docs/development/frontend.rst
@@ -92,3 +92,5 @@ specific. This tightly controls the cascade of styles.
 The majority of the SCSS styles are found within the 'blocks' layer,
 with each BEM block in its own file. All blocks are documented at the top of
 the file to provide guidelines for use and modification.
+
+One of these blocks provides code syntax highlighting, which can be tested on reference project provided at `<http://localhost/project/pypi-code-highlighting-demo/>`_ when using dev database dump. Source rst file is available `here <https://github.com/evemorgen/pypi-code-highlighting-demo>`_.

--- a/docs/development/frontend.rst
+++ b/docs/development/frontend.rst
@@ -94,6 +94,6 @@ with each BEM block in its own file. All blocks are documented at the top of
 the file to provide guidelines for use and modification.
 
 One of these blocks provides code syntax highlighting, which can be tested with
-reference project provided at `<http://localhost/project/pypi-code-highlighting-demo/>`_ 
-when using development database. Source reStructuredText file is available 
+reference project provided at `<http://localhost/project/pypi-code-highlighting-demo/>`_
+when using development database. Source reStructuredText file is available
 `here <https://github.com/evemorgen/pypi-code-highlighting-demo>`_.


### PR DESCRIPTION
This PR definitely closes #4400. 
It brings a paragraph about code-highlighting example project to `frontend.rst` docs.
Any language specific comments are more than welcome, since I'm not native english speaker 😅 