### PR TITLE
Don't pin to prereleases

### DIFF
--- a/requirements/main.in
+++ b/requirements/main.in
@@ -30,7 +30,7 @@ passlib>=1.6.4
 premailer
 psycopg2
 pycurl
-pyramid>=1.9a2
+pyramid>=1.9,<=1.9.2
 pyramid_jinja2>=2.5
 pyramid_mailer>=0.14.1
 pyramid_multiauth


### PR DESCRIPTION
Pinning to a prerelease causes pip-compile to think that we always will
accept a prerelease for a given package, which will potentially cause
the dependency checker to fail if subdependencies change between a
latest release and prerelease.