### PR TITLE
Don't attempt to link to missing submitted_from IP

### DIFF
--- a/warehouse/admin/templates/admin/journals/list.html
+++ b/warehouse/admin/templates/admin/journals/list.html
@@ -54,9 +54,11 @@
         <td>{{ journal.submitted_date }}</td>
         <td><a href="{{ request.route_path('admin.user.detail', user_id=journal.submitted_by.id) }}">{{ journal.submitted_by.username }}</a></td>
         <td>
+          {% if journal.submitted_from %}
           <a href="{{ request.route_path('admin.journals.list', _query={'q': 'ip:' + journal.submitted_from}) }}">
             {{ journal.submitted_from }}
           </a>
+          {% endif %}
         </td>
         <td>{{ journal.action }}</td>
       </tr>


### PR DESCRIPTION
Adds a conditional for old journals for which `submitted_from` is `None`.

Fixes https://sentry.io/organizations/python-software-foundation/issues/1086664519/