### PR TITLE
Use actual badges in 'Account emails' description

### DIFF
--- a/warehouse/templates/manage/account.html
+++ b/warehouse/templates/manage/account.html
@@ -189,7 +189,7 @@
   {{ form_error_anchor(add_email_form) }}
   <section id="account-emails">
     <h2 class="sub-title">Account emails</h2>
-    <p>You can associate several emails with your account. You can use any <strong>verified</strong> email to recover your account, but only your primary email will receive notifications.</p>
+    <p>You can associate several emails with your account. You can use any <span class="badge badge--success"><i class="fa fa-check"></i> Verified</span> email to recover your account, but only your <span class="badge">Primary</span> email will receive notifications.</p>
 
     {# Sort the emails as follows:
       * Primary email


### PR DESCRIPTION
Before:

<img width="827" alt="screen shot 2018-11-27 at 3 14 43 pm" src="https://user-images.githubusercontent.com/294415/49111979-34fef200-f257-11e8-8ac8-fe997a6b894e.png">

After:

<img width="833" alt="screen shot 2018-11-27 at 3 12 12 pm" src="https://user-images.githubusercontent.com/294415/49111930-14cf3300-f257-11e8-9a63-6446440de5e1.png">
