### PR TITLE
Add roles to notification messages

### DIFF
--- a/warehouse/static/js/warehouse/index.js
+++ b/warehouse/static/js/warehouse/index.js
@@ -56,7 +56,7 @@ docReady(() => {
     if (document.getElementById("unsupported-browser") !== null) return;
 
     let warning_div = document.createElement("div");
-    warning_div.innerHTML = "<div id='unsupported-browser' class='notification-bar notification-bar--danger'><span class='notification-bar__icon'><i class='fa fa-exclamation-triangle' aria-hidden='true'></i><span class='sr-only'>Warning:</span></span><span class='notification-bar__message'>You are using an unsupported browser, please upgrade to a newer version.</span></div>";
+    warning_div.innerHTML = "<div id='unsupported-browser' class='notification-bar notification-bar--warning' role='status'><span class='notification-bar__icon'><i class='fa fa-exclamation-triangle' aria-hidden='true'></i><span class='sr-only'>Warning:</span></span><span class='notification-bar__message'>You are using an unsupported browser, please upgrade to a newer version.</span></div>";
 
     document.getElementById("sticky-notifications").appendChild(warning_div);
   }

--- a/warehouse/static/sass/blocks/_notification-bar.scss
+++ b/warehouse/static/sass/blocks/_notification-bar.scss
@@ -13,14 +13,15 @@
  */
 
 /*
-  A dark, full width horizontal div that contains a short notification.
+  A full width horizontal div that contains a short notification.
   Use for single lines only, as all content will be styled as a h3.
 
-  Can be nested inside the .sticky-to-top helper to stick to the top of the page.
+  Can be nested inside the .stick-to-top helper to stick to the top of the page.
 
   <div class="notification-bar">
     <span class="notification-bar__icon">
-      // icon here
+      <i class="icon-classes" aria-hidden="true"></i>
+      <span class="sr-only">Icon label:</span>
     </span>
     <span class="notification-bar__message">
       // A one line notification goes here.
@@ -29,12 +30,34 @@
 
   Modifiers:
     - danger: Applies a red background
+    - warning: Applies a yellow background
     - success: Applies a green background
     - dismissable: Indicates notification can be dismissed. Defaults to hidden.
     - visible: Indicates a visible, non-dismissed notification
 
+  Accessibility:
+  Roles should be added to danger, warning and success notifications to help
+  users using screen readers:
+
+  - danger: Add role="alert". Use with care - as this will interrupt the
+    standard screen reader workflow
+  - warning: Add role="status"
+  - success: Add role="status"
+
+  Icons should also be added to danger, warning and success notifications, to
+  ensure that color is not the only way of conveying the status of the
+  notification. This is important for color blind users.
+
+  Icons should be hidden with "aria-hidden=true" and given a screen reader
+  label, as per the HTML example above.
+
+   - danger: Add "fa fa-exclamation-triangle", sr-only="Error:"
+   - warning: Add "fa fa-exclamation-triangle", sr-only="Warning:"
+   - success: Add "fa fa-check", sr-only="Success:"
+
   A notification bar can be made dismissable by adding the following to the main
   notification-bar div:
+
     - .notification-bar--dismissable to its classes
     - data-controller="notification" as an attribute
     - data-target="notification.notification" as an attribute

--- a/warehouse/templates/base.html
+++ b/warehouse/templates/base.html
@@ -139,7 +139,7 @@
     <section id="sticky-notifications" class="stick-to-top js-stick-to-top">
       <!-- Add browser warning. Will show for ie9 and below -->
       <!--[if IE]>
-      <div class="notification-bar notification-bar--danger">
+      <div class="notification-bar notification-bar--warning" role="status">
         <span class="notification-bar__icon">
           <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
           <span class="sr-only">Warning:</span>
@@ -148,7 +148,7 @@
       </div>
       <![endif]-->
       {% if testPyPI %}
-      <div class="notification-bar notification-bar--warning">
+      <div class="notification-bar notification-bar--warning" role="status">
         <span class="notification-bar__icon">
           <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
           <span class="sr-only">Warning:</span>
@@ -157,7 +157,7 @@
       </div>
       {% endif %}
       <noscript>
-      <div class="notification-bar notification-bar--danger">
+      <div class="notification-bar notification-bar--warning" role="status">
         {# TODO: This should be removed once GH-3828 is fixed. #}
         <span class="notification-bar__icon">
           <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
@@ -174,7 +174,7 @@
     {% endblock %}
 
     {% for flag in request.flags.notifications() %}
-    <div class="notification-bar notification-bar--danger">
+    <div class="notification-bar">
       <span class="notification-bar__message">{{ flag.description }}</span>
     </div>
     {% endfor %}

--- a/warehouse/templates/includes/flash-messages.html
+++ b/warehouse/templates/includes/flash-messages.html
@@ -13,7 +13,11 @@
 -#}
 
 {% for message in request.session.pop_flash(queue="error") %}
-<div class="notification-bar notification-bar--danger notification-bar--dismissable" data-controller="notification" data-target="notification.notification">
+<div class="notification-bar notification-bar--danger notification-bar--dismissable" data-controller="notification" data-target="notification.notification" role="alert">
+  <span class="notification-bar__icon">
+    <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
+    <span class="sr-only">Error:</span>
+  </span>
   <span class="notification-bar__message">{{ message }}</span>
   <button type="button" title="Dismiss this notification" data-target="notification.dismissButton" data-action="click->notification#dismiss" class="notification-bar__dismiss" aria-label="close"><i class="fa fa-times" aria-hidden="true"></i></button>
 </div>
@@ -27,7 +31,11 @@
 {% endfor %}
 
 {% for message in request.session.pop_flash(queue="success") %}
-<div class="notification-bar notification-bar--success notification-bar--dismissable" data-controller="notification" data-target="notification.notification">
+<div class="notification-bar notification-bar--success notification-bar--dismissable" data-controller="notification" data-target="notification.notification" role="status">
+  <span class="notification-bar__icon">
+    <i class="fa fa-check" aria-hidden="true"></i>
+    <span class="sr-only">Success:</span>
+  </span>
   <span class="notification-bar__message">{{ message }}</span>
   <button type="button" title="Dismiss this notification" data-target="notification.dismissButton" data-action="click->notification#dismiss" class="notification-bar__dismiss" aria-label="dismiss"><i class="fa fa-times" aria-hidden="true"></i></button>
 </div>

--- a/warehouse/templates/includes/session-notifications.html
+++ b/warehouse/templates/includes/session-notifications.html
@@ -13,9 +13,12 @@
 -#}
 
 {% if request.user and not request.user.primary_email.verified %}
-<div class="notification-bar notification-bar--danger">
+<div class="notification-bar notification-bar--warning" role="status">
+  <span class="notification-bar__icon">
+    <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
+    <span class="sr-only">Warning:</span>
+  </span>
   <span class="notification-bar__message">
-    <i class="fa fa-exclamation-triangle" aria-hidden="true"><span class="sr-only">Warning</span></i>
     {% if request.user.primary_email %}
     Your primary email address ({{ request.user.primary_email.email }}) is unverified.
     {% else %}


### PR DESCRIPTION
- fixes some notifications which were showing as danger (error) instead of warning
- Adds `role="alert"` for danger (error) notifications
- Adds `role="status"` for warning and success notifications
- Adds accessibility information to component documentation