### PR TITLE
warehouse: Avoid invalid button attribute for WebAuthn

### DIFF
--- a/warehouse/static/js/warehouse/utils/webauthn.js
+++ b/warehouse/static/js/warehouse/utils/webauthn.js
@@ -40,13 +40,8 @@ const doWebAuthn = (buttonId, func) => {
     return null;
   }
 
-  const csrfToken = webAuthnButton.getAttribute("csrf-token");
-  if (csrfToken === null) {
-    return;
-  }
-
   webAuthnButton.disabled = false;
-  webAuthnButton.addEventListener("click", async () => { func(csrfToken); });
+  webAuthnButton.addEventListener("click", async () => { func(webAuthnButton.value); });
 };
 
 const hexEncode = (buf) => {

--- a/warehouse/templates/accounts/two-factor.html
+++ b/warehouse/templates/accounts/two-factor.html
@@ -47,7 +47,7 @@
           type="button"
           id="webauthn-auth-begin"
           class="button button--primary"
-          csrf-token="{{ request.session.get_csrf_token() }}"
+          value="{{ request.session.get_csrf_token() }}"
           disabled>Authenticate with device
         </button>
         <ul id="webauthn-errors" class="form-errors form-errors--full-width margin-top--large">

--- a/warehouse/templates/manage/account/webauthn-provision.html
+++ b/warehouse/templates/manage/account/webauthn-provision.html
@@ -44,7 +44,7 @@
       type="button"
       id="webauthn-provision-begin"
       class="button button--primary"
-      csrf-token="{{ request.session.get_csrf_token() }}"
+      value="{{ request.session.get_csrf_token() }}"
       disabled>Set up security device
     </button>
     <ul id="webauthn-errors" class="form-errors margin-top--large">


### PR DESCRIPTION
Uses the `value` attribute to stash our CSRF token instead of the custom (and invalid) `csrf-token` attribute.

cc @nlhkabu 

closes #6387 