### PR TITLE
Show warning when user scopes API key to account

### DIFF
--- a/warehouse/static/sass/blocks/_callout-block.scss
+++ b/warehouse/static/sass/blocks/_callout-block.scss
@@ -24,6 +24,7 @@
 
   Modifiers:
     - danger: Makes border red
+    - warning: Makes border brown
     - success: Makes border green
     - bottom-margin: Adds extra margin below the callout
 */
@@ -65,6 +66,14 @@
 
     &:before {
       background-color: $danger-color;
+    }
+  }
+
+  &--warning {
+    border-color: $warn-text;
+
+    &:before {
+      background-color: $warn-text;
     }
   }
 

--- a/warehouse/templates/manage/token.html
+++ b/warehouse/templates/manage/token.html
@@ -79,6 +79,10 @@
         </select>
         {{ field_errors(create_macaroon_form.token_scope) }}
       </div>
+      <div class="callout-block callout-block--warning">
+        <h3 class="callout-block__heading">Proceed with caution!</h3>
+        <p>An API token scoped to your entire account will have the same power as your account password.</p>
+      </div>
       <div>
         <input value="Add token" class="button button--primary" type="submit">
       </div>


### PR DESCRIPTION
Closes https://github.com/pypa/warehouse/issues/6266

![Screenshot from 2019-07-26 07-49-19](https://user-images.githubusercontent.com/3323703/61931951-0a963d80-af7a-11e9-9933-c02a0831dd81.png)

@woodruffw would you be able to write a small snippet of JS that toggles the visibility of the warning, depending on whether or not "Entire account (all projects)" is selected above?