### PR TITLE
Increase button contrast. Use 1px for borders/outlines.

### DIFF
--- a/warehouse/static/sass/blocks/_badge.scss
+++ b/warehouse/static/sass/blocks/_badge.scss
@@ -24,7 +24,7 @@
 .badge {
   font-size: $small-font-size;
   text-transform: uppercase;
-  border: 2px solid $primary-color;
+  border: 1px solid $primary-color;
   background-color: $primary-color;
   color: $white;
   padding: 0 7px;
@@ -39,7 +39,7 @@
   &:focus,
   &:active {
     border-color: $white;
-    outline: 2px solid $primary-color;
+    outline: 1px solid $primary-color;
   }
 
   &--success {
@@ -48,7 +48,7 @@
 
     &:focus,
     &:active {
-      outline: 2px solid $success-color;
+      outline: 1px solid $success-color;
     }
   }
 
@@ -58,7 +58,7 @@
 
     &:focus,
     &:active {
-      outline: 2px solid $danger-color;
+      outline: 1px solid $danger-color;
     }
   }
 
@@ -73,7 +73,7 @@
 
     &:focus,
     &:active {
-      outline: 2px solid $warning-color;
+      outline: 1px solid $warning-color;
     }
   }
 }

--- a/warehouse/static/sass/blocks/_button-group.scss
+++ b/warehouse/static/sass/blocks/_button-group.scss
@@ -40,7 +40,7 @@
   }
 
   .button-group__button + .button-group__button {
-    margin-left: -2px;
+    margin-left: -1px;
   }
 
   &__button:first-child {

--- a/warehouse/static/sass/blocks/_button.scss
+++ b/warehouse/static/sass/blocks/_button.scss
@@ -40,7 +40,7 @@
   background-color: transparent;
   color: lighten($text-color, 10);
   line-height: 19px;
-  border: 2px solid darken($base-grey, 10);
+  border: 1px solid $accessible-border-color;
   border-radius: 3px;
   display: inline-block;
   @include link-without-underline;
@@ -111,7 +111,7 @@
   &--disabled {
     cursor: not-allowed;
     background-color: darken($background-color, 5%);
-    border: 2px solid darken($background-color, 5%);
+    border-color: darken($background-color, 5%);
     color: darken($background-color, 12%);
     text-decoration: line-through;
     pointer-events: none;
@@ -120,14 +120,14 @@
     &:hover,
     &:active {
       background-color: darken($background-color, 5%);
-      border: 2px solid darken($background-color, 5%);
+      border-color: darken($background-color, 5%);
       color: darken($background-color, 12%);
       outline: none;
     }
   }
 
   &--switch-to-desktop {
-    border: 2px solid transparentize($white, 0.3);
+    border-color: transparentize($white, 0.3);
     color: $white;
     margin: $spacing-unit auto 0;
 

--- a/warehouse/static/sass/blocks/_notification-bar.scss
+++ b/warehouse/static/sass/blocks/_notification-bar.scss
@@ -111,6 +111,7 @@
 
   &__dismiss {
     @include dismiss-button;
+    @include link-focus-state($white);
   }
 
   // Indicates that a notification is dismissable.

--- a/warehouse/static/sass/blocks/_vertical-tabs.scss
+++ b/warehouse/static/sass/blocks/_vertical-tabs.scss
@@ -80,8 +80,8 @@
 
     &:active,
     &:focus {
-      outline: 2px solid $white;
-      box-shadow: 0 0 0 4px $primary-color;
+      outline: 1px solid $white;
+      box-shadow: 0 0 0 2px $primary-color;
     }
 
     &--mobile {

--- a/warehouse/static/sass/tools/_link-utilities.scss
+++ b/warehouse/static/sass/tools/_link-utilities.scss
@@ -15,7 +15,7 @@
 @mixin link-focus-state($color) {
   &:focus,
   &:active {
-    outline: 2px solid $color;
+    outline: 1px solid $color;
   }
 }
 


### PR DESCRIPTION
Closes #6466 

- Uses higher contrast color for grey buttons
- Reduces border with to 1px (the previous width of 2px looked too heavy with the darker border)

![Screenshot from 2019-08-20 07-26-07](https://user-images.githubusercontent.com/3323703/63322770-19bf9f80-c31c-11e9-9fd4-a6e7be77a507.png)
