### PR TITLE
add a banner for PSF Q2 Fundraiser

### DIFF
--- a/warehouse/templates/base.html
+++ b/warehouse/templates/base.html
@@ -168,6 +168,13 @@
       </noscript>
     </section>
 
+    <div class="notification-bar">
+      <span class="notification-bar__message">
+        Donate to the Python Software Foundation or Purchase a PyCharm License to Benefit the PSF!
+        <a href="https://www.python.org/psf/donations/2019-q2-drive/" target="_blank" title="Donate to the Python Software Foundation">Donate Now</a>
+      </span>
+    </div>
+
     {% block flash_messages %}
       {% csi request.route_path("includes.flash-messages") %}
       {% endcsi %}


### PR DESCRIPTION
<img width="1070" alt="Screen Shot 2019-05-20 at 5 04 45 PM" src="https://user-images.githubusercontent.com/1200832/58051901-6333ff00-7b21-11e9-9d8f-93d67a9295d4.png">
