### PR TITLE
Remove De-normalization Of Name and Version

### DIFF
--- a/tests/common/db/packaging.py
+++ b/tests/common/db/packaging.py
@@ -46,7 +46,6 @@ class ReleaseFactory(WarehouseFactory):
         model = Release
 
     id = factory.LazyFunction(uuid.uuid4)
-    name = factory.LazyAttribute(lambda o: o.project.name)
     project = factory.SubFactory(ProjectFactory)
     version = factory.Sequence(lambda n: str(n) + ".0")
     canonical_version = factory.LazyAttribute(
@@ -61,7 +60,6 @@ class FileFactory(WarehouseFactory):
     class Meta:
         model = File
 
-    name = factory.LazyAttribute(lambda o: o.release.name)
     release = factory.SubFactory(ReleaseFactory)
     python_version = "source"
     md5_digest = factory.LazyAttribute(
@@ -99,9 +97,7 @@ class DependencyFactory(WarehouseFactory):
     class Meta:
         model = Dependency
 
-    name = factory.fuzzy.FuzzyText(length=12)
-    version = factory.Sequence(lambda n: str(n) + ".0")
-    release = project = factory.SubFactory(ReleaseFactory)
+    release = factory.SubFactory(ReleaseFactory)
     kind = factory.fuzzy.FuzzyChoice(int(kind) for kind in DependencyKind)
     specifier = factory.fuzzy.FuzzyText(length=12)
 

--- a/tests/unit/admin/views/test_blacklist.py
+++ b/tests/unit/admin/views/test_blacklist.py
@@ -211,9 +211,7 @@ class TestAddBlacklist:
 
         project = ProjectFactory.create(name="foo")
         release = ReleaseFactory.create(project=project)
-        FileFactory.create(
-            name=project.name, version=release.version, filename="who cares"
-        )
+        FileFactory.create(release=release, filename="who cares")
         RoleFactory.create(project=project, user=db_request.user)
 
         views.add_blacklist(db_request)

--- a/tests/unit/legacy/api/test_json.py
+++ b/tests/unit/legacy/api/test_json.py
@@ -194,8 +194,7 @@ class TestJSONRelease:
         for urlspec in project_urls:
             db_session.add(
                 Dependency(
-                    name=releases[3].project.name,
-                    version="3.0",
+                    release=releases[3],
                     kind=DependencyKind.project_url.value,
                     specifier=urlspec,
                 )
@@ -460,7 +459,9 @@ class TestJSONReleaseSlash:
         assert isinstance(resp, HTTPMovedPermanently)
         assert db_request.route_path.calls == [
             pretend.call(
-                "legacy.api.json.release", name=release.name, version=release.version
+                "legacy.api.json.release",
+                name=release.project.name,
+                version=release.version,
             )
         ]
         assert resp.headers["Location"] == "/project/the-redirect"

--- a/tests/unit/legacy/api/xmlrpc/test_xmlrpc.py
+++ b/tests/unit/legacy/api/xmlrpc/test_xmlrpc.py
@@ -785,7 +785,7 @@ def test_browse(db_request):
     expected_release._classifiers = classifiers
 
     assert set(xmlrpc.browse(db_request, ["Environment :: Other Environment"])) == {
-        (r.name, r.version) for r in releases
+        (r.project.name, r.version) for r in releases
     }
     assert set(
         xmlrpc.browse(
@@ -795,7 +795,7 @@ def test_browse(db_request):
                 "Development Status :: 5 - Production/Stable",
             ],
         )
-    ) == {(expected_release.name, expected_release.version)}
+    ) == {(expected_release.project.name, expected_release.version)}
     assert set(
         xmlrpc.browse(
             db_request,
@@ -805,7 +805,7 @@ def test_browse(db_request):
                 "Programming Language :: Python",
             ],
         )
-    ) == {(expected_release.name, expected_release.version)}
+    ) == {(expected_release.project.name, expected_release.version)}
     assert set(
         xmlrpc.browse(
             db_request,
@@ -814,7 +814,7 @@ def test_browse(db_request):
                 "Programming Language :: Python",
             ],
         )
-    ) == {(expected_release.name, expected_release.version)}
+    ) == {(expected_release.project.name, expected_release.version)}
 
 
 def test_multicall(pyramid_request):

--- a/tests/unit/packaging/test_models.py
+++ b/tests/unit/packaging/test_models.py
@@ -260,8 +260,7 @@ class TestRelease:
         for urlspec in project_urls:
             db_session.add(
                 Dependency(
-                    name=release.project.name,
-                    version=release.version,
+                    release=release,
                     kind=DependencyKind.project_url.value,
                     specifier=urlspec,
                 )

--- a/warehouse/admin/views/blacklist.py
+++ b/warehouse/admin/views/blacklist.py
@@ -88,11 +88,23 @@ def confirm_blacklist(request):
         .first()
     )
     if project is not None:
-        releases = request.db.query(Release).filter(Release.name == project.name).all()
-        files = request.db.query(File).filter(File.name == project.name).all()
+        releases = (
+            request.db.query(Release)
+            .join(Project)
+            .filter(Release.project == project)
+            .all()
+        )
+        files = (
+            request.db.query(File)
+            .join(Release)
+            .join(Project)
+            .filter(Release.project == project)
+            .all()
+        )
         roles = (
             request.db.query(Role)
             .join(User)
+            .join(Project)
             .filter(Role.project == project)
             .distinct(User.username)
             .order_by(User.username)

--- a/warehouse/admin/views/projects.py
+++ b/warehouse/admin/views/projects.py
@@ -174,7 +174,7 @@ def releases_list(project, request):
 def release_detail(release, request):
     journals = (
         request.db.query(JournalEntry)
-        .filter(JournalEntry.name == release.name)
+        .filter(JournalEntry.name == release.project.name)
         .filter(JournalEntry.version == release.version)
         .order_by(JournalEntry.submitted_date.desc(), JournalEntry.id.desc())
         .all()

--- a/warehouse/legacy/api/json.py
+++ b/warehouse/legacy/api/json.py
@@ -195,11 +195,13 @@ def json_release(release, request):
     context=Release,
     decorator=_CACHE_DECORATOR,
 )
-def json_release_slash(project, request):
+def json_release_slash(release, request):
     return HTTPMovedPermanently(
         # Respond with redirect to url without trailing slash
         request.route_path(
-            "legacy.api.json.release", name=project.name, version=project.version
+            "legacy.api.json.release",
+            name=release.project.name,
+            version=release.version,
         ),
         headers=_CORS_HEADERS,
     )

--- a/warehouse/legacy/api/simple.py
+++ b/warehouse/legacy/api/simple.py
@@ -80,16 +80,10 @@ def simple_detail(project, request):
     files = sorted(
         request.db.query(File)
         .options(joinedload(File.release))
-        .filter(
-            File.name == project.name,
-            File.version.in_(
-                request.db.query(Release)
-                .filter(Release.project == project)
-                .with_entities(Release.version)
-            ),
-        )
+        .join(Release)
+        .filter(Release.project == project)
         .all(),
-        key=lambda f: (parse(f.version), f.filename),
+        key=lambda f: (parse(f.release.version), f.filename),
     )
 
     return {"project": project, "files": files}

--- a/warehouse/legacy/api/xmlrpc/views.py
+++ b/warehouse/legacy/api/xmlrpc/views.py
@@ -491,15 +491,12 @@ def browse(request, classifiers: List[str]):
     )
 
     releases = (
-        request.db.query(Release.name, Release.version)
-        .join(
-            release_classifiers_q,
-            (Release.name == release_classifiers_q.c.name)
-            & (Release.version == release_classifiers_q.c.version),
-        )
-        .group_by(Release.name, Release.version)
+        request.db.query(Project.name, Release.version)
+        .join(Release)
+        .join(release_classifiers_q, Release.id == release_classifiers_q.c.release_id)
+        .group_by(Project.name, Release.version)
         .having(func.count() == len(classifiers))
-        .order_by(Release.name, Release.version)
+        .order_by(Project.name, Release.version)
         .all()
     )
 

--- a/warehouse/packaging/tasks.py
+++ b/warehouse/packaging/tasks.py
@@ -77,10 +77,10 @@ def compute_trending(request):
     # turn it into the primary key of the Project object and construct a list
     # of primary key: new zscore, including a default of None if the item isn't
     # in the result set.
-    query = request.db.query(Project.name, Project.normalized_name).all()
+    query = request.db.query(Project.id, Project.normalized_name).all()
     to_update = [
-        {"name": name, "zscore": zscores[normalized_name]}
-        for name, normalized_name in query
+        {"id": id, "zscore": zscores[normalized_name]}
+        for id, normalized_name in query
         if normalized_name in zscores
     ]
 


### PR DESCRIPTION
When we were using natural primary keys, a lot of tables had name and version keys on them, since that was how the FKs worked. With the move to surrogate keys for all of our primary keys, these existing name and version fields are just leftover bits of denormalization that needs to be handled.

In https://github.com/pypa/warehouse/pull/4958#issuecomment-433734700 I laid out a few options for solving this. This PR represents choice (3).

There may be performance implications here, I've tried to keep any index that still seemed like it made sense, but this is sort of drastically altering the performance characteristics of some of these queries, so it's possible that there will be a performance regression. However, if there is we can, at that time, either solve it with additional indexes or perhaps choose to denormalize our data then.