### PR TITLE
Fix "nuke user" view

### DIFF
--- a/warehouse/admin/views/users.py
+++ b/warehouse/admin/views/users.py
@@ -19,6 +19,7 @@ from paginate_sqlalchemy import SqlalchemyOrmPage as SQLAlchemyORMPage
 from pyramid.httpexceptions import HTTPBadRequest, HTTPNotFound, HTTPSeeOther
 from pyramid.view import view_config
 from sqlalchemy import or_
+from sqlalchemy.orm import joinedload
 from sqlalchemy.orm.exc import NoResultFound
 
 from warehouse import forms
@@ -189,7 +190,10 @@ def user_delete(request):
     deleted_user = request.db.query(User).filter(User.username == "deleted-user").one()
 
     journals = (
-        request.db.query(JournalEntry).filter(JournalEntry.submitted_by == user).all()
+        request.db.query(JournalEntry)
+        .options(joinedload("submitted_by"))
+        .filter(JournalEntry.submitted_by == user)
+        .all()
     )
 
     for journal in journals:


### PR DESCRIPTION
Use joinedload to `avoid raise_on_sql` exception. Fixes https://sentry.io/organizations/python-software-foundation/issues/851747167/