### PR TITLE
Improve error handling about duplicated email within current account

### DIFF
--- a/tests/unit/accounts/test_forms.py
+++ b/tests/unit/accounts/test_forms.py
@@ -336,8 +336,8 @@ class TestRegistrationForm:
         assert not form.validate()
         assert (
             form.email.errors.pop()
-            == "You can't create an account with an email address from "
-            "this domain. Use a different email."
+            == "You can't use an email address from this domain. Use a "
+            "different email."
         )
 
     def test_username_exists(self):

--- a/tests/unit/manage/test_forms.py
+++ b/tests/unit/manage/test_forms.py
@@ -114,7 +114,7 @@ class TestAddEmailForm:
         assert not form.validate()
         assert (
             form.email.errors.pop()
-            == "You can't add an email address from this domain. "
+            == "You can't use an email address from this domain. "
             "Use a different email."
         )
 

--- a/tests/unit/manage/test_forms.py
+++ b/tests/unit/manage/test_forms.py
@@ -104,6 +104,20 @@ class TestAddEmailForm:
             "Use a different email."
         )
 
+    def test_blacklisted_email_error(self):
+        form = forms.AddEmailForm(
+            data={"email": "foo@bearsarefuzzy.com"},
+            user_service=pretend.stub(find_userid_by_email=lambda _: None),
+            user_id=pretend.stub(),
+        )
+
+        assert not form.validate()
+        assert (
+            form.email.errors.pop()
+            == "You can't add an email address from this domain. "
+            "Use a different email."
+        )
+
 
 class TestChangePasswordForm:
     def test_creation(self):

--- a/tests/unit/manage/test_forms.py
+++ b/tests/unit/manage/test_forms.py
@@ -71,9 +71,38 @@ class TestCreateRoleForm:
 class TestAddEmailForm:
     def test_creation(self):
         user_service = pretend.stub()
-        form = forms.AddEmailForm(user_service=user_service)
+        form = forms.AddEmailForm(user_service=user_service, user_id=pretend.stub())
 
         assert form.user_service is user_service
+
+    def test_email_exists_error(self):
+        user_id = pretend.stub()
+        form = forms.AddEmailForm(
+            data={"email": "foo@bar.com"},
+            user_id=user_id,
+            user_service=pretend.stub(find_userid_by_email=lambda _: user_id),
+        )
+
+        assert not form.validate()
+        assert (
+            form.email.errors.pop()
+            == "This email address is already being used by this account. "
+            "Use a different email."
+        )
+
+    def test_email_exists_other_account_error(self):
+        form = forms.AddEmailForm(
+            data={"email": "foo@bar.com"},
+            user_id=pretend.stub(),
+            user_service=pretend.stub(find_userid_by_email=lambda _: pretend.stub()),
+        )
+
+        assert not form.validate()
+        assert (
+            form.email.errors.pop()
+            == "This email address is already being used by another account. "
+            "Use a different email."
+        )
 
 
 class TestChangePasswordForm:

--- a/tests/unit/manage/test_views.py
+++ b/tests/unit/manage/test_views.py
@@ -47,12 +47,13 @@ class TestManageAccount:
         breach_service = pretend.stub()
         user_service = pretend.stub()
         name = pretend.stub()
+        user_id = pretend.stub()
         request = pretend.stub(
             find_service=lambda iface, **kw: {
                 IPasswordBreachedService: breach_service,
                 IUserService: user_service,
             }[iface],
-            user=pretend.stub(name=name),
+            user=pretend.stub(name=name, id=user_id),
         )
         save_account_obj = pretend.stub()
         save_account_cls = pretend.call_recorder(lambda **kw: save_account_obj)
@@ -79,7 +80,9 @@ class TestManageAccount:
         assert view.request == request
         assert view.user_service == user_service
         assert save_account_cls.calls == [pretend.call(name=name)]
-        assert add_email_cls.calls == [pretend.call(user_service=user_service)]
+        assert add_email_cls.calls == [
+            pretend.call(user_id=user_id, user_service=user_service)
+        ]
         assert change_pass_cls.calls == [
             pretend.call(user_service=user_service, breach_service=breach_service)
         ]
@@ -229,7 +232,7 @@ class TestManageAccount:
             db=pretend.stub(flush=lambda: None),
             session=pretend.stub(flash=pretend.call_recorder(lambda *a, **kw: None)),
             find_service=lambda a, **kw: pretend.stub(),
-            user=pretend.stub(emails=[], name=pretend.stub()),
+            user=pretend.stub(emails=[], name=pretend.stub(), id=pretend.stub()),
         )
         add_email_obj = pretend.stub(
             validate=lambda: False, email=pretend.stub(data=email_address)

--- a/warehouse/accounts/forms.py
+++ b/warehouse/accounts/forms.py
@@ -163,9 +163,15 @@ class NewEmailMixin:
             )
         domain = field.data.split("@")[-1]
         if domain in disposable_email_domains.blacklist:
