### PR TITLE
Fix Safari date parsing

### DIFF
--- a/warehouse/static/js/warehouse/controllers/localized_time_controller.js
+++ b/warehouse/static/js/warehouse/controllers/localized_time_controller.js
@@ -15,16 +15,27 @@ import { Controller } from "stimulus";
 import distanceInWordsToNow from "date-fns/distance_in_words_to_now";
 
 export default class extends Controller {
+
+  getLocalTimeFromTimestamp(timestamp) {
+    // Safari returns "Invalid Date" when passing timezone
+    // it is assumed all timestamp attributes are UTC as modeled in the database
+    let date = timestamp.substr(0, 10).split("-").map(i => parseInt(i));
+    let time = timestamp.substr(11, 8).split(":").map(i => parseInt(i));
+    return new Date(
+      Date.UTC(parseInt(date[0]), parseInt(date[1]) - 1, parseInt(date[2]), ...time)
+    );
+  }
+
   connect() {
-    let date = new Date(this.element.getAttribute("datetime"));
+    const timestamp = this.element.getAttribute("datetime");
+    let localTime = this.getLocalTimeFromTimestamp(timestamp);
     let startOfDay = new Date();
     startOfDay.setUTCHours(0, 0, 0, 0);
-    if (this.data.get("relative") == "true" && date > startOfDay) {
-      this.element.innerHTML = distanceInWordsToNow(date, {includeSeconds: true}) + " ago";
+    if (this.data.get("relative") == "true" && localTime > startOfDay) {
+      this.element.innerHTML = distanceInWordsToNow(localTime, {includeSeconds: true}) + " ago";
     } else {
       const options = { month: "short", day: "numeric", year: "numeric" };
-      this.element.innerHTML = date.toLocaleDateString("en-US", options); 
+      this.element.innerHTML = localTime.toLocaleDateString("en-US", options);
     }
   }
 }
-


### PR DESCRIPTION
Fixes #5087, the joys of inconsistent browser implementations...

<img width="1370" alt="screen shot 2018-11-21 at 05 07 01" src="https://user-images.githubusercontent.com/6739793/48799817-02f20b00-ed00-11e8-9e55-a51d23b65512.png">

<img width="1275" alt="screen shot 2018-11-20 at 20 03 55" src="https://user-images.githubusercontent.com/6739793/48799852-1309ea80-ed00-11e8-912d-7d6f76f03a68.png">
