### PR TITLE
Change CI icon to tasks list

### DIFF
--- a/warehouse/templates/packaging/detail.html
+++ b/warehouse/templates/packaging/detail.html
@@ -37,7 +37,7 @@
   {% set icon = "fab fa-slack" %}
 {% elif parsed.netloc == "twitter.com" or parsed.netloc.endswith(".twitter.com") %}
   {% set icon = "fab fa-twitter" %}
-{% elif parsed.netloc in ["ci.appveyor.com", "circleci.com", "codecov.io", "coveralls.io", "travis-ci.com", "travis-ci.org"] or parsed.netloc.endswith((".appveyor.com", ".circleci.com", ".codecov.io", ".coveralls.io", ".travis-ci.org", ".travis-ci.com")) %}
+{% elif parsed.netloc in ["ci.appveyor.com", "circleci.com", "codecov.io", "coveralls.io", "shippable.com", "travis-ci.com", "travis-ci.org"] or parsed.netloc.endswith((".appveyor.com", ".circleci.com", ".codecov.io", ".coveralls.io", ".shippable.com", ".travis-ci.org", ".travis-ci.com")) %}
   {% set icon = "fas fa-check" %}
 {% elif parsed.netloc in ["cheeseshop.python.org", "pypi.io", "pypi.org", "pypi.python.org"] %}
   {% set icon = "fas fa-cube" %}

--- a/warehouse/templates/packaging/detail.html
+++ b/warehouse/templates/packaging/detail.html
@@ -38,7 +38,7 @@
 {% elif parsed.netloc == "twitter.com" or parsed.netloc.endswith(".twitter.com") %}
   {% set icon = "fab fa-twitter" %}
 {% elif parsed.netloc in ["ci.appveyor.com", "circleci.com", "codecov.io", "coveralls.io", "shippable.com", "travis-ci.com", "travis-ci.org"] or parsed.netloc.endswith((".appveyor.com", ".circleci.com", ".codecov.io", ".coveralls.io", ".shippable.com", ".travis-ci.org", ".travis-ci.com")) %}
-  {% set icon = "fas fa-check" %}
+  {% set icon = "fas fa-tasks" %}
 {% elif parsed.netloc in ["cheeseshop.python.org", "pypi.io", "pypi.org", "pypi.python.org"] %}
   {% set icon = "fas fa-cube" %}
 {% elif parsed.netloc == "python.org" or parsed.netloc.endswith(".python.org") %}


### PR DESCRIPTION
Further to https://github.com/pypa/warehouse/pull/4780#issuecomment-425795784, the check mark looked a bit too much like PyPI is reporting on the success of CI runs, which it isn't.

Instead, use the "tasks" icon, which would look like this:

![image](https://user-images.githubusercontent.com/1324225/46304055-45c41c00-c5b6-11e8-8c0f-04ffb46742e2.png)

https://pypi.org/project/aiohttp/

This also adds Shippable to the list of CIs, as found by chance on that list.