### PR TITLE
Revert "error `make initdb` if xz isn't installed"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,9 +149,6 @@ ifneq ($(PR), false)
 endif
 
 initdb:
-	ifeq (, $(shell which xz))
-	$(error "No xz available on PATH, install xz-utils!")
-	endif
 	docker-compose run --rm web psql -h db -d postgres -U postgres -c "DROP DATABASE IF EXISTS warehouse"
 	docker-compose run --rm web psql -h db -d postgres -U postgres -c "CREATE DATABASE warehouse ENCODING 'UTF8'"
 	xz -d -f -k dev/$(DB).sql.xz --stdout | docker-compose run --rm web psql -h db -d warehouse -U postgres -v ON_ERROR_STOP=1 -1 -f -


### PR DESCRIPTION
Reverts pypa/warehouse#5872

This seems to be broken on the most recent release of MacOS, perhaps due to weird `which` behavior.