### PR TITLE
[WIP] [DO NOT MERGE] Implement proper WebAuthn feature detection in Chrome

### DIFF
--- a/warehouse/static/js/warehouse/utils/webauthn.js
+++ b/warehouse/static/js/warehouse/utils/webauthn.js
@@ -159,8 +159,15 @@ const postAssertion = async (assertion, token) => {
   return await resp.json();
 };
 
-export const GuardWebAuthn = () => {
-  if (!window.PublicKeyCredential) {
+export const GuardWebAuthn = async () => {
+  if (
+      !window.PublicKeyCredential ||
+      !(
+          await window
+              .PublicKeyCredential
+              .isUserVerifyingPlatformAuthenticatorAvailable()
+      )
+  ) {
     let webauthn_button = document.getElementById("webauthn-button");
     if (webauthn_button) {
       webauthn_button.className += " button--disabled";

--- a/warehouse/static/js/warehouse/utils/webauthn.js
+++ b/warehouse/static/js/warehouse/utils/webauthn.js
@@ -175,7 +175,7 @@ export const GuardWebAuthn = async () => {
 
     let webauthn_error = document.getElementById("webauthn-browser-support");
     if (webauthn_error) {
-      webauthn_error.style.display = "block";
+      webauthn_error.classList.remove("hidden");
     }
 
     let webauthn_label = document.getElementById("webauthn-provision-label");

--- a/warehouse/static/js/warehouse/utils/webauthn.js
+++ b/warehouse/static/js/warehouse/utils/webauthn.js
@@ -46,7 +46,7 @@ const doWebAuthn = (buttonId, func) => {
   }
 
   webAuthnButton.disabled = false;
-  webAuthnButton.addEventListener("click", async () => { func(csrfToken); });
+  webAuthnButton.addEventListener("click", async () => { await func(csrfToken); });
 };
 
 const hexEncode = (buf) => {


### PR DESCRIPTION
This patch enables Chrome versions, which support
some creds verification but not the latest WebAuthn
standard, show a proper error message with
recommendations to upgrade.

Fixes #6050

Ref: https://www.ubisecure.com/api/fido-webauthn-api/