### PR TITLE
Warehouse: Don't allow TOTP code reuse within a window

### DIFF
--- a/tests/unit/accounts/test_forms.py
+++ b/tests/unit/accounts/test_forms.py
@@ -588,10 +588,7 @@ class TestTOTPAuthenticationForm:
         form = forms.TOTPAuthenticationForm(
             data={"totp_value": "not_a_real_value"},
             user_id=pretend.stub(),
-            user_service=pretend.stub(
-                check_totp_value=lambda *a: True,
-                get_last_totp_value=lambda *a: None,
-            ),
+            user_service=pretend.stub(check_totp_value=lambda *a: True),
         )
         assert not form.validate()
         assert form.totp_value.errors.pop() == "TOTP code must be 6 digits."
@@ -599,10 +596,7 @@ class TestTOTPAuthenticationForm:
         form = forms.TOTPAuthenticationForm(
             data={"totp_value": "123456"},
             user_id=pretend.stub(),
-            user_service=pretend.stub(
-                check_totp_value=lambda *a: False,
-                get_last_totp_value=lambda *a: None,
-            ),
+            user_service=pretend.stub(check_totp_value=lambda *a: False),
         )
         assert not form.validate()
         assert form.totp_value.errors.pop() == "Invalid TOTP code."
@@ -610,21 +604,7 @@ class TestTOTPAuthenticationForm:
         form = forms.TOTPAuthenticationForm(
             data={"totp_value": "123456"},
             user_id=pretend.stub(),
-            user_service=pretend.stub(
-                check_totp_value=lambda *a: True,
-                get_last_totp_value=lambda *a: "123456",
-            ),
-        )
-        assert not form.validate()
-        assert form.totp_value.errors.pop() == "Reused TOTP code."
-
-        form = forms.TOTPAuthenticationForm(
-            data={"totp_value": "123456"},
-            user_id=pretend.stub(),
-            user_service=pretend.stub(
-                check_totp_value=lambda *a: True,
-                get_last_totp_value=lambda *a: None,
-            ),
+            user_service=pretend.stub(check_totp_value=lambda *a: True),
         )
         assert form.validate()
 

--- a/tests/unit/accounts/test_forms.py
+++ b/tests/unit/accounts/test_forms.py
@@ -588,7 +588,10 @@ class TestTOTPAuthenticationForm:
         form = forms.TOTPAuthenticationForm(
             data={"totp_value": "not_a_real_value"},
             user_id=pretend.stub(),
-            user_service=pretend.stub(check_totp_value=lambda *a: True),
+            user_service=pretend.stub(
+                check_totp_value=lambda *a: True,
+                get_last_totp_value=lambda *a: None,
+            ),
         )
         assert not form.validate()
         assert form.totp_value.errors.pop() == "TOTP code must be 6 digits."
@@ -596,7 +599,10 @@ class TestTOTPAuthenticationForm:
         form = forms.TOTPAuthenticationForm(
             data={"totp_value": "123456"},
             user_id=pretend.stub(),
-            user_service=pretend.stub(check_totp_value=lambda *a: False),
+            user_service=pretend.stub(
+                check_totp_value=lambda *a: False,
+                get_last_totp_value=lambda *a: None,
+            ),
         )
         assert not form.validate()
         assert form.totp_value.errors.pop() == "Invalid TOTP code."
@@ -604,7 +610,21 @@ class TestTOTPAuthenticationForm:
         form = forms.TOTPAuthenticationForm(
             data={"totp_value": "123456"},
             user_id=pretend.stub(),
-            user_service=pretend.stub(check_totp_value=lambda *a: True),
+            user_service=pretend.stub(
+                check_totp_value=lambda *a: True,
+                get_last_totp_value=lambda *a: "123456",
+            ),
+        )
+        assert not form.validate()
+        assert form.totp_value.errors.pop() == "Reused TOTP code."
+
+        form = forms.TOTPAuthenticationForm(
+            data={"totp_value": "123456"},
+            user_id=pretend.stub(),
+            user_service=pretend.stub(
+                check_totp_value=lambda *a: True,
+                get_last_totp_value=lambda *a: None,
+            ),
         )
         assert form.validate()
 

