### PR TITLE
Warn users about browsers and devices on webauthn provisioning page

### DIFF
--- a/warehouse/templates/manage/account/webauthn-provision.html
+++ b/warehouse/templates/manage/account/webauthn-provision.html
@@ -57,7 +57,8 @@
   <br>
 
   <div class="callout-block">
-    <p><strong>Device not being recognised?</strong> Some older USB keys do not adhere to the FIDO standard and will not work with PyPI.</p>
+    <p><strong>Not working?</strong> Check you're using a device that follows the <a href="https://fidoalliance.org/specifications/download/" title="External link" target="_blank" rel="noopener">FIDO specification</a> and a <a href="https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredential#Browser_compatibility" title="External link" target="_blank" rel="noopener">compatible browser</a>.</p>
+    <p>Note that some older USB keys do not adhere to the FIDO standard and will not work with PyPI.</p>
   </div>
 
 </section>


### PR DESCRIPTION
As discussed @woodruffw 

This should go some way towards addressing https://github.com/pypa/warehouse/issues/6050

![Screenshot from 2019-07-19 06-38-39](https://user-images.githubusercontent.com/3323703/61511901-2173e780-a9f0-11e9-9e11-b52064971406.png)
