### PR TITLE
Add and re-prioritize icons in url_icon

### DIFF
--- a/warehouse/templates/includes/packaging/project-data.html
+++ b/warehouse/templates/includes/packaging/project-data.html
@@ -18,7 +18,6 @@
   {% for name, url in release.urls.items() %}
   {% if is_valid_uri(url) %}
   <a class="vertical-tabs__tab vertical-tabs__tab--with-icon vertical-tabs__tab--condensed" href="{{ url }}" rel="nofollow">
-    {# TODO: We need to figure out a way to get better icons here, like fa-github, fa-book, etc. #}
     {{ url_icon(name, url) }}{{ name }}
   </a>
   {% endif %}

--- a/warehouse/templates/packaging/detail.html
+++ b/warehouse/templates/packaging/detail.html
@@ -26,7 +26,7 @@
 {% elif name.lower().startswith(("bug", "issue", "tracker", "report")) %}
   {% set icon = "fas fa-bug" %}
 {% elif name.lower().startswith(("funding", "donate", "donation")) %}
-  {% set icon = "fas fa-coins" %}
+  {% set icon = "fas fa-donate" %}
 {% elif parsed.netloc in ["github.com", "github.io"] or parsed.netloc.endswith((".github.com", ".github.io")) %}
   {% set icon = "fab fa-github" %}
 {% elif parsed.netloc == "gitlab.com" or parsed.netloc.endswith(".gitlab.com") %}

--- a/warehouse/templates/packaging/detail.html
+++ b/warehouse/templates/packaging/detail.html
@@ -18,7 +18,15 @@
 {% set parsed = url|urlparse %}
 
 {% if name|lower == "download" %}
-   {% set icon = "fa fa-cloud-download-alt" %}
+   {% set icon = "fas fa-cloud-download-alt" %}
+{% elif name|lower in ["home", "homepage", "home page"] %}
+  {% set icon = "fas fa-home" %}
+{% elif name.lower().startswith(("docs", "documentation")) or parsed.netloc in ["readthedocs.io", "readthedocs.org", "rtfd.io", "rtfd.org"] or parsed.netloc.endswith((".readthedocs.io", ".readthedocs.org", ".rtfd.io", ".rtfd.org")) or parsed.netloc.startswith(("docs.", "documentation.")) %}
+  {% set icon = "fas fa-book" %}
+{% elif name.lower().startswith(("bug", "issue", "tracker", "report")) %}
+  {% set icon = "fas fa-bug" %}
+{% elif name.lower().startswith(("funding", "donate", "donation")) %}
+  {% set icon = "fas fa-coins" %}
 {% elif parsed.netloc in ["github.com", "github.io"] or parsed.netloc.endswith((".github.com", ".github.io")) %}
   {% set icon = "fab fa-github" %}
 {% elif parsed.netloc == "gitlab.com" or parsed.netloc.endswith(".gitlab.com") %}
@@ -29,8 +37,6 @@
   {% set icon = "fab fa-google" %}
 {% elif parsed.netloc == "bitbucket.org" or parsed.netloc.endswith(".bitbucket.org") %}
   {% set icon = "fab fa-bitbucket" %}
-{% elif parsed.netloc in ["readthedocs.io", "readthedocs.org", "rtfd.io", "rtfd.org"] or parsed.netloc.endswith((".readthedocs.io", ".readthedocs.org", ".rtfd.io", ".rtfd.org")) or parsed.netloc.startswith(("docs.", "documentation.")) %}
-  {% set icon = "fas fa-book" %}
 {% elif parsed.netloc == "reddit.com" or parsed.netloc.endswith(".reddit.com") %}
   {% set icon = "fab fa-reddit-alien" %}
 {% elif parsed.netloc == "slack.com" or parsed.netloc.endswith(".slack.com") %}
@@ -43,10 +49,8 @@
   {% set icon = "fas fa-cube" %}
 {% elif parsed.netloc == "python.org" or parsed.netloc.endswith(".python.org") %}
   {% set icon = "fab fa-python" %}
-{% elif name|lower == "home" or name|lower == "homepage" or name|lower == "home page" %}
-  {% set icon = "fa fa-home" %}
 {% else %}
-  {% set icon = "fa fa-external-link-square-alt" %}
+  {% set icon = "fas fa-external-link-square-alt" %}
 {% endif %}
 
 <i class="{{ icon }}" aria-hidden="true"></i>


### PR DESCRIPTION
This PR adds some new URL icons for project URLs:
* [`fa-bug`](https://fontawesome.com/icons/bug?style=solid) for issue tracker,
* [`fa-coins`](https://fontawesome.com/icons/coins?style=solid) for donations link.

The trigger strings are those recommended in specs for `project_urls` ([PEP-459](https://www.python.org/dev/peps/pep-0459/#project-urls), [pypa/sampleproject/setup.py](https://github.com/pypa/sampleproject/blob/559a84bd6ecbd6b8cd02a105b1f8933956b3f7e7/setup.py#L194-L197)).

Additionally, homepage (`fa-home`) and documentation (`fa-book`) icons are reordered so that they are preferred over more generic service (e.g. GitHub) icons.