### PR TITLE
Add actual date and time to 'timeago' dates (#5085)

### DIFF
--- a/tests/functional/test_templates.py
+++ b/tests/functional/test_templates.py
@@ -48,6 +48,7 @@ def test_templates_for_empty_titles():
             "contains_valid_uris": "warehouse.filters:contains_valid_uris",
             "format_package_type": "warehouse.filters:format_package_type",
             "parse_version": "warehouse.filters:parse_version",
+            "localize_datetime": "warehouse.filters:localize_datetime",
         }
     )
 

--- a/tests/unit/test_filters.py
+++ b/tests/unit/test_filters.py
@@ -11,6 +11,7 @@
 # limitations under the License.
 
 import urllib.parse
+import datetime
 
 from functools import partial
 
@@ -186,3 +187,17 @@ def test_format_package_type(inp, expected):
 )
 def test_parse_version(inp, expected):
     assert filters.parse_version(inp) == expected
+
+@pytest.mark.parametrize(
+    ("inp", "expected"),
+    [
+        (
+            datetime.datetime(2018, 12, 26, 13, 36, 5, 789013),
+            "2018-12-26 13:36:05.789013 UTC"
+        ),
+    ]
+) 
+
+def test_localize_datetime(inp, expected):
+    datetime_format = "%Y-%m-%d %H:%M:%S.%f %Z"
+    assert filters.localize_datetime(inp).strftime(datetime_format) == expected

--- a/tests/unit/test_filters.py
+++ b/tests/unit/test_filters.py
@@ -10,8 +10,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import urllib.parse
 import datetime
+import urllib.parse
 
 from functools import partial
 
@@ -188,16 +188,16 @@ def test_format_package_type(inp, expected):
 def test_parse_version(inp, expected):
     assert filters.parse_version(inp) == expected
 
+
 @pytest.mark.parametrize(
     ("inp", "expected"),
     [
         (
             datetime.datetime(2018, 12, 26, 13, 36, 5, 789013),
-            "2018-12-26 13:36:05.789013 UTC"
-        ),
-    ]
-) 
-
+            "2018-12-26 13:36:05.789013 UTC",
+        )
+    ],
+)
 def test_localize_datetime(inp, expected):
     datetime_format = "%Y-%m-%d %H:%M:%S.%f %Z"
     assert filters.localize_datetime(inp).strftime(datetime_format) == expected

--- a/warehouse/config.py
+++ b/warehouse/config.py
@@ -280,6 +280,7 @@ def configure(settings=None):
     filters.setdefault("contains_valid_uris", "warehouse.filters:contains_valid_uris")
     filters.setdefault("format_package_type", "warehouse.filters:format_package_type")
     filters.setdefault("parse_version", "warehouse.filters:parse_version")
+    filters.setdefault("localize_datetime", "warehouse.filters:localize_datetime")
 
     # We also want to register some global functions for Jinja
     jglobals = config.get_settings().setdefault("jinja2.globals", {})

--- a/warehouse/filters.py
+++ b/warehouse/filters.py
@@ -17,6 +17,7 @@ import hmac
 import json
 import re
 import urllib.parse
+import pytz
 
 import html5lib
 import html5lib.serializer
@@ -156,3 +157,6 @@ def parse_version(version_str):
 
 def includeme(config):
     config.add_request_method(_camo_url, name="camo_url")
+
+def localize_datetime(timestamp):
+    return pytz.utc.localize(timestamp)

--- a/warehouse/filters.py
+++ b/warehouse/filters.py
@@ -17,13 +17,13 @@ import hmac
 import json
 import re
 import urllib.parse
-import pytz
 
 import html5lib
 import html5lib.serializer
 import html5lib.treewalkers
 import jinja2
 import packaging.version
+import pytz
 
 from pyramid.threadlocal import get_current_request
 
@@ -157,6 +157,7 @@ def parse_version(version_str):
 
 def includeme(config):
     config.add_request_method(_camo_url, name="camo_url")
+
 
 def localize_datetime(timestamp):
     return pytz.utc.localize(timestamp)

--- a/warehouse/filters.py
+++ b/warehouse/filters.py
@@ -155,9 +155,9 @@ def parse_version(version_str):
     return packaging.version.parse(version_str)
 
 
-def includeme(config):
-    config.add_request_method(_camo_url, name="camo_url")
-
-
 def localize_datetime(timestamp):
     return pytz.utc.localize(timestamp)
+
+
+def includeme(config):
+    config.add_request_method(_camo_url, name="camo_url")

--- a/warehouse/templates/packaging/detail.html
+++ b/warehouse/templates/packaging/detail.html
@@ -234,7 +234,7 @@
                   {{ hversion.version }} {% if hversion.is_prerelease %}<span class="badge badge--warning release__version-badge">pre-release</span>{% endif %}
                 </p>
                 <p class="release__version-date">
-                <span class="tooltipped tooltipped-s" aria-label="{{ hversion.created.strftime('%Y-%m-%d %H:%M') }} UTC" data-original-label="{{ hversion.created.strftime('%Y-%m-%d %H:%M') }} UTC">
+                <span class="tooltipped tooltipped-s" aria-label="{{ hversion.created|localize_datetime|format_datetime('yyyy-MM-dd HH:mm z') }}" data-original-label="{{ hversion.created|localize_datetime|format_datetime('yyyy-MM-dd HH:mm z') }}">
                       {{ humanize(hversion.created) }}
                   </span>
                 </p>

--- a/warehouse/templates/packaging/detail.html
+++ b/warehouse/templates/packaging/detail.html
@@ -234,8 +234,8 @@
                   {{ hversion.version }} {% if hversion.is_prerelease %}<span class="badge badge--warning release__version-badge">pre-release</span>{% endif %}
                 </p>
                 <p class="release__version-date">
-                <span class="tooltipped tooltipped-s" aria-label="{{ hversion.created|localize_datetime|format_datetime('yyyy-MM-dd HH:mm z') }}" data-original-label="{{ hversion.created|localize_datetime|format_datetime('yyyy-MM-dd HH:mm z') }}">
-                      {{ humanize(hversion.created) }}
+                  <span class="tooltipped tooltipped-s" aria-label="{{ hversion.created|localize_datetime|format_datetime('yyyy-MM-dd HH:mm z') }}" data-original-label="{{ hversion.created|localize_datetime|format_datetime('yyyy-MM-dd HH:mm z') }}">
+                    {{ humanize(hversion.created) }}
                   </span>
                 </p>
               </a>

--- a/warehouse/templates/packaging/detail.html
+++ b/warehouse/templates/packaging/detail.html
@@ -233,7 +233,11 @@
                 <p class="release__version">
                   {{ hversion.version }} {% if hversion.is_prerelease %}<span class="badge badge--warning release__version-badge">pre-release</span>{% endif %}
                 </p>
-                <p class="release__version-date">{{ humanize(hversion.created) }}</p>
+                <p class="release__version-date">
+                <span class="tooltipped tooltipped-s" aria-label="{{ hversion.created.strftime('%Y-%m-%d %H:%M') }} UTC" data-original-label="{{ hversion.created.strftime('%Y-%m-%d %H:%M') }} UTC">
+                      {{ humanize(hversion.created) }}
+                  </span>
+                </p>
               </a>
             </div>
             {% endfor %}


### PR DESCRIPTION
Fixes #5085.

As per @dstufft every date time is stored in UTC so I added "UTC" in the end. Let me know if that's not what I was supposed to do.
* Added a tooltip for date time to 'timeago' dates with timezone