### PR TITLE
Make container wide enough to no wrap buttons

### DIFF
--- a/warehouse/static/sass/blocks/_package-snippet.scss
+++ b/warehouse/static/sass/blocks/_package-snippet.scss
@@ -76,7 +76,7 @@
   }
 
   &__buttons {
-    width: 165px;
+    width: 166px;
 
     .button {
       display: inline-block;


### PR DESCRIPTION
At least for me on OSX/Chrome, this leads to
https://pypi.org/manage/projects/ view with button next to each other
instead of below each other. Which seem to look more in line with the
design.

Otherwise I guess "Manage" and "View" should have the same width.

After

<img width="819" alt="screen shot 2018-10-02 at 14 41 02" src="https://user-images.githubusercontent.com/335567/46378666-3ba32b80-c651-11e8-826f-076a11e2e83b.png">

--- 

Before
<img width="815" alt="screen shot 2018-10-02 at 14 40 51" src="https://user-images.githubusercontent.com/335567/46378668-3ba32b80-c651-11e8-83a4-0bee574d4128.png">



