### PR TITLE
[WIP] Improve delete release warning (closes #4737)

### DIFF
--- a/warehouse/templates/manage/release.html
+++ b/warehouse/templates/manage/release.html
@@ -126,7 +126,9 @@
         files
       {% endtrans %}
     {% else %}
-      Deleting will irreversibly delete this release
+      Deleting will irreversibly delete this release.
+      You will not be able to re-upload a new distribution of the same type with the same version number.
+      Consider making a new release or a post release instead
     {% endif %}
     </p>
     {{ confirm_button("Delete release", "Version", release.version) }}


### PR DESCRIPTION
Adding warning when user try to delete a release " You will not be able to re-upload a new distribution of the same type with the same version number." also suggest "Consider making a new release or a post release instead."

work in progress, still need testing

closes #4737