### PR TITLE
Prevent blue line on image links in project descriptions

### DIFF
--- a/warehouse/static/sass/blocks/_project-description.scss
+++ b/warehouse/static/sass/blocks/_project-description.scss
@@ -48,6 +48,10 @@
     margin-top: $spacing-unit;
   }
 
+  a > img {
+    background-color: #fff;
+  }
+
   // Remove top margin on elements at the top of the description
   > div:first-child > *:first-child,
   > *:first-child,


### PR DESCRIPTION
Closes #6158 

## Before
![Screenshot from 2019-07-09 06-29-31](https://user-images.githubusercontent.com/3323703/60861695-262be500-a213-11e9-98f5-38c4e4404a67.png)

## After
![Screenshot from 2019-07-09 06-29-50](https://user-images.githubusercontent.com/3323703/60861694-262be500-a213-11e9-9dde-e02aa619d167.png)