### PR TITLE
Put "Security History" menu item in "Sentence case"

### DIFF
--- a/warehouse/templates/includes/manage/manage-project-menu.html
+++ b/warehouse/templates/includes/manage/manage-project-menu.html
@@ -28,7 +28,7 @@
     <li>
       <a href="{{ request.route_path('manage.project.history', project_name=project.normalized_name)}}" class="vertical-tabs__tab vertical-tabs__tab--with-icon {% if active_tab == 'history' %}vertical-tabs__tab--is-active{% endif %} {% if mode == 'mobile' %}vertical-tabs__tab--mobile{% endif %}">
         <i class="fa fa-history" aria-hidden="true"></i>
-        Security History
+        Security history
       </a>
     </li>
     <li>


### PR DESCRIPTION
The secondary navigation uses "Sentence case".

At https://test.pypi.org/manage/projects/:

![image](https://user-images.githubusercontent.com/1324225/63149272-47e76b80-c00c-11e9-98ff-b448fcbf07e5.png)

At https://test.pypi.org/project/MYPROJECT/:

![image](https://user-images.githubusercontent.com/1324225/63149314-63eb0d00-c00c-11e9-864e-4599355f3736.png)

---

However, the new "Security History" is in "Title Case".

At https://test.pypi.org/manage/project/MYPROJECT/history/:

![image](https://user-images.githubusercontent.com/1324225/63149252-3bfba980-c00c-11e9-9162-e8d34e02c160.png)

This PR changes it to match.
