### PR TITLE
Add "trending" sort order to search page

### DIFF
--- a/tests/unit/packaging/test_search.py
+++ b/tests/unit/packaging/test_search.py
@@ -35,6 +35,7 @@ def test_build_search():
         platform="any platform",
         created=datetime.datetime(1956, 1, 31),
         classifiers=["Alpha", "Beta"],
+        zscore=None,
     )
     obj = Project.from_db(release)
 
@@ -54,3 +55,4 @@ def test_build_search():
     assert obj["platform"] == "any platform"
     assert obj["created"] == datetime.datetime(1956, 1, 31)
     assert obj["classifiers"] == ["Alpha", "Beta"]
+    assert obj["zscore"] is None

--- a/warehouse/packaging/search.py
+++ b/warehouse/packaging/search.py
@@ -12,7 +12,7 @@
 
 import packaging.version
 
-from elasticsearch_dsl import Date, Document, Keyword, Text, analyzer
+from elasticsearch_dsl import Date, Document, Keyword, Text, Float, analyzer
 
 from warehouse.search.utils import doc_type
 
@@ -49,6 +49,7 @@ class Project(Document):
     platform = Keyword()
     created = Date()
     classifiers = Keyword(multi=True)
+    zscore = Float()
 
     @classmethod
     def from_db(cls, release):
@@ -71,5 +72,6 @@ class Project(Document):
         obj["platform"] = release.platform
         obj["created"] = release.created
         obj["classifiers"] = release.classifiers
+        obj["zscore"] = release.zscore
 
         return obj

--- a/warehouse/packaging/search.py
+++ b/warehouse/packaging/search.py
@@ -12,7 +12,7 @@
 
 import packaging.version
 
-from elasticsearch_dsl import Date, Document, Keyword, Text, Float, analyzer
+from elasticsearch_dsl import Date, Document, Float, Keyword, Text, analyzer
 
 from warehouse.search.utils import doc_type
 

--- a/warehouse/search/tasks.py
+++ b/warehouse/search/tasks.py
@@ -85,6 +85,7 @@ def _project_docs(db, project_name=None):
             classifiers,
             Project.normalized_name,
             Project.name,
+            Project.zscore,
         )
         .select_from(releases_list)
         .join(Release, Release.id == releases_list.c.id)

--- a/warehouse/templates/search/results.html
+++ b/warehouse/templates/search/results.html
@@ -165,6 +165,7 @@
             <select class="-js-form-submit-trigger" id="order" name="o">
               {{ search_option("Relevance", "") }}
               {{ search_option("Date last updated", "-created") }}
+              {{ search_option("Trending", "-zscore") }}
             </select>
             {% endif %}
           </div>


### PR DESCRIPTION
Fixes #3447

Add zscore to Project document mapping
Add zscore to `_project_docs` query to populate on reindex
Add "Trending" sort order to search ordering dropdown

<img width="855" alt="screenshot 2018-12-16 at 13 19 32" src="https://user-images.githubusercontent.com/6739793/50054030-4a1fc000-0135-11e9-8dc5-cb2ee5bcc58f.png">

The results in the screenshot are not particularly relevant since I populated the `zscore` with random values on 100 project. It'd be nice to test it with proper values if possible to guage how useful the sort order is.