### PR TITLE
warehouse: Friendlier token "username", prefix

### DIFF
--- a/tests/unit/macaroons/test_auth_policy.py
+++ b/tests/unit/macaroons/test_auth_policy.py
@@ -32,7 +32,7 @@ from warehouse.macaroons.services import InvalidMacaroon
         ("maybeafuturemethod foobar", None),
         ("token foobar", "foobar"),
         ("basic QHRva2VuOmZvb2Jhcg==", "foobar"),  # "@token:foobar"
-        ("basic JHRva2VuOmZvb2Jhcg==", "foobar"),  # "$token:foobar"
+        ("basic XnRva2VuOmZvb2Jhcg==", "foobar"),  # "$token:foobar"
     ],
 )
 def test_extract_http_macaroon(auth, result):
@@ -50,7 +50,7 @@ def test_extract_http_macaroon(auth, result):
         ("bm90YXJlYWx0b2tlbg==", None),  # "notarealtoken"
         ("QGJhZHVzZXI6Zm9vYmFy", None),  # "@baduser:foobar"
         ("QHRva2VuOmZvb2Jhcg==", "foobar"),  # "@token:foobar"
-        ("JHRva2VuOmZvb2Jhcg==", "foobar"),  # "$token:foobar"
+        ("XnRva2VuOmZvb2Jhcg==", "foobar"),  # "$token:foobar"
     ],
 )
 def test_extract_basic_macaroon(auth, result):

--- a/tests/unit/macaroons/test_auth_policy.py
+++ b/tests/unit/macaroons/test_auth_policy.py
@@ -32,7 +32,7 @@ from warehouse.macaroons.services import InvalidMacaroon
         ("maybeafuturemethod foobar", None),
         ("token foobar", "foobar"),
         ("basic QHRva2VuOmZvb2Jhcg==", "foobar"),  # "@token:foobar"
-        ("basic XnRva2VuOmZvb2Jhcg==", "foobar"),  # "$token:foobar"
+        ("basic XnRva2VuOmZvb2Jhcg==", "foobar"),  # "^token:foobar"
     ],
 )
 def test_extract_http_macaroon(auth, result):
@@ -50,7 +50,7 @@ def test_extract_http_macaroon(auth, result):
         ("bm90YXJlYWx0b2tlbg==", None),  # "notarealtoken"
         ("QGJhZHVzZXI6Zm9vYmFy", None),  # "@baduser:foobar"
         ("QHRva2VuOmZvb2Jhcg==", "foobar"),  # "@token:foobar"
-        ("XnRva2VuOmZvb2Jhcg==", "foobar"),  # "$token:foobar"
+        ("XnRva2VuOmZvb2Jhcg==", "foobar"),  # "^token:foobar"
     ],
 )
 def test_extract_basic_macaroon(auth, result):

--- a/tests/unit/macaroons/test_auth_policy.py
+++ b/tests/unit/macaroons/test_auth_policy.py
@@ -32,6 +32,7 @@ from warehouse.macaroons.services import InvalidMacaroon
         ("maybeafuturemethod foobar", None),
         ("token foobar", "foobar"),
         ("basic QHRva2VuOmZvb2Jhcg==", "foobar"),  # "@token:foobar"
+        ("basic JHRva2VuOmZvb2Jhcg==", "foobar"),  # "$token:foobar"
     ],
 )
 def test_extract_http_macaroon(auth, result):
@@ -49,6 +50,7 @@ def test_extract_http_macaroon(auth, result):
         ("bm90YXJlYWx0b2tlbg==", None),  # "notarealtoken"
         ("QGJhZHVzZXI6Zm9vYmFy", None),  # "@baduser:foobar"
         ("QHRva2VuOmZvb2Jhcg==", "foobar"),  # "@token:foobar"
+        ("JHRva2VuOmZvb2Jhcg==", "foobar"),  # "$token:foobar"
     ],
 )
 def test_extract_basic_macaroon(auth, result):

--- a/tests/unit/macaroons/test_auth_policy.py
+++ b/tests/unit/macaroons/test_auth_policy.py
@@ -32,7 +32,7 @@ from warehouse.macaroons.services import InvalidMacaroon
         ("maybeafuturemethod foobar", None),
         ("token foobar", "foobar"),
         ("basic QHRva2VuOmZvb2Jhcg==", "foobar"),  # "@token:foobar"
