### PR TITLE
Match more icons for project links

### DIFF
--- a/warehouse/templates/packaging/detail.html
+++ b/warehouse/templates/packaging/detail.html
@@ -19,18 +19,30 @@
 
 {% if name|lower == "download" %}
    {% set icon = "fa fa-cloud-download-alt" %}
-{% elif parsed.netloc == "github.com" or parsed.netloc.endswith(".github.com") %}
+{% elif parsed.netloc in ["github.com", "github.io"] or parsed.netloc.endswith((".github.com", ".github.io")) %}
   {% set icon = "fab fa-github" %}
 {% elif parsed.netloc == "gitlab.com" or parsed.netloc.endswith(".gitlab.com") %}
   {% set icon = "fab fa-gitlab" %}
+{% elif parsed.netloc == "gitter.im" or parsed.netloc.endswith(".gitter.im") %}
+  {% set icon = "fab fa-gitter" %}
+{% elif parsed.netloc == "google.com" or parsed.netloc.endswith(".google.com") %}
+  {% set icon = "fab fa-google" %}
 {% elif parsed.netloc == "bitbucket.org" or parsed.netloc.endswith(".bitbucket.org") %}
   {% set icon = "fab fa-bitbucket" %}
+{% elif parsed.netloc in ["readthedocs.io", "readthedocs.org", "rtfd.io", "rtfd.org"] or parsed.netloc.endswith((".readthedocs.io", ".readthedocs.org", ".rtfd.io", ".rtfd.org")) %}
+  {% set icon = "fas fa-book" %}
 {% elif parsed.netloc == "reddit.com" or parsed.netloc.endswith(".reddit.com") %}
   {% set icon = "fab fa-reddit-alien" %}
 {% elif parsed.netloc == "slack.com" or parsed.netloc.endswith(".slack.com") %}
   {% set icon = "fab fa-slack" %}
 {% elif parsed.netloc == "twitter.com" or parsed.netloc.endswith(".twitter.com") %}
   {% set icon = "fab fa-twitter" %}
+{% elif parsed.netloc in ["ci.appveyor.com", "circleci.com", "travis-ci.com", "travis-ci.org"] or parsed.netloc.endswith((".appveyor.com", ".circleci.com", ".travis-ci.org", ".travis-ci.com")) %}
+  {% set icon = "fas fa-check" %}
+{% elif parsed.netloc in ["cheeseshop.python.org", "pypi.io", "pypi.org", "pypi.python.org"] %}
+  {% set icon = "fas fa-cube" %}
+{% elif parsed.netloc == "python.org" or parsed.netloc.endswith(".python.org") %}
+  {% set icon = "fab fa-python" %}
 {% elif name|lower == "home" or name|lower == "homepage" or name|lower == "home page" %}
   {% set icon = "fa fa-home" %}
 {% else %}


### PR DESCRIPTION
This PR adds some more icons for the "Project links" section of the side bar, by checking the most downloaded packages to find some common sites.


# GitHub

* Match `github.io` as well as `github.com`

![image](https://user-images.githubusercontent.com/1324225/46213589-9a129600-c341-11e8-9ca2-8943e8db4bbb.png)

https://fontawesome.com/icons/github?style=brands

# Gitter

* Add `gitter.im`

![image](https://user-images.githubusercontent.com/1324225/46213633-bf070900-c341-11e8-831e-20a5f092d9f2.png)

https://fontawesome.com/icons/gitter?style=brands

# Google

* Add `google.com`, there's some `code.google.com` and `developers.google.com`

![image](https://user-images.githubusercontent.com/1324225/46213685-ea89f380-c341-11e8-9740-bdb74c467702.png)

https://fontawesome.com/icons/google?style=brands

# Read the Docs

* Add `readthedocs.io`, `readthedocs.org`, `rtfd.io` and `rtfd.org`
* There's no RTD icon in Font Awesome, but the book icon is quite a good match

![image](https://user-images.githubusercontent.com/1324225/46213772-20c77300-c342-11e8-978d-a4bd0daf47f0.png)

![image](https://user-images.githubusercontent.com/1324225/46213798-3177e900-c342-11e8-94ff-8e9d2ed2bb28.png)

https://fontawesome.com/icons/book?style=solid

# CI

* Add `ci.appveyor.com`, `circleci.com`, `travis-ci.com` and `travis-ci.org`
* There's no icons for these, but I think the check/tick is a good match as it's used for example on GitHub for code checks.
* Maybe add CodeCov and Coveralls to this?

![image](https://user-images.githubusercontent.com/1324225/46213963-9f241500-c342-11e8-8b42-ea634e65e87d.png)

![image](https://user-images.githubusercontent.com/1324225/46213929-8ae01800-c342-11e8-9ee5-68f5f866cc00.png)

https://fontawesome.com/icons/check?style=solid

# PyPI

* It's quite annoying to click a "Homepage" link from PyPI and end up back at the same PyPI page! 
* This adds a number of PyPI domains
* There's no PyPI logo on FA, is there one that can be re-used?
* Otherwise, the cube icon is quite good

![image](https://user-images.githubusercontent.com/1324225/46214083-f3c79000-c342-11e8-89ec-6b9dde01d3ee.png)
![image](https://user-images.githubusercontent.com/1324225/46214103-0215ac00-c343-11e8-81e4-1e74addf4b07.png)

https://fontawesome.com/icons/cube?style=solid

# Python

* Finally, there's some going to `python.org` pages, so we can use the Python logo

![image](https://user-images.githubusercontent.com/1324225/46214157-1fe31100-c343-11e8-9cfa-566d94e39608.png)

https://fontawesome.com/icons/python?style=brands