### PR TITLE
warehouse: Don't supply icon_url to WebAuthn

### DIFF
--- a/tests/unit/accounts/test_forms.py
+++ b/tests/unit/accounts/test_forms.py
@@ -615,7 +615,6 @@ class TestWebAuthnAuthenticationForm:
         user_service = pretend.stub()
         challenge = pretend.stub()
         origin = pretend.stub()
-        icon_url = pretend.stub()
         rp_id = pretend.stub()
 
         form = forms.WebAuthnAuthenticationForm(
@@ -623,7 +622,6 @@ class TestWebAuthnAuthenticationForm:
             user_service=user_service,
             challenge=challenge,
             origin=origin,
-            icon_url=icon_url,
             rp_id=rp_id,
         )
 
@@ -636,7 +634,6 @@ class TestWebAuthnAuthenticationForm:
             user_service=pretend.stub(),
             challenge=pretend.stub(),
             origin=pretend.stub(),
-            icon_url=pretend.stub(),
             rp_id=pretend.stub(),
         )
         assert not form.validate()
@@ -653,7 +650,6 @@ class TestWebAuthnAuthenticationForm:
             ),
             challenge=pretend.stub(),
             origin=pretend.stub(),
-            icon_url=pretend.stub(),
             rp_id=pretend.stub(),
         )
         assert not form.validate()
@@ -670,7 +666,6 @@ class TestWebAuthnAuthenticationForm:
             ),
             challenge=pretend.stub(),
             origin=pretend.stub(),
-            icon_url=pretend.stub(),
             rp_id=pretend.stub(),
         )
         assert form.validate()

--- a/tests/unit/accounts/test_services.py
+++ b/tests/unit/accounts/test_services.py
@@ -426,22 +426,15 @@ class TestDatabaseUserService:
         ]
 
     @pytest.mark.parametrize(
-        ("challenge", "rp_name", "rp_id", "icon_url"),
-        (
-            ["fake_challenge", "fake_rp_name", "fake_rp_id", "fake_icon_url"],
-            [None, None, None, None],
-        ),
+        ("challenge", "rp_name", "rp_id"),
+        (["fake_challenge", "fake_rp_name", "fake_rp_id"], [None, None, None]),
     )
     def test_get_webauthn_credential_options(
-        self, user_service, challenge, rp_name, rp_id, icon_url
+        self, user_service, challenge, rp_name, rp_id
     ):
         user = UserFactory.create()
         options = user_service.get_webauthn_credential_options(
-            user.id,
-            challenge=challenge,
-            rp_name=rp_name,
-            rp_id=rp_id,
-            icon_url=icon_url,
+            user.id, challenge=challenge, rp_name=rp_name, rp_id=rp_id
         )
 
         assert options["user"]["id"] == str(user.id)
@@ -450,11 +443,7 @@ class TestDatabaseUserService:
         assert options["challenge"] == challenge
         assert options["rp"]["name"] == rp_name
         assert options["rp"]["id"] == rp_id
-
-        if icon_url:
-            assert options["user"]["icon"] == icon_url
-        else:
-            assert "icon" not in options["user"]
+        assert "icon" not in options["user"]
 
     def test_get_webauthn_assertion_options(self, user_service):
         user = UserFactory.create()
@@ -467,10 +456,7 @@ class TestDatabaseUserService:
         )
 
         options = user_service.get_webauthn_assertion_options(
-            user.id,
-            challenge="fake_challenge",
-            icon_url="fake_icon_url",
-            rp_id="fake_rp_id",
+            user.id, challenge="fake_challenge", rp_id="fake_rp_id"
         )
 
         assert options["challenge"] == "fake_challenge"
@@ -550,7 +536,6 @@ class TestDatabaseUserService:
             pretend.stub(),
             challenge=pretend.stub(),
             origin=pretend.stub(),
-            icon_url=pretend.stub(),
             rp_id=pretend.stub(),
         )
         assert updated_sign_count == 2

--- a/tests/unit/manage/test_views.py
+++ b/tests/unit/manage/test_views.py
@@ -1138,12 +1138,7 @@ class TestProvisionWebAuthn:
                 get_webauthn_challenge=pretend.call_recorder(lambda: "fake_challenge")
             ),
             find_service=lambda *a, **kw: user_service,
-            registry=pretend.stub(
-                settings={
-                    "site.name": "fake_site_name",
-                    "warehouse.domain": "fake_domain",
-                }
-            ),
+            registry=pretend.stub(settings={"site.name": "fake_site_name"}),
             domain="fake_domain",
         )
 
