### PR TITLE
Revert "Add a note that you need to use Twine to take advantage of metadata fields."

### DIFF
--- a/warehouse/templates/manage/settings.html
+++ b/warehouse/templates/manage/settings.html
@@ -25,13 +25,11 @@
     <p>
       To set the '{{ project.name }}' description, author, links,
       classifiers, and other details for your next release, use
-      the <a href="https://packaging.python.org/tutorials/distributing-packages/#setup-args" rel="noopener" target="_blank"><tt>setup()</tt>
+      the <a href="https://packaging.python.org/tutorials/distributing-packages/#setup-args"><tt>setup()</tt>
       arguments in your <tt>setup.py</tt> file</a>. Updating these
       fields will not change the metadata for past
-      releases. Additionally, you <strong>must</strong> use
-      <a href="https://twine.readthedocs.io/en/latest/" rel="noopener" target="_blank">Twine</a>
-      to upload your files in order to get full support for these fields. See
-      <a href="https://packaging.python.org/tutorials/distributing-packages/" rel="noopener" target="_blank">the Python Packaging User Guide</a> for more help.
+      releases. See <a href="https://packaging.python.org/tutorials/distributing-packages/">the
+      Python Packaging User Guide</a> for more help.
     </p>
     <button type="button" title="Dismiss" data-action="click->dismissable#dismiss" class="callout-block__dismiss" aria-label="close"><i class="fa fa-times" aria-hidden="true"></i></button>
   </div>


### PR DESCRIPTION
Reverts pypa/warehouse#5488
theacodes:add-twine-to-description-notice
@brosner @alex @robhudson @alexwlchan #5595 #5749 