### PR TITLE
Expose TOTP secret for non-QR provisioning

### DIFF
--- a/tests/unit/manage/test_views.py
+++ b/tests/unit/manage/test_views.py
@@ -10,6 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import base64
 import datetime
 import uuid
 
@@ -782,6 +783,7 @@ class TestProvisionTOTP:
 
         assert provision_totp_cls.calls == [pretend.call(totp_secret=b"secret")]
         assert result == {
+            "provision_totp_secret": base64.b32encode(b"secret").decode(),
             "provision_totp_form": provision_totp_obj,
             "provision_totp_uri": "not_a_real_uri",
         }
@@ -912,7 +914,7 @@ class TestProvisionTOTP:
             POST={},
             session=pretend.stub(
                 flash=pretend.call_recorder(lambda *a, **kw: None),
-                get_totp_secret=lambda: pretend.stub(),
+                get_totp_secret=lambda: b"secret",
             ),
             find_service=lambda *a, **kw: user_service,
             user=pretend.stub(
@@ -943,6 +945,7 @@ class TestProvisionTOTP:
 
         assert request.session.flash.calls == []
         assert result == {
+            "provision_totp_secret": base64.b32encode(b"secret").decode(),
             "provision_totp_form": provision_totp_obj,
             "provision_totp_uri": "not_a_real_uri",
         }

--- a/warehouse/manage/views.py
+++ b/warehouse/manage/views.py
@@ -10,6 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import base64
 import io
 
 from collections import defaultdict
@@ -323,6 +324,7 @@ class ProvisionTOTPViews:
     def default_response(self):
         totp_secret = self.request.session.get_totp_secret()
         return {
+            "provision_totp_secret": base64.b32encode(totp_secret).decode(),
             "provision_totp_form": ProvisionTOTPForm(totp_secret=totp_secret),
             "provision_totp_uri": otp.generate_totp_provisioning_uri(
                 totp_secret,

--- a/warehouse/static/sass/blocks/_totp-form.scss
+++ b/warehouse/static/sass/blocks/_totp-form.scss
@@ -16,12 +16,17 @@
   TOTP qr code and form, found on the TOTP provisioning page:
 
   <div class="totp-form">
-    <div class="totp-form__qr">
-      // QR code here
+    <div>
+      <div class="totp-form__qr">
+        // QR code here
+      </div>
+      <div class="totp-form__manual-code">
+        // code for manual entry here
+      </div>
     </div>
-    <div class="totp-form__form">
+    <form class="totp-form__form">
       // form here
-    </div>
+    </form>
   </div>
 */
 
@@ -31,6 +36,18 @@
 
   &__qr {
     border: 1px solid $border-color;
+    margin-bottom: $spacing-unit;
+
+    img {
+      width: 100%;
+    }
+  }
+
+  &__manual-code {
+    code {
+      display: inline-block;
+      margin: 0 5px 5px 0;
+    }
   }
 
   &__form {

--- a/warehouse/templates/manage/account/totp-provision.html
+++ b/warehouse/templates/manage/account/totp-provision.html
@@ -46,8 +46,13 @@
   </p>
 
   <div class="totp-form">
-    <div class="totp-form__qr">
-      <img src="{{ request.route_path('manage.account.totp-provision.image') }}" aria-label="{{ provision_totp_uri }}">
+    <div>
+      <div class="totp-form__qr">
+        <img src="{{ request.route_path('manage.account.totp-provision.image') }}" aria-label="{{ provision_totp_uri }}">
+      </div>
+      <div>
+        <p>{{ provision_totp_secret }}</p>
+      </div>
     </div>
     <form method="POST" class="totp-form__form">
       <input name="csrf_token" type="hidden" value="{{ request.session.get_csrf_token() }}">

--- a/warehouse/templates/manage/account/totp-provision.html
+++ b/warehouse/templates/manage/account/totp-provision.html
@@ -50,8 +50,13 @@
       <div class="totp-form__qr">
         <img src="{{ request.route_path('manage.account.totp-provision.image') }}" aria-label="{{ provision_totp_uri }}">
       </div>
-      <div>
-        <p>{{ provision_totp_secret }}</p>
+      <div class="totp-form__manual-code">
+        <p><strong>No QR scanner?</strong> Manually enter the code instead:
+          <code>{{ provision_totp_secret }}</code>
+          <button class="button button--small -js-copy-hash tooltipped tooltipped-w" aria-label="Copy to clipboard" data-original-label="Copy to clipboard" data-clipboard-text="{{ provision_totp_secret }}">
+            Copy
+          </button>
+        </p>
       </div>
     </div>
     <form method="POST" class="totp-form__form">


### PR DESCRIPTION
For users who don't have the ability to or don't want to scan a QR code.

cc @nlhkabu @garyemiller

Closes #6114 