### PR TITLE
warehouse: Guard macaroon deserialization

### DIFF
--- a/warehouse/macaroons/services.py
+++ b/warehouse/macaroons/services.py
@@ -15,8 +15,8 @@ import json
 import uuid
 
 import pymacaroons
-from pymacaroons.exceptions import MacaroonDeserializationException
 
+from pymacaroons.exceptions import MacaroonDeserializationException
 from sqlalchemy.orm import joinedload
 from sqlalchemy.orm.exc import NoResultFound
 from zope.interface import implementer

--- a/warehouse/macaroons/services.py
+++ b/warehouse/macaroons/services.py
@@ -78,7 +78,11 @@ class DatabaseMacaroonService:
         if raw_macaroon is None:
             return None
 
-        m = pymacaroons.Macaroon.deserialize(raw_macaroon)
+        try:
+            m = pymacaroons.Macaroon.deserialize(raw_macaroon)
+        except pymacaroons.MacaroonDeserializationException:
+            return None
+
         dm = self.find_macaroon(m.identifier.decode())
 
         if dm is None:
@@ -97,7 +101,11 @@ class DatabaseMacaroonService:
         if raw_macaroon is None:
             raise InvalidMacaroon("malformed or nonexistent macaroon")
 
-        m = pymacaroons.Macaroon.deserialize(raw_macaroon)
+        try:
+            m = pymacaroons.Macaroon.deserialize(raw_macaroon)
+        except pymacaroons.MacaroonDeserializationException:
+            raise InvalidMacaroon("malformed macaroon")
+
         dm = self.find_macaroon(m.identifier.decode())
 
         if dm is None:

--- a/warehouse/macaroons/services.py
+++ b/warehouse/macaroons/services.py
@@ -15,6 +15,7 @@ import json
 import uuid
 
 import pymacaroons
+from pymacaroons.exceptions import MacaroonDeserializationException
 
 from sqlalchemy.orm import joinedload
 from sqlalchemy.orm.exc import NoResultFound
@@ -80,7 +81,7 @@ class DatabaseMacaroonService:
 
         try:
             m = pymacaroons.Macaroon.deserialize(raw_macaroon)
-        except pymacaroons.MacaroonDeserializationException:
+        except MacaroonDeserializationException:
             return None
 
         dm = self.find_macaroon(m.identifier.decode())
@@ -103,7 +104,7 @@ class DatabaseMacaroonService:
 
         try:
             m = pymacaroons.Macaroon.deserialize(raw_macaroon)
-        except pymacaroons.MacaroonDeserializationException:
+        except MacaroonDeserializationException:
             raise InvalidMacaroon("malformed macaroon")
 
         dm = self.find_macaroon(m.identifier.decode())


### PR DESCRIPTION
Guards calls to `Macaroon.deserialize`, preventing a malformed macaroon from causing an unexpected exception.
