### PR TITLE
Disable elasticsearch xpack.security

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,8 @@ services:
 
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:6.2.4
+    environment:
+      - xpack.security.enabled=false
 
   camo:
     image: pypa/warehouse-camo:latest


### PR DESCRIPTION
This was producing an annoying license warning in development.

More details:
* https://www.elastic.co/guide/en/elasticsearch/reference/current/security-settings.html
* https://medium.com/@ospaarmann/tidbits-solving-the-elasticsearch-x-pack-license-issue-in-docker-d15bb22d82fd