### PR TITLE
Underline badges that are links

### DIFF
--- a/warehouse/static/sass/blocks/_badge.scss
+++ b/warehouse/static/sass/blocks/_badge.scss
@@ -77,3 +77,7 @@
     }
   }
 }
+
+a.badge {
+  text-decoration: underline;
+}


### PR DESCRIPTION
closes #6467 

![Screenshot from 2019-08-22 07-12-00](https://user-images.githubusercontent.com/3323703/63490341-5de1aa00-c4ac-11e9-95ed-ee183e4196ea.png)