@@ -1157,7 +1152,6 @@ class TestProvisionWebAuthn:
                 challenge="fake_challenge",
                 rp_name=request.registry.settings["site.name"],
                 rp_id=request.domain,
-                icon_url=request.registry.settings["warehouse.domain"],
             )
         ]
 

--- a/tests/unit/utils/test_webauthn.py
+++ b/tests/unit/utils/test_webauthn.py
@@ -80,12 +80,11 @@ def test_verify_assertion_response(monkeypatch):
         challenge="not_a_real_challenge",
         user=not_a_real_user,
         origin="fake_origin",
-        icon_url="fake_icon_url",
         rp_id="fake_rp_id",
     )
 
     assert get_webauthn_users.calls == [
-        pretend.call(not_a_real_user, icon_url="fake_icon_url", rp_id="fake_rp_id")
+        pretend.call(not_a_real_user, rp_id="fake_rp_id")
     ]
     assert assertion_cls.calls == [
         pretend.call(
@@ -117,6 +116,5 @@ def test_verify_assertion_response_failure(monkeypatch):
             challenge="not_a_real_challenge",
             user=pretend.stub(),
             origin="fake_origin",
-            icon_url="fake_icon_url",
             rp_id="fake_rp_id",
         )

--- a/warehouse/accounts/forms.py
+++ b/warehouse/accounts/forms.py
@@ -268,11 +268,10 @@ class TOTPAuthenticationForm(TOTPValueMixin, _TwoFactorAuthenticationForm):
 class WebAuthnAuthenticationForm(WebAuthnCredentialMixin, _TwoFactorAuthenticationForm):
     __params__ = ["credential"]
 
-    def __init__(self, *args, challenge, origin, icon_url, rp_id, **kwargs):
+    def __init__(self, *args, challenge, origin, rp_id, **kwargs):
         super().__init__(*args, **kwargs)
         self.challenge = challenge
         self.origin = origin
-        self.icon_url = icon_url
         self.rp_id = rp_id
 
     def validate_credential(self, field):
@@ -289,7 +288,6 @@ class WebAuthnAuthenticationForm(WebAuthnCredentialMixin, _TwoFactorAuthenticati
                 assertion_dict,
                 challenge=self.challenge,
                 origin=self.origin,
-                icon_url=self.icon_url,
                 rp_id=self.rp_id,
             )
 

--- a/warehouse/accounts/interfaces.py
+++ b/warehouse/accounts/interfaces.py
@@ -137,9 +137,7 @@ class IUserService(Interface):
         Returns None if the user already has this credential.
         """
 
-    def get_webauthn_credential_options(
-        user_id, *, challenge, rp_name, rp_id
-    ):
+    def get_webauthn_credential_options(user_id, *, challenge, rp_name, rp_id):
         """
         Returns a dictionary of credential options suitable for beginning the WebAuthn
         provisioning process for the given user.
@@ -160,9 +158,7 @@ class IUserService(Interface):
         webauthn.RegistrationRejectedException on failure.
         """
 
-    def verify_webauthn_assertion(
-        user_id, assertion, *, challenge, origin, rp_id
-    ):
+    def verify_webauthn_assertion(user_id, assertion, *, challenge, origin, rp_id):
         """
         Checks whether the given assertion was produced by the given user's WebAuthn
         device.

--- a/warehouse/accounts/interfaces.py
+++ b/warehouse/accounts/interfaces.py
@@ -138,14 +138,14 @@ class IUserService(Interface):
         """
 
     def get_webauthn_credential_options(
-        user_id, *, challenge, rp_name, rp_id, icon_url
+        user_id, *, challenge, rp_name, rp_id
     ):
         """
         Returns a dictionary of credential options suitable for beginning the WebAuthn
         provisioning process for the given user.
         """
 
-    def get_webauthn_assertion_options(user_id, *, challenge, icon_url, rp_id):
+    def get_webauthn_assertion_options(user_id, *, challenge, rp_id):
         """
         Returns a dictionary of assertion options suitable for beginning the WebAuthn
         authentication process for the given user.
@@ -161,7 +161,7 @@ class IUserService(Interface):
         """
 
     def verify_webauthn_assertion(
-        user_id, assertion, *, challenge, origin, icon_url, rp_id
+        user_id, assertion, *, challenge, origin, rp_id
     ):
         """
         Checks whether the given assertion was produced by the given user's WebAuthn

--- a/warehouse/accounts/services.py
+++ b/warehouse/accounts/services.py
@@ -328,7 +328,7 @@ class DatabaseUserService:
         return valid
 
     def get_webauthn_credential_options(
-        self, user_id, *, challenge, rp_name, rp_id, icon_url
+        self, user_id, *, challenge, rp_name, rp_id
     ):
         """
         Returns a dictionary of credential options suitable for beginning the WebAuthn
@@ -337,10 +337,10 @@ class DatabaseUserService:
         user = self.get_user(user_id)
 
         return webauthn.get_credential_options(
-            user, challenge=challenge, rp_name=rp_name, rp_id=rp_id, icon_url=icon_url
+            user, challenge=challenge, rp_name=rp_name, rp_id=rp_id
         )
 
-    def get_webauthn_assertion_options(self, user_id, *, challenge, icon_url, rp_id):
+    def get_webauthn_assertion_options(self, user_id, *, challenge, rp_id):
         """
         Returns a dictionary of assertion options suitable for beginning the WebAuthn
         authentication process for the given user.
@@ -348,7 +348,7 @@ class DatabaseUserService:
         user = self.get_user(user_id)
 
         return webauthn.get_assertion_options(
-            user, challenge=challenge, icon_url=icon_url, rp_id=rp_id
+            user, challenge=challenge, rp_id=rp_id
         )
 
     def verify_webauthn_credential(self, credential, *, challenge, rp_id, origin):
@@ -375,7 +375,7 @@ class DatabaseUserService:
         return validated_credential
 
     def verify_webauthn_assertion(
-        self, user_id, assertion, *, challenge, origin, icon_url, rp_id
+        self, user_id, assertion, *, challenge, origin, rp_id
     ):
         """
         Checks whether the given assertion was produced by the given user's WebAuthn
@@ -391,7 +391,6 @@ class DatabaseUserService:
             challenge=challenge,
             user=user,
             origin=origin,
-            icon_url=icon_url,
             rp_id=rp_id,
         )
 

--- a/warehouse/accounts/services.py
+++ b/warehouse/accounts/services.py
@@ -327,9 +327,7 @@ class DatabaseUserService:
 
         return valid
 
-    def get_webauthn_credential_options(
-        self, user_id, *, challenge, rp_name, rp_id
-    ):
+    def get_webauthn_credential_options(self, user_id, *, challenge, rp_name, rp_id):
         """
         Returns a dictionary of credential options suitable for beginning the WebAuthn
         provisioning process for the given user.
@@ -347,9 +345,7 @@ class DatabaseUserService:
         """
         user = self.get_user(user_id)
 
-        return webauthn.get_assertion_options(
-            user, challenge=challenge, rp_id=rp_id
-        )
+        return webauthn.get_assertion_options(user, challenge=challenge, rp_id=rp_id)
 
     def verify_webauthn_credential(self, credential, *, challenge, rp_id, origin):
         """
@@ -387,11 +383,7 @@ class DatabaseUserService:
         user = self.get_user(user_id)
 
         return webauthn.verify_assertion_response(
-            assertion,
-            challenge=challenge,
-            user=user,
-            origin=origin,
-            rp_id=rp_id,
+            assertion, challenge=challenge, user=user, origin=origin, rp_id=rp_id
         )
 
     def add_webauthn(self, user_id, **kwargs):

--- a/warehouse/accounts/views.py
+++ b/warehouse/accounts/views.py
@@ -252,9 +252,7 @@ def webauthn_authentication_options(request):
     userid = two_factor_data.get("userid")
     user_service = request.find_service(IUserService, context=None)
     return user_service.get_webauthn_assertion_options(
-        userid,
-        challenge=request.session.get_webauthn_challenge(),
-        rp_id=request.domain,
+        userid, challenge=request.session.get_webauthn_challenge(), rp_id=request.domain
     )
 
 

--- a/warehouse/accounts/views.py
+++ b/warehouse/accounts/views.py
@@ -254,7 +254,6 @@ def webauthn_authentication_options(request):
     return user_service.get_webauthn_assertion_options(
         userid,
         challenge=request.session.get_webauthn_challenge(),
-        icon_url=request.registry.settings.get("warehouse.domain", request.domain),
         rp_id=request.domain,
     )
 
@@ -288,7 +287,6 @@ def webauthn_authentication_validate(request):
         user_service=user_service,
         challenge=request.session.get_webauthn_challenge(),
         origin=request.host_url,
-        icon_url=request.registry.settings.get("warehouse.domain", request.domain),
         rp_id=request.domain,
     )
 

