### PR TITLE
Update delete warnings' text

### DIFF
--- a/warehouse/templates/manage/manage_base.html
+++ b/warehouse/templates/manage/manage_base.html
@@ -86,7 +86,7 @@
           {% if warning %}
           <div class="callout-block callout-block--danger callout-block--bottom-margin no-top-margin">
             <p>
-              <i class="fa fa-exclamation-triangle" aria-hidden="true"><span class="sr-only">Warning</span></i>warning
+              <i class="fa fa-exclamation-triangle" aria-hidden="true"><span class="sr-only">Warning</span></i>
               This action cannot be undone!
               {% if confirm_name == "Version" %}
               You will not be able to re-upload a new distribution of the same type with the same version number.

--- a/warehouse/templates/manage/release.html
+++ b/warehouse/templates/manage/release.html
@@ -122,9 +122,9 @@
     {% if files %}
       Deleting will irreversibly delete this release along with {{ files|length() }}
       {% trans count=files|length %}
-        file
+        file.
       {% pluralize %}
-        files
+        files.
       {% endtrans %}
     {% else %}
       Deleting will irreversibly delete this release.


### PR DESCRIPTION
* Missing fullstop after "2 files":

![image](https://user-images.githubusercontent.com/1324225/57701240-48b2df00-7664-11e9-8510-d0fa1d25181a.png)

https://test.pypi.org/manage/project/pypistats/release/0.5.0/

* No need for the "warning" text right after the icon (compare previous screenshot):

![image](https://user-images.githubusercontent.com/1324225/57701400-9af40000-7664-11e9-9df2-c9889d2dfeb4.png)

https://test.pypi.org/manage/project/pypistats/releases/ > Options > Delete

* Additionally, should the fullstop be dropped after "Confirm the version to continue.", because it has no subsequent sentence?