--- a/tests/unit/accounts/test_services.py
+++ b/tests/unit/accounts/test_services.py
@@ -377,16 +377,29 @@ class TestDatabaseUserService:
         user_service.update_user(user.id, last_totp_value="123456")
         assert user_service.get_last_totp_value(user.id) == "123456"
 
-    @pytest.mark.parametrize("valid", [True, False])
-    def test_check_totp_value(self, user_service, monkeypatch, valid):
+    @pytest.mark.parametrize(
+        ("last_totp_value", "valid"),
+        ([None, True], ["000000", True], ["000000", False]),
+    )
+    def test_check_totp_value(self, user_service, monkeypatch, last_totp_value, valid):
         verify_totp = pretend.call_recorder(lambda *a: valid)
         monkeypatch.setattr(otp, "verify_totp", verify_totp)
 
         user = UserFactory.create()
-        user_service.update_user(user.id, totp_secret=b"foobar")
+        user_service.update_user(
+            user.id, last_totp_value=last_totp_value, totp_secret=b"foobar"
+        )
         user_service.add_email(user.id, "foo@bar.com", primary=True, verified=True)
 
         assert user_service.check_totp_value(user.id, b"123456") == valid
+
+    def test_check_totp_value_reused(self, user_service):
+        user = UserFactory.create()
+        user_service.update_user(
+            user.id, last_totp_value="123456", totp_secret=b"foobar"
+        )
+
+        assert not user_service.check_totp_value(user.id, b"123456")
 
     def test_check_totp_value_no_secret(self, user_service):
         user = UserFactory.create()

--- a/tests/unit/accounts/test_services.py
+++ b/tests/unit/accounts/test_services.py
@@ -370,6 +370,13 @@ class TestDatabaseUserService:
         )
         assert user_service.has_webauthn(user.id)
 
+    def test_get_last_totp_value(self, user_service):
+        user = UserFactory.create()
+        assert user_service.get_last_totp_value(user.id) is None
+
+        user_service.update_user(user.id, last_totp_value="123456")
+        assert user_service.get_last_totp_value(user.id) == "123456"
+
     @pytest.mark.parametrize("valid", [True, False])
     def test_check_totp_value(self, user_service, monkeypatch, valid):
         verify_totp = pretend.call_recorder(lambda *a: valid)

--- a/warehouse/accounts/forms.py
+++ b/warehouse/accounts/forms.py
@@ -260,14 +260,10 @@ class _TwoFactorAuthenticationForm(forms.Form):
 
 class TOTPAuthenticationForm(TOTPValueMixin, _TwoFactorAuthenticationForm):
     def validate_totp_value(self, field):
-        last_totp_value = self.user_service.get_last_totp_value(self.user_id)
         totp_value = field.data.encode("utf8")
 
         if not self.user_service.check_totp_value(self.user_id, totp_value):
             raise wtforms.validators.ValidationError("Invalid TOTP code.")
-
-        if last_totp_value is not None and totp_value == last_totp_value.encode():
-            raise wtforms.validators.ValidationError("Reused TOTP code.")
 
 
 class WebAuthnAuthenticationForm(WebAuthnCredentialMixin, _TwoFactorAuthenticationForm):

--- a/warehouse/accounts/forms.py
+++ b/warehouse/accounts/forms.py
@@ -266,7 +266,7 @@ class TOTPAuthenticationForm(TOTPValueMixin, _TwoFactorAuthenticationForm):
         if not self.user_service.check_totp_value(self.user_id, totp_value):
             raise wtforms.validators.ValidationError("Invalid TOTP code.")
 
-        if last_totp_value is not None and totp_value == self.last_totp_value.encode():
+        if last_totp_value is not None and totp_value == last_totp_value.encode():
             raise wtforms.validators.ValidationError("Reused TOTP code.")
 
 

--- a/warehouse/accounts/forms.py
+++ b/warehouse/accounts/forms.py
@@ -260,9 +260,14 @@ class _TwoFactorAuthenticationForm(forms.Form):
 
 class TOTPAuthenticationForm(TOTPValueMixin, _TwoFactorAuthenticationForm):
     def validate_totp_value(self, field):
