### PR TITLE
Force window scrolling to hash on connect

### DIFF
--- a/warehouse/static/js/warehouse/controllers/project_tabs_controller.js
+++ b/warehouse/static/js/warehouse/controllers/project_tabs_controller.js
@@ -39,6 +39,10 @@ export default class extends Controller {
     // Handle hash change events to update the displayed content
     this._handleHashChange = this._handleHashChange.bind(this);
     window.addEventListener("hashchange", this._handleHashChange, false);
+    // force scrolling after hiding element, only necessary in Firefox
+    if (contentId) {
+      window.location.hash = "#" + contentId;
+    }
   }
 
   onTabClick(event) {


### PR DESCRIPTION
Fixes #6036 

The project detail page renders all the tabs as HTML and then on Stimulus `connect` hides the unselected ones. Firefox triggers scrolling *before* this hiding process which results in the described bug.

This PR adds another window scroll after the tabs are hidden showing to match the behaviour in other browsers. Here's a capture of the result, you can see how the window scrolls and then resets to the correct place:

![firefox_tab_scrolling_fast](https://user-images.githubusercontent.com/6739793/60497232-57089900-9cac-11e9-9c04-eb7b68b420e1.gif)
