### PR TITLE
Normalize classifier IDs for HTML4 compatibility

### DIFF
--- a/tests/functional/test_templates.py
+++ b/tests/functional/test_templates.py
@@ -40,6 +40,7 @@ def test_templates_for_empty_titles():
             "format_rfc822_datetime": "warehouse.i18n.filters:format_rfc822_datetime",
             "format_number": "warehouse.i18n.filters:format_number",
             "format_classifiers": "warehouse.filters:format_classifiers",
+            "classifier_id": "warehouse.filters:classifier_id",
             "format_tags": "warehouse.filters:format_tags",
             "json": "warehouse.filters:tojson",
             "camoify": "warehouse.filters:camoify",

--- a/tests/unit/test_filters.py
+++ b/tests/unit/test_filters.py
@@ -153,6 +153,13 @@ def test_format_classifiers(inp, expected):
 
 
 @pytest.mark.parametrize(
+    ("inp", "expected"), [("Foo", "Foo"), ("Foo :: Foo", "Foo_._Foo")]
+)
+def test_classifier_id(inp, expected):
+    assert filters.classifier_id(inp) == expected
+
+
+@pytest.mark.parametrize(
     ("inp", "expected"),
     [
         (["abcdef", "ghijkl"], False),

--- a/warehouse/config.py
+++ b/warehouse/config.py
@@ -284,6 +284,7 @@ def configure(settings=None):
     # We'll want to configure some filters for Jinja2 as well.
     filters = config.get_settings().setdefault("jinja2.filters", {})
     filters.setdefault("format_classifiers", "warehouse.filters:format_classifiers")
+    filters.setdefault("classifier_id", "warehouse.filters:classifier_id")
     filters.setdefault("format_tags", "warehouse.filters:format_tags")
     filters.setdefault("json", "warehouse.filters:tojson")
     filters.setdefault("camoify", "warehouse.filters:camoify")

--- a/warehouse/filters.py
+++ b/warehouse/filters.py
@@ -144,6 +144,10 @@ def format_classifiers(classifiers):
     return structured
 
 
+def classifier_id(classifier):
+    return classifier.replace(" ", "_").replace("::", ".")
+
+
 def contains_valid_uris(items):
     """Returns boolean representing whether the input list contains any valid
     URIs

--- a/warehouse/templates/search/results.html
+++ b/warehouse/templates/search/results.html
@@ -58,8 +58,8 @@
   {% endif %}
   {% set id = level_id + ' :: ' + classifier %}
   <li>
-    <input name="c" type="checkbox" id="{{ id }}" class="-js-form-submit-trigger checkbox-tree__checkbox" value="{{ id }}" {{ 'checked' if id in applied_filters else '' }}>
-    <label class="checkbox-tree__label" for="{{ id }}">{{ classifier }}</label>
+    <input name="c" type="checkbox" id="{{ id|classifier_id }}" class="-js-form-submit-trigger checkbox-tree__checkbox" value="{{ id }}" {{ 'checked' if id in applied_filters else '' }}>
+    <label class="checkbox-tree__label" for="{{ id|classifier_id }}">{{ classifier }}</label>
     {%- if children %}
     <ul>{{ generate_classifier_tree(level_id, children, applied_filters, parent=classifier) }}</ul>
     {%- endif %}


### PR DESCRIPTION
Needs discussion on a few items:

* This normalizes spaces and `::`, but leaves in slashes, apostrophes and other potentially HTML4-invalid characters. I can't find a formal definition of the classifier format anywhere (PEP 301 mentions some basic constraints), so I didn't include them in this changeset (yet).
* If the classifier format isn't well specified or sufficiently constrained (e.g., allows for Unicode), then we might want to consider using (urlsafe) base64-encoded IDs. That would solve the normalization issues *and* avoid any potential duplication caused by the normalization process.
* HTML5 doesn't these constraints on the content of identifiers. If the plan is to make PyPI strictly HTML5, then it might not make sense to apply these changes at all.

Closes #6380.

cc @nlhkabu 