### PR TITLE
Update security policy

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,7 @@
+# Security Policy
+
+**Note**: Please do not submit security reports via Github issues.
+
+To read the most up to date version of our security policy, including
+directions for submitting security vulnerabilities, please visit
+https://pypi.org/security/.

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -5,12 +5,11 @@ Security
 
 Security policy
 ---------------
-To read the most up to date version of our security policy,  visit the
-application security page, available via the site_ footer.
+To read the most up to date version of our security policy, including
+directions for submitting security vulnerabilities, please visit
+`<https://pypi.org/security/>`_.
 
 Project and release activity details
 ------------------------------------
 See :doc:`api-reference/feeds` for how to track new and updated releases on
 PyPI.
-
-.. _site: https://pypi.org


### PR DESCRIPTION
Github now supports adding a security policy. It's currently picking up on our existing security documentation which is producing a mis-formatted page: https://github.com/pypa/warehouse/security/policy

This PR adds a Github-specific policy, and updates our existing documentation to point directly to https://pypi.org/security/