### PR TITLE
Show slack icon for "slack" link name

### DIFF
--- a/warehouse/templates/packaging/detail.html
+++ b/warehouse/templates/packaging/detail.html
@@ -39,7 +39,7 @@
   {% set icon = "fab fa-bitbucket" %}
 {% elif parsed.netloc == "reddit.com" or parsed.netloc.endswith(".reddit.com") %}
   {% set icon = "fab fa-reddit-alien" %}
-{% elif parsed.netloc == "slack.com" or parsed.netloc.endswith(".slack.com") %}
+{% elif name.lower().startswith("slack") or parsed.netloc == "slack.com" or parsed.netloc.endswith(".slack.com") %}
   {% set icon = "fab fa-slack" %}
 {% elif parsed.netloc == "twitter.com" or parsed.netloc.endswith(".twitter.com") %}
   {% set icon = "fab fa-twitter" %}


### PR DESCRIPTION
Show the slack icon when the link name starts with "slack", as well as if it is a slack.com URL.
Use case: I personally use a custom redirect domain for my slack invite so that I can easily change the invite if needed without updating everything everywhere.