+            if self.user_id is not None:
+                base_msg = "You can't add an email address from this domain."
+            else:
+                base_msg = (
+                    "You can't create an account with an email address "
+                    "from this domain."
+                )
             raise wtforms.validators.ValidationError(
-                "You can't create an account with an email address "
-                "from this domain. Use a different email."
+                f"{base_msg} Use a different email."
             )
 
 

--- a/warehouse/accounts/forms.py
+++ b/warehouse/accounts/forms.py
@@ -154,10 +154,12 @@ class NewEmailMixin:
     )
 
     def validate_email(self, field):
-        if self.user_service.find_userid_by_email(field.data) is not None:
+        userid = self.user_service.find_userid_by_email(field.data)
+        if userid is not None:
+            which = "this" if userid == self.user_id else "another"
             raise wtforms.validators.ValidationError(
-                "This email address is already being used by another account. "
-                "Use a different email."
+                f"This email address is already being used by {which} account. "
+                f"Use a different email."
             )
         domain = field.data.split("@")[-1]
         if domain in disposable_email_domains.blacklist:
@@ -193,6 +195,7 @@ class RegistrationForm(
     def __init__(self, *args, user_service, **kwargs):
         super().__init__(*args, **kwargs)
         self.user_service = user_service
+        self.user_id = None
 
 
 class LoginForm(PasswordMixin, UsernameMixin, forms.Form):

--- a/warehouse/accounts/forms.py
+++ b/warehouse/accounts/forms.py
@@ -155,23 +155,23 @@ class NewEmailMixin:
 
     def validate_email(self, field):
         userid = self.user_service.find_userid_by_email(field.data)
-        if userid is not None:
-            which = "this" if userid == self.user_id else "another"
+
+        if userid and userid == self.user_id:
             raise wtforms.validators.ValidationError(
-                f"This email address is already being used by {which} account. "
+                f"This email address is already being used by this account. "
                 f"Use a different email."
             )
+        if userid:
+            raise wtforms.validators.ValidationError(
+                f"This email address is already being used by another account. "
+                f"Use a different email."
+            )
+
         domain = field.data.split("@")[-1]
         if domain in disposable_email_domains.blacklist:
-            if self.user_id is not None:
-                base_msg = "You can't add an email address from this domain."
-            else:
-                base_msg = (
-                    "You can't create an account with an email address "
-                    "from this domain."
-                )
             raise wtforms.validators.ValidationError(
-                f"{base_msg} Use a different email."
+                "You can't use an email address from this domain. Use a "
+                "different email."
             )
 
 

--- a/warehouse/manage/forms.py
+++ b/warehouse/manage/forms.py
@@ -68,9 +68,10 @@ class AddEmailForm(NewEmailMixin, forms.Form):
 
     __params__ = ["email"]
 
-    def __init__(self, *args, user_service, **kwargs):
+    def __init__(self, *args, user_service, user_id, **kwargs):
         super().__init__(*args, **kwargs)
         self.user_service = user_service
+        self.user_id = user_id
 
 
 class ChangePasswordForm(PasswordMixin, NewPasswordMixin, forms.Form):

--- a/warehouse/manage/views.py
+++ b/warehouse/manage/views.py
@@ -106,7 +106,9 @@ class ManageAccountViews:
     def default_response(self):
         return {
             "save_account_form": SaveAccountForm(name=self.request.user.name),
-            "add_email_form": AddEmailForm(user_service=self.user_service),
+            "add_email_form": AddEmailForm(
+                user_service=self.user_service, user_id=self.request.user.id
+            ),
             "change_password_form": ChangePasswordForm(
                 user_service=self.user_service, breach_service=self.breach_service
             ),
@@ -129,7 +131,11 @@ class ManageAccountViews:
 
     @view_config(request_method="POST", request_param=AddEmailForm.__params__)
     def add_email(self):
-        form = AddEmailForm(self.request.POST, user_service=self.user_service)
+        form = AddEmailForm(
+            self.request.POST,
+            user_service=self.user_service,
+            user_id=self.request.user.id,
+        )
 
         if form.validate():
             email = self.user_service.add_email(self.request.user.id, form.email.data)


### PR DESCRIPTION
Previously, when trying to add an email to one's account that was
already registered we'd get the generic error message about email being
already used by *another* account from NewEmailMixin (in
warehouse/accounts/forms.py).

We improve this feedback by adding a check in AddEmailForm to validate
that specified email does not match with emails already used by this
account. As we need the current user to perform this check, we now store
the "request" as an attribute in AddEmailForm.

Fixes #5124.