### PR TITLE
clean journal action field for xmlrpc since filename is user-supplied

### DIFF
--- a/warehouse/legacy/api/xmlrpc/views.py
+++ b/warehouse/legacy/api/xmlrpc/views.py
@@ -492,7 +492,7 @@ def changelog_since_serial(request, serial: int):
             e.name,
             e.version,
             int(e.submitted_date.replace(tzinfo=datetime.timezone.utc).timestamp()),
-            e.action,
+            _clean_for_xml(e.action),
             e.id,
         )
         for e in entries


### PR DESCRIPTION
Should resolve #5653, As far as the reporting use case goes (bandersnatch), this should unblock mirrors. Up-to-date bandersnatch versions use the JSON API for all further interactions, which properly handle this concern.