### PR TITLE
Add extra space after commas in `requires_python` on template

### DIFF
--- a/warehouse/templates/includes/packaging/project-data.html
+++ b/warehouse/templates/includes/packaging/project-data.html
@@ -89,7 +89,7 @@
   {% endif %}
   {% if release.requires_python %}
   <p>
-    <strong>Requires:</strong> Python {{ release.requires_python }}
+    <strong>Requires:</strong> Python {{ release.requires_python|replace(',', ', ') }}
   </p>
   {% endif %}
 </div>


### PR DESCRIPTION
Fixes #5173

`requires_python` does not enforce whitespace, so in the template we add a space after all commas to allow for proper wrapping. If there is already whitespace in the string the browser will visually collapse it to one.

Before:

<img width="294" alt="screen shot 2018-12-08 at 10 55 02" src="https://user-images.githubusercontent.com/6739793/49685259-a6049c00-fad8-11e8-99fc-6403bb647f79.png">

After:

<img width="307" alt="screen shot 2018-12-08 at 10 54 31" src="https://user-images.githubusercontent.com/6739793/49685262-ad2baa00-fad8-11e8-89d7-25b377707626.png">
