### PR TITLE
Improve API UI

### DIFF
--- a/warehouse/templates/manage/token.html
+++ b/warehouse/templates/manage/token.html
@@ -30,6 +30,14 @@
   {% if serialized_macaroon %}
   <section id="provisioned-key">
     <h2>Token for "{{ macaroon.description }}"</h2>
+    <p>
+      <strong>Permissions:</strong> Upload packages<br>
+      {% if macaroon.caveats.permissions == "user" %}
+      <strong>Scope:</strong> Entire account (all projects)
+      {% else %}
+      <strong>Scope:</strong> Project "{{ macaroon.caveats.permissions.projects[0] }}"
+      {% endif %}
+    </p>
     <p>For instructions on how to use this token, <a href="/help#apitoken">visit the PyPI help page</a>.</p>
     <code class="api-token">{{ serialized_macaroon }}</code>
     <div class="margin-bottom--large">
@@ -60,6 +68,9 @@
 
   {{ form_error_anchor(create_macaroon_form) }}
   <section id="add-token">
+    {% if serialized_macaroon %}
+    <h2>Add another token</h2>
+    {% endif %}
     <form method="POST">
       <input type="hidden" name="csrf_token" value="{{ request.session.get_csrf_token() }}">
       {{ form_errors(create_macaroon_form) }}
@@ -70,10 +81,13 @@
         <p id="description-help-text" class="form-group__help-text">What is this token for?</p>
       </div>
       <div class="form-group">
+        <span class="form-group__label">Permissions</span>
+        <p class="form-group__text">Upload packages</p>
+      </div>
+      <div class="form-group">
         <label for="token_scope" class="form-group__label">Scope</label>
         <select name="token_scope" id="token_scope" class="form-group__input" aria-describedby="token_scope-errors">
           <option disabled selected value="scope:unspecified">Select scope...</option>
-          <option value="scope:user">Entire account (all projects)</option>
         {% for project in project_names %}
           <option value="scope:project:{{ project }}">Project: {{ project }}</option>
         {% endfor %}

--- a/warehouse/templates/pages/help.html
+++ b/warehouse/templates/pages/help.html
@@ -275,7 +275,7 @@
 
         <h3 id="apitoken">{{ apitoken() }}</h3>
 
-        <p>API tokens provide an alternative way (instead of username and password) to authenticate when uploading packages to PyPI.</p>
+        <p>API tokens provide an alternative way (instead of username and password) to authenticate when <strong>uploading packages</strong> to PyPI.</p>
         <p>You can create a token for an entire PyPI account, in which case, the token will work for all projects associated with that account. Alternatively, you can limit a token's scope to a specific project.</p>
         <p><strong>We strongly recommend you authenticate with an API token where possible.</strong></p>
 


### PR DESCRIPTION
Closes #6257 

![Screenshot from 2019-07-29 06-48-50](https://user-images.githubusercontent.com/3323703/62024623-a370c700-b1cd-11e9-9a05-9ca17a678342.png)

- Makes permissions explicit in token creation form
- Lists permission and scope above API token display
- Adds "Add another token" heading, when displaying API token