-        ("basic XnRva2VuOmZvb2Jhcg==", "foobar"),  # "^token:foobar"
+        ("basic X190b2tlbl9fOmZvb2Jhcg==", "foobar"),  # "__token__:foobar"
     ],
 )
 def test_extract_http_macaroon(auth, result):
@@ -50,7 +50,7 @@ def test_extract_http_macaroon(auth, result):
         ("bm90YXJlYWx0b2tlbg==", None),  # "notarealtoken"
         ("QGJhZHVzZXI6Zm9vYmFy", None),  # "@baduser:foobar"
         ("QHRva2VuOmZvb2Jhcg==", "foobar"),  # "@token:foobar"
-        ("XnRva2VuOmZvb2Jhcg==", "foobar"),  # "^token:foobar"
+        ("X190b2tlbl9fOmZvb2Jhcg==", "foobar"),  # "__token__:foobar"
     ],
 )
 def test_extract_basic_macaroon(auth, result):

--- a/tests/unit/macaroons/test_services.py
+++ b/tests/unit/macaroons/test_services.py
@@ -45,6 +45,7 @@ class TestDatabaseMacaroonService:
             ("noprefixhere", None),
             ("invalid:prefix", None),
             ("pypi:validprefix", "validprefix"),
+            ("pypi-validprefix", "validprefix"),
         ],
     )
     def test_extract_raw_macaroon(self, macaroon_service, raw_macaroon, result):
@@ -74,7 +75,7 @@ class TestDatabaseMacaroonService:
             key=b"fake key",
             version=pymacaroons.MACAROON_V2,
         ).serialize()
-        raw_macaroon = f"pypi:{raw_macaroon}"
+        raw_macaroon = f"pypi-{raw_macaroon}"
 
         assert macaroon_service.find_userid(raw_macaroon) is None
 
@@ -107,7 +108,7 @@ class TestDatabaseMacaroonService:
             key=b"fake key",
             version=pymacaroons.MACAROON_V2,
         ).serialize()
