### PR TITLE
Downloads boost in search

### DIFF
--- a/tests/unit/packaging/test_search.py
+++ b/tests/unit/packaging/test_search.py
@@ -36,6 +36,7 @@ def test_build_search():
         created=datetime.datetime(1956, 1, 31),
         classifiers=["Alpha", "Beta"],
         zscore=None,
+        downloads_month_to_date=None,
     )
     obj = Project.from_db(release)
 
@@ -56,3 +57,4 @@ def test_build_search():
     assert obj["created"] == datetime.datetime(1956, 1, 31)
     assert obj["classifiers"] == ["Alpha", "Beta"]
     assert obj["zscore"] is None
+    assert obj["downloads_month_to_date"] is None

--- a/tests/unit/packaging/test_search.py
+++ b/tests/unit/packaging/test_search.py
@@ -36,7 +36,7 @@ def test_build_search():
         created=datetime.datetime(1956, 1, 31),
         classifiers=["Alpha", "Beta"],
         zscore=None,
-        downloads_month_to_date=None,
+        downloads_last_30_days=None,
     )
     obj = Project.from_db(release)
 
@@ -57,4 +57,4 @@ def test_build_search():
     assert obj["created"] == datetime.datetime(1956, 1, 31)
     assert obj["classifiers"] == ["Alpha", "Beta"]
     assert obj["zscore"] is None
-    assert obj["downloads_month_to_date"] is None
+    assert obj["downloads_last_30_days"] is None

--- a/tests/unit/packaging/test_tasks.py
+++ b/tests/unit/packaging/test_tasks.py
@@ -33,11 +33,11 @@ class TestComputeTrending:
             [
                 Row(
                     (projects[1].normalized_name, 2, 3),
-                    {"project": 0, "zscore": 1, "downloads_month_to_date": 2},
+                    {"project": 0, "zscore": 1, "downloads_last_30_days": 2},
                 ),
                 Row(
                     (projects[2].normalized_name, -1, 6),
-                    {"project": 0, "zscore": 1, "downloads_month_to_date": 2},
+                    {"project": 0, "zscore": 1, "downloads_last_30_days": 2},
                 ),
             ]
         )
