### PR TITLE
reduce email validation strictness

### DIFF
--- a/tests/unit/accounts/test_forms.py
+++ b/tests/unit/accounts/test_forms.py
@@ -308,6 +308,18 @@ class TestRegistrationForm:
         assert not form.validate()
         assert form.email.errors.pop() == "The email address isn't valid. Try again."
 
+    def test_exotic_email_success(self):
+        form = forms.RegistrationForm(
+            data={"email": "foo@n--tree.net"},
+            user_service=pretend.stub(
+                find_userid_by_email=pretend.call_recorder(lambda _: None)
+            ),
+            breach_service=pretend.stub(check_password=lambda pw, tags=None: False),
+        )
+
+        form.validate()
+        assert len(form.email.errors) == 0
+
     def test_email_exists_error(self):
         form = forms.RegistrationForm(
             data={"email": "foo@bar.com"},

--- a/warehouse/accounts/forms.py
+++ b/warehouse/accounts/forms.py
@@ -147,8 +147,8 @@ class NewEmailMixin:
     email = wtforms.fields.html5.EmailField(
         validators=[
             wtforms.validators.DataRequired(),
-            wtforms.validators.Email(
-                message=("The email address isn't valid. Try again.")
+            wtforms.validators.Regexp(
+                r".+@.+\..+", message=("The email address isn't valid. Try again.")
             ),
         ]
     )


### PR DESCRIPTION
Hi 👋, I took a shot at https://github.com/pypa/warehouse/issues/3733

The email validation is replaced by a simpler regex validation as suggested in the issue.

Please let me know if I can improve anything as this is my first contribution to the project.