### PR TITLE
Make form errors work better for screen readers

### DIFF
--- a/warehouse/static/js/warehouse/utils/forms.js
+++ b/warehouse/static/js/warehouse/utils/forms.js
@@ -68,14 +68,14 @@ const fieldRequiredValidator = (value) => {
 };
 
 const showFormError = (field, message) => {
-  let error = "<ul id='"+ field.name +"-error' class='form-errors' role='alert'><li>" + message + "</li></ul>";
-  field.insertAdjacentHTML('afterend', error);
+  let error = "<ul id='"+ field.name +"-error' class='form-errors field-errors' role='alert'><li>" + message + "</li></ul>";
+  field.insertAdjacentHTML("afterend", error);
   field.setAttribute("aria-describedby", field.name + "-error");
   document.title = "Error processing form – " + document.title;
 };
 
 const removeFormErrors = () => {
-  let errors = passwordFormRoot.querySelectorAll(".form-errors");
+  let errors = passwordFormRoot.querySelectorAll(".field-errors");
   for (let error of errors) {
     error.parentNode.removeChild(error);
   }

--- a/warehouse/static/js/warehouse/utils/forms.js
+++ b/warehouse/static/js/warehouse/utils/forms.js
@@ -50,7 +50,6 @@ export function submitTriggers() {
   }
 }
 