@@ -65,7 +65,7 @@ class TestComputeTrending:
         assert bigquery.query.calls == [
             pretend.call(
                 """ SELECT project,
-                   SUM(downloads) as downloads_month_to_date,
+                   SUM(downloads) as downloads_last_30_days,
                    IF(
                         STDDEV(downloads) > 0,
                         (todays_downloads - AVG(downloads))/STDDEV(downloads),
@@ -111,7 +111,7 @@ class TestComputeTrending:
         results = {
             name: (zscore, downloads)
             for name, zscore, downloads in db_request.db.query(
-                Project.name, Project.zscore, Project.downloads_month_to_date
+                Project.name, Project.zscore, Project.downloads_last_30_days
             )
         }
 

--- a/tests/unit/test_search.py
+++ b/tests/unit/test_search.py
@@ -11,8 +11,9 @@
 # limitations under the License.
 
 
-from elasticsearch_dsl import Search
 import pytest
+
+from elasticsearch_dsl import Search
 
 from warehouse.search import queries
 

--- a/tests/unit/test_search.py
+++ b/tests/unit/test_search.py
@@ -1,0 +1,216 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from elasticsearch_dsl import Search
+import pytest
+
+from warehouse.search import queries
+
+EXPECTED_SEARCH_FIELDS = [
+    "author",
+    "author_email",
+    "description^5",
+    "download_url",
+    "home_page",
+    "keywords^5",
+    "license",
+    "maintainer",
+    "maintainer_email",
+    "normalized_name^10",
+    "platform",
+    "summary^5",
+]
+
+
+class TestQueries:
+    def test_no_querystring(self):
+        es = Search()
+
+        query = queries.get_es_query(es, "", queries.SearchModes.relevance, [])
+
+        assert query == es.query()
+
+    @pytest.mark.parametrize(
+        "querystring,expected_prefix,expected_type",
+        [
+            ('"foo bar"', '"foo bar"', "phrase"),
+            ('"a"', '"a"', "phrase"),
+            ("foo bar", "foo bar", "best_fields"),
+        ],
+    )
+    def test_quoted_query(self, querystring, expected_prefix, expected_type):
+        es = Search()
+
+        query = queries.get_es_query(es, querystring, queries.SearchModes.relevance, [])
+
+        query_dict = query.to_dict()
+        assert len(query_dict["query"]["bool"]["should"]) == 2
+        assert query_dict["query"]["bool"]["should"][1] == {
+            "prefix": {"normalized_name": expected_prefix}
+        }
+        must_params = query_dict["query"]["bool"]["should"][0]["bool"]["must"]
+        assert len(must_params) == 1
+        assert must_params[0]["multi_match"] == {
+            "fields": EXPECTED_SEARCH_FIELDS,
+            "type": expected_type,
+            "query": "foo bar" if querystring != '"a"' else "a",
+        }
+        assert query_dict["suggest"] == {
+            "name_suggestion": {"text": querystring, "term": {"field": "name"}}
+        }
+        assert "sort" not in query_dict  # default "relevance" mode does no sorting
+
+    def test_single_not_quoted_character(self):
+        es = Search()
+        querystring = "a"
+
+        query = queries.get_es_query(es, querystring, queries.SearchModes.relevance, [])
+
+        query_dict = query.to_dict()
+        must_params = query_dict["query"]["bool"]["must"]
+        assert len(must_params) == 1
+        assert must_params[0]["multi_match"] == {
+            "fields": EXPECTED_SEARCH_FIELDS,
+            "type": "best_fields",
+            "query": "a",
+        }
+        assert query_dict["suggest"] == {
+            "name_suggestion": {"text": querystring, "term": {"field": "name"}}
+        }
+        assert "sort" not in query_dict  # default "relevance" mode does no sorting
+
+    def test_mixed_quoted_query(self):
+        es = Search()
+        querystring = '"foo bar" baz'
+
+        query = queries.get_es_query(es, querystring, queries.SearchModes.relevance, [])
+
+        query_dict = query.to_dict()
+        assert len(query_dict["query"]["bool"]["should"]) == 2
+        assert query_dict["query"]["bool"]["should"][1] == {
+            "prefix": {"normalized_name": '"foo bar" baz'}
+        }
+        must_params = query_dict["query"]["bool"]["should"][0]["bool"]["must"]
+        assert len(must_params) == 2
+        assert must_params[0]["multi_match"] == {
+            "fields": EXPECTED_SEARCH_FIELDS,
+            "type": "phrase",
+            "query": "foo bar",
+        }
+        assert must_params[1]["multi_match"] == {
+            "fields": EXPECTED_SEARCH_FIELDS,
+            "type": "best_fields",
+            "query": "baz",
+        }
+        assert query_dict["suggest"] == {
+            "name_suggestion": {"text": querystring, "term": {"field": "name"}}
+        }
+        assert "sort" not in query_dict  # default "relevance" mode does no sorting
+
+    @pytest.mark.parametrize(
+        "mode,expected_field",
+        [
+            (queries.SearchModes.created, "created"),
+            (queries.SearchModes.trending, "zscore"),
+        ],
+    )
+    def test_sort_modes(self, mode, expected_field):
+        es = Search()
+        querystring = "foo bar"
+
+        query = queries.get_es_query(es, querystring, mode, [])
+
+        query_dict = query.to_dict()
+        assert len(query_dict["query"]["bool"]["should"]) == 2
+        assert query_dict["query"]["bool"]["should"][1] == {
+            "prefix": {"normalized_name": "foo bar"}
+        }
+        must_params = query_dict["query"]["bool"]["should"][0]["bool"]["must"]
+        assert len(must_params) == 1
+        assert must_params[0]["multi_match"] == {
+            "fields": EXPECTED_SEARCH_FIELDS,
+            "type": "best_fields",
+            "query": "foo bar",
+        }
+        assert query_dict["suggest"] == {
+            "name_suggestion": {"text": querystring, "term": {"field": "name"}}
+        }
+        assert query_dict["sort"] == [
+            {expected_field: {"order": "desc", "unmapped_type": "long"}}
+        ]
+
+    def test_popularity_mode(self):
+        es = Search()
+        querystring = "foo bar"
+
+        query = queries.get_es_query(
+            es, querystring, queries.SearchModes.popularity, []
+        )
+
+        query_dict = query.to_dict()
+        assert query_dict["query"]["function_score"]["functions"] == [
+            {
+                "field_value_factor": {
+                    "field": "downloads_month_to_date",
+                    "modifier": "sqrt",
+                    "factor": 0.001,
+                    "missing": 0,
+                }
+            }
+        ]
+        inner_query_dict = query_dict["query"]["function_score"]["query"]
+        assert len(inner_query_dict["bool"]["should"]) == 2
+        assert inner_query_dict["bool"]["should"][1] == {
+            "prefix": {"normalized_name": "foo bar"}
+        }
+        must_params = inner_query_dict["bool"]["should"][0]["bool"]["must"]
+        assert len(must_params) == 1
+        assert must_params[0]["multi_match"] == {
+            "fields": EXPECTED_SEARCH_FIELDS,
+            "type": "best_fields",
+            "query": "foo bar",
+        }
+        assert query_dict["suggest"] == {
+            "name_suggestion": {"text": querystring, "term": {"field": "name"}}
+        }
+        assert "sort" not in query_dict
+
+    def test_with_classifiers(self):
+        es = Search()
+        querystring = "foo bar"
+        classifiers = [("c", "foo :: bar"), ("c", "fiz :: buz")]
+
+        query = queries.get_es_query(
+            es, querystring, queries.SearchModes.relevance, classifiers
+        )
+
+        query_dict = query.to_dict()
+        assert len(query_dict["query"]["bool"]["should"]) == 2
+        assert query_dict["query"]["bool"]["should"][1] == {
+            "prefix": {"normalized_name": "foo bar"}
+        }
+        must_params = query_dict["query"]["bool"]["should"][0]["bool"]["must"]
+        assert len(must_params) == 1
+        assert must_params[0]["multi_match"] == {
+            "fields": EXPECTED_SEARCH_FIELDS,
+            "type": "best_fields",
+            "query": "foo bar",
+        }
+        assert query_dict["suggest"] == {
+            "name_suggestion": {"text": querystring, "term": {"field": "name"}}
+        }
+        assert "sort" not in query_dict
+        assert query_dict["query"]["bool"]["must"] == [
+            {"prefix": {"classifiers": classifier}} for classifier in classifiers
+        ]
+        assert query_dict["query"]["bool"]["minimum_should_match"] == 1

--- a/tests/unit/test_search.py
+++ b/tests/unit/test_search.py
@@ -162,7 +162,7 @@ class TestQueries:
         assert query_dict["query"]["function_score"]["functions"] == [
             {
                 "field_value_factor": {
-                    "field": "downloads_month_to_date",
+                    "field": "downloads_last_30_days",
                     "modifier": "sqrt",
                     "factor": 0.001,
                     "missing": 0,

--- a/tests/unit/test_search.py
+++ b/tests/unit/test_search.py
@@ -150,12 +150,12 @@ class TestQueries:
             {expected_field: {"order": "desc", "unmapped_type": "long"}}
         ]
 
-    def test_popularity_mode(self):
+    def test_download_frequency_mode(self):
         es = Search()
         querystring = "foo bar"
 
         query = queries.get_es_query(
-            es, querystring, queries.SearchModes.popularity, []
+            es, querystring, queries.SearchModes.download_frequency, []
         )
 
         query_dict = query.to_dict()

--- a/tests/unit/test_views.py
+++ b/tests/unit/test_views.py
@@ -233,7 +233,7 @@ class TestSearch:
         assert search(db_request) == {
             "page": page_obj,
             "term": params.get("q", ""),
-            "order": "relevance",
+            "mode": "relevance",
             "applied_filters": [],
             "available_filters": [],
         }
@@ -283,7 +283,7 @@ class TestSearch:
         assert search_view == {
             "page": page_obj,
             "term": params.get("q", ""),
-            "order": "relevance",
+            "mode": "relevance",
             "applied_filters": params.getall("c"),
             "available_filters": [
                 {

--- a/tests/unit/test_views.py
+++ b/tests/unit/test_views.py
@@ -19,6 +19,7 @@ import pytest
 from pyramid.httpexceptions import HTTPBadRequest, HTTPNotFound, HTTPServiceUnavailable
 from webob.multidict import MultiDict
 
+from warehouse.search import queries
 from warehouse import views
 from warehouse.views import (
     classifiers,
@@ -216,12 +217,10 @@ class TestSearch:
             params["page"] = page
         db_request.params = params
 
-        sort = pretend.stub()
-        suggest = pretend.stub(sort=pretend.call_recorder(lambda *a, **kw: sort))
-        es_query = pretend.stub(suggest=pretend.call_recorder(lambda *a, **kw: suggest))
-        db_request.es = pretend.stub(
-            query=pretend.call_recorder(lambda *a, **kw: es_query)
-        )
+        db_request.es = pretend.stub()
+        es_query = pretend.stub()
+        get_es_query = pretend.call_recorder(lambda *a, **kw: es_query)
+        monkeypatch.setattr(views, "get_es_query", get_es_query)
 
         page_obj = pretend.stub(page_count=(page or 1) + 10, item_count=1000)
         page_cls = pretend.call_recorder(lambda *a, **kw: page_obj)
@@ -234,167 +233,19 @@ class TestSearch:
         assert search(db_request) == {
             "page": page_obj,
             "term": params.get("q", ""),
-            "order": params.get("o", ""),
+            "order": "relevance",
             "applied_filters": [],
             "available_filters": [],
         }
-        assert page_cls.calls == [
-            pretend.call(suggest, url_maker=url_maker, page=page or 1)
-        ]
-        assert url_maker_factory.calls == [pretend.call(db_request)]
-        assert db_request.es.query.calls == [
-            pretend.call(views.gather_es_queries(params["q"]))
-        ]
-        assert es_query.suggest.calls == [
-            pretend.call("name_suggestion", params["q"], term={"field": "name"})
-        ]
-        assert metrics.histogram.calls == [
-            pretend.call("warehouse.views.search.results", 1000)
-        ]
-
-    @pytest.mark.parametrize("page", [None, 1, 5])
-    def test_with_exact_phrase_query(self, monkeypatch, db_request, metrics, page):
-        params = MultiDict({"q": '"foo bar"'})
-        if page is not None:
-            params["page"] = page
-        db_request.params = params
-
-        sort = pretend.stub()
-        suggest = pretend.stub(sort=pretend.call_recorder(lambda *a, **kw: sort))
-        es_query = pretend.stub(suggest=pretend.call_recorder(lambda *a, **kw: suggest))
-        db_request.es = pretend.stub(
-            query=pretend.call_recorder(lambda *a, **kw: es_query)
-        )
-
-        page_obj = pretend.stub(
-            page_count=(page or 1) + 10, item_count=(page or 1) + 10
-        )
-        page_cls = pretend.call_recorder(lambda *a, **kw: page_obj)
-        monkeypatch.setattr(views, "ElasticsearchPage", page_cls)
-
-        url_maker = pretend.stub()
-        url_maker_factory = pretend.call_recorder(lambda request: url_maker)
-        monkeypatch.setattr(views, "paginate_url_factory", url_maker_factory)
-
-        assert search(db_request) == {
-            "page": page_obj,
-            "term": params.get("q", ""),
-            "order": params.get("o", ""),
-            "applied_filters": [],
-            "available_filters": [],
-        }
-        assert page_cls.calls == [
-            pretend.call(suggest, url_maker=url_maker, page=page or 1)
-        ]
-        assert url_maker_factory.calls == [pretend.call(db_request)]
-        assert db_request.es.query.calls == [
-            pretend.call(views.gather_es_queries(params["q"]))
-        ]
-        assert es_query.suggest.calls == [
-            pretend.call("name_suggestion", params["q"], term={"field": "name"})
-        ]
-        assert metrics.histogram.calls == [
-            pretend.call("warehouse.views.search.results", (page or 1) + 10)
-        ]
-
-    @pytest.mark.parametrize("page", [None, 1, 5])
-    def test_with_a_single_char_query(self, monkeypatch, db_request, metrics, page):
-        params = MultiDict({"q": "a"})
-        if page is not None:
-            params["page"] = page
-        db_request.params = params
-
-        sort = pretend.stub()
-        suggest = pretend.stub(sort=pretend.call_recorder(lambda *a, **kw: sort))
-        es_query = pretend.stub(suggest=pretend.call_recorder(lambda *a, **kw: suggest))
-        db_request.es = pretend.stub(
-            query=pretend.call_recorder(lambda *a, **kw: es_query)
-        )
-
-        page_obj = pretend.stub(page_count=(page or 1) + 10, item_count=1000)
-        page_cls = pretend.call_recorder(lambda *a, **kw: page_obj)
-        monkeypatch.setattr(views, "ElasticsearchPage", page_cls)
-
-        url_maker = pretend.stub()
-        url_maker_factory = pretend.call_recorder(lambda request: url_maker)
-        monkeypatch.setattr(views, "paginate_url_factory", url_maker_factory)
-
-        assert search(db_request) == {
-            "page": page_obj,
-            "term": params.get("q", ""),
-            "order": params.get("o", ""),
-            "applied_filters": [],
-            "available_filters": [],
-        }
-        assert page_cls.calls == [
-            pretend.call(suggest, url_maker=url_maker, page=page or 1)
-        ]
-        assert url_maker_factory.calls == [pretend.call(db_request)]
-        assert db_request.es.query.calls == [
-            pretend.call(views.gather_es_queries(params["q"]))
-        ]
-        assert es_query.suggest.calls == [
-            pretend.call("name_suggestion", params["q"], term={"field": "name"})
-        ]
-        assert metrics.histogram.calls == [
-            pretend.call("warehouse.views.search.results", 1000)
-        ]
-
-    @pytest.mark.parametrize(
-        ("page", "order", "expected"),
-        [
-            (None, None, []),
-            (1, "-created", [{"created": {"order": "desc", "unmapped_type": "long"}}]),
-            (5, "created", [{"created": {"unmapped_type": "long"}}]),
-        ],
-    )
-    def test_with_an_ordering(
-        self, monkeypatch, db_request, metrics, page, order, expected
-    ):
-        params = MultiDict({"q": "foo bar"})
-        if page is not None:
-            params["page"] = page
-        if order is not None:
-            params["o"] = order
-        db_request.params = params
-
-        sort = pretend.stub()
-        suggest = pretend.stub(sort=pretend.call_recorder(lambda *a, **kw: sort))
-        es_query = pretend.stub(suggest=pretend.call_recorder(lambda *a, **kw: suggest))
-        db_request.es = pretend.stub(
-            query=pretend.call_recorder(lambda *a, **kw: es_query)
-        )
-
-        page_obj = pretend.stub(page_count=(page or 1) + 10, item_count=1000)
-        page_cls = pretend.call_recorder(lambda *a, **kw: page_obj)
-        monkeypatch.setattr(views, "ElasticsearchPage", page_cls)
-
-        url_maker = pretend.stub()
-        url_maker_factory = pretend.call_recorder(lambda request: url_maker)
-        monkeypatch.setattr(views, "paginate_url_factory", url_maker_factory)
-
-        assert search(db_request) == {
-            "page": page_obj,
-            "term": params.get("q", ""),
-            "order": params.get("o", ""),
-            "applied_filters": [],
-            "available_filters": [],
-        }
-        assert page_cls.calls == [
+        assert get_es_query.calls == [
             pretend.call(
-                sort if order is not None else suggest,
-                url_maker=url_maker,
-                page=page or 1,
+                db_request.es, params.get("q"), queries.SearchModes.relevance, []
             )
         ]
+        assert page_cls.calls == [
+            pretend.call(es_query, url_maker=url_maker, page=page or 1)
+        ]
         assert url_maker_factory.calls == [pretend.call(db_request)]
-        assert db_request.es.query.calls == [
-            pretend.call(views.gather_es_queries(params["q"]))
-        ]
-        assert es_query.suggest.calls == [
-            pretend.call("name_suggestion", params["q"], term={"field": "name"})
-        ]
-        assert suggest.sort.calls == [pretend.call(i) for i in expected]
         assert metrics.histogram.calls == [
             pretend.call("warehouse.views.search.results", 1000)
         ]
@@ -405,16 +256,10 @@ class TestSearch:
         if page is not None:
             params["page"] = page
         db_request.params = params
-
-        es_query = pretend.stub(
-            suggest=pretend.call_recorder(lambda *a, **kw: es_query),
-            filter=pretend.call_recorder(lambda *a, **kw: es_query),
-            query=pretend.call_recorder(lambda *a, **kw: es_query),
-            sort=pretend.call_recorder(lambda *a, **kw: es_query),
-        )
-        db_request.es = pretend.stub(
-            query=pretend.call_recorder(lambda *a, **kw: es_query)
-        )
+        es_query = pretend.stub()
+        db_request.es = pretend.stub()
+        get_es_query = pretend.call_recorder(lambda *a, **kw: es_query)
+        monkeypatch.setattr(views, "get_es_query", get_es_query)
 
         classifier1 = ClassifierFactory.create(classifier="foo :: bar")
         classifier2 = ClassifierFactory.create(classifier="foo :: baz")
@@ -438,7 +283,7 @@ class TestSearch:
         assert search_view == {
             "page": page_obj,
             "term": params.get("q", ""),
-            "order": params.get("o", ""),
+            "order": "relevance",
             "applied_filters": params.getall("c"),
             "available_filters": [
                 {
@@ -454,49 +299,14 @@ class TestSearch:
             pretend.call(es_query, url_maker=url_maker, page=page or 1)
         ]
         assert url_maker_factory.calls == [pretend.call(db_request)]
-        assert db_request.es.query.calls == [
-            pretend.call(views.gather_es_queries(params["q"]))
+        assert get_es_query.calls == [
+            pretend.call(
+                db_request.es,
+                params.get("q"),
+                queries.SearchModes.relevance,
+                params.getall("c"),
+            )
         ]
-        assert es_query.suggest.calls == [
-            pretend.call("name_suggestion", params["q"], term={"field": "name"})
-        ]
-        assert es_query.query.calls == [
-            pretend.call("prefix", classifiers="foo :: bar"),
-            pretend.call("prefix", classifiers="fiz :: buz"),
-        ]
-        assert metrics.histogram.calls == [
-            pretend.call("warehouse.views.search.results", 1000)
-        ]
-
-    @pytest.mark.parametrize("page", [None, 1, 5])
-    def test_without_a_query(self, monkeypatch, db_request, metrics, page):
-        params = MultiDict()
-        if page is not None:
-            params["page"] = page
-        db_request.params = params
-
-        es_query = pretend.stub()
-        db_request.es = pretend.stub(query=lambda *a, **kw: es_query)
-
-        page_obj = pretend.stub(page_count=(page or 1) + 10, item_count=1000)
-        page_cls = pretend.call_recorder(lambda *a, **kw: page_obj)
-        monkeypatch.setattr(views, "ElasticsearchPage", page_cls)
-
-        url_maker = pretend.stub()
-        url_maker_factory = pretend.call_recorder(lambda request: url_maker)
-        monkeypatch.setattr(views, "paginate_url_factory", url_maker_factory)
-
-        assert search(db_request) == {
-            "page": page_obj,
-            "term": params.get("q", ""),
-            "order": params.get("o", ""),
-            "applied_filters": [],
-            "available_filters": [],
-        }
-        assert page_cls.calls == [
-            pretend.call(es_query, url_maker=url_maker, page=page or 1)
-        ]
-        assert url_maker_factory.calls == [pretend.call(db_request)]
         assert metrics.histogram.calls == [
             pretend.call("warehouse.views.search.results", 1000)
         ]

--- a/tests/unit/test_views.py
+++ b/tests/unit/test_views.py
@@ -19,8 +19,8 @@ import pytest
 from pyramid.httpexceptions import HTTPBadRequest, HTTPNotFound, HTTPServiceUnavailable
 from webob.multidict import MultiDict
 
-from warehouse.search import queries
 from warehouse import views
+from warehouse.search import queries
 from warehouse.views import (
     classifiers,
     current_user_indicator,

--- a/warehouse/migrations/versions/20ee7dfaddc7_add_project_downloads.py
+++ b/warehouse/migrations/versions/20ee7dfaddc7_add_project_downloads.py
@@ -17,9 +17,9 @@ Revises: 2d6390eebe90
 Create Date: 2019-01-06 16:17:43.846366
 """
 
-from alembic import op
 import sqlalchemy as sa
 
+from alembic import op
 
 revision = "20ee7dfaddc7"
 down_revision = "2d6390eebe90"

--- a/warehouse/migrations/versions/20ee7dfaddc7_add_project_downloads.py
+++ b/warehouse/migrations/versions/20ee7dfaddc7_add_project_downloads.py
@@ -1,0 +1,44 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Add `downloads_month_to_date` column on project for indexing.
+
+Revision ID: 20ee7dfaddc7
+Revises: 2d6390eebe90
+Create Date: 2019-01-06 16:17:43.846366
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20ee7dfaddc7"
+down_revision = "2d6390eebe90"
+
+# Note: It is VERY important to ensure that a migration does not lock for a
+#       long period of time and to ensure that each individual migration does
+#       not break compatibility with the *previous* version of the code base.
+#       This is because the migrations will be ran automatically as part of the
+#       deployment process, but while the previous version of the code is still
+#       up and running. Thus backwards incompatible changes must be broken up
+#       over multiple migrations inside of multiple pull requests in order to
+#       phase them in over multiple deploys.
+
+
+def upgrade():
+    op.add_column(
+        "projects", sa.Column("downloads_month_to_date", sa.Integer(), nullable=True)
+    )
+
+
+def downgrade():
+    op.drop_column("projects", "downloads_month_to_date")

--- a/warehouse/migrations/versions/20ee7dfaddc7_add_project_downloads.py
+++ b/warehouse/migrations/versions/20ee7dfaddc7_add_project_downloads.py
@@ -13,7 +13,7 @@
 Add `downloads_month_to_date` column on project for indexing.
 
 Revision ID: 20ee7dfaddc7
-Revises: 2d6390eebe90
+Revises: 67f52a64a389
 Create Date: 2019-01-06 16:17:43.846366
 """
 
@@ -22,7 +22,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision = "20ee7dfaddc7"
-down_revision = "2d6390eebe90"
+down_revision = "67f52a64a389"
 
 # Note: It is VERY important to ensure that a migration does not lock for a
 #       long period of time and to ensure that each individual migration does

--- a/warehouse/migrations/versions/20ee7dfaddc7_add_project_downloads.py
+++ b/warehouse/migrations/versions/20ee7dfaddc7_add_project_downloads.py
@@ -13,7 +13,7 @@
 Add `downloads_last_30_days` column on project for indexing.
 
 Revision ID: 20ee7dfaddc7
-Revises: 3db69c05dd11
+Revises: c4a1ee483bb3
 Create Date: 2019-01-06 16:17:43.846366
 """
 
@@ -22,7 +22,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision = "20ee7dfaddc7"
-down_revision = "3db69c05dd11"
+down_revision = "c4a1ee483bb3"
 
 # Note: It is VERY important to ensure that a migration does not lock for a
 #       long period of time and to ensure that each individual migration does

--- a/warehouse/migrations/versions/20ee7dfaddc7_add_project_downloads.py
+++ b/warehouse/migrations/versions/20ee7dfaddc7_add_project_downloads.py
@@ -13,7 +13,7 @@
 Add `downloads_last_30_days` column on project for indexing.
 
 Revision ID: 20ee7dfaddc7
-Revises: 67f52a64a389
+Revises: 3db69c05dd11
 Create Date: 2019-01-06 16:17:43.846366
 """
 
@@ -22,7 +22,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision = "20ee7dfaddc7"
-down_revision = "67f52a64a389"
+down_revision = "3db69c05dd11"
 
 # Note: It is VERY important to ensure that a migration does not lock for a
 #       long period of time and to ensure that each individual migration does

--- a/warehouse/migrations/versions/20ee7dfaddc7_add_project_downloads.py
+++ b/warehouse/migrations/versions/20ee7dfaddc7_add_project_downloads.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Add `downloads_month_to_date` column on project for indexing.
+Add `downloads_last_30_days` column on project for indexing.
 
 Revision ID: 20ee7dfaddc7
 Revises: 67f52a64a389
@@ -36,9 +36,9 @@ down_revision = "67f52a64a389"
 
 def upgrade():
     op.add_column(
-        "projects", sa.Column("downloads_month_to_date", sa.Integer(), nullable=True)
+        "projects", sa.Column("downloads_last_30_days", sa.Integer(), nullable=True)
     )
 
 
 def downgrade():
-    op.drop_column("projects", "downloads_month_to_date")
+    op.drop_column("projects", "downloads_last_30_days")

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -121,6 +121,7 @@ class Project(SitemapMixin, db.Model):
     last_serial = Column(Integer, nullable=False, server_default=sql.text("0"))
     allow_legacy_files = Column(Boolean, nullable=False, server_default=sql.false())
     zscore = Column(Float, nullable=True)
+    downloads_month_to_date = Column(Integer, nullable=True)
 
     users = orm.relationship(User, secondary=Role.__table__, backref="projects")
 

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -121,7 +121,7 @@ class Project(SitemapMixin, db.Model):
     last_serial = Column(Integer, nullable=False, server_default=sql.text("0"))
     allow_legacy_files = Column(Boolean, nullable=False, server_default=sql.false())
     zscore = Column(Float, nullable=True)
-    downloads_month_to_date = Column(Integer, nullable=True)
+    downloads_last_30_days = Column(Integer, nullable=True)
 
     users = orm.relationship(User, secondary=Role.__table__, backref="projects")
 

--- a/warehouse/packaging/search.py
+++ b/warehouse/packaging/search.py
@@ -12,7 +12,7 @@
 
 import packaging.version
 
-from elasticsearch_dsl import Date, Document, Float, Keyword, Text, analyzer
+from elasticsearch_dsl import Date, Document, Float, Integer, Keyword, Text, analyzer
 
 from warehouse.search.utils import doc_type
 
@@ -50,6 +50,7 @@ class Project(Document):
     created = Date()
     classifiers = Keyword(multi=True)
     zscore = Float()
+    downloads_month_to_date = Integer()
 
     @classmethod
     def from_db(cls, release):
@@ -73,5 +74,6 @@ class Project(Document):
         obj["created"] = release.created
         obj["classifiers"] = release.classifiers
         obj["zscore"] = release.zscore
+        obj["downloads_month_to_date"] = release.downloads_month_to_date
 
         return obj

--- a/warehouse/packaging/search.py
+++ b/warehouse/packaging/search.py
@@ -50,7 +50,7 @@ class Project(Document):
     created = Date()
     classifiers = Keyword(multi=True)
     zscore = Float()
-    downloads_month_to_date = Integer()
+    downloads_last_30_days = Integer()
 
     @classmethod
     def from_db(cls, release):
@@ -74,6 +74,6 @@ class Project(Document):
         obj["created"] = release.created
         obj["classifiers"] = release.classifiers
         obj["zscore"] = release.zscore
-        obj["downloads_month_to_date"] = release.downloads_month_to_date
+        obj["downloads_last_30_days"] = release.downloads_last_30_days
 
         return obj

--- a/warehouse/packaging/tasks.py
+++ b/warehouse/packaging/tasks.py
@@ -80,9 +80,8 @@ def compute_trending(request):
     # turn it into the primary key of the Project object and construct a list
     # of primary key: new zscore, including a default of None if the item isn't
     # in the result set.
-    query = (
-        request.db.query(Project.id, Project.normalized_name)
-        .filter(Project.normalized_name.in_(zscores))
+    query = request.db.query(Project.id, Project.normalized_name).filter(
+        Project.normalized_name.in_(zscores)
     )
     to_update = [
         {

--- a/warehouse/packaging/tasks.py
+++ b/warehouse/packaging/tasks.py
@@ -71,7 +71,7 @@ def compute_trending(request):
     (
         request.db.query(Project)
         .filter(
-            (Project.zscore != None) | (Project.downloads_last_30_days != None)
+            (Project.zscore.isnot(None)) | (Project.downloads_last_30_days.isnot(None))
         )  # noqa
         .update({Project.zscore: None, Project.downloads_last_30_days: None})
     )

--- a/warehouse/search/queries.py
+++ b/warehouse/search/queries.py
@@ -51,7 +51,7 @@ SEARCH_FILTER_ORDER = (
 
 class SearchModes(enum.Enum):
     relevance = "relevance"
-    popularity = "popularity"
+    download_frequency = "download_frequency"
     created = "created"
     trending = "trending"
 
@@ -116,7 +116,7 @@ def query_for_mode(query, mode):
     """
     Applies transformations on the ES query based on the search mode
     """
-    if mode == SearchModes.popularity:
+    if mode == SearchModes.download_frequency:
         functions = [
             {
                 "field_value_factor": {

--- a/warehouse/search/queries.py
+++ b/warehouse/search/queries.py
@@ -120,7 +120,7 @@ def query_for_mode(query, mode):
         functions = [
             {
                 "field_value_factor": {
-                    "field": "downloads_month_to_date",
+                    "field": "downloads_last_30_days",
                     "modifier": "sqrt",
                     "factor": 0.001,
                     "missing": 0,

--- a/warehouse/search/queries.py
+++ b/warehouse/search/queries.py
@@ -10,6 +10,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import enum
+import re
+
+from elasticsearch_dsl import Q
+
 SEARCH_FIELDS = [
     "author",
     "author_email",
@@ -42,3 +47,86 @@ SEARCH_FILTER_ORDER = (
     "Intended Audience",
     "Natural Language",
 )
+
+
+class SearchModes(enum.Enum):
+    relevance = "relevance"
+    popularity = "popularity"
+    created = "created"
+    trending = "trending"
+
+
+def get_es_query(es, querystring, mode, classifiers):
+    """Returns an Elasticsearch query from data from the request."""
+    if not querystring:
+        return es.query()
+
+    bool_query = gather_es_queries(querystring)
+    query = es.query(bool_query)
+    query = query.suggest("name_suggestion", querystring, term={"field": "name"})
+    query = query_for_mode(query, mode)
+
+    # Require match to all specified classifiers
+    for classifier in classifiers:
+        query = query.query("prefix", classifiers=classifier)
+
+    return query
+
+
+def query_for_mode(query, mode):
+    """Applies transformations on the ES query based on the search mode"""
+    if mode == SearchModes.popularity:
+        functions = [
+            {
+                "field_value_factor": {
+                    "field": "downloads_month_to_date",
+                    "modifier": "sqrt",
+                    "factor": 0.001,
+                    "missing": 0
+                }
+            }
+        ]
+        query.query = Q("function_score", query=query.query, functions=functions)
+    elif mode == SearchModes.created:
+        query.sort({"created": {"order": "desc", "unmapped_type": "long"}})
+    elif mode == SearchModes.trending:
+        query.sort({"zscore": {"order": "desc", "unmapped_type": "long"}})
+
+    return query
+
+
+def gather_es_queries(q):
+    quoted_string, unquoted_string = filter_query(q)
+    must = [form_query("phrase", i) for i in quoted_string] + [
+        form_query("best_fields", i) for i in unquoted_string
+    ]
+
+    bool_query = Q("bool", must=must)
+
+    # Allow to optionally match on prefix
+    # if ``q`` is longer than one character.
+    if len(q) > 1:
+        bool_query = bool_query | Q("prefix", normalized_name=q)
+    return bool_query
+
+
+def filter_query(s):
+    """
+    Filters given query with the below regex
+    and returns lists of quoted and unquoted strings
+    """
+    matches = re.findall(r'(?:"([^"]*)")|([^"]*)', s)
+    result_quoted = [t[0].strip() for t in matches if t[0]]
+    result_unquoted = [t[1].strip() for t in matches if t[1]]
+    return result_quoted, result_unquoted
+
+
+def form_query(query_type, query):
+    """
+    Returns a multi match query
+    """
+    fields = [
+        field + "^" + str(SEARCH_BOOSTS[field]) if field in SEARCH_BOOSTS else field
+        for field in SEARCH_FIELDS
+    ]
+    return Q("multi_match", fields=fields, query=query, type=query_type)

--- a/warehouse/search/tasks.py
+++ b/warehouse/search/tasks.py
@@ -86,6 +86,7 @@ def _project_docs(db, project_name=None):
             Project.normalized_name,
             Project.name,
             Project.zscore,
+            Project.downloads_month_to_date,
         )
         .select_from(releases_list)
         .join(Release, Release.id == releases_list.c.id)

--- a/warehouse/search/tasks.py
+++ b/warehouse/search/tasks.py
@@ -86,7 +86,7 @@ def _project_docs(db, project_name=None):
             Project.normalized_name,
             Project.name,
             Project.zscore,
-            Project.downloads_month_to_date,
+            Project.downloads_last_30_days,
         )
         .select_from(releases_list)
         .join(Release, Release.id == releases_list.c.id)

--- a/warehouse/templates/search/results.html
+++ b/warehouse/templates/search/results.html
@@ -164,7 +164,7 @@
             <label for="order">Order by &nbsp;</label>
             <select class="-js-form-submit-trigger" id="order" name="mode">
               {{ search_option("Relevance", "relevance") }}
-              {{ search_option("Popularity", "popularity") }}
+              {{ search_option("Download frequency", "download_frequency") }}
               {{ search_option("Date last updated", "created") }}
               {{ search_option("Trending", "trending") }}
             </select>

--- a/warehouse/templates/search/results.html
+++ b/warehouse/templates/search/results.html
@@ -23,7 +23,7 @@
     <h3 class="package-snippet__title">
       <span class="package-snippet__name">{{ item.name }}</span>
       <span class="package-snippet__version">{{ item.latest_version }}</span>
-      {% if order == "-created" %}
+      {% if mode == "created" %}
       <span class="package-snippet__released">{{ humanize(item.created) }}</span>
       {% endif %}
     </h3>
@@ -45,7 +45,7 @@
 
 
 {% macro search_option(text, value) -%}
-<option value="{{ value }}" {{ 'selected' if value == order else ''}}>{{ text }}</option>
+<option value="{{ value }}" {{ 'selected' if value == mode else ''}}>{{ text }}</option>
 {%- endmacro %}
 
 
@@ -96,7 +96,7 @@
         </h2>
         <form id="classifiers">
         <input id="search" type="hidden" name="q" value="{{ term }}">
-        <input type="hidden" name="o" value="{{ order }}">
+        <input type="hidden" name="o" value="{{ mode }}">
 
         {% set applied_filters_str = applied_filters|join(' ') %}
         {% for each_filter in available_filters %}

--- a/warehouse/templates/search/results.html
+++ b/warehouse/templates/search/results.html
@@ -162,10 +162,11 @@
             {% if term or applied_filters %}
             <input id="search" type="hidden" name="q" value="{{ term }}">
             <label for="order">Order by &nbsp;</label>
-            <select class="-js-form-submit-trigger" id="order" name="o">
-              {{ search_option("Relevance", "") }}
-              {{ search_option("Date last updated", "-created") }}
-              {{ search_option("Trending", "-zscore") }}
+            <select class="-js-form-submit-trigger" id="order" name="mode">
+              {{ search_option("Relevance", "relevance") }}
+              {{ search_option("Popularity", "popularity") }}
+              {{ search_option("Date last updated", "created") }}
+              {{ search_option("Trending", "trending") }}
             </select>
             {% endif %}
           </div>

--- a/warehouse/views.py
+++ b/warehouse/views.py
@@ -334,7 +334,7 @@ def search(request):
     return {
         "page": page,
         "term": querystring,
-        "order": mode.value,  # TODO: rename to `mode`
+        "mode": mode.value,
         "available_filters": process_available_filters(),
         "applied_filters": request.params.getall("c"),
     }

--- a/warehouse/views.py
+++ b/warehouse/views.py
@@ -11,11 +11,9 @@
 # limitations under the License.
 
 import collections
-import re
 
 import elasticsearch
 
-from elasticsearch_dsl import Q
 from pyramid.exceptions import PredicateMismatch
 from pyramid.httpexceptions import (
     HTTPBadRequest,
@@ -46,7 +44,7 @@ from warehouse.classifiers.models import Classifier
 from warehouse.db import DatabaseNotAvailable
 from warehouse.metrics import IMetricsService
 from warehouse.packaging.models import File, Project, Release, release_classifiers
-from warehouse.search.queries import SEARCH_BOOSTS, SEARCH_FIELDS, SEARCH_FILTER_ORDER
+from warehouse.search.queries import get_es_query, SearchModes, SEARCH_FILTER_ORDER
 from warehouse.utils.paginate import ElasticsearchPage, paginate_url_factory
 from warehouse.utils.row_counter import RowCount
 
@@ -252,30 +250,13 @@ def classifiers(request):
 def search(request):
     metrics = request.find_service(IMetricsService, context=None)
 
-    q = request.params.get("q", "")
-    q = q.replace("'", '"')
-
-    if q:
-        bool_query = gather_es_queries(q)
-
-        query = request.es.query(bool_query)
-
-        query = query.suggest("name_suggestion", q, term={"field": "name"})
-    else:
-        query = request.es.query()
-
-    if request.params.get("o"):
-        sort_key = request.params["o"]
-        if sort_key.startswith("-"):
-            sort = {sort_key[1:]: {"order": "desc", "unmapped_type": "long"}}
-        else:
-            sort = {sort_key: {"unmapped_type": "long"}}
-
-        query = query.sort(sort)
-
-    # Require match to all specified classifiers
-    for classifier in request.params.getall("c"):
-        query = query.query("prefix", classifiers=classifier)
+    querystring = request.params.get("q", "").replace("'", '"')
+    try:
+        mode = SearchModes(request.params.get("mode"))
+    except ValueError:
+        mode = SearchModes.relevance
+    classifiers = request.params.getall("c")
+    query = get_es_query(request.es, querystring, mode, classifiers)
 
     try:
         page_num = int(request.params.get("page", 1))
@@ -352,8 +333,8 @@ def search(request):
 
     return {
         "page": page,
-        "term": q,
-        "order": request.params.get("o", ""),
+        "term": querystring,
+        "order": mode.value,  # TODO: rename to `mode`
         "available_filters": process_available_filters(),
         "applied_filters": request.params.getall("c"),
     }
@@ -440,40 +421,3 @@ def force_status(request):
         raise exception_response(int(request.matchdict["status"]))
     except KeyError:
         raise exception_response(404) from None
-
-
-def filter_query(s):
-    """
-    Filters given query with the below regex
-    and returns lists of quoted and unquoted strings
-    """
-    matches = re.findall(r'(?:"([^"]*)")|([^"]*)', s)
-    result_quoted = [t[0].strip() for t in matches if t[0]]
-    result_unquoted = [t[1].strip() for t in matches if t[1]]
-    return result_quoted, result_unquoted
-
-
-def form_query(query_type, query):
-    """
-    Returns a multi match query
-    """
-    fields = [
-        field + "^" + str(SEARCH_BOOSTS[field]) if field in SEARCH_BOOSTS else field
-        for field in SEARCH_FIELDS
-    ]
-    return Q("multi_match", fields=fields, query=query, type=query_type)
-
-
-def gather_es_queries(q):
-    quoted_string, unquoted_string = filter_query(q)
-    must = [form_query("phrase", i) for i in quoted_string] + [
-        form_query("best_fields", i) for i in unquoted_string
-    ]
-
-    bool_query = Q("bool", must=must)
-
-    # Allow to optionally match on prefix
-    # if ``q`` is longer than one character.
-    if len(q) > 1:
-        bool_query = bool_query | Q("prefix", normalized_name=q)
-    return bool_query

--- a/warehouse/views.py
+++ b/warehouse/views.py
@@ -44,7 +44,7 @@ from warehouse.classifiers.models import Classifier
 from warehouse.db import DatabaseNotAvailable
 from warehouse.metrics import IMetricsService
 from warehouse.packaging.models import File, Project, Release, release_classifiers
-from warehouse.search.queries import get_es_query, SearchModes, SEARCH_FILTER_ORDER
+from warehouse.search.queries import SEARCH_FILTER_ORDER, SearchModes, get_es_query
 from warehouse.utils.paginate import ElasticsearchPage, paginate_url_factory
 from warehouse.utils.row_counter import RowCount
 


### PR DESCRIPTION
~Fixes~ Helps with #3932

- Pull the packages monthly downloads as part of the BigQuery trending query.
- Add the monthly downloads to the database and index.
- Refactor the Elasticsearch logic into its own module
- Remove hardcoded sorting in the template in favor of "search modes"
- Include an additional "Popularity" mode applying a [function score](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-function-score-query.html) modifier to the search to allow more popular packages to score higher

![downloads_boost](https://user-images.githubusercontent.com/6739793/51442527-92527500-1cd5-11e9-954b-1048ba2ce8c5.gif)

The boost modifier to the query is implemented in a fairly naive way, I am by no means an Elasticsearch expert and would very much welcome some feedback on how to improve it.

I've tested it locally by:
1. running the BQ query manually,
2. exporting the results as a CSV,
3. modify the code in the `compute_trending` task to read from the CSV as a source of results
4. trigger `compute_trending` manually and reindexing