### PR TITLE
Don't route create_macaroon with request_param

### DIFF
--- a/warehouse/manage/views.py
+++ b/warehouse/manage/views.py
@@ -579,7 +579,7 @@ class ProvisionMacaroonViews:
     def manage_macaroons(self):
         return self.default_response
 
-    @view_config(request_method="POST", request_param=CreateMacaroonForm.__params__)
+    @view_config(request_method="POST")
     def create_macaroon(self):
         if not self.request.user.has_primary_verified_email:
             self.request.session.flash(


### PR DESCRIPTION
We don't need to specify `request_param` here as long as the other routes do. This allows us to optionally provide `token_scope` and keep the default, disabled select option on the form.

Closes #6332, cc @woodruffw 