### PR TITLE
Revert "RFE: display date in project list #3626 (pypa/warehouse#3626)"

### DIFF
--- a/warehouse/static/sass/blocks/_package-snippet.scss
+++ b/warehouse/static/sass/blocks/_package-snippet.scss
@@ -37,20 +37,10 @@
   background-image: url("../images/white-cube.svg"), linear-gradient(transparent, transparent);
   background-position: 20px;
 
-  // Mobile specific visibility
   @media screen and (max-width: $mobile) {
-    .hide-on-mobile {
-      display: none;
-    }
-
-    .break-on-mobile {
-      word-break: break-all;
-    }
-
-    &__released {
-      float: none;
-      display: block;
-    }
+    margin: 5px 0 ($spacing-unit / 2);
+    padding: 10px;
+    background-image: none;
   }
 
   &__title {
@@ -73,18 +63,14 @@
   }
 
   &__version {
+    color: $text-color;
     font-weight: $bold-font-weight;
-  }
-
-  &__released {
-    font-size: 1rem;
-    font-weight: $base-font-weight;
-    float: right;
   }
 
   &__description {
     @include add-ellipsis;
     clear: both;
+    color: $text-color;
     font-size: 1rem;
   }
 

--- a/warehouse/templates/search/results.html
+++ b/warehouse/templates/search/results.html
@@ -23,9 +23,6 @@
     <h3 class="package-snippet__title">
       <span class="package-snippet__name">{{ item.name }}</span>
       <span class="package-snippet__version">{{ item.latest_version }}</span>
-      {% if order == "-created" %}
-      <span class="package-snippet__released">{{ humanize(item.created) }}</span>
-      {% endif %}
     </h3>
     <p class="package-snippet__description">{{ item.summary }}</p>
   </a>

--- a/warehouse/views.py
+++ b/warehouse/views.py
@@ -12,7 +12,6 @@
 
 import collections
 import re
-from datetime import datetime
 
 import elasticsearch
 
@@ -351,10 +350,6 @@ def search(request):
 
     metrics = request.find_service(IMetricsService, context=None)
     metrics.histogram("warehouse.views.search.results", page.item_count)
-
-    if hasattr(page, "items"):
-        for item in page.items:
-            item.created = datetime.strptime(item.created, "%Y-%m-%dT%H:%M:%S.%f")
 
     return {
         "page": page,


### PR DESCRIPTION
Reverts pypa/warehouse#4402

Ref: https://sentry.io/python-software-foundation/warehouse-production/issues/769496585/
Ref: https://sentry.io/python-software-foundation/warehouse-production/issues/769496582/

Seems something is misaligned between our local dev and production elastic search.