### PR TITLE
Match Codecov and Coveralls for the check icon

### DIFF
--- a/warehouse/templates/packaging/detail.html
+++ b/warehouse/templates/packaging/detail.html
@@ -37,7 +37,7 @@
   {% set icon = "fab fa-slack" %}
 {% elif parsed.netloc == "twitter.com" or parsed.netloc.endswith(".twitter.com") %}
   {% set icon = "fab fa-twitter" %}
-{% elif parsed.netloc in ["ci.appveyor.com", "circleci.com", "travis-ci.com", "travis-ci.org"] or parsed.netloc.endswith((".appveyor.com", ".circleci.com", ".travis-ci.org", ".travis-ci.com")) %}
+{% elif parsed.netloc in ["ci.appveyor.com", "circleci.com", "codecov.io", "coveralls.io", "travis-ci.com", "travis-ci.org"] or parsed.netloc.endswith((".appveyor.com", ".circleci.com", ".codecov.io", ".coveralls.io", ".travis-ci.org", ".travis-ci.com")) %}
   {% set icon = "fas fa-check" %}
 {% elif parsed.netloc in ["cheeseshop.python.org", "pypi.io", "pypi.org", "pypi.python.org"] %}
   {% set icon = "fas fa-cube" %}


### PR DESCRIPTION
Follow on from https://github.com/pypa/warehouse/pull/4780.

# CI

* In addition to code build sites, add code coverage sites
* There's no icons for these, but I think the check/tick is a good match as it's used for example on GitHub for code checks.

![image](https://user-images.githubusercontent.com/1324225/46213963-9f241500-c342-11e8-8b42-ea634e65e87d.png)

![image](https://user-images.githubusercontent.com/1324225/46213929-8ae01800-c342-11e8-9ee5-68f5f866cc00.png)

https://fontawesome.com/icons/check?style=solid