-        raw_macaroon = f"pypi:{raw_macaroon}"
+        raw_macaroon = f"pypi-{raw_macaroon}"
 
         with pytest.raises(services.InvalidMacaroon):
             macaroon_service.verify(

--- a/warehouse/macaroons/auth_policy.py
+++ b/warehouse/macaroons/auth_policy.py
@@ -38,7 +38,7 @@ def _extract_basic_macaroon(auth):
     except ValueError:
         return None
 
-    # TODO: Remove @token as an acceptable token username.
+    # TODO: Remove @token as an acceptable token username (GH-6345)
     if auth_method != "@token" and auth_method != "^token":
         return None
 

--- a/warehouse/macaroons/auth_policy.py
+++ b/warehouse/macaroons/auth_policy.py
@@ -38,7 +38,8 @@ def _extract_basic_macaroon(auth):
     except ValueError:
         return None
 
-    if auth_method != "@token" and auth_method != "$token":
+    # TODO: Remove @token as an acceptable token username.
+    if auth_method != "@token" and auth_method != "^token":
         return None
 
     return auth

--- a/warehouse/macaroons/auth_policy.py
+++ b/warehouse/macaroons/auth_policy.py
@@ -38,7 +38,7 @@ def _extract_basic_macaroon(auth):
     except ValueError:
         return None
 
-    if auth_method != "@token":
+    if auth_method != "@token" and auth_method != "$token":
         return None
 
     return auth

--- a/warehouse/macaroons/auth_policy.py
+++ b/warehouse/macaroons/auth_policy.py
@@ -39,7 +39,7 @@ def _extract_basic_macaroon(auth):
         return None
 
     # TODO: Remove @token as an acceptable token username (GH-6345)
-    if auth_method != "@token" and auth_method != "^token":
+    if auth_method != "@token" and auth_method != "__token__":
         return None
 
     return auth

--- a/warehouse/macaroons/services.py
+++ b/warehouse/macaroons/services.py
@@ -43,7 +43,7 @@ class DatabaseMacaroonService:
             return None
 
         prefix, split, raw_macaroon = prefixed_macaroon.partition("-")
-        # TODO: Remove ':' as an acceptable delimiter for tokens.
+        # TODO: Remove ':' as an acceptable delimiter for tokens (GH-6345)
         if prefix != "pypi" or not split:
             prefix, _, raw_macaroon = prefixed_macaroon.partition(":")
 

--- a/warehouse/macaroons/services.py
+++ b/warehouse/macaroons/services.py
@@ -43,6 +43,7 @@ class DatabaseMacaroonService:
             return None
 
         prefix, split, raw_macaroon = prefixed_macaroon.partition("-")
+        # TODO: Remove ':' as an acceptable delimiter for tokens.
         if prefix != "pypi" or not split:
             prefix, _, raw_macaroon = prefixed_macaroon.partition(":")
 

--- a/warehouse/macaroons/services.py
+++ b/warehouse/macaroons/services.py
@@ -31,7 +31,7 @@ class DatabaseMacaroonService:
     def __init__(self, db_session):
         self.db = db_session
 
-    def _extract_raw_macaroon(self, raw_macaroon):
+    def _extract_raw_macaroon(self, prefixed_macaroon):
         """
         Returns the base64-encoded macaroon component of a PyPI macaroon,
         dropping the prefix.
@@ -39,12 +39,12 @@ class DatabaseMacaroonService:
         Returns None if the macaroon is None, has no prefix, or has the
         wrong prefix.
         """
-        if raw_macaroon is None:
+        if prefixed_macaroon is None:
             return None
 
-        prefix, split, raw_macaroon = raw_macaroon.partition("-")
+        prefix, split, raw_macaroon = prefixed_macaroon.partition("-")
         if prefix != "pypi" or not split:
-            prefix, _, raw_macaroon = raw_macaroon.partition(":")
+            prefix, _, raw_macaroon = prefixed_macaroon.partition(":")
 
         if prefix != "pypi":
             return None

--- a/warehouse/macaroons/services.py
+++ b/warehouse/macaroons/services.py
@@ -42,10 +42,9 @@ class DatabaseMacaroonService:
         if raw_macaroon is None:
             return None
 
-        try:
-            prefix, raw_macaroon = raw_macaroon.split(":", 1)
-        except ValueError:
-            return None
+        prefix, split, raw_macaroon = raw_macaroon.partition("-")
+        if prefix != "pypi" or not split:
+            prefix, _, raw_macaroon = raw_macaroon.partition(":")
 
         if prefix != "pypi":
             return None
@@ -129,7 +128,7 @@ class DatabaseMacaroonService:
             version=pymacaroons.MACAROON_V2,
         )
         m.add_first_party_caveat(json.dumps(caveats))
-        serialized_macaroon = f"pypi:{m.serialize()}"
+        serialized_macaroon = f"pypi-{m.serialize()}"
         return serialized_macaroon, dm
 
     def delete_macaroon(self, macaroon_id):

--- a/warehouse/templates/pages/help.html
+++ b/warehouse/templates/pages/help.html
@@ -289,7 +289,7 @@
         <p>To use an API token:</p>
 
         <ul>
-          <li>Set your username to <code>@token</code></li>
+          <li>Set your username to <code>$token</code></li>
           <li>Set your password to the token value</li>
         </ul>
 

--- a/warehouse/templates/pages/help.html
+++ b/warehouse/templates/pages/help.html
@@ -289,8 +289,8 @@
         <p>To use an API token:</p>
 
         <ul>
-          <li>Set your username to <code>$token</code></li>
-          <li>Set your password to the token value</li>
+          <li>Set your username to <code>__token__</code></li>
+          <li>Set your password to the token value, including the <code>pypi-</code> prefix</li>
         </ul>
 
         <p>Where you edit or add these values will depend on your individual use case. For example, some users may need to edit <a href="https://packaging.python.org/guides/distributing-packages-using-setuptools/#create-an-account" title="External link" target="_blank" rel="noopener">their <code>.pypirc</code> file</a>, while others may need to update their CI configuration file (e.g. <a href="https://docs.travis-ci.com/user/deployment/pypi/" title="External link" target="_blank" rel="noopener"><code>travis.yml</code> if you are using Travis</a>).</p>


### PR DESCRIPTION
Changes the token username to `__token__` and the prefix to `pypi-`.

Preserves the original `@token` username and `pypi:` token prefix for backwards compatibility during the beta.

Closes #6287.