### PR TITLE
Fix various issues related to vertical spacing

### DIFF
--- a/warehouse/static/sass/blocks/_form-group.scss
+++ b/warehouse/static/sass/blocks/_form-group.scss
@@ -30,13 +30,17 @@
   &__label {
     display: block;
     font-weight: bold;
-    margin-bottom: 7px;
+  }
+
+  &__label:not(:first-child) {
+    margin-top: 7px;
   }
 
   #{$all-text-inputs}.form-group__input,
   select.form-group__input {
     display: block;
     width: 350px;
+    margin-top: 4px;
     max-width: 100%;
   }
 

--- a/warehouse/templates/manage/release.html
+++ b/warehouse/templates/manage/release.html
@@ -110,8 +110,8 @@
     {% else %}
     <h3>No files found</h3>
     {% endif %}
-    <p>Learn how to upload files on the <a href="https://packaging.python.org/tutorials/distributing-packages/#uploading-your-project-to-pypi" title="External link" target="_blank" rel="noopener">Python Packaging User Guide</a></p>
     <button type="button" title="Dismiss" data-action="click->dismissable#dismiss" class="callout-block__dismiss" aria-label="close"><i class="fa fa-times" aria-hidden="true"></i></button>
+    <p>Learn how to upload files on the <a href="https://packaging.python.org/tutorials/distributing-packages/#uploading-your-project-to-pypi" title="External link" target="_blank" rel="noopener">Python Packaging User Guide</a></p>
   </div>
 
   <h3>Release settings</h3>

--- a/warehouse/templates/manage/releases.html
+++ b/warehouse/templates/manage/releases.html
@@ -96,7 +96,7 @@
     {% else %}
     <h3>No releases found</h3>
     {% endif %}
-    <p>Learn how to create a new release on the <a href="https://packaging.python.org/tutorials/distributing-packages/" title="External link" target="_blank" rel="noopener">Python Packaging User Guide</a></p>
     <button type="button" title="Dismiss" data-action="click->dismissable#dismiss" class="callout-block__dismiss" aria-label="close"><i class="fa fa-times" aria-hidden="true"></i></button>
+    <p>Learn how to create a new release on the <a href="https://packaging.python.org/tutorials/distributing-packages/" title="External link" target="_blank" rel="noopener">Python Packaging User Guide</a></p>
   </div>
 {% endblock %}

--- a/warehouse/templates/manage/roles.html
+++ b/warehouse/templates/manage/roles.html
@@ -21,6 +21,7 @@
   <h2>Collaborators</h2>
   <p class="lede-paragraph">Use this page to control which PyPI users can help you to manage {{ project.name }}</p>
   <div class="callout-block" data-controller="dismissable" data-dismissable-identifier="roles">
+    <button type="button" title="Dismiss" data-action="click->dismissable#dismiss" class="callout-block__dismiss" aria-label="close"><i class="fa fa-times" aria-hidden="true"></i></button>
     <p>There are two possible roles for collaborators:</p>
     <dl>
       <dt>Maintainer</dt>
@@ -28,7 +29,6 @@
       <dt>Owner</dt>
       <dd>Can upload releases. Can add other collaborators. Can delete files, releases, or the entire project.</dd>
     </dl>
-    <button type="button" title="Dismiss" data-action="click->dismissable#dismiss" class="callout-block__dismiss" aria-label="close"><i class="fa fa-times" aria-hidden="true"></i></button>
   </div>
   <table class="table table--light table--collaborators">
     <caption class="sr-only">Users who can manage {{ project.name }}</caption>


### PR DESCRIPTION
Partially fixes #6291 

form-group's screenshot
<img width="390" alt="Screen Shot 2019-08-05 at 2 05 17 PM" src="https://user-images.githubusercontent.com/7127939/62439989-74d88a80-b791-11e9-871d-3e962f0c1cf7.png">

The styling was actually correct for the alerts, however, the dismiss button was rendered as last element, hence the css selector of disabling padding didn't work. Rearranging the order of components fixes it.
<img width="805" alt="Screen Shot 2019-08-05 at 2 36 18 PM" src="https://user-images.githubusercontent.com/7127939/62440048-b5380880-b791-11e9-9f66-a9dc2d4c64fa.png">
<img width="799" alt="Screen Shot 2019-08-05 at 2 36 31 PM" src="https://user-images.githubusercontent.com/7127939/62440049-b5380880-b791-11e9-9b9d-4463a4ec0067.png">

Regarding the last point in the issue, the admin page uses external css library and doesn't seem to be appropriate to create a css/scss file just to fix that. Maybe worth opening an issue in the upstream library AdminLTE (https://github.com/ColorlibHQ/AdminLTE).