--- a/warehouse/manage/views.py
+++ b/warehouse/manage/views.py
@@ -474,9 +474,6 @@ class ProvisionWebAuthnViews:
             challenge=self.request.session.get_webauthn_challenge(),
             rp_name=self.request.registry.settings["site.name"],
             rp_id=self.request.domain,
-            icon_url=self.request.registry.settings.get(
-                "warehouse.domain", self.request.domain
-            ),
         )
 
     @view_config(

--- a/warehouse/static/js/warehouse/utils/webauthn.js
+++ b/warehouse/static/js/warehouse/utils/webauthn.js
@@ -206,6 +206,7 @@ export const ProvisionWebAuthn = () => {
 
       window.location.replace("/manage/account");
     }).catch((error) => {
+      console.log(credentialOptions);
       populateWebAuthnErrorList([error.message]);
       return;
     });

--- a/warehouse/static/js/warehouse/utils/webauthn.js
+++ b/warehouse/static/js/warehouse/utils/webauthn.js
@@ -206,7 +206,6 @@ export const ProvisionWebAuthn = () => {
 
       window.location.replace("/manage/account");
     }).catch((error) => {
-      console.log(credentialOptions);
       populateWebAuthnErrorList([error.message]);
       return;
     });

--- a/warehouse/utils/webauthn.py
+++ b/warehouse/utils/webauthn.py
@@ -32,7 +32,7 @@ class RegistrationRejectedException(Exception):
 WebAuthnCredential = pywebauthn.WebAuthnCredential
 
 
