### PR TITLE
WIP: Make links more visible

### DIFF
--- a/warehouse/static/sass/base/_typography.scss
+++ b/warehouse/static/sass/base/_typography.scss
@@ -107,11 +107,9 @@ strong {
 
 a {
   color: $primary-color;
-  text-decoration: none;
 
   &:hover {
     color: darken($primary-color, 10);
-    text-decoration: underline;
   }
 
   @include link-focus(underline);

--- a/warehouse/static/sass/base/_typography.scss
+++ b/warehouse/static/sass/base/_typography.scss
@@ -106,16 +106,62 @@ strong {
 }
 
 a {
-  color: $primary-color;
+  text-decoration: none;
+  background-position: 0 1.15em;
+  background-repeat: repeat-x;
+  background-size: 100% 1.5px;
+  @include primary-underlined-link;
+  @include link-focus;
 
-  &:hover {
-    color: darken($primary-color, 10);
+  // Add 'external link' icon to most external links
+  &[target="_blank"]:not(.tooltipped):not(.sponsors__sponsor) {
+    &::after {
+      white-space: nowrap;
+      font-size: 80%;
+      font-family: "Font Awesome 5 Free";
+      font-weight: 900;
+      content: "\f35d";
+      margin: 0 0 0 4px;
+      color: inherit;
+      position: relative;
+      top: -1px;
+    }
   }
 
-  @include link-focus(underline);
+  // Add 'email' icon to email links
+  &[href^="mailto:"] {
+    &::after {
+      font-size: 90%;
+      font-family: "Font Awesome 5 Free";
+      font-weight: 400;
+      content: "\f0e0";
+      color: inherit;
+      margin: 0 0 0 4px;
+      position: relative;
+      top: 0.5px;
+    }
+  }
+
+  // Handle badges and code in links nicely
+  .badge {
+    position: relative;
+    top: -1px;
+  }
+
+  code,
+  kbd,
+  pre,
+  samp,
+  tt {
+    font-size: 70%;
+    position: relative;
+    top: -2px;
+    padding: 0 2px;
+  }
 }
 
 button {
+  @include link-without-underline;
   @include link-focus;
 }
 

--- a/warehouse/static/sass/blocks/_accordion.scss
+++ b/warehouse/static/sass/blocks/_accordion.scss
@@ -29,15 +29,11 @@
   &__link {
     padding: 5px;
     display: block;
-    text-decoration: none;
     cursor: pointer;
     border: 0;
     background-color: transparent;
     color: $primary-color;
-
-    &:hover {
-      text-decoration: none;
-    }
+    @include link-without-underline;
 
     &:before {
       font-family: "Font Awesome 5 Free";
@@ -49,7 +45,6 @@
     @media only screen and (max-width: $desktop) {
       color: $white;
     }
-
   }
 
   &__content {

--- a/warehouse/static/sass/blocks/_badge.scss
+++ b/warehouse/static/sass/blocks/_badge.scss
@@ -17,6 +17,8 @@
   Use for small strings, or numbers.
 
   <span class="badge">Contributor</span>
+  or
+  <a class="badge">Sole owner</span>
 */
 
 .badge {
@@ -24,9 +26,14 @@
   text-transform: uppercase;
   background-color: $primary-color;
   color: $white;
-  padding: 2px 7px;
+  padding: 0 7px;
   border-radius: 3px;
   font-weight: 600;
+  @include link-without-underline;
+
+  &:hover {
+    color: $white;
+  }
 
   &--success {
     background-color: $success-color;
@@ -39,5 +46,9 @@
   &--warning {
     background-color: $warn-color;
     color: $warn-text;
+
+    &:hover {
+      color: $warn-text;
+    }
   }
 }

--- a/warehouse/static/sass/blocks/_button.scss
+++ b/warehouse/static/sass/blocks/_button.scss
@@ -33,7 +33,6 @@
   font-size: $button-font-size;
   font-weight: $bold-font-weight;
   cursor: pointer;
-  text-decoration: none;
   padding: 0 ($spacing-unit / 2);
   background-color: transparent;
   color: lighten($text-color, 10);
@@ -43,6 +42,7 @@
   border-radius: 3px;
   display: inline-block;
   white-space: nowrap;
+  @include link-without-underline;
 
   i.fa {
     position: relative;
@@ -54,7 +54,6 @@
   &:active {
     border-color: $primary-color;
     color: darken($primary-color, 10);
-    text-decoration: none;
     z-index: index($z-index-scale, "active-button"); // Needed for button groups
     outline: none;
   }

--- a/warehouse/static/sass/blocks/_callout-block.scss
+++ b/warehouse/static/sass/blocks/_callout-block.scss
@@ -59,12 +59,7 @@
       color: $danger-color;
 
       a:not(.button) {
-        color: $danger-color;
-        text-decoration: underline;
-
-        &:hover {
-          color: darken($danger-color, 4);
-        }
+        @include danger-underlined-link;
       }
     }
 

--- a/warehouse/static/sass/blocks/_dropdown.scss
+++ b/warehouse/static/sass/blocks/_dropdown.scss
@@ -68,6 +68,7 @@
   &__link,
   button.dropdown__link {
     display: block;
+    text-decoration: none;
     padding: 15px 15px 15px 15px;
     border: 0; // Remove default border on buttons
     border-bottom: 1px solid $border-color;

--- a/warehouse/static/sass/blocks/_dropdown.scss
+++ b/warehouse/static/sass/blocks/_dropdown.scss
@@ -68,7 +68,6 @@
   &__link,
   button.dropdown__link {
     display: block;
-    text-decoration: none;
     padding: 15px 15px 15px 15px;
     border: 0; // Remove default border on buttons
     border-bottom: 1px solid $border-color;
@@ -78,12 +77,12 @@
     cursor: pointer;
     text-align: left;
     position: relative;
+    @include link-without-underline;
 
     &:hover,
     &:focus {
       background-color: mix($white, $primary-color-light, 90%);
       color: $primary-color-dark;
-      text-decoration: none;
     }
 
     &:focus {

--- a/warehouse/static/sass/blocks/_faq-group.scss
+++ b/warehouse/static/sass/blocks/_faq-group.scss
@@ -26,7 +26,6 @@
 
 .faq-group {
   h2 {
-    border-bottom: 2px solid $base-grey;
     padding-bottom: 5px;
     margin-top: $spacing-unit * 2;
   }

--- a/warehouse/static/sass/blocks/_footer.scss
+++ b/warehouse/static/sass/blocks/_footer.scss
@@ -35,7 +35,6 @@
 */
 
 .footer {
-  $footer-link-color: mix($white, $primary-color, 95%);
   background-color: lighten($primary-color, 2);
   color: $white;
   padding: 60px 0;
@@ -73,15 +72,9 @@
       text-align: center;
 
       a {
-        color: $footer-link-color;
-        text-decoration: none;
-
-        &:hover {
-          color: $white;
-          text-decoration: underline;
-        }
-
-        @include link-focus(underline);
+        @include white-underlined-link;
+        background-image: none;
+        @include link-focus;
       }
 
       h2 {
@@ -100,7 +93,7 @@
   }
 
   &__text {
-    color: $footer-link-color;
+    color: transparentize($white, 0.05);
     font-size: $base-font-size * 0.9;
     margin: auto;
     max-width: 600px;
@@ -108,10 +101,8 @@
     padding: 0 20px;
 
     a {
-      color: $white;
-      text-decoration: underline;
-
-      @include link-focus(underline);
+      @include white-underlined-link;
+      @include link-focus;
     }
   }
 }

--- a/warehouse/static/sass/blocks/_form-errors.scss
+++ b/warehouse/static/sass/blocks/_form-errors.scss
@@ -42,12 +42,7 @@
     }
 
     a {
-      color: $danger-color;
-      text-decoration: underline;
-
-      &:hover {
-        color: darken($danger-color, 10);
-      }
+      @include danger-underlined-link;
     }
   }
 

--- a/warehouse/static/sass/blocks/_homepage-banner.scss
+++ b/warehouse/static/sass/blocks/_homepage-banner.scss
@@ -47,13 +47,6 @@
 
     a {
       color: $white;
-      text-decoration: underline;
-      text-decoration-color: $transparent-white;
-
-      &:hover {
-        text-decoration-color: $white;
-      }
-
       @include link-focus(underline);
     }
   }

--- a/warehouse/static/sass/blocks/_homepage-banner.scss
+++ b/warehouse/static/sass/blocks/_homepage-banner.scss
@@ -46,8 +46,8 @@
     margin: $spacing-unit 0 10px 0;
 
     a {
-      color: $white;
-      @include link-focus(underline);
+      @include white-underlined-link;      
+      @include link-focus;
     }
   }
 }

--- a/warehouse/static/sass/blocks/_horizontal-menu.scss
+++ b/warehouse/static/sass/blocks/_horizontal-menu.scss
@@ -29,6 +29,7 @@
     text-decoration: none;
     display: inline-block;
     padding: 8px 10px;
+    @include link-without-underline;
 
     &--with-icon {
       .fa {
@@ -51,7 +52,7 @@
         text-decoration-color: $transparent-white;
       }
 
-      @include link-focus(underline);
+      @include link-focus;
     }
   }
 

--- a/warehouse/static/sass/blocks/_modal.scss
+++ b/warehouse/static/sass/blocks/_modal.scss
@@ -95,9 +95,9 @@
     right: 0;
     text-align: center;
     top: 0;
-    text-decoration: none;
     border-radius: 0 3px 0 4px;
     color: $border-color;
+    @include link-without-underline;
   }
 
   // Styles for inline forms

--- a/warehouse/static/sass/blocks/_notification-bar.scss
+++ b/warehouse/static/sass/blocks/_notification-bar.scss
@@ -82,10 +82,8 @@
     @include h3;
 
     a {
-      color: $white;
-      text-decoration: underline;
-
-      @include link-focus(underline);
+      @include white-underlined-link;
+      @include link-focus;
     }
   }
 
@@ -118,7 +116,7 @@
     border-color: darken($primary-color, 10);
 
     a {
-      color: $warn-text;
+      @include colored-link($warn-text);
     }
   }
 

--- a/warehouse/static/sass/blocks/_package-snippet.scss
+++ b/warehouse/static/sass/blocks/_package-snippet.scss
@@ -31,11 +31,15 @@
   display: block;
   padding: ($spacing-unit / 2) 20px ($spacing-unit / 2) 75px;
   margin: 0 0 20px;
-  // Use png fallback
-  background: $white url("../images/white-cube.png") no-repeat 0 50%;
-  // Or svg if the browser supports it
-  background-image: url("../images/white-cube.svg"), linear-gradient(transparent, transparent);
-  background-position: 20px;
+
+  &,
+  &:hover {
+    // Use png fallback
+    background: $white url("../images/white-cube.png") no-repeat 0 50%;
+    // Or svg if the browser supports it
+    background-image: url("../images/white-cube.svg"), linear-gradient(transparent, transparent);
+    background-position: 20px;
+  }
 
   &__title {
     @include add-ellipsis;

--- a/warehouse/static/sass/blocks/_release.scss
+++ b/warehouse/static/sass/blocks/_release.scss
@@ -88,10 +88,8 @@
   }
 
   &__card {
-    border: 1px solid darken(#ececec, 5);
-    background-color: $white;
-    box-shadow: 1px 1px 2px 1px transparentize($black, 0.95);
     display: block;
+    @include card;
     padding: $spacing-unit / 2;
     margin: ($spacing-unit / 2) 0;
   }

--- a/warehouse/static/sass/blocks/_sidebar-section.scss
+++ b/warehouse/static/sass/blocks/_sidebar-section.scss
@@ -34,7 +34,7 @@
   }
 
   .sidebar-section__user-gravatar {
-    text-decoration: none;
+    @include link-without-underline;
   }
 
   &:last-of-type {

--- a/warehouse/static/sass/blocks/_site-header.scss
+++ b/warehouse/static/sass/blocks/_site-header.scss
@@ -33,6 +33,7 @@
     padding: ($spacing-unit / 2) 0;
     max-width: 65px;
     float: left;
+    @include link-without-underline;
 
     @media screen and (max-width: $small-tablet) {
       max-width: 50px;

--- a/warehouse/static/sass/blocks/_skip-to-content.scss
+++ b/warehouse/static/sass/blocks/_skip-to-content.scss
@@ -27,6 +27,7 @@
   overflow: hidden;
   color: $white;
   z-index: index($z-index-scale, "skip-to-content");
+  @include link-without-underline;
 
   &:focus {
     top: 7px;

--- a/warehouse/static/sass/blocks/_sponsors.scss
+++ b/warehouse/static/sass/blocks/_sponsors.scss
@@ -51,10 +51,9 @@
     text-align: center;
     padding: ($spacing-unit / 2) 13px 10px 13px;
     opacity: 0.95;
-    text-decoration: none;
+    @include link-without-underline;
 
     &:hover {
-      text-decoration: none;
       opacity: 1;
 
       .sponsors__image {

--- a/warehouse/static/sass/blocks/_status-badge.scss
+++ b/warehouse/static/sass/blocks/_status-badge.scss
@@ -40,6 +40,7 @@
   padding: 0 12px 0 0;
   text-align: left;
   min-height: 40px;
+  @include link-without-underline;
 
   &:hover {
     color: $text-color;

--- a/warehouse/static/sass/blocks/_vertical-tabs.scss
+++ b/warehouse/static/sass/blocks/_vertical-tabs.scss
@@ -55,6 +55,7 @@
     display: block;
     padding: $spacing-unit / 2;
     cursor: pointer;
+    text-decoration: none;
 
     &:hover,
     &:focus {

--- a/warehouse/static/sass/blocks/_vertical-tabs.scss
+++ b/warehouse/static/sass/blocks/_vertical-tabs.scss
@@ -55,11 +55,10 @@
     display: block;
     padding: $spacing-unit / 2;
     cursor: pointer;
-    text-decoration: none;
+    @include link-without-underline;
 
     &:hover,
     &:focus {
-      text-decoration: none;
       color: darken($primary-color, 10)
     }
 

--- a/warehouse/static/sass/blocks/_viewport-section.scss
+++ b/warehouse/static/sass/blocks/_viewport-section.scss
@@ -69,8 +69,7 @@
     color: $white;
 
     a {
-      color: $white;
-      text-decoration: underline;
+      @include white-underlined-link;
     }
   }
 

--- a/warehouse/static/sass/tools/_design-utilities.scss
+++ b/warehouse/static/sass/tools/_design-utilities.scss
@@ -16,18 +16,12 @@
   border: 1px solid $border-color;
   box-shadow: 1px 1px 2px 1px rgba(0, 0, 0, 0.05);
   background-color: $white;
-}
+  background-image: none;
 
-@mixin link-focus($underline: "none") {
-  &:focus {
-    outline: 1px solid $primary-color-light;
-    background-color: transparentize($primary-color-light, 0.9);
-    cursor: pointer;
-    @if $underline == "none" {
-      text-decoration: none;
-    } @else {
-      text-decoration: underline;
-    }
+  &:hover,
+  &:active {
+    border-color: $border-color;
+    background-image: none;
   }
 }
 

--- a/warehouse/static/sass/tools/_link-utilities.scss
+++ b/warehouse/static/sass/tools/_link-utilities.scss
@@ -1,0 +1,61 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@mixin colored-link($color) {
+  color: $color;
+  background-image: linear-gradient(to right, $color, transparentize($color, 0.3));
+
+  &:hover,
+  &:active {
+    color: darken($color, 10);
+    background-image: linear-gradient(to right, darken($color, 10), darken($color, 10));
+  }
+}
+
+@mixin primary-underlined-link {
+  @include colored-link($primary-color);
+}
+
+@mixin danger-underlined-link {
+  @include colored-link($danger-color);
+}
+
+@mixin white-underlined-link {
+  color: transparentize($white, 0.05);
+  background-image: linear-gradient(to right, $white, transparentize($white, 0.3));
+
+  &:hover,
+  &:active {
+    color: $white;
+    background-image: linear-gradient(to right, $white, $white);
+  }
+}
+
+@mixin link-without-underline {
+  background-image: none;
+
+  &:hover,
+  &:active {
+    background-image: none;
+  }
+}
+
+@mixin link-focus {
+  &:focus,
+  &:active {
+    outline: 1px solid $primary-color-light;
+    background-color: transparentize($primary-color-light, 0.9);
+    cursor: pointer;
+  }
+}

--- a/warehouse/static/sass/warehouse.scss
+++ b/warehouse/static/sass/warehouse.scss
@@ -30,6 +30,7 @@
 @import "tools/neat/neat"; // Also imports neat's default settings
 @import "tools/design-utilities";
 @import "tools/layout-utilities";
+@import "tools/link-utilities";
 @import "tools/typography";
 
 // SETTINGS LAYER: settings we use throughout the codebase

--- a/warehouse/templates/500.html
+++ b/warehouse/templates/500.html
@@ -23,8 +23,8 @@
   <p>We are aware of the problem and are working to resolve it as soon as possible.</p>
 
   <ul class="unstyled">
-    <li><a href="https://status.python.org/">Check our status page</a></li>
-    <li><a href="https://twitter.com/PythonStatus">View Python Status on Twitter</a></li>
+    <li><a href="https://status.python.org/" title="External link" target="_blank" rel="noopener">Check our status page</a></li>
+    <li><a href="https://twitter.com/PythonStatus" title="External link" target="_blank" rel="noopener">View Python Status on Twitter</a></li>
   </ul>
   <br>
   <p class="no-bottom-padding"><strong>Error code 500</strong></p>
@@ -32,7 +32,7 @@
   <p>
     <strong>
       Rely on PyPI to get your job done?<br>
-      Consider <a href="https://github.com/pypa/warehouse">contributing</a> or <a href="https://psfmember.org/civicrm/contribute/transact?reset=1&id=13">donating</a> to help us build a more stable and secure platform.
+      Consider <a href="https://github.com/pypa/warehouse" target="_blank" rel="noopener">contributing</a> or <a href="https://psfmember.org/civicrm/contribute/transact?reset=1&id=13" target="_blank" rel="noopener">donating</a> to help us build a more stable and secure platform.
     </strong>
   </p>
 </div>

--- a/warehouse/templates/base.html
+++ b/warehouse/templates/base.html
@@ -171,7 +171,7 @@
     <div class="notification-bar">
       <span class="notification-bar__message">
         Donate to the Python Software Foundation or Purchase a PyCharm License to Benefit the PSF!
-        <a href="https://www.python.org/psf/donations/2019-q2-drive/" target="_blank" title="Donate to the Python Software Foundation">Donate Now</a>
+        <a href="https://www.python.org/psf/donations/2019-q2-drive/" title="External link" target="_blank" rel="noopener" title="Donate to the Python Software Foundation">Donate Now</a>
       </span>
     </div>
 
@@ -255,18 +255,18 @@
           <li>
             <h2>Help</h2>
           </li>
-          <li><a href="https://packaging.python.org/installing/">Installing packages</a></li>
-          <li><a href="https://packaging.python.org/tutorials/packaging-projects/">Uploading packages</a></li>
-          <li><a href="https://packaging.python.org/">User guide</a></li>
+          <li><a href="https://packaging.python.org/installing/" title="External link" target="_blank" rel="noopener">Installing packages</a></li>
+          <li><a href="https://packaging.python.org/tutorials/packaging-projects/" title="External link" target="_blank" rel="noopener">Uploading packages</a></li>
+          <li><a href="https://packaging.python.org/" title="External link" target="_blank" rel="noopener">User guide</a></li>
           <li><a href="{{ request.route_path('help')}}">FAQs</a></li>
         </ul>
         <ul class="footer__menu">
           <li>
             <h2>About PyPI</h2>
           </li>
-          <li><a href="https://twitter.com/PyPI">PyPI on Twitter</a></li>
-          <li><a href="https://dtdg.co/pypi">Infrastructure dashboard</a></li>
-          <li><a href="https://www.python.org/dev/peps/pep-0541/">Package index name retention</a></li>
+          <li><a href="https://twitter.com/PyPI" title="External link" target="_blank" rel="noopener">PyPI on Twitter</a></li>
+          <li><a href="https://dtdg.co/pypi" title="External link" target="_blank" rel="noopener">Infrastructure dashboard</a></li>
+          <li><a href="https://www.python.org/dev/peps/pep-0541/" title="External link" target="_blank" rel="noopener">Package index name retention</a></li>
           <li><a href="{{ request.route_path('sponsors') }}">Our sponsors</a></li>
         </ul>
 
@@ -276,16 +276,16 @@
             <h2>Contributing to PyPI</h2>
           </li>
           <li><a href="{{ request.route_path('help')}}#feedback">Bugs and feedback</a></li>
-          <li><a href="https://github.com/pypa/warehouse">Contribute on GitHub</a></li>
-          <li><a href="https://github.com/pypa/warehouse/graphs/contributors">Development credits</a></li>
+          <li><a href="https://github.com/pypa/warehouse" title="External link" target="_blank" rel="noopener">Contribute on GitHub</a></li>
+          <li><a href="https://github.com/pypa/warehouse/graphs/contributors" title="External link" target="_blank" rel="noopener">Development credits</a></li>
         </ul>
         <ul class="footer__menu">
           <li>
             <h2>Using PyPI</h2>
           </li>
-          <li><a href="https://www.pypa.io/en/latest/code-of-conduct/">Code of conduct</a></li>
+          <li><a href="https://www.pypa.io/en/latest/code-of-conduct/" title="External link" target="_blank" rel="noopener">Code of conduct</a></li>
           <li><a href="{{ request.route_path('security') }}">Report security issue</a></li>
-          <li><a href="https://www.python.org/privacy/">Privacy policy</a></li>
+          <li><a href="https://www.python.org/privacy/" title="External link" target="_blank" rel="noopener">Privacy policy</a></li>
           <li><a href="{{ request.route_path('policy.terms-of-use') }}">Terms of use</a></li>
         </ul>
       </div>
@@ -294,14 +294,16 @@
 
       <div class="footer__text">
         {% if request.registry.settings.get("statuspage.url") %}
-        <p>Status: <a href="https://status.python.org/"><span data-statuspage-domain="{{ request.registry.settings['statuspage.url'] }}">all systems operational</span></a></p>
+        <p>Status: <a href="https://status.python.org/" title="External link" target="_blank" rel="noopener">
+          <span data-statuspage-domain="{{ request.registry.settings['statuspage.url'] }}">all systems operational</span></a>
+        </p>
         {% endif %}
         <p>
           Developed and maintained by the Python community, for the Python community.
           <br>
           <a href="https://donate.pypi.org">Donate today!</a>
         </p>
-        <p>© {{ now()|format_date('yyyy') }} <a href="https://www.python.org/psf/">Python Software Foundation</a></p>
+        <p>© {{ now()|format_date('yyyy') }} <a href="https://www.python.org/psf/" title="External link" target="_blank" rel="noopener">Python Software Foundation</a></p>
       </div>
 
       <div class="centered hide-on-desktop">

--- a/warehouse/templates/includes/accounts/profile-actions.html
+++ b/warehouse/templates/includes/accounts/profile-actions.html
@@ -17,11 +17,11 @@
 
   <div class="sidebar-section">
     <h3 class="sidebar-section__title">Statistics</h3>
-    <p>View statistics for your projects via <a href="https://libraries.io/">Libraries.io</a>, or by using <a href="https://packaging.python.org/guides/analyzing-pypi-package-downloads/">Google BigQuery</a></p>
+    <p>View statistics for your projects via <a href="https://libraries.io/" title="External link" target="_blank" rel="noopener">Libraries.io</a>, or by using <a href="https://packaging.python.org/guides/analyzing-pypi-package-downloads/" target="_blank" rel="noopener">Google BigQuery</a></p>
   </div>
 {% else %}
 <div class="sidebar-section">
   <h3 class="sidebar-section__title">Statistics</h3>
-  <p>View statistics for {{ user.username }}'s projects via <a href="https://libraries.io/">Libraries.io</a>, or by using <a href="https://packaging.python.org/guides/analyzing-pypi-package-downloads/">Google BigQuery</a></p>
+  <p>View statistics for {{ user.username }}'s projects via <a href="https://libraries.io/" title="External link" target="_blank" rel="noopener">Libraries.io</a>, or by using <a href="https://packaging.python.org/guides/analyzing-pypi-package-downloads/" target="_blank" rel="noopener">Google BigQuery</a></p>
 </div>
 {% endif %}

--- a/warehouse/templates/includes/accounts/profile-callout.html
+++ b/warehouse/templates/includes/accounts/profile-callout.html
@@ -14,7 +14,7 @@
 
 <div class="callout-block no-top-margin">
   {% if user.id == request.user.id %}
-  <p>You have not uploaded any projects to PyPI, yet. To learn how to get started, visit the <a href="https://packaging.python.org/">Python Packaging User Guide</a></p>
+  <p>You have not uploaded any projects to PyPI, yet. To learn how to get started, visit the <a href="https://packaging.python.org/" title="External link" target="_blank" rel="noopener">Python Packaging User Guide</a></p>
   {% else %}
   <p>{{ user.name|default(user.username, true) }} has not uploaded any projects to PyPI, yet.</p>
   {% endif %}

--- a/warehouse/templates/includes/packaging/project-data.html
+++ b/warehouse/templates/includes/packaging/project-data.html
@@ -54,8 +54,8 @@
   </div>
   {% endif %}
   <p>View statistics for this project via <a
-          href="https://libraries.io/pypi/{{ release.project.name }}">Libraries.io</a>, or by using
-    <a href="https://packaging.python.org/guides/analyzing-pypi-package-downloads/">Google
+          href="https://libraries.io/pypi/{{ release.project.name }}" title="External link" target="_blank" rel="noopener">Libraries.io</a>, or by using
+    <a href="https://packaging.python.org/guides/analyzing-pypi-package-downloads/" target="_blank" rel="noopener">Google
       BigQuery</a></p>
 </div>
 

--- a/warehouse/templates/index.html
+++ b/warehouse/templates/index.html
@@ -81,11 +81,11 @@
       <p class="lede-paragraph">The Python Package Index (PyPI) is a repository of software for the Python programming language.</p>
       <p>
         PyPI helps you find and install software developed and shared by the Python community.
-        <a href="https://packaging.python.org/installing/">Learn about installing packages</a>.
+        <a href="https://packaging.python.org/installing/" title="External link" target="_blank" rel="noopener">Learn about installing packages</a>.
       </p>
       <p>
         Package authors use PyPI to distribute their software.
-        <a href="https://packaging.python.org/tutorials/packaging-projects/">Learn how to package your Python code for PyPI</a>.
+        <a href="https://packaging.python.org/tutorials/packaging-projects/" title="External link" target="_blank" rel="noopener">Learn how to package your Python code for PyPI</a>.
       </p>
     </div>
   </div>
@@ -117,9 +117,6 @@
           {{ project_snippet(release) }}
         {% endfor %}
       </ul>
-      {#
-      <a class="button" href="TODO">Show more</a>
-      #}
     </div>
   </div>
 </section>

--- a/warehouse/templates/manage/account.html
+++ b/warehouse/templates/manage/account.html
@@ -148,12 +148,10 @@
       <img src="{{ gravatar(request, user.email, size=140) }}" alt="{{ alt }}" title="{{ alt }}" class="gravatar-form__image">
       <div class="gravatar-form__content">
         <p>
-        We use <a href="https://gravatar.com/">gravatar.com</a> to generate your profile picture based on your primary email address — <code class="break-on-mobile">{{ user.email }}</code>
+        We use <a href="https://gravatar.com/" title="External link" target="_blank" rel="noopener">gravatar.com</a> to generate your profile picture based on your primary email address — <code class="break-on-mobile">{{ user.email }}</code>
         </p>
-        <a href="{{ gravatar_profile(user.email) }}" target="_blank" rel="noopener" class="button">
+        <a href="{{ gravatar_profile(user.email) }}" title="External link" target="_blank" rel="noopener" class="button">
           Change image<span class="hide-on-mobile"> on gravatar.com</span>
-          <i class="fa fa-external-link-alt" aria-hidden="true"></i>
-          <span class="sr-only">Opens in new window</span>
         </a>
       </div>
     </div>
@@ -374,13 +372,7 @@
         {% for project in active_projects %}
         <li>
           <strong>{{ project.name }}</strong> -
-          <a href="{{ request.route_path('manage.project.roles', project_name=project.name) }}">
-            transfer ownership
-          </a>
-          or
-          <a href="{{ request.route_path('manage.project.settings', project_name=project.name) }}">
-            delete
-          </a>
+          <a href="{{ request.route_path('manage.project.roles', project_name=project.name) }}">transfer ownership</a> or <a href="{{ request.route_path('manage.project.settings', project_name=project.name) }}">delete</a>
         </li>
         {% endfor %}
       </ul>

--- a/warehouse/templates/manage/manage_base.html
+++ b/warehouse/templates/manage/manage_base.html
@@ -90,7 +90,7 @@
               This action cannot be undone!
               {% if confirm_name == "Version" %}
               You will not be able to re-upload a new distribution of the same type with the same version number.
-              Consider making a new release or a <a href="https://www.python.org/dev/peps/pep-0440/#post-releases">post release</a> instead.
+              Consider making a new release or a <a href="https://www.python.org/dev/peps/pep-0440/#post-releases" title="External link" target="_blank" rel="noopener">post release</a> instead.
               {% endif %}
             </p>
           </div>

--- a/warehouse/templates/manage/projects.html
+++ b/warehouse/templates/manage/projects.html
@@ -29,9 +29,7 @@
         <div>
           <h3 class="package-snippet__title">{{ project.name }}
             {% if project.name in projects_sole_owned %}
-            <a href="{{ request.route_path('manage.project.roles', project_name=project.normalized_name) }}">
-              <span class="badge badge--warning package-snippet__sole-owner-badge">Sole owner</span>
-            </a>
+            <a href="{{ request.route_path('manage.project.roles', project_name=project.normalized_name) }}" class="badge badge--warning package-snippet__sole-owner-badge">Sole owner</a>
             {% endif %}
           </h3>
           {% if release %}
@@ -74,7 +72,7 @@
     {% endfor %}
     {% else %}
       <div class="callout-block no-top-margin">
-        <p>You have not uploaded any projects to PyPI, yet. To learn how to get started, visit the <a href="https://packaging.python.org/">Python Packaging User Guide</a></p>
+        <p>You have not uploaded any projects to PyPI, yet. To learn how to get started, visit the <a href="https://packaging.python.org/" target="_blank" rel="noopener">Python Packaging User Guide</a></p>
       </div>
     {% endif %}
   </div>

--- a/warehouse/templates/manage/release.html
+++ b/warehouse/templates/manage/release.html
@@ -109,7 +109,7 @@
     {% else %}
     <h3>No files found</h3>
     {% endif %}
-    <p>Learn how to upload files on the <a href="https://packaging.python.org/tutorials/distributing-packages/#uploading-your-project-to-pypi">Python Packaging User Guide</a></p>
+    <p>Learn how to upload files on the <a href="https://packaging.python.org/tutorials/distributing-packages/#uploading-your-project-to-pypi" title="External link" target="_blank" rel="noopener">Python Packaging User Guide</a></p>
     <button type="button" title="Dismiss" data-action="click->dismissable#dismiss" class="callout-block__dismiss" aria-label="close"><i class="fa fa-times" aria-hidden="true"></i></button>
   </div>
 
@@ -130,7 +130,7 @@
       Deleting will irreversibly delete this release.
     {% endif %}
       You will not be able to re-upload a new distribution of the same type with the same version number.
-      Consider making a new release or a <a href="https://www.python.org/dev/peps/pep-0440/#post-releases">post release</a> instead.
+      Consider making a new release or a <a href="https://www.python.org/dev/peps/pep-0440/#post-releases" title="External link" target="_blank" rel="noopener">post release</a> instead.
     </p>
     {{ confirm_button("Delete release", "Version", release.version) }}
   </div>

--- a/warehouse/templates/manage/releases.html
+++ b/warehouse/templates/manage/releases.html
@@ -91,7 +91,7 @@
     {% else %}
     <h3>No releases found</h3>
     {% endif %}
-    <p>Learn how to create a new release on the <a href="https://packaging.python.org/tutorials/distributing-packages/">Python Packaging User Guide</a></p>
+    <p>Learn how to create a new release on the <a href="https://packaging.python.org/tutorials/distributing-packages/" title="External link" target="_blank" rel="noopener">Python Packaging User Guide</a></p>
     <button type="button" title="Dismiss" data-action="click->dismissable#dismiss" class="callout-block__dismiss" aria-label="close"><i class="fa fa-times" aria-hidden="true"></i></button>
   </div>
 {% endblock %}

--- a/warehouse/templates/packaging/detail.html
+++ b/warehouse/templates/packaging/detail.html
@@ -250,14 +250,14 @@
           {# Tab: Downloads #}
           <div id="files" data-target="project-tabs.content" class="vertical-tabs__content" role="tabpanel" aria-labelledby="files-tab mobile-files-tab">
             <h2 class="page-title">Download files</h2>
-            <p>Download the file for your platform. If you're not sure which to choose, learn more about <a href="https://packaging.python.org/installing/">installing packages</a>.</p>
+            <p>Download the file for your platform. If you're not sure which to choose, learn more about <a href="https://packaging.python.org/installing/" title="External link" target="_blank" rel="noopener">installing packages</a>.</p>
 
             <table class="table table--downloads">
               <thead>
                 <tr>
                   <th class="table__filename">
                     Filename, size &amp; hash
-                    <a href="https://pip.pypa.io/en/stable/reference/pip_install/#hash-checking-mode" class="tooltipped tooltipped-n" aria-label="what's this?" data-original-label="what's this?">
+                    <a href="https://pip.pypa.io/en/stable/reference/pip_install/#hash-checking-mode" target="_blank" rel="noopener" class="tooltipped tooltipped-n" aria-label="what's this?" data-original-label="what's this?">
                       <i class="fa fa-question-circle" aria-hidden="true"></i>
                       <span class="sr-only">SHA256 hash help</span>
                     </a>

--- a/warehouse/templates/pages/classifiers.html
+++ b/warehouse/templates/pages/classifiers.html
@@ -21,7 +21,7 @@
     <h1 class="page-title">Classifiers</h1>
     <p>Each project's maintainers provide PyPI with a list of "trove classifiers" to categorize each release, describing who it's for, what systems it can run on, and how mature it is.</p>
     <p>These standardized classifiers can then be used by community members to find projects based on their desired criteria.</p>
-    <p>Instructions for how to add trove classifiers to a project can be found on the <a href="https://packaging.python.org/tutorials/distributing-packages/#classifiers">Python Packaging User Guide</a>. To read the original classifier specification, refer to <a href="https://www.python.org/dev/peps/pep-0301/#distutils-trove-classification">PEP 301</a>.</p>
+    <p>Instructions for how to add trove classifiers to a project can be found on the <a href="https://packaging.python.org/tutorials/distributing-packages/#classifiers" title="External link" target="_blank" rel="noopener">Python Packaging User Guide</a>. To read the original classifier specification, refer to <a href="https://www.python.org/dev/peps/pep-0301/#distutils-trove-classification" title="External link" target="_blank" rel="noopener">PEP 301</a>.</p>
 
     <h2>List of classifiers</h2>
     <ul>

--- a/warehouse/templates/pages/help.html
+++ b/warehouse/templates/pages/help.html
@@ -15,7 +15,7 @@
 
 {% macro code_of_conduct() %}
   <div class="callout-block">
-    <p><strong>Note:</strong> All users submitting feedback, reporting issues or contributing to Warehouse are expected to follow the <a href="https://www.pypa.io/en/latest/code-of-conduct/">PyPA Code of Conduct</a>.</p>
+    <p><strong>Note:</strong> All users submitting feedback, reporting issues or contributing to Warehouse are expected to follow the <a href="https://www.pypa.io/en/latest/code-of-conduct/" title="External link" target="_blank" rel="noopener">PyPA Code of Conduct</a>.</p>
   </div>
 {% endmacro %}
 
@@ -147,10 +147,10 @@
         <p>A "file", also known as a "package", on PyPI is something that you can download and install. Because of different hardware, operating systems, and file formats, a release may have several files (packages), like an archive containing source code or a binary <a href="https://pypi.org/project/wheel/#files">wheel</a>.</p>
 
         <h3 id="installing">{{ installing() }}</h3>
-        <p>To learn how to install a file from PyPI, visit the <a href="https://packaging.python.org/installing/">installation tutorial</a> on the <a href="https://packaging.python.org/">Python Packaging User Guide</a>.</p>
+        <p>To learn how to install a file from PyPI, visit the <a href="https://packaging.python.org/installing/" title="External link" target="_blank" rel="noopener">installation tutorial</a> on the <a href="https://packaging.python.org/" title="External link" target="_blank" rel="noopener">Python Packaging User Guide</a>.</p>
 
         <h3 id="publishing">{{ publishing() }}</h3>
-        <p>For full instructions on configuring, packaging and distributing your Python project, refer to the <a href="https://packaging.python.org/distributing/">packaging tutorial</a> on the <a href="https://packaging.python.org">Python Packaging User Guide</a>.</p>
+        <p>For full instructions on configuring, packaging and distributing your Python project, refer to the <a href="https://packaging.python.org/distributing/" title="External link" target="_blank" rel="noopener">packaging tutorial</a> on the <a href="https://packaging.python.org" title="External link" target="_blank" rel="noopener">Python Packaging User Guide</a>.</p>
 
         <h3 id="trove-classifier">{{ trove_classifier() }}</h3>
         <p>Classifiers are used to categorize projects on PyPI. See <a href="{{ request.route_path('classifiers') }}"> {{ request.route_url('classifiers') }}</a> for more information, as well as a list of valid classifiers.</p>
@@ -166,54 +166,54 @@
           <li>Upload a new version or file.</li>
         </ul>
         <p>The list of activities that require a verified email address is likely to grow over time.</p>
-        <p>This policy will allow us to enforce a key policy of <a href="https://www.python.org/dev/peps/pep-0541/">PEP 541</a> regarding maintainer reachability. It also reduces the viability of spam attacks to create many accounts in an automated fashion.</p>
+        <p>This policy will allow us to enforce a key policy of <a href="https://www.python.org/dev/peps/pep-0541/" title="External link" target="_blank" rel="noopener">PEP 541</a> regarding maintainer reachability. It also reduces the viability of spam attacks to create many accounts in an automated fashion.</p>
         <p>You can manage your account's email addresses in your <a href="{{ request.route_path('manage.account') }}">Profile</a>. This also allows for sending a new confirmation email for users who signed up in the past, before we began enforcing this policy.</p>
 
         <h3 id="compromised-password">{{ compromised_password() }}</h3>
-        <p>PyPI itself has not suffered a breach. This is a protective measure to reduce the risk of <a href="https://www.owasp.org/index.php/Credential_stuffing" target="_blank" rel="noopener">credential stuffing</a> attacks against PyPI and its users.</p>
+        <p>PyPI itself has not suffered a breach. This is a protective measure to reduce the risk of <a href="https://www.owasp.org/index.php/Credential_stuffing" title="External link" target="_blank" rel="noopener">credential stuffing</a> attacks against PyPI and its users.</p>
         <p>Each time a user supplies a password — while registering, authenticating, or updating their password — PyPI securely checks whether that password has appeared in public data breaches.</p>
-        <p>During each of these processes, PyPI generates a SHA-1 hash of the supplied password and uses the first five (5) characters of the hash to check the <a href="https://haveibeenpwned.com/API/v2#SearchingPwnedPasswordsByRange" target="_blank" rel="noopener">Have I Been Pwned API</a> and determine if the password has been previously compromised. The plaintext password is never stored by PyPI or submitted to the Have I Been Pwned API.</p>
+        <p>During each of these processes, PyPI generates a SHA-1 hash of the supplied password and uses the first five (5) characters of the hash to check the <a href="https://haveibeenpwned.com/API/v2#SearchingPwnedPasswordsByRange" title="External link" target="_blank" rel="noopener">Have I Been Pwned API</a> and determine if the password has been previously compromised. The plaintext password is never stored by PyPI or submitted to the Have I Been Pwned API.</p>
         <p>PyPI will not allow such passwords to be used when setting a password at registration or updating your password.</p>
         <p>If you receive an error message saying that "This password appears in a breach or has been compromised and cannot be used", you should change it all other places that you use it as soon as possible.</p>
         <p>If you have received this error while attempting to log in or upload to PyPI, then your password has been reset and you cannot log in to PyPI until you <a href="{{ request.route_url('accounts.request-password-reset') }}">reset your password</a>.</p>
 
         <h3 id="twofa">{{ twoFA() }}</h3>
-        <p>Users who have chosen to set up two factor authentication (2FA) on their PyPI account must provide a second method of identity verification (other than their username and password) to log in. This only affects login via browser, and not (yet) package uploads (<a href="https://discuss.python.org/t/pypi-security-work-multifactor-auth-progress-help-needed/1042">details</a>).</p>
+        <p>Users who have chosen to set up two factor authentication (2FA) on their PyPI account must provide a second method of identity verification (other than their username and password) to log in. This only affects login via browser, and not (yet) package uploads (<a href="https://discuss.python.org/t/pypi-security-work-multifactor-auth-progress-help-needed/1042" title="External link" target="_blank" rel="noopener">details</a>).</p>
         <p>PyPI supports two 2FA methods: <a href="#totp">generating a code through a TOTP application</a>, and <a href="#utfkey">using a U2F security key</a>.</p>
 
         <h3 id="totp">{{ totp() }}</h3>
-        <p>When enabling two factor authentication (2FA) via <a href="https://en.wikipedia.org/wiki/Time-based_One-time_Password_algorithm">TOTP</a> in your account admin, you were asked to provision an application (usually a mobile phone app) in order to generate authentication codes. Popular applications include:</p>
+        <p>When enabling two factor authentication (2FA) via <a href="https://en.wikipedia.org/wiki/Time-based_One-time_Password_algorithm" title="External link" target="_blank" rel="noopener">TOTP</a> in your account admin, you were asked to provision an application (usually a mobile phone app) in order to generate authentication codes. Popular applications include:</p>
         <ul>
-          <li><a href="https://freeotp.github.io/">FreeOTP</a> (open source)</li>
-          <li><a href="https://play.google.com/store/apps/details?id=org.liberty.android.freeotpplus">FreeOTP+</a> (open source)</li>
-          <li>Google Authenticator for <a href="https://play.google.com/store/apps/details?id=com.google.android.apps.authenticator2">Android</a> or <a href="https://itunes.apple.com/app/google-authenticator/id388497605">iPhone</a> (proprietary)</li>
-          <li><a href="https://authy.com/">Authy</a> (proprietary)</li>
-          <li>Duo Mobile for <a href="https://play.google.com/store/apps/details?id=com.duosecurity.duomobile">Android</a> and <a href="https://itunes.apple.com/app/duo-mobile/id422663827">iPhone</a> (proprietary)</li>
+          <li><a href="https://freeotp.github.io/" title="External link" target="_blank" rel="noopener">FreeOTP</a> (open source)</li>
+          <li><a href="https://play.google.com/store/apps/details?id=org.liberty.android.freeotpplus" title="External link" target="_blank" rel="noopener">FreeOTP+</a> (open source)</li>
+          <li>Google Authenticator for <a href="https://play.google.com/store/apps/details?id=com.google.android.apps.authenticator2" title="External link" target="_blank" rel="noopener">Android</a> or <a href="https://itunes.apple.com/app/google-authenticator/id388497605" title="External link" target="_blank" rel="noopener">iPhone</a> (proprietary)</li>
+          <li><a href="https://authy.com/" title="External link" target="_blank" rel="noopener">Authy</a> (proprietary)</li>
+          <li>Duo Mobile for <a href="https://play.google.com/store/apps/details?id=com.duosecurity.duomobile" title="External link" target="_blank" rel="noopener">Android</a> and <a href="https://itunes.apple.com/app/duo-mobile/id422663827" title="External link" target="_blank" rel="noopener">iPhone</a> (proprietary)</li>
         </ul>
         <p>Open the application of your choice to generate a code.</p>
 
         <h3 id="utfkey">{{ utfkey() }}</h3>
-        <p>A security key (also known as a universal second factor, or U2F key) is hardware device that communicates via USB, NFC, or Bluetooth. Popular keys include Yubikey, Google Titan and Thetis. PyPI supports any <a href="https://fidoalliance.org/specifications/download/">FIDO U2F compatible key</a> and follows the <a href="https://www.w3.org/TR/webauthn/">WebAuthn standard</a>.</p>
+        <p>A security key (also known as a universal second factor, or U2F key) is hardware device that communicates via USB, NFC, or Bluetooth. Popular keys include Yubikey, Google Titan and Thetis. PyPI supports any <a href="https://fidoalliance.org/specifications/download/" title="External link" target="_blank" rel="noopener">FIDO U2F compatible key</a> and follows the <a href="https://www.w3.org/TR/webauthn/" title="External link" target="_blank" rel="noopener">WebAuthn standard</a>.</p>
         <p>Users who have set up this second factor will be prompted to use their key (usually by inserting it into a USB port and pressing a button) when logging in.</p>
-        <p>To use a security key with WebAuthn, you'll need to <a href="https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredential">use a browser that supports WebAuthn and PublicKeyCredential</a>, and turn on JavaScript.</p>
+        <p>To use a security key with WebAuthn, you'll need to <a href="https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredential" title="External link" target="_blank" rel="noopener">use a browser that supports WebAuthn and PublicKeyCredential</a>, and turn on JavaScript.</p>
       </section>
 
       <section class="faq-group" id="integrating">
         <h2>Integrating</h2>
 
         <h3 id="APIs">{{ APIs() }}</h3>
-        <p>Yes, including RSS feeds of new packages and new releases. <a href="https://warehouse.readthedocs.io/api-reference/">See the API reference.</a></p>
+        <p>Yes, including RSS feeds of new packages and new releases. <a href="https://warehouse.readthedocs.io/api-reference/" title="External link" target="_blank" rel="noopener">See the API reference.</a></p>
 
         <h3 id="mirroring">{{ mirroring() }}</h3>
         <p>If you need to run your own mirror of PyPI, the <a href="https://pypi.org/project/bandersnatch/">bandersnatch project</a> is the recommended solution. Note that the storage requirements for a PyPI mirror would exceed 1 terabyte—and growing!</p>
 
         <h3 id="project-release-notifications">{{ project_release_notifications() }}</h3>
-        <p>PyPI itself does not offer a way to get notified when a project uploads new releases. However, there are several third-party services that offer comprehensive monitoring and notifications for project releases and vulnerabilities listed as <a href="https://github.com/works-with/category/dependency-management?query=python" target="_blank" rel="noopener">GitHub apps</a>.</p>
+        <p>PyPI itself does not offer a way to get notified when a project uploads new releases. However, there are several third-party services that offer comprehensive monitoring and notifications for project releases and vulnerabilities listed as <a href="https://github.com/works-with/category/dependency-management?query=python" title="External link" target="_blank" rel="noopener">GitHub apps</a>.</p>
 
         <h3 id="statistics">{{ statistics() }}</h3>
-        <p>You can <a href="https://packaging.python.org/guides/analyzing-pypi-package-downloads/">analyze PyPI download usage statistics via Google BigQuery</a>.</p>
-        <p><a href="https://libraries.io/pypi" target="_blank" rel="noopener">Libraries.io provides statistics for PyPI projects</a> (<a href="https://libraries.io/pypi/twine/" target="_blank" rel="noopener">example</a>, <a href="https://libraries.io/api" target="_blank" rel="noopener">API</a>) including GitHub stars and forks, dependency tracking (<a href="https://github.com/librariesio/bibliothecary/issues/415" target="_blank" rel="noopener">in progress</a>), and <a href="https://docs.libraries.io/overview#sourcerank" target="_blank" rel="noopener">other relevant factors</a>.</p>
-        <p>For recent statistics on uptime and performance, see <a href="https://status.python.org/" target="_blank" rel="noopener">our status page</a>.</p>
+        <p>You can <a href="https://packaging.python.org/guides/analyzing-pypi-package-downloads/" title="External link" target="_blank" rel="noopener">analyze PyPI download usage statistics via Google BigQuery</a>.</p>
+        <p><a href="https://libraries.io/pypi" title="External link" target="_blank" rel="noopener">Libraries.io provides statistics for PyPI projects</a> (<a href="https://libraries.io/pypi/twine/" title="External link" target="_blank" rel="noopener">example</a>, <a href="https://libraries.io/api" title="External link" target="_blank" rel="noopener">API</a>) including GitHub stars and forks, dependency tracking (<a href="https://github.com/librariesio/bibliothecary/issues/415" title="External link" target="_blank" rel="noopener">in progress</a>), and <a href="https://docs.libraries.io/overview#sourcerank" title="External link" target="_blank" rel="noopener">other relevant factors</a>.</p>
+        <p>For recent statistics on uptime and performance, see <a href="https://status.python.org/" title="External link" target="_blank" rel="noopener">our status page</a>.</p>
       </section>
 
       <section class="faq-group" id="administration">
@@ -225,14 +225,14 @@
         <h3 id="project-name">{{ project_name() }}</h3>
         <p>Your publishing tool may return an error that your new project can't be created with your desired name, despite no evidence of a project or release of the same name on PyPI. Currently, there are three primary reasons this may occur:</p>
         <ul>
-          <li>The project name conflicts with a <a href="https://docs.python.org/3/library/index.html">Python Standard Library</a> module from any major version from 2.5 to present.</li>
+          <li>The project name conflicts with a <a href="https://docs.python.org/3/library/index.html" title="External link" target="_blank" rel="noopener">Python Standard Library</a> module from any major version from 2.5 to present.</li>
           <li>The project name has been explicitly prohibited by the PyPI administrators. For example, <code>pip install requirements.txt</code> is a common typo for <code>pip install -r requirements.txt</code>, and should not surprise the user with a malicious package.</li>
           <li>The project name has been registered by another user, but no releases have been created.</li>
         </ul>
 
         <h3 id="project-name-claim">{{ project_name_claim() }}</h3>
-        <p>There is currently no established process for performing this administrative task that is explicit and fair for all parties. However, one is currently in development per <a href="https://www.python.org/dev/peps/pep-0541/">PEP 541</a>.</p>
-        <p>PEP 541 has been accepted, and PyPI is <a href="https://github.com/pypa/warehouse/issues/1506">creating a workflow</a> which will be documented here.</p>
+        <p>There is currently no established process for performing this administrative task that is explicit and fair for all parties. However, one is currently in development per <a href="https://www.python.org/dev/peps/pep-0541/" title="External link" target="_blank" rel="noopener">PEP 541</a>.</p>
+        <p>PEP 541 has been accepted, and PyPI is <a href="https://github.com/pypa/warehouse/issues/1506" title="External link" target="_blank" rel="noopener">creating a workflow</a> which will be documented here.</p>
 
         <h3 id="collaborator-roles">{{ collaborator_roles() }}</h3>
         <p>There are two possible roles for collaborators:</p>
@@ -244,12 +244,12 @@
         <p>If the owner is unresponsive, see <a href="#project-name-claim">{{ project_name_claim() }}</a></p>
 
         <h3 id="description-content-type">{{ description_content_type() }}</h3>
-        <p>By default, an upload's description will render with <a href="http://docutils.sourceforge.net/rst.html">reStructuredText</a>. If the description is in an alternate format like Markdown, a package may set the <code>long_description_content_type</code> in <code>setup.py</code> to the alternate format.</p>
-        <p>Refer to the <a href="https://packaging.python.org/tutorials/distributing-packages/#description">Python Packaging User Guide</a> for details on the available formats.</p>
-        <p>PyPI will reject uploads if the description fails to render. To check a description locally for validity, you may use <a href="https://github.com/pypa/readme_renderer">readme_renderer</a>, which is the same description renderer used by PyPI.</p>
+        <p>By default, an upload's description will render with <a href="http://docutils.sourceforge.net/rst.html" title="External link" target="_blank" rel="noopener">reStructuredText</a>. If the description is in an alternate format like Markdown, a package may set the <code>long_description_content_type</code> in <code>setup.py</code> to the alternate format.</p>
+        <p>Refer to the <a href="https://packaging.python.org/tutorials/distributing-packages/#description" title="External link" target="_blank" rel="noopener">Python Packaging User Guide</a> for details on the available formats.</p>
+        <p>PyPI will reject uploads if the description fails to render. To check a description locally for validity, you may use <a href="https://pypi.org/project/readme_renderer/">readme_renderer</a>, which is the same description renderer used by PyPI.</p>
 
         <h3 id="file-size-limit">{{ file_size_limit() }}</h3>
-        <p>If you can't upload your project's release to PyPI because you're hitting the upload file size limit, we can sometimes increase your limit. Make sure you've uploaded at least one release for the project that's <i>under</i> the limit (a <a href="https://www.python.org/dev/peps/pep-0440/#developmental-releases">developmental release version number</a> is fine). Then, <a href="https://github.com/pypa/warehouse/issues/new" target="_blank" rel="noopener">file an issue</a> and tell us:</p>
+        <p>If you can't upload your project's release to PyPI because you're hitting the upload file size limit, we can sometimes increase your limit. Make sure you've uploaded at least one release for the project that's <i>under</i> the limit (a <a href="https://www.python.org/dev/peps/pep-0440/#developmental-releases" title="External link" target="_blank" rel="noopener">developmental release version number</a> is fine). Then, <a href="https://github.com/pypa/warehouse/issues/new" title="External link" target="_blank" rel="noopener">file an issue</a> and tell us:</p>
         <ul>
           <li>A link to your project on PyPI (or Test PyPI)</li>
           <li>The size of your release, in megabytes</li>
@@ -268,30 +268,30 @@
           <li>Go to <a href="{{ request.route_path('accounts.reset-password') }}">reset your password</a>.</li>
           <li>Enter the email address or username you used for PyPI and submit the form.</li>
           <li>You'll receive an email with a password reset link.</li>
-          <li>If you no longer have access to the email address associated with your account, <a href="https://github.com/pypa/warehouse/issues" target="_blank" rel="noopener">file an issue on our tracker</a>.</li>
+          <li>If you no longer have access to the email address associated with your account, <a href="https://github.com/pypa/warehouse/issues" title="External link" target="_blank" rel="noopener">file an issue on our tracker</a>.</li>
         </ol>
         {{ code_of_conduct() }}
 
         <h3 id="tls-deprecation">{{ tls_deprecation() }}</h3>
-        <p>Transport Layer Security, or TLS, is part of how we make sure connections between your computer and PyPI are private and secure. It's a cryptographic protocol that's had several versions over time. PyPI <a href="https://mail.python.org/pipermail/python-announce-list/2018-April/011885.html" target="_blank" rel="noopener">turned off support for TLS versions 1.0 and 1.1</a> in April 2018 (<a href="https://pyfound.blogspot.com/2017/01/time-to-upgrade-your-python-tls-v12.html" target="_blank" rel="noopener">reason</a>).</p>
+        <p>Transport Layer Security, or TLS, is part of how we make sure connections between your computer and PyPI are private and secure. It's a cryptographic protocol that's had several versions over time. PyPI <a href="https://mail.python.org/pipermail/python-announce-list/2018-April/011885.html" title="External link" target="_blank" rel="noopener">turned off support for TLS versions 1.0 and 1.1</a> in April 2018 (<a href="https://pyfound.blogspot.com/2017/01/time-to-upgrade-your-python-tls-v12.html" title="External link" target="_blank" rel="noopener">reason</a>).</p>
         <p>If you are having trouble with <code> pip install</code> and get a <code>No matching distribution found</code> or <code>Could not fetch URL</code> error, try adding <code>-v</code> to the command to get more information:</p>
         <p><code>pip install --upgrade -v pip</code></p>
         <p>If you see an error like <code>There was a problem confirming the ssl certificate</code> or <code>tlsv1 alert protocol version</code> or <code>TLSV1_ALERT_PROTOCOL_VERSION</code>, you need to be connecting to PyPI with a newer TLS support library.</p>
         <p>The specific steps you need to take will depend on your operating system version, where your installation of Python originated (python.org, your OS vendor, or an intermediate distributor), and the installed versions of Python, <code>setuptools</code>, and <code>pip</code>.</p>
-        <p>For help, go to <a href="https://webchat.freenode.net/?channels=%23pypa" target="_blank" rel="noopener">the <code>#pypa</code> IRC channel on Freenode</a>, file an issue at <a href="https://github.com/pypa/packaging-problems/issues" target="_blank" rel="noopener">pypa/packaging-problems/issues</a>, or <a href="https://www.python.org/community/lists/" target="_blank" rel="noopener">post to the python-help mailing list</a>, including your OS and installation details and the output of <code>pip install --upgrade -vvv pip</code>.</p>
+        <p>For help, go to <a href="https://webchat.freenode.net/?channels=%23pypa" title="External link" target="_blank" rel="noopener">the <code>#pypa</code> IRC channel on Freenode</a>, file an issue at <a href="https://github.com/pypa/packaging-problems/issues" title="External link" target="_blank" rel="noopener">pypa/packaging-problems/issues</a>, or <a href="https://www.python.org/community/lists/" title="External link" target="_blank" rel="noopener">post to the python-help mailing list</a>, including your OS and installation details and the output of <code>pip install --upgrade -vvv pip</code>.</p>
         {{ code_of_conduct() }}
 
         <h3 id="accessibility">{{ accessibility() }}</h3>
-        <p>We take <a href="https://en.wikipedia.org/wiki/Web_accessibility" target="_blank" rel="noopener">accessibility</a> very seriously and want to make the website easy to use for everyone.</p>
-        <p>If you are experiencing an accessibility problem, <a href="https://github.com/pypa/warehouse/issues" target="_blank" rel="noopener">report it to us on GitHub</a>, so we can try to fix the problem, for you and others.</p>
+        <p>We take <a href="https://en.wikipedia.org/wiki/Web_accessibility" title="External link" target="_blank" rel="noopener">accessibility</a> very seriously and want to make the website easy to use for everyone.</p>
+        <p>If you are experiencing an accessibility problem, <a href="https://github.com/pypa/warehouse/issues" title="External link" target="_blank" rel="noopener">report it to us on GitHub</a>, so we can try to fix the problem, for you and others.</p>
         {{ code_of_conduct() }}
 
         <h3 id="uploading">{{ uploading() }}</h3>
-        <p>In a previous version of PyPI, it used to be possible for maintainers to upload releases to PyPI using a form in the web browser. This feature was deprecated with the new version of PyPI – we instead recommend that you <a href="https://packaging.python.org/tutorials/distributing-packages/#uploading-your-project-to-pypi">use twine to upload your project to PyPI</a>.</p>
+        <p>In a previous version of PyPI, it used to be possible for maintainers to upload releases to PyPI using a form in the web browser. This feature was deprecated with the new version of PyPI – we instead recommend that you <a href="https://packaging.python.org/tutorials/distributing-packages/#uploading-your-project-to-pypi" title="External link" target="_blank" rel="noopener">use twine to upload your project to PyPI</a>.</p>
 
         <h3 id="admin-intervention">{{ admin_intervention() }}</h3>
         <p>Spammers return to PyPI with some regularity hoping to place their Search Engine Optimized phishing, scam, and click-farming content on the site. Since PyPI allows for indexing of the Long Description and other data related to projects and has a generally solid search reputation, it is a prime target.</p>
-        <p>When the PyPI administrators are overwhelmed by spam <strong>or</strong> determine that there is some other threat to PyPI, new user registration and/or new project registration may be disabled. Check <a href="https://status.python.org" target="_blank" rel="noopener">our status page</a> for more details, as we'll likely have updated it with reasoning for the intervention.</p>
+        <p>When the PyPI administrators are overwhelmed by spam <strong>or</strong> determine that there is some other threat to PyPI, new user registration and/or new project registration may be disabled. Check <a href="https://status.python.org" title="External link" target="_blank" rel="noopener">our status page</a> for more details, as we'll likely have updated it with reasoning for the intervention.</p>
 
         <h3 id="file-name-reuse">{{ file_name_reuse() }}</h3>
         <p>PyPI will return these errors for one of these reasons:</p>
@@ -301,14 +301,14 @@
           <li>A file with the exact same content exists</li>
         </ul>
         <p>PyPI does not allow for a filename to be reused, even once a project has been deleted and recreated.</p>
-        <p>To avoid this situation, <a href="https://packaging.python.org/guides/using-testpypi/">use Test PyPI to perform and check your upload first</a>, before uploading to <a href="https://pypi.org">pypi.org</a>.</p>
+        <p>To avoid this situation, <a href="https://packaging.python.org/guides/using-testpypi/" title="External link" target="_blank" rel="noopener">use Test PyPI to perform and check your upload first</a>, before uploading to <a href="https://pypi.org">pypi.org</a>.</p>
 
         <h3 id="new-classifier">{{ new_classifier() }}</h3>
-        <p>If you would like to request a new trove classifier file a bug on our <a href="https://github.com/pypa/warehouse/issues/new?title=Request+trove+classifier&template=new-trove-classifier.md" target="_blank" rel="noopener">issue tracker</a>. Include the name of the requested classifier and a brief justification of why it is important.</p>
+        <p>If you would like to request a new trove classifier file a bug on our <a href="https://github.com/pypa/warehouse/issues/new?title=Request+trove+classifier&template=new-trove-classifier.md" title="External link" target="_blank" rel="noopener">issue tracker</a>. Include the name of the requested classifier and a brief justification of why it is important.</p>
         {{ code_of_conduct() }}
 
         <h3 id="feedback">{{ feedback() }}</h3>
-        <p>If you're experiencing an issue with PyPI itself, we welcome <strong>constructive</strong> feedback and bug reports via our <a href="https://github.com/pypa/warehouse/issues" target="_blank" rel="noopener">issue tracker</a>. Please note that this tracker is only for issues with the software that runs PyPI. Before writing a new issue, first check that a similar issue does not already exist.</p>
+        <p>If you're experiencing an issue with PyPI itself, we welcome <strong>constructive</strong> feedback and bug reports via our <a href="https://github.com/pypa/warehouse/issues" title="External link" target="_blank" rel="noopener">issue tracker</a>. Please note that this tracker is only for issues with the software that runs PyPI. Before writing a new issue, first check that a similar issue does not already exist.</p>
         <p>If you are having an issue is with a specific package installed from PyPI, you should reach out to the maintainers of that project directly instead.</p>
         {{ code_of_conduct() }}
       </section>
@@ -317,28 +317,28 @@
         <h2>About</h2>
 
         <h3 id="maintainers">{{ maintainers() }}</h3>
-        <p>PyPI is powered by the Warehouse project; <a href="https://warehouse.readthedocs.io/">Warehouse</a> is an open source project developed under the umbrella of the Python Packaging Authority (PyPA) and supported by the Python Packaging Working Group (PackagingWG).</p>
-        <p>The <a href="https://www.pypa.io/en/latest/">PyPA</a> is an independent group of developers whose goal is to improve and maintain many of the core projects related to Python packaging.</p>
-        <p>The <a href="https://wiki.python.org/psf/PackagingWG">PackagingWG</a> is a working group of the Python Software Foundation (PSF) whose goal is to raise and disburse funds to support the ongoing improvement of Python packaging. Most recently it <a href="https://pyfound.blogspot.com/2019/03/commencing-security-accessibility-and.html" target="_blank" rel="noopener">secured an award from the Open Technology Fund</a> whose funding is enabling developers to improve Warehouse's security and accessibility.</p>
+        <p>PyPI is powered by the Warehouse project; <a href="https://warehouse.readthedocs.io/" title="External link" target="_blank" rel="noopener">Warehouse</a> is an open source project developed under the umbrella of the Python Packaging Authority (PyPA) and supported by the Python Packaging Working Group (PackagingWG).</p>
+        <p>The <a href="https://www.pypa.io/en/latest/" title="External link" target="_blank" rel="noopener">PyPA</a> is an independent group of developers whose goal is to improve and maintain many of the core projects related to Python packaging.</p>
+        <p>The <a href="https://wiki.python.org/psf/PackagingWG" title="External link" target="_blank" rel="noopener">PackagingWG</a> is a working group of the Python Software Foundation (PSF) whose goal is to raise and disburse funds to support the ongoing improvement of Python packaging. Most recently it <a href="https://pyfound.blogspot.com/2019/03/commencing-security-accessibility-and.html" title="External link" target="_blank" rel="noopener">secured an award from the Open Technology Fund</a> whose funding is enabling developers to improve Warehouse's security and accessibility.</p>
 
         <h3 id="sponsors">{{ sponsors() }}</h3>
-        <p>PyPI is powered by <a href="https://warehouse.readthedocs.io/">Warehouse</a> and by a variety of tools and services provided by our <a href="{{ request.route_path('sponsors') }}">generous sponsors</a>.</p>
+        <p>PyPI is powered by <a href="https://warehouse.readthedocs.io/" title="External link" target="_blank" rel="noopener">Warehouse</a> and by a variety of tools and services provided by our <a href="{{ request.route_path('sponsors') }}">generous sponsors</a>.</p>
 
         <h3 id="availability">{{ availability() }}</h3>
         <p>As of April 16, 2018, PyPI.org is at "production" status, meaning that it has moved out of beta and replaced the old site (pypi.python.org). It is now robust, tested, and ready for expected browser and API traffic.</p>
-        <p>PyPI is heavily cached and distributed via CDN thanks to our sponsor <a href="https://www.fastly.com/" target="_blank" rel="noopener">Fastly</a> and thus is generally available globally. However, the site is mostly maintained by volunteers, we do not provide any specific Service Level Agreement, and as could be expected for a giant distributed system, things can and sometimes do go wrong. See <a href="https://status.python.org/">our status page</a> for current and past outages and incidents. If you have high availability requirements for your package index, consider either a <a href="#mirroring">mirror</a> or a <a href="#private-indices">private index</a>.</p>
+        <p>PyPI is heavily cached and distributed via CDN thanks to our sponsor <a href="https://www.fastly.com/" title="External link" target="_blank" rel="noopener">Fastly</a> and thus is generally available globally. However, the site is mostly maintained by volunteers, we do not provide any specific Service Level Agreement, and as could be expected for a giant distributed system, things can and sometimes do go wrong. See <a href="https://status.python.org/" title="External link" target="_blank" rel="noopener">our status page</a> for current and past outages and incidents. If you have high availability requirements for your package index, consider either a <a href="#mirroring">mirror</a> or a <a href="#private-indices">private index</a>.</p>
 
         <h3 id="contributing">{{ contributing() }}</h3>
-        <p>We have a huge amount of work to do to continue to maintain and improve PyPI (also known as <a href="https://warehouse.readthedocs.io/">the Warehouse project</a>).</p>
+        <p>We have a huge amount of work to do to continue to maintain and improve PyPI (also known as <a href="https://warehouse.readthedocs.io/" title="External link" target="_blank" rel="noopener">the Warehouse project</a>).</p>
         <p><strong>Financial</strong>: We would deeply appreciate <a href="https://donate.pypi.org/">your donations to fund development and maintenance</a>.</p>
         <p><strong>Development</strong>: Warehouse is open source, and we would love to see some new faces working on the project. You <strong>do not</strong> need to be an experienced open-source developer to make a contribution – in fact, we'd love to help you make your first open source pull request!</p>
-        <p>If you have skills in Python, ElasticSearch, HTML, SCSS, JavaScript, or SQLAlchemy then skim our <a href="https://warehouse.readthedocs.io/development/getting-started/" target="_blank" rel="noopener">"Getting started" guide</a>, then take a look at the <a href="https://github.com/pypa/warehouse/issues" target="_blank" rel="noopener">issue tracker</a>. We've created a <a href="https://github.com/pypa/warehouse/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22" target="_blank" rel="noopener">'Good first issue'</a> label – we recommend you start here.</p>
-        <p>Issues are grouped into <a href="https://github.com/pypa/warehouse/milestones" target="_blank" rel="noopener">milestones</a>; working on issues in the current milestone is a great way to help push the project forward. If you're interested in working on a particular issue, leave a comment and we can guide you through the contribution process.</p>
-        <p><strong>Stay updated</strong>: You can also follow the ongoing development of the project on the <a href="https://mail.python.org/mailman/listinfo/distutils-sig">distutils-sig mailing list</a> and the <a href="https://groups.google.com/forum/#!forum/pypa-dev" target="_blank" rel="noopener">PyPA Dev message group</a>.</p>
+        <p>If you have skills in Python, ElasticSearch, HTML, SCSS, JavaScript, or SQLAlchemy then skim our <a href="https://warehouse.readthedocs.io/development/getting-started/" title="External link" target="_blank" rel="noopener">"Getting started" guide</a>, then take a look at the <a href="https://github.com/pypa/warehouse/issues" title="External link" target="_blank" rel="noopener">issue tracker</a>. We've created a <a href="https://github.com/pypa/warehouse/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22" title="External link" target="_blank" rel="noopener">'Good first issue'</a> label – we recommend you start here.</p>
+        <p>Issues are grouped into <a href="https://github.com/pypa/warehouse/milestones" title="External link" target="_blank" rel="noopener">milestones</a>; working on issues in the current milestone is a great way to help push the project forward. If you're interested in working on a particular issue, leave a comment and we can guide you through the contribution process.</p>
+        <p><strong>Stay updated</strong>: You can also follow the ongoing development of the project on the <a href="https://mail.python.org/mailman/listinfo/distutils-sig" title="External link" target="_blank" rel="noopener">distutils-sig mailing list</a> and the <a href="https://groups.google.com/forum/#!forum/pypa-dev" title="External link" target="_blank" rel="noopener">PyPA Dev message group</a>.</p>
         {{ code_of_conduct() }}
 
         <h3 id="upcoming-changes">{{ upcoming_changes() }}</h3>
-        <p>Changes to PyPI are generally announced on both the <a href="https://mail.python.org/mm3/mailman3/lists/pypi-announce.python.org/" target="_blank" rel="noopener">pypi-announce mailing list</a> and the <a href="https://pyfound.blogspot.com/search/label/pypi" target="_blank" rel="noopener">PSF blog</a> under the label "pypi". The PSF blog also has <a href="https://pyfound.blogspot.com/feeds/posts/default/-/pypi" target="_blank" rel="noopener">Atom</a> and <a href="https://pyfound.blogspot.com/feeds/posts/default/-/pypi?alt=rss" target="_blank" rel="noopener">RSS</a> feeds for the "pypi" label.</p>
+        <p>Changes to PyPI are generally announced on both the <a href="https://mail.python.org/mm3/mailman3/lists/pypi-announce.python.org/" title="External link" target="_blank" rel="noopener">pypi-announce mailing list</a> and the <a href="https://pyfound.blogspot.com/search/label/pypi" title="External link" target="_blank" rel="noopener">PSF blog</a> under the label "pypi". The PSF blog also has <a href="https://pyfound.blogspot.com/feeds/posts/default/-/pypi" title="External link" target="_blank" rel="noopener">Atom</a> and <a href="https://pyfound.blogspot.com/feeds/posts/default/-/pypi?alt=rss" title="External link" target="_blank" rel="noopener">RSS</a> feeds for the "pypi" label.</p>
 
         <h3 id="beta-badge">{{ beta_badge() }}</h3>
         <p>When Warehouse's maintainers are deploying new features, at first we mark them with a small "beta" symbol to tell you: this should probably work fine, but it's new and less tested than other site functionality.</p>
@@ -356,14 +356,14 @@
       <h3>Resources</h3>
       <p>Looking for something not listed above? Perhaps these links will help:</p>
       <ul>
-        <li><a href="https://packaging.python.org">Python Packaging User Guide</a></li>
-        <li><a href="https://docs.python.org">Python Documentation</a></li>
-        <li><a href="https://python.org/">Python.org</a> (main Python website)</li>
-        <li><a href="https://python.org/community/">Python community page</a> (lists IRC channels, mailing lists, etc.)</li>
+        <li><a href="https://packaging.python.org" title="External link" target="_blank" rel="noopener">Python Packaging User Guide</a></li>
+        <li><a href="https://docs.python.org" title="External link" target="_blank" rel="noopener">Python Documentation</a></li>
+        <li><a href="https://python.org/" title="External link" target="_blank" rel="noopener">Python.org</a> (main Python website)</li>
+        <li><a href="https://python.org/community/" title="External link" target="_blank" rel="noopener">Python community page</a> (lists IRC channels, mailing lists, etc.)</li>
       </ul>
 
       <h3>Contact</h3>
-      <p>The <a href="https://pypa.io">Python Packaging Authority (PyPA)</a> is a working group who work together to improve Python packaging. If you'd like to get in touch with a core packaging developer, use <a href="https://webchat.freenode.net/?channels=%23pypa" target="_blank" rel="noopener">#pypa on IRC (freenode)</a>, or <a href="https://mail.python.org/mailman/listinfo/distutils-sig">join the distutils-sig mailing list</a>.</p>
+      <p>The <a href="https://pypa.io" title="External link" target="_blank" rel="noopener">Python Packaging Authority (PyPA)</a> is a working group who work together to improve Python packaging. If you'd like to get in touch with a core packaging developer, use <a href="https://webchat.freenode.net/?channels=%23pypa" title="External link" target="_blank" rel="noopener">#pypa on IRC (freenode)</a>, or <a href="https://mail.python.org/mailman/listinfo/distutils-sig" title="External link" target="_blank" rel="noopener">join the distutils-sig mailing list</a>.</p>
 
     </div>
   </section>

--- a/warehouse/templates/pages/security.html
+++ b/warehouse/templates/pages/security.html
@@ -33,7 +33,7 @@
       <br>
 
       <p>Instead, email <a href="mailto:security@python.org">security at python dot org</a> directly, providing as much relevant information as possible.</p>
-      <p>Messages may be optionally encrypted with GPG using key fingerprints available <a href="https://www.python.org/news/security/">at the Python Security page</a>.</p>
+      <p>Messages may be optionally encrypted with GPG using key fingerprints available <a href="https://www.python.org/news/security/" title="External link" target="_blank" rel="noopener">at the Python Security page</a>.</p>
 
       <h2>What happens next?</h2>
 

--- a/warehouse/templates/search/results.html
+++ b/warehouse/templates/search/results.html
@@ -85,13 +85,12 @@
           <span class="sr-only">Close</span>
         </button>
         <h2 class="no-top-padding">
-          Filter by classifier
+          Filter by
           <a href="{{ request.route_path('help')}}#trove-classifier"
              class="tooltipped tooltipped-s"
              aria-label="What's a trove classifier?"
              data-original-label="What's a trove classifier?">
-            <i class="fa fa-question-circle" aria-hidden="true"></i>
-            <span class="sr-only">Classifier information<span>
+            classifier
           </a>
         </h2>
         <form id="classifiers">

--- a/warehouse/templates/upload.html
+++ b/warehouse/templates/upload.html
@@ -23,7 +23,7 @@
     <div class="viewport-section__text no-top-margin">
       <p>
         This URL is an API endpoint for uploading files to PyPI.<br>
-        For more information on uploading projects to PyPI, visit the <a href="https://packaging.python.org/distributing/#uploading-your-project-to-pypi">Python Packaging User Guide.</a>
+        For more information on uploading projects to PyPI, visit the <a href="https://packaging.python.org/distributing/#uploading-your-project-to-pypi" title="External link" target="_blank" rel="noopener">Python Packaging User Guide.</a>
       </p>
       <p>Otherwise, we suggest you <a href="https://pypi.org/">go to the PyPI homepage</a>.</p>
     </div>


### PR DESCRIPTION
Closes #6038 
Closes #3925

## Underline content links for greater visibility

Adds underline to body links - ref https://www.w3.org/TR/WCAG20-TECHS/F73.html

A note from the guidelines: links that are "visually evident from page design and context, such as navigational links" would not lead to an accessibility failure.

I have therefore *not* added underlines to the following areas:

1. Links in the main menu

![Screenshot from 2019-06-20 07-12-27](https://user-images.githubusercontent.com/3323703/59825036-ca182400-932a-11e9-8f00-262a5699422a.png)

2. Links in dropdown menus

![Screenshot from 2019-06-20 07-14-35](https://user-images.githubusercontent.com/3323703/59825151-1f543580-932b-11e9-80c4-90b88b34f769.png)

3. Links in the footer menus

![Screenshot from 2019-06-20 07-15-15](https://user-images.githubusercontent.com/3323703/59825170-2d09bb00-932b-11e9-893b-d6b40e8c9407.png)

(although, please note that the links in footer *content* are underlined)

4. Links in the sidebar (secondary) menu 

![Screenshot from 2019-06-20 07-17-03](https://user-images.githubusercontent.com/3323703/59825257-7528dd80-932b-11e9-9b5f-a04547563e8b.png)

## Mark external links

Previously, we were inconsistent in the way that we mark external links (e.g. links that are not on the `pypi.org` domain.  This PR updates all external links so that they:

- Behave consistently (`target="_blank" rel="noopener"`)
- Are given a title as further help text (`title="External link"`)
- Are visually marked with an external link icon

## Style external links (and email links)

Because of the addition of an icon, we had some rather gnarly styling happening:

![Screenshot from 2019-06-27 06-51-04](https://user-images.githubusercontent.com/3323703/60240637-6309ea80-98a9-11e9-95a3-d961d7b96fab.png)

This was even more obvious on email links (where I also added an icon):

![Screenshot from 2019-06-27 06-52-49](https://user-images.githubusercontent.com/3323703/60240636-6309ea80-98a9-11e9-9638-2814a5388489.png)

To address this, I have restyled links to look like this:

![Screenshot from 2019-06-27 06-53-47](https://user-images.githubusercontent.com/3323703/60240683-82a11300-98a9-11e9-8c72-476595e7f64a.png)
![Screenshot from 2019-06-27 06-53-25](https://user-images.githubusercontent.com/3323703/60240684-8339a980-98a9-11e9-9066-ab205ea79f0b.png)

At the same time, I handled badges and code in links:

![Screenshot from 2019-06-27 06-54-35](https://user-images.githubusercontent.com/3323703/60240727-9ba9c400-98a9-11e9-8361-63c215f83cf4.png)
![Screenshot from 2019-06-27 06-54-28](https://user-images.githubusercontent.com/3323703/60240728-9ba9c400-98a9-11e9-8a37-103c1f0ef2c9.png)