### PR TITLE
Remove the backfill query

### DIFF
--- a/warehouse/migrations/versions/e612a92c1017_add_uploader_field_to_release.py
+++ b/warehouse/migrations/versions/e612a92c1017_add_uploader_field_to_release.py
@@ -32,29 +32,6 @@ def upgrade():
         "releases",
         sa.Column("uploader_id", postgresql.UUID(as_uuid=True), nullable=True),
     )
-    op.execute(
-        """
-        UPDATE releases
-        SET uploader_id = s.user_id
-        FROM (
-            SELECT accounts_user.id as user_id,
-                    packages.id as project_id,
-                    releases.version as release_version,
-                    ROW_NUMBER() OVER (
-                        PARTITION BY journals.name, journals.version
-                        ORDER BY journals.id DESC
-                    ) as rn
-            FROM accounts_user, packages, journals, releases
-            WHERE journals.name = packages.name
-                AND journals.version = releases.version
-                AND journals.action = 'new release'
-                AND accounts_user.username = journals.submitted_by
-        ) s
-        WHERE releases.project_id = s.project_id
-            AND releases.version = s.release_version
-            AND s.rn = 1
-        """
-    )
     op.create_foreign_key(
         None,
         "releases",


### PR DESCRIPTION
Backfilling this data in production is taking a massive amount of temporary storage, and a very long time. This column is only currently being used in the admin, and it is nullable, so we can easily backfill at a later date.

Putting this up now, incase we run out of temporary storage in prod again, and we need to do the backfill out of band in smaller chunks.