### PR TITLE
Add pronunciation guide to FAQ

### DIFF
--- a/warehouse/templates/pages/help.html
+++ b/warehouse/templates/pages/help.html
@@ -71,6 +71,7 @@
 {% macro contributing() %}How can I contribute to PyPI?{% endmacro %}
 {% macro upcoming_changes() %}How do I keep up with upcoming changes to PyPI?{% endmacro %}
 {% macro beta_badge() %}What does the "beta" badge mean? What are Warehouse's current beta features?{% endmacro %}
+{% macro pronunciation_guide() %}How do I pronounce "PyPI"?{% endmacro %}
 
 {% block title %}Help{% endblock %}
 
@@ -148,6 +149,7 @@
           <li><a href="#contributing">{{ contributing() }}</a></li>
           <li><a href="#upcoming-changes">{{ upcoming_changes() }}</a></li>
           <li><a href="#beta-badge">{{ beta_badge() }}</a></li>
+          <li><a href="#pronunciation-guide">{{ pronunciation_guide() }}</a></li>
         </ul>
       </section>
 
@@ -446,6 +448,9 @@
           <li><a href="#utfdevices">{{ utfdevices() }}</a></li>
           <li><a href="#apitoken">{{ apitoken() }}</a></li>
         </ul>
+
+        <h3 id="pronunciation-guide">{{ pronunciation_guide() }}</h3>
+        <p>"PyPI" is intended to be pronounced as "Pie Pea Eye", with the "PI" pronounced as individual letters, rather as a word. This minimizes confusion with the <a href="https://pypy.org/">PyPy</a> project, which is a popular alternative implementation of the Python language.</p>
 
       </section>
     </div>

--- a/warehouse/templates/pages/help.html
+++ b/warehouse/templates/pages/help.html
@@ -71,7 +71,7 @@
 {% macro contributing() %}How can I contribute to PyPI?{% endmacro %}
 {% macro upcoming_changes() %}How do I keep up with upcoming changes to PyPI?{% endmacro %}
 {% macro beta_badge() %}What does the "beta" badge mean? What are Warehouse's current beta features?{% endmacro %}
-{% macro pronunciation_guide() %}How do I pronounce "PyPI"?{% endmacro %}
+{% macro pronunciation() %}How do I pronounce "PyPI"?{% endmacro %}
 
 {% block title %}Help{% endblock %}
 
@@ -149,7 +149,7 @@
           <li><a href="#contributing">{{ contributing() }}</a></li>
           <li><a href="#upcoming-changes">{{ upcoming_changes() }}</a></li>
           <li><a href="#beta-badge">{{ beta_badge() }}</a></li>
-          <li><a href="#pronunciation-guide">{{ pronunciation_guide() }}</a></li>
+          <li><a href="#pronunciation">{{ pronunciation() }}</a></li>
         </ul>
       </section>
 
@@ -450,7 +450,7 @@
         </ul>
 
         <h3 id="pronunciation-guide">{{ pronunciation_guide() }}</h3>
-        <p>"PyPI" is intended to be pronounced as "Pie Pea Eye", with the "PI" pronounced as individual letters, rather as a word. This minimizes confusion with the <a href="https://pypy.org/">PyPy</a> project, which is a popular alternative implementation of the Python language.</p>
+        <p>"PyPI" should be pronounced like "pie pea eye", specifically with the "PI" pronounced as individual letters, rather as a single sound. This minimizes confusion with the <a href="https://pypy.org/">PyPy</a> project, which is a popular alternative implementation of the Python language.</p>
 
       </section>
     </div>


### PR DESCRIPTION
When responding to [this thread on twitter](https://twitter.com/Captain_Joannah/status/1154825071887822850), I realized that while I am fairly certain I've heard fairly official proclamations of the fact that PyPI is intended to be pronouncd as "Py-P-I", I could not find any official documentation of this fact that I could reference.

This PR adds a FAQ item to clarify. Bikeshedding welcome (famous last words).