### PR TITLE
warehouse: Change default scope from disabled to hidden

### DIFF
--- a/warehouse/templates/manage/token.html
+++ b/warehouse/templates/manage/token.html
@@ -87,7 +87,7 @@
       <div class="form-group">
         <label for="token_scope" class="form-group__label">Scope</label>
         <select name="token_scope" id="token_scope" class="form-group__input" aria-describedby="token_scope-errors">
-          <option disabled selected value="scope:unspecified">Select scope...</option>
+          <option hidden selected value="scope:unspecified">Select scope...</option>
           <option value="scope:user">Entire account (all projects)</option>
         {% for project in project_names %}
           <option value="scope:project:{{ project }}">Project: {{ project }}</option>


### PR DESCRIPTION
Prevents empty value submission, which in turn causes a routing
match failure, which in turn causes a 404 instead of a form error.

cc @di 