-const tooltipClasses = ["tooltipped", "tooltipped-s", "tooltipped-immediate"];
 let passwordFormRoot = document;
 
 const passwordStrengthValidator = () => {
@@ -68,27 +67,28 @@ const fieldRequiredValidator = (value) => {
     "Please fill out this field" : null;
 };
 
-const attachTooltip = (field, message) => {
-  let parentNode = field.parentNode;
-  parentNode.classList.add.apply(parentNode.classList, tooltipClasses);
-  parentNode.setAttribute("aria-label", message);
+const showFormError = (field, message) => {
+  let error = "<ul id='"+ field.name +"-error' class='form-errors' role='alert'><li>" + message + "</li></ul>";
+  field.insertAdjacentHTML('afterend', error);
+  field.setAttribute("aria-describedby", field.name + "-error");
+  document.title = "Error processing form – " + document.title;
 };
 
-const removeTooltips = () => {
-  let tooltippedNodes = passwordFormRoot.querySelectorAll(".tooltipped");
-  for (let tooltippedNode of tooltippedNodes) {
-    tooltippedNode.classList.remove.apply(tooltippedNode.classList, tooltipClasses);
-    tooltippedNode.removeAttribute("aria-label");
+const removeFormErrors = () => {
+  let errors = passwordFormRoot.querySelectorAll(".form-errors");
+  for (let error of errors) {
+    error.parentNode.removeChild(error);
   }
+  document.title = document.title.replace("Error processing form – ","");
 };
 
 const validateForm = (event) => {
-  removeTooltips();
+  removeFormErrors();
   let inputFields = passwordFormRoot.querySelectorAll("input[required='required']");
   for (let inputField of inputFields) {
     let requiredMessage = fieldRequiredValidator(inputField.value);
     if (requiredMessage !== null) {
-      attachTooltip(inputField, requiredMessage);
+      showFormError(inputField, requiredMessage);
       event.preventDefault();
       return false;
     }
@@ -97,7 +97,7 @@ const validateForm = (event) => {
   let password = passwordFormRoot.querySelector("#new_password");
   let passwordStrengthMessage = passwordStrengthValidator(password.value);
   if (passwordStrengthMessage !== null) {
-    attachTooltip(password, passwordStrengthMessage);
+    showFormError(password, passwordStrengthMessage);
     event.preventDefault();
     return false;
   }

--- a/warehouse/static/sass/base/_forms.scss
+++ b/warehouse/static/sass/base/_forms.scss
@@ -43,6 +43,19 @@ input[type="checkbox"]:active {
   outline: none;
 }
 
+input:disabled,
+input:disabled:focus,
+input:disabled:hover,
+input:disabled:active,
+select:disabled,
+select:disabled:focus,
+select:disabled:hover,
+select:disabled:active {
+  cursor: not-allowed;
+  box-shadow: none;
+  background-color: $base-grey;
+}
+
 label {
   vertical-align: middle;
 }

--- a/warehouse/static/sass/blocks/_notification-bar.scss
+++ b/warehouse/static/sass/blocks/_notification-bar.scss
@@ -47,9 +47,13 @@
   Icons should also be added to danger, warning and success notifications, to
   ensure that color is not the only way of conveying the status of the
   notification. This is important for color blind users.
+<<<<<<< HEAD
 
   Icons should be hidden with "aria-hidden=true" and given a screen reader
   label, as per the HTML example above.
+=======
+  Note "aria-hidden=true" in the HTML example above.
+>>>>>>> Add roles to notification messages
 
    - danger: Add "fa fa-exclamation-triangle", sr-only="Error:"
    - warning: Add "fa fa-exclamation-triangle", sr-only="Warning:"

--- a/warehouse/templates/accounts/login.html
+++ b/warehouse/templates/accounts/login.html
@@ -13,7 +13,10 @@
 -#}
 {% extends "base.html" %}
 
-{% block title %}Log in{% endblock %}
+{% block title %}
+  {% if form.errors %}Error processing form &ndash;{% endif %}
+  Log in
+{% endblock %}
 
 {% block content %}
   {% if testPyPI %}
@@ -34,7 +37,7 @@
         {% endif %}
 
         {% if form.errors.__all__ %}
-        <ul class="form-errors">
+        <ul class="form-errors" role="alert">
           {% for error in form.errors.__all__ %}
           <li>{{ error }}</li>
           {% endfor %}
@@ -43,9 +46,9 @@
 
         <div class="form-group">
           <label for="username" class="form-group__label">Username</label>
-          {{ form.username(placeholder="Your username", autocorrect="off", autocapitalize="off", autocomplete="username", spellcheck="false", required="required", class_="form-group__input", autofocus=true) }}
+          {{ form.username(placeholder="Your username", autocorrect="off", autocapitalize="off", autocomplete="username", spellcheck="false", required="required", class_="form-group__input", **{'aria-describedby':"username-errors"}) }}
           {% if form.username.errors %}
-          <ul class="form-errors">
+          <ul id="username-errors" class="form-errors" role="alert">
             {% for error in form.username.errors %}
             <li>{{ error }}</li>
             {% endfor %}
@@ -61,9 +64,9 @@
                 id="show-password" type="checkbox">&nbsp;Show password
             </label>
           </div>
-          {{ form.password(placeholder="Your password", required="required", class_="form-group__input", autocomplete="current-password", data_target="password.password") }}
+          {{ form.password(placeholder="Your password", required="required", class_="form-group__input", autocomplete="current-password", data_target="password.password", **{'aria-describedby':"password-errors"}) }}
           {% if form.password.errors %}
-          <ul class="form-errors">
+          <ul id="password-errors" class="form-errors" role="alert">
             {% for error in form.password.errors %}
             <li>{{ error }}</li>
             {% endfor %}

--- a/warehouse/templates/accounts/login.html
+++ b/warehouse/templates/accounts/login.html
@@ -14,7 +14,7 @@
 {% extends "base.html" %}
 
 {% block title %}
-  {% if form.errors %}Error processing form &ndash;{% endif %}
+  {% if form.errors %}Error processing form –{% endif %}
   Log in
 {% endblock %}
 
@@ -46,7 +46,7 @@
 
         <div class="form-group">
           <label for="username" class="form-group__label">Username</label>
-          {{ form.username(placeholder="Your username", autocorrect="off", autocapitalize="off", autocomplete="username", spellcheck="false", required="required", class_="form-group__input", **{'aria-describedby':"username-errors"}) }}
+          {{ form.username(placeholder="Your username", autocorrect="off", autocapitalize="off", autocomplete="username", spellcheck="false", required="required", class_="form-group__input", **{"aria-describedby":"username-errors"}) }}
           {% if form.username.errors %}
           <ul id="username-errors" class="form-errors" role="alert">
             {% for error in form.username.errors %}
@@ -64,7 +64,7 @@
                 id="show-password" type="checkbox">&nbsp;Show password
             </label>
           </div>
-          {{ form.password(placeholder="Your password", required="required", class_="form-group__input", autocomplete="current-password", data_target="password.password", **{'aria-describedby':"password-errors"}) }}
+          {{ form.password(placeholder="Your password", required="required", class_="form-group__input", autocomplete="current-password", data_target="password.password", **{"aria-describedby":"password-errors"}) }}
           {% if form.password.errors %}
           <ul id="password-errors" class="form-errors" role="alert">
             {% for error in form.password.errors %}

--- a/warehouse/templates/accounts/register.html
+++ b/warehouse/templates/accounts/register.html
@@ -14,7 +14,7 @@
 {% extends "base.html" %}
 
 {% block title %}
-  {% if form.errors %}Error processing form &ndash;{% endif %}
+  {% if form.errors %}Error processing form –{% endif %}
   Register
 {% endblock %}
 
@@ -42,7 +42,7 @@
 
         <div class="form-group">
           <label for="full_name" class="form-group__label">Name</label>
-          {{ form.full_name(placeholder="Your name", class_="form-group__input", **{'aria-describedby':"name-errors"}) }}
+          {{ form.full_name(placeholder="Your name", class_="form-group__input", **{"aria-describedby":"name-errors"}) }}
           {% if form.full_name.errors %}
           <ul id="name-errors" class="form-errors" role="alert">
             {% for error in form.full_name.errors %}
@@ -54,7 +54,7 @@
 
         <div class="form-group">
           <label for="email" class="form-group__label">Email address</label>
-          {{ form.email(placeholder="Your email address", autocomplete="email", required="required", class_="form-group__input", **{'aria-describedby':"email-errors"}) }}
+          {{ form.email(placeholder="Your email address", autocomplete="email", required="required", class_="form-group__input", **{"aria-describedby":"email-errors"}) }}
           {% if form.email.errors %}
           <ul id="email-errors" class="form-errors" role="alert">
             {% for error in form.email.errors %}
@@ -72,7 +72,7 @@
 
         <div class="form-group">
           <label for="username" class="form-group__label">Username</label>
-          {{ form.username(placeholder="Select a username", autocorrect="off", autocapitalize="off", autocomplete="username", spellcheck="false", required="required", class_="form-group__input", **{'aria-describedby':"username-errors"}) }}
+          {{ form.username(placeholder="Select a username", autocorrect="off", autocapitalize="off", autocomplete="username", spellcheck="false", required="required", class_="form-group__input", **{"aria-describedby":"username-errors"}) }}
           {% if form.username.errors %}
           <ul id="username-errors" class="form-errors" role="alert">
             {% for error in form.username.errors %}
@@ -93,7 +93,7 @@
             </div>
             {# the password field needs to be wrapped in a div to properly place tooltips #}
             <div>
-              {{ form.new_password(placeholder="Select a password", required="required", class_="form-group__input", autocomplete="new-password", data_target="password.password password-match.passwordMatch password-strength-gauge.password", data_action="input->password-match#checkPasswordsMatch input->password-strength-gauge#checkPasswordStrength", **{'aria-describedby':"password-errors, password-strength"}) }}
+              {{ form.new_password(placeholder="Select a password", required="required", class_="form-group__input", autocomplete="new-password", data_target="password.password password-match.passwordMatch password-strength-gauge.password", data_action="input->password-match#checkPasswordsMatch input->password-strength-gauge#checkPasswordStrength", **{"aria-describedby":"password-errors password-strength"}) }}
             </div>
             {% if form.new_password.errors %}
             <ul id="password-errors" class="form-errors" role="alert">
@@ -107,7 +107,7 @@
 
           <div class="form-group">
             <label for="password_confirm" class="form-group__label">Confirm password</label>
-            {{ form.password_confirm(placeholder="Confirm password", required="required", class_="form-group__input", data_target="password.password password-match.passwordMatch", data_action="input->password-match#checkPasswordsMatch", **{'aria-describedby':"password-confirm-errors"}) }}
+            {{ form.password_confirm(placeholder="Confirm password", required="required", class_="form-group__input", data_target="password.password password-match.passwordMatch", data_action="input->password-match#checkPasswordsMatch", **{"aria-describedby":"password-confirm-errors"}) }}
             {% if form.password_confirm.errors %}
             <ul id="password-confirm-errors" class="form-errors" role="alert">
               {% for error in form.password_confirm.errors %}

--- a/warehouse/templates/accounts/register.html
+++ b/warehouse/templates/accounts/register.html
@@ -13,8 +13,10 @@
 -#}
 {% extends "base.html" %}
 
-
-{% block title %}Register{% endblock %}
+{% block title %}
+  {% if form.errors %}Error processing form &ndash;{% endif %}
+  Register
+{% endblock %}
 
 {% block content %}
   {% if testPyPI %}
@@ -31,7 +33,7 @@
         <input name="csrf_token" type="hidden" value="{{ request.session.get_csrf_token() }}">
 
         {% if form.errors.__all__ %}
-        <ul class="form-errors">
+        <ul class="form-errors" role="alert">
           {% for error in form.errors.__all__ %}
           <li>{{ error }}</li>
           {% endfor %}
@@ -40,9 +42,9 @@
 
         <div class="form-group">
           <label for="full_name" class="form-group__label">Name</label>
-          {{ form.full_name(placeholder="Your name", required="required", class_="form-group__input", autofocus=true, tabindex="1") }}
+          {{ form.full_name(placeholder="Your name", class_="form-group__input", **{'aria-describedby':"name-errors"}) }}
           {% if form.full_name.errors %}
-          <ul class="form-errors">
+          <ul id="name-errors" class="form-errors" role="alert">
             {% for error in form.full_name.errors %}
             <li>{{ error }}</li>
             {% endfor %}
@@ -51,10 +53,10 @@
         </div>
 
         <div class="form-group">
-          <label for="full_name" class="form-group__label">Email address</label>
-          {{ form.email(placeholder="Your email address", autocomplete="email", required="required", class_="form-group__input", tabindex="2") }}
+          <label for="email" class="form-group__label">Email address</label>
+          {{ form.email(placeholder="Your email address", autocomplete="email", required="required", class_="form-group__input", **{'aria-describedby':"email-errors"}) }}
           {% if form.email.errors %}
-          <ul class="form-errors">
+          <ul id="email-errors" class="form-errors" role="alert">
             {% for error in form.email.errors %}
             <li>{{ error }}</li>
             {% endfor %}
@@ -70,9 +72,9 @@
 
         <div class="form-group">
           <label for="username" class="form-group__label">Username</label>
-          {{ form.username(placeholder="Select a username", autocorrect="off", autocapitalize="off", autocomplete="username", spellcheck="false", required="required", class_="form-group__input", tabindex="3") }}
+          {{ form.username(placeholder="Select a username", autocorrect="off", autocapitalize="off", autocomplete="username", spellcheck="false", required="required", class_="form-group__input", **{'aria-describedby':"username-errors"}) }}
           {% if form.username.errors %}
-          <ul class="form-errors">
+          <ul id="username-errors" class="form-errors" role="alert">
             {% for error in form.username.errors %}
             <li>{{ error }}</li>
             {% endfor %}
@@ -86,15 +88,15 @@
               <label for="password" class="form-group__label">Password</label>
               <label for="show-password">
                 <input data-action="change->password#togglePasswords" data-target="password.showPassword"
-                  id="show-password" type="checkbox" tabindex="7">&nbsp;Show passwords
+                  id="show-password" type="checkbox">&nbsp;Show passwords
               </label>
             </div>
             {# the password field needs to be wrapped in a div to properly place tooltips #}
             <div>
-              {{ form.new_password(placeholder="Select a password", required="required", class_="form-group__input", autocomplete="new-password", data_target="password.password password-match.passwordMatch password-strength-gauge.password", data_action="input->password-match#checkPasswordsMatch input->password-strength-gauge#checkPasswordStrength", tabindex="4") }}
+              {{ form.new_password(placeholder="Select a password", required="required", class_="form-group__input", autocomplete="new-password", data_target="password.password password-match.passwordMatch password-strength-gauge.password", data_action="input->password-match#checkPasswordsMatch input->password-strength-gauge#checkPasswordStrength", **{'aria-describedby':"password-errors, password-strength"}) }}
             </div>
             {% if form.new_password.errors %}
-            <ul class="form-errors">
+            <ul id="password-errors" class="form-errors" role="alert">
               {% for error in form.new_password.errors %}
               <li>{{ error }}</li>
               {% endfor %}
@@ -105,9 +107,9 @@
 
           <div class="form-group">
             <label for="password_confirm" class="form-group__label">Confirm password</label>
-            {{ form.password_confirm(placeholder="Confirm password", required="required", class_="form-group__input", data_target="password.password password-match.passwordMatch", data_action="input->password-match#checkPasswordsMatch", tabindex="5") }}
+            {{ form.password_confirm(placeholder="Confirm password", required="required", class_="form-group__input", data_target="password.password password-match.passwordMatch", data_action="input->password-match#checkPasswordsMatch", **{'aria-describedby':"password-confirm-errors"}) }}
             {% if form.password_confirm.errors %}
-            <ul class="form-errors">
+            <ul id="password-confirm-errors" class="form-errors" role="alert">
               {% for error in form.password_confirm.errors %}
               <li>{{ error }}</li>
               {% endfor %}
@@ -122,7 +124,7 @@
           </ul>
         </div>
 
-        <input type="submit" value="Create account" class="button button--primary" data-target="password-match.submit" tabindex="6">
+        <input type="submit" value="Create account" class="button button--primary" data-target="password-match.submit">
       </form>
     </div>
   </section>

--- a/warehouse/templates/accounts/request-password-reset.html
+++ b/warehouse/templates/accounts/request-password-reset.html
@@ -14,7 +14,7 @@
 {% extends "base.html" %}
 
 {% block title %}
-  {% if form and form.errors %}Error processing form &ndash;{% endif %}
+  {% if form and form.errors %}Error processing form –{% endif %}
   Password reset
 {% endblock %}
 

--- a/warehouse/templates/accounts/request-password-reset.html
+++ b/warehouse/templates/accounts/request-password-reset.html
@@ -13,7 +13,10 @@
 -#}
 {% extends "base.html" %}
 
-{% block title %}Password reset{% endblock %}
+{% block title %}
+  {% if form and form.errors %}Error processing form &ndash;{% endif %}
+  Password reset
+{% endblock %}
 
 {% block content %}
   <section class="horizontal-section">
@@ -24,7 +27,7 @@
           <p>To reset your password, enter your username or email below.</p>
           <input name="csrf_token" type="hidden" value="{{ request.session.get_csrf_token() }}">
           {% if form.errors.__all__ %}
-            <ul class="form-errors">
+            <ul class="form-errors" role="alert">
               {% for error in form.errors.__all__ %}
               <li>{{ error }}</li>
               {% endfor %}
@@ -35,7 +38,7 @@
             <label for="username_or_email" class="form-group__label">Username or email</label>
             {% include "warehouse:templates/includes/input-user-name.html" %}
           </div>
-          <input type="submit" value="Password reset" class="button button--primary">
+          <input type="submit" value="Request password reset" class="button button--primary">
         </form>
       {% else %}
         <div class="callout-block callout-block--success">

--- a/warehouse/templates/accounts/reset-password.html
+++ b/warehouse/templates/accounts/reset-password.html
@@ -13,7 +13,10 @@
 -#}
 {% extends "base.html" %}
 
-{% block title %}Reset your password{% endblock %}
+{% block title %}
+  {% if form.errors %}Error processing form &ndash;{% endif %}
+  Reset your password
+{% endblock %}
 
 {% block content %}
   <section class="horizontal-section">
@@ -39,10 +42,10 @@
           </div>
           {# the password field needs to be wrapped in a div to properly place tooltips #}
           <div>
-            {{ form.new_password(placeholder="Select a new password", required="required", class_="form-group__input", data_target="password.password password-match.passwordMatch password-strength-gauge.password", data_action="input->password-match#checkPasswordsMatch input->password-strength-gauge#checkPasswordStrength", tabindex="1", autofocus=true) }}
+            {{ form.new_password(placeholder="Select a new password", required="required", class_="form-group__input", data_target="password.password password-match.passwordMatch password-strength-gauge.password", data_action="input->password-match#checkPasswordsMatch input->password-strength-gauge#checkPasswordStrength", **{'aria-describedby':"password-errors, password-strength"}) }}
           </div>
           {% if form.new_password.errors %}
-          <ul class="form-errors">
+          <ul id="password-errors" class="form-errors" role="alert">
             {% for error in form.new_password.errors %}
             <li>{{ error }}</li>
             {% endfor %}
@@ -53,9 +56,9 @@
 
         <div class="form-group">
           <label for="password_confirm" class="form-group__label">Confirm password</label>
-          {{ form.password_confirm(placeholder="Confirm password", required="required", class_="form-group__input", data_target="password.password password-match.passwordMatch", data_action="input->password-match#checkPasswordsMatch", tabindex="2") }}
+          {{ form.password_confirm(placeholder="Confirm password", required="required", class_="form-group__input", data_target="password.password password-match.passwordMatch", data_action="input->password-match#checkPasswordsMatch", **{'aria-describedby':"confirm-password-errors"}) }}
           {% if form.password_confirm.errors %}
-          <ul class="form-errors">
+          <ul id="confirm-password-errors" class="form-errors" role="alert">
             {% for error in form.password_confirm.errors %}
             <li>{{ error }}</li>
             {% endfor %}
@@ -64,7 +67,7 @@
         </div>
 
         <div class="form-group">
-          <ul class="form-errors">
+          <ul class="form-errors" role="alert">
             <li data-target="password-match.matchMessage" class="hidden"></li>
           </ul>
         </div>

--- a/warehouse/templates/accounts/reset-password.html
+++ b/warehouse/templates/accounts/reset-password.html
@@ -14,7 +14,7 @@
 {% extends "base.html" %}
 
 {% block title %}
-  {% if form.errors %}Error processing form &ndash;{% endif %}
+  {% if form.errors %}Error processing form –{% endif %}
   Reset your password
 {% endblock %}
 
@@ -42,7 +42,7 @@
           </div>
           {# the password field needs to be wrapped in a div to properly place tooltips #}
           <div>
-            {{ form.new_password(placeholder="Select a new password", required="required", class_="form-group__input", data_target="password.password password-match.passwordMatch password-strength-gauge.password", data_action="input->password-match#checkPasswordsMatch input->password-strength-gauge#checkPasswordStrength", **{'aria-describedby':"password-errors, password-strength"}) }}
+            {{ form.new_password(placeholder="Select a new password", required="required", class_="form-group__input", data_target="password.password password-match.passwordMatch password-strength-gauge.password", data_action="input->password-match#checkPasswordsMatch input->password-strength-gauge#checkPasswordStrength", **{"aria-describedby":"password-errors password-strength"}) }}
           </div>
           {% if form.new_password.errors %}
           <ul id="password-errors" class="form-errors" role="alert">
@@ -56,7 +56,7 @@
 
         <div class="form-group">
           <label for="password_confirm" class="form-group__label">Confirm password</label>
-          {{ form.password_confirm(placeholder="Confirm password", required="required", class_="form-group__input", data_target="password.password password-match.passwordMatch", data_action="input->password-match#checkPasswordsMatch", **{'aria-describedby':"confirm-password-errors"}) }}
+          {{ form.password_confirm(placeholder="Confirm password", required="required", class_="form-group__input", data_target="password.password password-match.passwordMatch", data_action="input->password-match#checkPasswordsMatch", **{"aria-describedby":"confirm-password-errors"}) }}
           {% if form.password_confirm.errors %}
           <ul id="confirm-password-errors" class="form-errors" role="alert">
             {% for error in form.password_confirm.errors %}

--- a/warehouse/templates/accounts/two-factor.html
+++ b/warehouse/templates/accounts/two-factor.html
@@ -13,7 +13,10 @@
 -#}
 {% extends "base.html" %}
 
-{% block title %}Two-factor authentication{% endblock %}
+{% block title %}
+  {% if totp_form and totp_form.errors %}Error processing form &ndash;{% endif %}
+  Two-factor authentication
+{% endblock %}
 
 {% block content %}
 {% if testPyPI %}
@@ -28,7 +31,7 @@
 
     <div class="twofa-login">
       {% if has_webauthn %}
-      <div class="twofa-login__method {% if totp_form %}twofa-login__method--padded{% endif %}">
+      <div class="twofa-login__method {% if form %}twofa-login__method--padded{% endif %}">
         <h2>
           Authenticate with a security key
           &nbsp;<span class="badge badge--warning">Beta</span>
@@ -44,7 +47,7 @@
           <button
             type="button"
             id="webauthn-auth-begin"
-            class="button button--primary"
+            class="webauthn-button button button--primary"
             csrf-token="{{ request.session.get_csrf_token() }}"
             disabled>Authenticate with key
           </button>
@@ -72,7 +75,7 @@
           <input name="method" type="hidden" value="totp">
 
           {% if totp_form.errors.__all__ %}
-          <ul class="form-errors">
+          <ul class="form-errors" role="alert">
             {% for error in totp_form.errors.__all__ %}
             <li>{{ error }}</li>
             {% endfor %}
@@ -81,9 +84,9 @@
 
           <div class="form-group">
             <label for="totp_value" class="form-group__label">Authentication code</label>
-            {{ totp_form.totp_value(placeholder="Authentication code", autocorrect="off", autocapitalize="off", spellcheck="false", required="required", class_="form-group__input", tabindex="1", autocomplete="off") }}
+            {{ totp_form.totp_value(autocorrect="off", autocapitalize="off", spellcheck="false", required="required", class_="form-group__input", autocomplete="off", **{'aria-describedby':"totp-errors"}) }}
             {% if totp_form.totp_value.errors %}
-            <ul class="form-errors">
+            <ul id="totp-errors" class="form-errors" role="alert">
               {% for error in totp_form.totp_value.errors %}
               <li>{{ error }}</li>
               {% endfor %}

--- a/warehouse/templates/accounts/two-factor.html
+++ b/warehouse/templates/accounts/two-factor.html
@@ -14,7 +14,7 @@
 {% extends "base.html" %}
 
 {% block title %}
-  {% if totp_form and totp_form.errors %}Error processing form &ndash;{% endif %}
+  {% if totp_form and totp_form.errors %}Error processing form –{% endif %}
   Two-factor authentication
 {% endblock %}
 
@@ -84,7 +84,7 @@
 
           <div class="form-group">
             <label for="totp_value" class="form-group__label">Authentication code</label>
-            {{ totp_form.totp_value(autocorrect="off", autocapitalize="off", spellcheck="false", required="required", class_="form-group__input", autocomplete="off", **{'aria-describedby':"totp-errors"}) }}
+            {{ totp_form.totp_value(autocorrect="off", autocapitalize="off", spellcheck="false", required="required", class_="form-group__input", autocomplete="off", **{"aria-describedby":"totp-errors"}) }}
             {% if totp_form.totp_value.errors %}
             <ul id="totp-errors" class="form-errors" role="alert">
               {% for error in totp_form.totp_value.errors %}

--- a/warehouse/templates/accounts/two-factor.html
+++ b/warehouse/templates/accounts/two-factor.html
@@ -31,7 +31,7 @@
 
     <div class="twofa-login">
       {% if has_webauthn %}
-      <div class="twofa-login__method {% if form %}twofa-login__method--padded{% endif %}">
+      <div class="twofa-login__method {% if totp_form %}twofa-login__method--padded{% endif %}">
         <h2>
           Authenticate with a security key
           &nbsp;<span class="badge badge--warning">Beta</span>
@@ -47,7 +47,7 @@
           <button
             type="button"
             id="webauthn-auth-begin"
-            class="webauthn-button button button--primary"
+            class="button button--primary"
             csrf-token="{{ request.session.get_csrf_token() }}"
             disabled>Authenticate with key
           </button>

--- a/warehouse/templates/base.html
+++ b/warehouse/templates/base.html
@@ -25,17 +25,19 @@
 {%- endmacro %}
 
 {% macro password_strength_gauge(data_target=None) -%}
-<p class="form-group__help-text">
-  Choose a strong password that contains letters (uppercase and lowercase), numbers and special characters. Avoid common words or repetition.
-</p>
-<p class="form-group__help-text">
-  <strong>Password strength:</strong>
-  <span class="password-strength">
-    <span class="password-strength__gauge"{% if data_target %} data-target="{{ data_target }}"{% endif %}>
-      <span class="sr-only">Password field is empty</span>
+<div id="password-strength">
+  <p class="form-group__help-text">
+    Choose a strong password that contains letters (uppercase and lowercase), numbers and special characters. Avoid common words or repetition.
+  </p>
+  <p class="form-group__help-text">
+    <strong>Password strength:</strong>
+    <span class="password-strength">
+      <span class="password-strength__gauge"{% if data_target %} data-target="{{ data_target }}"{% endif %}>
+        <span class="sr-only">Password field is empty</span>
+      </span>
     </span>
-  </span>
-</p>
+  </p>
+</div>
 {%- endmacro %}
 
 {% macro main_navigation_logged_out() -%}

--- a/warehouse/templates/includes/input-user-name.html
+++ b/warehouse/templates/includes/input-user-name.html
@@ -11,7 +11,7 @@
  # See the License for the specific language governing permissions and
  # limitations under the License.
 -#}
-{{ form.username_or_email(autocorrect="off", autocapitalize="off", spellcheck="false", class="form-group__input", required="true", **{'aria-describedby':"username-errors"}) }}
+{{ form.username_or_email(autocorrect="off", autocapitalize="off", spellcheck="false", class="form-group__input", required="true", **{"aria-describedby":"username-errors"}) }}
 {% if form.username_or_email.errors %}
   <ul id="username-errors" class="form-errors" role="alert">
     {% for error in form.username_or_email.errors %}

--- a/warehouse/templates/includes/input-user-name.html
+++ b/warehouse/templates/includes/input-user-name.html
@@ -11,9 +11,9 @@
  # See the License for the specific language governing permissions and
  # limitations under the License.
 -#}
-{{ form.username_or_email(placeholder="Username or email", autocorrect="off", autocapitalize="off", spellcheck="false", class="form-group__input", required="true", autofocus="true") }}
+{{ form.username_or_email(autocorrect="off", autocapitalize="off", spellcheck="false", class="form-group__input", required="true", **{'aria-describedby':"username-errors"}) }}
 {% if form.username_or_email.errors %}
-  <ul class="form-errors">
+  <ul id="username-errors" class="form-errors" role="alert">
     {% for error in form.username_or_email.errors %}
     <li>{{ error }}</li>
     {% endfor %}

--- a/warehouse/templates/manage/account.html
+++ b/warehouse/templates/manage/account.html
@@ -19,7 +19,12 @@
 {% block account_active %}vertical-tabs__tab--is-active{% endblock %}
 {% block account_mobile_active %}vertical-tabs__tab--is-active{% endblock %}
 
-{% block title %}{{ title }}{% endblock %}
+{% block title %}
+  {% if add_email_form.errors or change_password_form.errors %}
+  Error processing form –
+  {% endif %}
+  {{ title }}
+{% endblock %}
 
 {% macro form_error_anchor(form) %}
   {% if form.errors %}
@@ -39,7 +44,7 @@
 
 {% macro field_errors(field) %}
   {% if field.errors %}
-  <ul class="form-errors" role="alert">
+  <ul id="{{field.name}}-errors" class="form-errors" role="alert">
     {% for error in field.errors %}
     <li>{{ error }}</li>
     {% endfor %}
@@ -184,7 +189,7 @@
       {{ form_errors(save_account_form) }}
       <div class="form-group">
         <label class="form-group__label" for="name">Full name</label>
-        {{ save_account_form.name(placeholder="No name set", class_="form-group__input") }}
+        {{ save_account_form.name(placeholder="No name set", class_="form-group__input", **{"aria-describedby":"name-errors"}) }}
         {{ field_errors(save_account_form.name) }}
         <p class="form-group__help-text">Displayed on your <a href="{{ request.route_path('accounts.profile', username=user.username) }}">public profile</a></p>
       </div>
@@ -228,7 +233,7 @@
         <label class="form-group__label" for="email">Add email</label>
         <div class="form-group__horizontal">
           <div class="form-group__horizontal-left">
-            {{ add_email_form.email(placeholder="Your email address", autocomplete="email", required="required", class_="form-group__input") }}
+            {{ add_email_form.email(placeholder="Your email address", autocomplete="email", required="required", class_="form-group__input", **{"aria-describedby":"email-errors"}) }}
             {{ field_errors(add_email_form.email) }}
           </div>
           <div class="form-group__horizontal-right">
@@ -255,21 +260,21 @@
               id="show-password" type="checkbox">&nbsp;Show passwords
           </label>
         </div>
-        {{ change_password_form.password(placeholder="Your current password", required="required", class_="form-group__input", data_target="password.password")}}
+        {{ change_password_form.password(placeholder="Your current password", required="required", class_="form-group__input", data_target="password.password", **{"aria-describedby":"password-errors"}) }}
         {{ field_errors(change_password_form.password) }}
       </div>
       <div class="form-group">
         <label class="form-group__label" for="name">New password</label>
         {# the password field needs to be wrapped in a div to properly place tooltips #}
         <div>
-          {{ change_password_form.new_password(placeholder="Select a new password", required="required", class_="form-group__input", data_target="password.password password-match.passwordMatch password-strength-gauge.password", data_action="input->password-match#checkPasswordsMatch input->password-strength-gauge#checkPasswordStrength") }}
+          {{ change_password_form.new_password(placeholder="Select a new password", required="required", class_="form-group__input", data_target="password.password password-match.passwordMatch password-strength-gauge.password", data_action="input->password-match#checkPasswordsMatch input->password-strength-gauge#checkPasswordStrength", **{"aria-describedby":"new_password-errors"}) }}
         </div>
         {{ field_errors(change_password_form.new_password) }}
         {{ password_strength_gauge(data_target="password-strength-gauge.strengthGauge") }}
       </div>
       <div class="form-group">
         <label class="form-group__label" for="name">Confirm new password</label>
-        {{ change_password_form.password_confirm(placeholder="Confirm password", required="required", class_="form-group__input", data_target="password.password password-match.passwordMatch", data_action="input->password-match#checkPasswordsMatch") }}
+        {{ change_password_form.password_confirm(placeholder="Confirm password", required="required", class_="form-group__input", data_target="password.password password-match.passwordMatch", data_action="input->password-match#checkPasswordsMatch", **{"aria-describedby":"password_confirm-errors"}) }}
         {{ field_errors(change_password_form.password_confirm) }}
       </div>
       <div class="form-group">

--- a/warehouse/templates/manage/account.html
+++ b/warehouse/templates/manage/account.html
@@ -29,7 +29,7 @@
 
 {% macro form_errors(form) %}
   {% if form.errors.__all__ %}
-  <ul class="form-errors">
+  <ul class="form-errors" role="alert">
     {% for error in form.errors.__all__ %}
     <li>{{ error }}</li>
     {% endfor %}
@@ -39,7 +39,7 @@
 
 {% macro field_errors(field) %}
   {% if field.errors %}
-  <ul class="form-errors">
+  <ul class="form-errors" role="alert">
     {% for error in field.errors %}
     <li>{{ error }}</li>
     {% endfor %}
@@ -273,7 +273,7 @@
         {{ field_errors(change_password_form.password_confirm) }}
       </div>
       <div class="form-group">
-        <ul class="form-errors">
+        <ul class="form-errors" role="alert">
           <li data-target="password-match.matchMessage" class="hidden"></li>
         </ul>
       </div>

--- a/warehouse/templates/manage/account/totp-provision.html
+++ b/warehouse/templates/manage/account/totp-provision.html
@@ -16,7 +16,10 @@
 {% set user = request.user %}
 {% set title = "Set up two factor authentication using an application (TOTP)" %}
 
-{% block title %}{{ title }}{% endblock %}
+{% block title %}
+  {% if provision_totp_form.errors %}Error processing form &ndash;{% endif %}
+  {{ title }}
+{% endblock %}
 
 {# Hide mobile search on manager pages #}
 {% block mobile_search %}{% endblock %}
@@ -63,10 +66,10 @@
       <input name="csrf_token" type="hidden" value="{{ request.session.get_csrf_token() }}">
       <div class="form-group">
         <label for="totp_value" class="form-group__label">Verify application</label>
-        {{ provision_totp_form.totp_value(placeholder="TOTP value", autocorrect="off", autocapitalize="off", spellcheck="false", required="required", class_="form-group__input", tabindex="1", autofocus=true, autocomplete="off") }}
-        <p class="form-group__help-text">To finalize the provisioning process, enter the TOTP value provided by your application.</p>
+        {{ provision_totp_form.totp_value(placeholder="TOTP value", autocorrect="off", autocapitalize="off", spellcheck="false", required="required", class_="form-group__input", autocomplete="off", **{'aria-describedby':"totp-help totp-errors"}) }}
+        <p id="totp-help" class="form-group__help-text">To finalize the provisioning process, enter the TOTP value provided by your application.</p>
         {% if provision_totp_form.totp_value.errors %}
-        <ul class="form-errors">
+        <ul id="totp-errors" class="form-errors" role="alert">
           {% for error in provision_totp_form.totp_value.errors %}
           <li>{{ error }}</li>
           {% endfor %}

--- a/warehouse/templates/manage/account/totp-provision.html
+++ b/warehouse/templates/manage/account/totp-provision.html
@@ -17,7 +17,7 @@
 {% set title = "Set up two factor authentication using an application (TOTP)" %}
 
 {% block title %}
-  {% if provision_totp_form.errors %}Error processing form &ndash;{% endif %}
+  {% if provision_totp_form.errors %}Error processing form –{% endif %}
   {{ title }}
 {% endblock %}
 
@@ -66,7 +66,7 @@
       <input name="csrf_token" type="hidden" value="{{ request.session.get_csrf_token() }}">
       <div class="form-group">
         <label for="totp_value" class="form-group__label">Verify application</label>
-        {{ provision_totp_form.totp_value(placeholder="TOTP value", autocorrect="off", autocapitalize="off", spellcheck="false", required="required", class_="form-group__input", autocomplete="off", **{'aria-describedby':"totp-help totp-errors"}) }}
+        {{ provision_totp_form.totp_value(placeholder="TOTP value", autocorrect="off", autocapitalize="off", spellcheck="false", required="required", class_="form-group__input", autocomplete="off", **{"aria-describedby":"totp-help totp-errors"}) }}
         <p id="totp-help" class="form-group__help-text">To finalize the provisioning process, enter the TOTP value provided by your application.</p>
         {% if provision_totp_form.totp_value.errors %}
         <ul id="totp-errors" class="form-errors" role="alert">


### PR DESCRIPTION
To merge after #https://github.com/pypa/warehouse/pull/6150

To test:

- [x] Login page
- [x] Request password reset page
- [x] Complete password reset page
- [x] Registration page
- [x] My account page
- [x] TOTP login page
- [x] TOTP provisioning page

Note: webauthn is out of scope for this PR, we will need to make a separate PR for this