### PR TITLE
warehouse: Allow anonymous WebAuthn attestation

### DIFF
--- a/tests/unit/utils/test_webauthn.py
+++ b/tests/unit/utils/test_webauthn.py
@@ -46,6 +46,7 @@ def test_verify_registration_response(monkeypatch):
             "fake_origin",
             {},
             webauthn._webauthn_b64encode("not_a_real_challenge".encode()).decode(),
+            self_attestation_permitted=True,
         )
     ]
     assert resp == "not a real object"

--- a/warehouse/utils/webauthn.py
+++ b/warehouse/utils/webauthn.py
@@ -111,7 +111,11 @@ def verify_registration_response(response, challenge, *, rp_id, origin):
     # first for the entire clientData payload, and then again
     # for the individual challenge.
     response = pywebauthn.WebAuthnRegistrationResponse(
-        rp_id, origin, response, _webauthn_b64encode(challenge.encode()).decode()
+        rp_id,
+        origin,
+        response,
+        _webauthn_b64encode(challenge.encode()).decode(),
+        self_attestation_permitted=True,
     )
     try:
         return response.verify()

--- a/warehouse/utils/webauthn.py
+++ b/warehouse/utils/webauthn.py
@@ -110,12 +110,9 @@ def verify_registration_response(response, challenge, *, rp_id, origin):
     # response's clientData.challenge is encoded twice:
     # first for the entire clientData payload, and then again
     # for the individual challenge.
+    encoded_challenge = _webauthn_b64encode(challenge.encode()).decode()
     response = pywebauthn.WebAuthnRegistrationResponse(
-        rp_id,
-        origin,
-        response,
-        _webauthn_b64encode(challenge.encode()).decode(),
-        self_attestation_permitted=True,
+        rp_id, origin, response, encoded_challenge, self_attestation_permitted=True
     )
     try:
         return response.verify()
@@ -133,12 +130,13 @@ def verify_assertion_response(assertion, *, challenge, user, origin, icon_url, r
     """
     webauthn_users = _get_webauthn_users(user, icon_url=icon_url, rp_id=rp_id)
     cred_ids = [cred.credential_id for cred in webauthn_users]
+    encoded_challenge = _webauthn_b64encode(challenge.encode()).decode()
 
     for webauthn_user in webauthn_users:
         response = pywebauthn.WebAuthnAssertionResponse(
             webauthn_user,
             assertion,
-            _webauthn_b64encode(challenge.encode()).decode(),
+            encoded_challenge,
             origin,
             allow_credentials=cred_ids,
         )


### PR DESCRIPTION
This allows users to use TouchID and other methods
that don't use separate public keys.

cc @di @jacobian

Fixes #6183 