### PR TITLE
Make forms meet WCAG color contrast requirements

### DIFF
--- a/warehouse/static/sass/base/_forms.scss
+++ b/warehouse/static/sass/base/_forms.scss
@@ -22,7 +22,7 @@ select {
   padding: 0 8px;
   height: 40px;
   line-height: 37px;
-  border: 1px solid $border-color;
+  border: 1px solid $accessible-border-color;
   color: $text-color;
   vertical-align: middle;
   width: 250px;
@@ -38,8 +38,8 @@ select:active,
 input[type="checkbox"]:focus,
 input[type="checkbox"]:hover,
 input[type="checkbox"]:active {
-  box-shadow: inset 0 0 0 2px $primary-color-light;
-  border-color: $primary-color-light;
+  box-shadow: inset 0 0 0 1px $primary-color;
+  border-color: $primary-color;
   outline: none;
 }
 

--- a/warehouse/static/sass/blocks/_search-form.scss
+++ b/warehouse/static/sass/blocks/_search-form.scss
@@ -37,6 +37,7 @@
     display: inline;
     padding-right: 28px;
     min-width: auto;
+    border-color: $white;
   }
 
   &__button {

--- a/warehouse/static/sass/settings/_colours.scss
+++ b/warehouse/static/sass/settings/_colours.scss
@@ -30,6 +30,7 @@ $background-color:            #fdfdfd;
 $base-grey:                   #ececec;
 $light-grey:                  #bbb;
 $border-color:                darken($base-grey, 10);
+$accessible-border-color:     #949494;
 $text-color:                  #464646;
 $transparent-white:           transparentize($white, 0.6);
 


### PR DESCRIPTION
![Screenshot from 2019-08-16 07-42-31](https://user-images.githubusercontent.com/3323703/63148953-9e4bae80-bffa-11e9-8034-aa9c09978060.png)

As per https://webaim.org/resources/contrastchecker/ (Graphical Objects and User Interface Components)