### PR TITLE
Fixup #4402

### DIFF
--- a/warehouse/static/sass/blocks/_package-snippet.scss
+++ b/warehouse/static/sass/blocks/_package-snippet.scss
@@ -37,10 +37,20 @@
   background-image: url("../images/white-cube.svg"), linear-gradient(transparent, transparent);
   background-position: 20px;
 
+  // Mobile specific visibility
   @media screen and (max-width: $mobile) {
-    margin: 5px 0 ($spacing-unit / 2);
-    padding: 10px;
-    background-image: none;
+    .hide-on-mobile {
+      display: none;
+    }
+
+    .break-on-mobile {
+      word-break: break-all;
+    }
+
+    &__released {
+      float: none;
+      display: block;
+    }
   }
 
   &__title {
@@ -63,14 +73,18 @@
   }
 
   &__version {
-    color: $text-color;
     font-weight: $bold-font-weight;
+  }
+
+  &__released {
+    font-size: 1rem;
+    font-weight: $base-font-weight;
+    float: right;
   }
 
   &__description {
     @include add-ellipsis;
     clear: both;
-    color: $text-color;
     font-size: 1rem;
   }
 

--- a/warehouse/templates/search/results.html
+++ b/warehouse/templates/search/results.html
@@ -23,6 +23,9 @@
     <h3 class="package-snippet__title">
       <span class="package-snippet__name">{{ item.name }}</span>
       <span class="package-snippet__version">{{ item.latest_version }}</span>
+      {% if order == "-created" %}
+      <span class="package-snippet__released">{{ humanize(item.created) }}</span>
+      {% endif %}
     </h3>
     <p class="package-snippet__description">{{ item.summary }}</p>
   </a>

--- a/warehouse/views.py
+++ b/warehouse/views.py
@@ -12,6 +12,7 @@
 
 import collections
 import re
+from datetime import datetime
 
 import elasticsearch
 
@@ -350,6 +351,10 @@ def search(request):
 
     metrics = request.find_service(IMetricsService, context=None)
     metrics.histogram("warehouse.views.search.results", page.item_count)
+
+    if hasattr(page, "items"):
+        for item in page.items:
+            item.created = datetime.strptime(item.created, "%Y-%m-%dT%H:%M:%S.%f")
 
     return {
         "page": page,

--- a/warehouse/views.py
+++ b/warehouse/views.py
@@ -354,7 +354,10 @@ def search(request):
 
     if hasattr(page, "items"):
         for item in page.items:
-            item.created = datetime.strptime(item.created, "%Y-%m-%dT%H:%M:%S.%f")
+            try:
+                item.created = datetime.strptime(item.created, "%Y-%m-%dT%H:%M:%S.%f")
+            except ValueError:
+                item.created = datetime.strptime(item.created, "%Y-%m-%dT%H:%M:%S")
 
     return {
         "page": page,


### PR DESCRIPTION
restores #4402 and fixes up handling of ancient timestamps without a millisecond part.