### PR TITLE
Remove issuer_name="PyPI" default kwarg

### DIFF
--- a/warehouse/utils/otp.py
+++ b/warehouse/utils/otp.py
@@ -45,7 +45,7 @@ def generate_totp_secret():
     return os.urandom(20)
 
 
-def generate_totp_provisioning_uri(secret, username, issuer_name="PyPI"):
+def generate_totp_provisioning_uri(secret, username, issuer_name):
     """
     Generates a URL to be presented as a QR-code for time-based OTP.
     """


### PR DESCRIPTION
Remove an unnecessary and confusing kwarg in `generate_totp_provisioning_uri`. This value should always come from the `site.name` configuration value instead, and that value should always be set.

From #5809, cc @woodruffw.