+        last_totp_value = self.user_service.get_last_totp_value(self.user_id)
         totp_value = field.data.encode("utf8")
+
         if not self.user_service.check_totp_value(self.user_id, totp_value):
             raise wtforms.validators.ValidationError("Invalid TOTP code.")
+
+        if last_totp_value is not None and totp_value == self.last_totp_value.encode():
+            raise wtforms.validators.ValidationError("Reused TOTP code.")
 
 
 class WebAuthnAuthenticationForm(WebAuthnCredentialMixin, _TwoFactorAuthenticationForm):

--- a/warehouse/accounts/models.py
+++ b/warehouse/accounts/models.py
@@ -83,6 +83,7 @@ class User(SitemapMixin, db.Model):
     )
 
     totp_secret = Column(Binary(length=20), nullable=True)
+    last_totp_value = Column(String, nullable=True)
 
     webauthn = orm.relationship(
         "WebAuthn", backref="user", cascade="all, delete-orphan", lazy=False

--- a/warehouse/accounts/services.py
+++ b/warehouse/accounts/services.py
@@ -321,6 +321,11 @@ class DatabaseUserService:
             self.ratelimiters["global"].hit()
             return False
 
+        last_totp_value = self.get_last_totp_value(user_id)
+
+        if last_totp_value is not None and totp_value == last_totp_value.encode():
+            return False
+
         valid = otp.verify_totp(totp_secret, totp_value)
 
         if valid:

--- a/warehouse/accounts/services.py
+++ b/warehouse/accounts/services.py
@@ -264,6 +264,17 @@ class DatabaseUserService:
 
         return user.totp_secret
 
+    def get_last_totp_value(self, user_id):
+        """
+        Returns the user's last (accepted) TOTP value.
+
+        If the user doesn't have a TOTP or hasn't used their TOTP
+        method, returns None.
+        """
+        user = self.get_user(user_id)
+
+        return user.last_totp_value
+
     def check_totp_value(self, user_id, totp_value, *, tags=None):
         """
         Returns True if the given TOTP is valid against the user's secret.

--- a/warehouse/accounts/views.py
+++ b/warehouse/accounts/views.py
@@ -215,6 +215,7 @@ def two_factor_and_totp_validate(request, _form_class=TOTPAuthenticationForm):
         form = two_factor_state["totp_form"]
         if form.validate():
             _login_user(request, userid, two_factor_method="totp")
+            user_service.update_user(userid, last_totp_value=form.totp_value.data)
 
             resp = HTTPSeeOther(redirect_to)
             resp.set_cookie(

--- a/warehouse/migrations/versions/34b18e18775c_add_last_totp_value_to_user.py
+++ b/warehouse/migrations/versions/34b18e18775c_add_last_totp_value_to_user.py
@@ -1,0 +1,33 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+add last totp value to user
+
+Revision ID: 34b18e18775c
+Revises: d83f20495c10
+Create Date: 2019-08-15 21:28:47.621282
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "34b18e18775c"
+down_revision = "d83f20495c10"
+
+
+def upgrade():
+    op.add_column("users", sa.Column("last_totp_value", sa.String(), nullable=True))
+
+
+def downgrade():
+    op.drop_column("users", "last_totp_value")

--- a/warehouse/migrations/versions/34b18e18775c_add_last_totp_value_to_user.py
+++ b/warehouse/migrations/versions/34b18e18775c_add_last_totp_value_to_user.py
@@ -13,7 +13,7 @@
 add last totp value to user
 
 Revision ID: 34b18e18775c
-Revises: d83f20495c10
+Revises: 0ac2f506ef2e
 Create Date: 2019-08-15 21:28:47.621282
 """
 
@@ -22,7 +22,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision = "34b18e18775c"
-down_revision = "d83f20495c10"
+down_revision = "0ac2f506ef2e"
 
 
 def upgrade():


### PR DESCRIPTION
Prevents a user from using a TOTP code more than once within its valid window.

cc @ewdurbin @di @dstufft 