### PR TITLE
Highlight 'Account settings' tab when provisioning 2fa

### DIFF
--- a/warehouse/templates/manage/account/totp-provision.html
+++ b/warehouse/templates/manage/account/totp-provision.html
@@ -16,6 +16,9 @@
 {% set user = request.user %}
 {% set title = "Set up 2FA with an authentication application (TOTP)" %}
 
+{% block account_active %}vertical-tabs__tab--is-active{% endblock %}
+{% block account_mobile_active %}vertical-tabs__tab--is-active{% endblock %}
+
 {% block title %}
   {% if provision_totp_form.errors %}Error processing form –{% endif %}
   {{ title }}

--- a/warehouse/templates/manage/account/webauthn-provision.html
+++ b/warehouse/templates/manage/account/webauthn-provision.html
@@ -16,10 +16,10 @@
 {% set user = request.user %}
 {% set title = "Set up 2FA with a security device (e.g. USB key)" %}
 
-{% block title %}{{ title }}{% endblock %}
+{% block account_active %}vertical-tabs__tab--is-active{% endblock %}
+{% block account_mobile_active %}vertical-tabs__tab--is-active{% endblock %}
 
-{# Hide mobile search on manager pages #}
-{% block mobile_search %}{% endblock %}
+{% block title %}{{ title }}{% endblock %}
 
 {% block main %}
 <h1 class="page-title page-title--wsubtitle heading-wsubtitle__heading">{{ title }} <span class="badge badge--warning">Beta</span></h1>


### PR DESCRIPTION
![Screenshot from 2019-07-23 07-06-17](https://user-images.githubusercontent.com/3323703/61686714-63669b80-ad18-11e9-934c-0cbea2a5db23.png)

`{% block mobile_search %}{% endblock %}` also not required, as this is on the base template.