### PR TITLE
Add fetch step for git instructions

### DIFF
--- a/docs/development/getting-started.rst
+++ b/docs/development/getting-started.rst
@@ -51,6 +51,7 @@ you stay up-to-date with our repository:
 
     git remote add upstream https://github.com/pypa/warehouse.git
     git checkout master
+    git fetch master
     git merge upstream/master
 
 


### PR DESCRIPTION
If a developer doesn't run the `fetch` step then the `merge` step gives a "can't do this" error.