-def _get_webauthn_users(user, *, icon_url, rp_id):
+def _get_webauthn_users(user, *, rp_id):
     """
     Returns a webauthn.WebAuthnUser instance corresponding
     to the given user model, with properties suitable for
@@ -43,7 +43,7 @@ def _get_webauthn_users(user, *, icon_url, rp_id):
             str(user.id),
             user.username,
             user.name,
-            icon_url,
+            None,
             credential.credential_id,
             credential.public_key,
             credential.sign_count,
@@ -74,25 +74,25 @@ def generate_webauthn_challenge():
     return _webauthn_b64encode(os.urandom(32)).decode()
 
 
-def get_credential_options(user, *, challenge, rp_name, rp_id, icon_url):
+def get_credential_options(user, *, challenge, rp_name, rp_id):
     """
     Returns a dictionary of options for credential creation
     on the client side.
     """
     options = pywebauthn.WebAuthnMakeCredentialOptions(
-        challenge, rp_name, rp_id, str(user.id), user.username, user.name, icon_url
+        challenge, rp_name, rp_id, str(user.id), user.username, user.name, None
     )
 
     return options.registration_dict
 
 
-def get_assertion_options(user, *, challenge, icon_url, rp_id):
+def get_assertion_options(user, *, challenge, rp_id):
     """
     Returns a dictionary of options for assertion retrieval
     on the client side.
     """
     options = pywebauthn.WebAuthnAssertionOptions(
-        _get_webauthn_users(user, icon_url=icon_url, rp_id=rp_id), challenge
+        _get_webauthn_users(user, rp_id=rp_id), challenge
     )
 
     return options.assertion_dict
@@ -120,7 +120,7 @@ def verify_registration_response(response, challenge, *, rp_id, origin):
         raise RegistrationRejectedException(str(e))
 
 
-def verify_assertion_response(assertion, *, challenge, user, origin, icon_url, rp_id):
+def verify_assertion_response(assertion, *, challenge, user, origin, rp_id):
     """
     Validates the challenge and assertion information
     sent from the client during authentication.
@@ -128,7 +128,7 @@ def verify_assertion_response(assertion, *, challenge, user, origin, icon_url, r
     Returns an updated signage count on success.
     Raises AuthenticationRejectedException on failure.
     """
-    webauthn_users = _get_webauthn_users(user, icon_url=icon_url, rp_id=rp_id)
+    webauthn_users = _get_webauthn_users(user, rp_id=rp_id)
     cred_ids = [cred.credential_id for cred in webauthn_users]
     encoded_challenge = _webauthn_b64encode(challenge.encode()).decode()
 


### PR DESCRIPTION
We were previously supplying this with the base domain,
which was neither an image nor (necessarily) a secure context.

Fixes #6343 