### PR TITLE
Make beta badge more explicit

### DIFF
--- a/warehouse/templates/accounts/two-factor.html
+++ b/warehouse/templates/accounts/two-factor.html
@@ -34,7 +34,7 @@
       <div class="twofa-login__method {% if totp_form %}twofa-login__method--padded{% endif %}">
         <h2>
           Authenticate with a security device (e.g. USB key)
-          &nbsp;<span class="badge badge--warning">Beta</span>
+          &nbsp;<span class="badge badge--warning">Beta feature</span>
         </h2>
 
         <p>Connect your security device and click below.</p>

--- a/warehouse/templates/manage/account.html
+++ b/warehouse/templates/manage/account.html
@@ -394,7 +394,7 @@
           <tr>
             <td>
               <strong>"{{ credential.label }}"</strong> - Security device (WebAuthn)
-              <span class="badge badge--warning">Beta</span>
+              <span class="badge badge--warning">Beta feature</span>
             </td>
             <td class="table__action">
               <a href="#disable-webauthn-{{ credential.id }}" class="button button--primary">Remove</a>
@@ -426,7 +426,7 @@
   <hr>
 
   <section id="api-tokens">
-    <h2>API tokens <span class="badge badge--warning">Beta</span></h2>
+    <h2>API tokens <span class="badge badge--warning">Beta feature</span></h2>
     <p>API tokens provide an alternative way to authenticate when uploading packages to PyPI. <a href="/help#apitoken">Learn more</a>.</p>
 
     {% if user.macaroons|length > 0 %}

--- a/warehouse/templates/manage/account/webauthn-provision.html
+++ b/warehouse/templates/manage/account/webauthn-provision.html
@@ -22,7 +22,7 @@
 {% block title %}{{ title }}{% endblock %}
 
 {% block main %}
-<h1 class="page-title page-title--wsubtitle heading-wsubtitle__heading">{{ title }} <span class="badge badge--warning">Beta</span></h1>
+<h1 class="page-title page-title--wsubtitle heading-wsubtitle__heading">{{ title }} <span class="badge badge--warning">Beta feature</span></h1>
 <p class="heading-wsubtitle__subtitle">
   PyPI supports any device that adheres to the <a href="https://fidoalliance.org/certification/fido-certified-products/" title="External link" target="_blank" rel="noopener">FIDO standard</a>.
   <br>

--- a/warehouse/templates/manage/token.html
+++ b/warehouse/templates/manage/token.html
@@ -25,7 +25,7 @@
 {% endblock %}
 
 {% block main %}
-  <h1 class="page-title">{{ title }} <span class="badge badge--warning">Beta</span></h1>
+  <h1 class="page-title">{{ title }} <span class="badge badge--warning">Beta feature</span></h1>
 
   {% if serialized_macaroon %}
   <section id="provisioned-key">

--- a/warehouse/templates/pages/help.html
+++ b/warehouse/templates/pages/help.html
@@ -39,9 +39,9 @@
 {% macro compromised_password() %}Why is PyPI telling me my password is compromised?{% endmacro %}
 {% macro twoFA() %}What is two factor authentication and how does it work on PyPI?{% endmacro %}
 {% macro totp() %}How does two factor authentication with an authentication application (TOTP) work? How do I set it up on PyPI?{% endmacro %}
-{% macro utfkey() %}How does two factor authentication with a security device (e.g. USB key) work? How do I set it up on PyPI? <span class="badge badge--warning">Beta</span>{% endmacro %}
-{% macro utfdevices() %}What devices (other than a USB key) can I use as a security device? <span class="badge badge--warning">Beta</span>{% endmacro %}
-{% macro apitoken() %}How can I use API tokens to authenticate with PyPI? <span class="badge badge--warning">Beta</span>{% endmacro %}
+{% macro utfkey() %}How does two factor authentication with a security device (e.g. USB key) work? How do I set it up on PyPI? <span class="badge badge--warning">Beta feature</span>{% endmacro %}
+{% macro utfdevices() %}What devices (other than a USB key) can I use as a security device? <span class="badge badge--warning">Beta feature</span>{% endmacro %}
+{% macro apitoken() %}How can I use API tokens to authenticate with PyPI? <span class="badge badge--warning">Beta feature</span>{% endmacro %}
 
 {% macro mirroring() %}How can I run a mirror of PyPI?{% endmacro %}
 {% macro APIs() %}Does PyPI have APIs I can use?{% endmacro %}
@@ -70,7 +70,7 @@
 {% macro availability() %}Can I depend on PyPI being available?{% endmacro %}
 {% macro contributing() %}How can I contribute to PyPI?{% endmacro %}
 {% macro upcoming_changes() %}How do I keep up with upcoming changes to PyPI?{% endmacro %}
-{% macro beta_badge() %}What does the "beta" badge mean? What are Warehouse's current beta features?{% endmacro %}
+{% macro beta_badge() %}What does the "beta feature" badge mean? What are Warehouse's current beta features?{% endmacro %}
 {% macro pronunciation() %}How do I pronounce "PyPI"?{% endmacro %}
 
 {% block title %}Help{% endblock %}
@@ -441,8 +441,8 @@
         <p>Changes to PyPI are generally announced on both the <a href="https://mail.python.org/mm3/mailman3/lists/pypi-announce.python.org/" title="External link" target="_blank" rel="noopener">pypi-announce mailing list</a> and the <a href="https://pyfound.blogspot.com/search/label/pypi" title="External link" target="_blank" rel="noopener">PSF blog</a> under the label "pypi". The PSF blog also has <a href="https://pyfound.blogspot.com/feeds/posts/default/-/pypi" title="External link" target="_blank" rel="noopener">Atom</a> and <a href="https://pyfound.blogspot.com/feeds/posts/default/-/pypi?alt=rss" title="External link" target="_blank" rel="noopener">RSS</a> feeds for the "pypi" label.</p>
 
         <h3 id="beta-badge">{{ beta_badge() }}</h3>
-        <p>When Warehouse's maintainers are deploying new features, at first we mark them with a small "beta" symbol to tell you: this should probably work fine, but it's new and less tested than other site functionality.</p>
-        <p>Currently, the following features are in beta.</p>
+        <p>When Warehouse's maintainers are deploying new features, at first we mark them with a small "beta feature" symbol to tell you: this should probably work fine, but it's new and less tested than other site functionality.</p>
+        <p>Currently, the following features are in beta:</p>
         <ul>
           <li><a href="#utfkey">{{ utfkey() }}</a></li>
           <li><a href="#utfdevices">{{ utfdevices() }}</a></li>


### PR DESCRIPTION
Rename "beta" to "beta feature" to make it more explicit.
Based on user feedback.