### PR TITLE
Expose email validation information in table

### DIFF
--- a/warehouse/static/sass/blocks/_table.scss
+++ b/warehouse/static/sass/blocks/_table.scss
@@ -505,6 +505,12 @@
       min-width: 160px;
     }
 
+    .table__status-detail {
+      display: inline-block;
+      font-size: $small-font-size;
+      margin-top: 5px;
+    }
+
     .table__action {
       width: 100px;
     }

--- a/warehouse/templates/manage/account.html
+++ b/warehouse/templates/manage/account.html
@@ -29,32 +29,43 @@
 {% macro email_verification_label(email) -%}
 {% if email.verified %}
   {% if email.transient_bounces %}
-  {% set message = "Intermittent delivery problems may lead to verification loss" %}
-  <span class="badge badge--warning tooltipped tooltipped-s" data-original-label="{{ message }}" aria-label="{{ message }}"><i class="fa fa-exclamation-triangle"></i> Verified</span>
+  <span class="badge badge--warning">
+    <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
+    Verified*
+  </span>
+  <span class="table__status-detail">*Intermittent delivery problems may lead to verification loss</span>
   {% else %}
   <span class="badge badge--success">
     <i class="fa fa-check" aria-hidden="true"></i>
     Verified
   </span>
   {% endif %}
-  {% else %}
-  {% set icon = 'exclamation-triangle' %}
+{% else %}
   {% if email.unverify_reason.value == "spam complaint" %}
-    {% set message = "Email from PyPI being treated as spam" %}
-    {% set icon = 'ban' %}
+  <span class="badge badge--danger">
+    <i class="fa fa-ban" aria-hidden="true"></i>
+    Unverified*
+  </span>
+  <span class="table__status-detail">*Email from PyPI being treated as spam</span>
   {% elif email.unverify_reason.value == "hard bounce" %}
-    {% set message = "Hard failure during delivery" %}
+  <span class="badge badge--danger">
+    <i class="fa fa-ban" aria-hidden="true"></i>
+    Unverified*
+  </span>
+  <span class="table__status-detail">*Hard failure during delivery</span>
   {% elif email.unverify_reason.value == "soft bounce" %}
-    {% set message = "Too many delivery problems" %}
+  <span class="badge badge--danger">
+    <i class="fa fa-ban" aria-hidden="true"></i>
+    Unverified*
+  </span>
+  <span class="table__status-detail">*Too many delivery problems</span>
   {% else %}
-    {% set message = "Verification in progress" %}
-    {% set icon = 'spinner' %}
-  {% endif %}
-  <span class="badge badge--danger tooltipped tooltipped-s" aria-label="{{ message }}" data-original-label="{{ message }}">
-    <i class="fa fa-{{ icon }}" aria-hidden="true"></i>
+  <span class="badge badge--danger">
+    <i class="fa fa-times" aria-hidden="true"></i>
     Unverified
   </span>
   {% endif %}
+{% endif %}
 {% endmacro %}
 
 {% macro email_row(email) -%}


### PR DESCRIPTION
Closes #6488 

Removes "status" information from tooltips and exposes it directly within the table:

![Screenshot from 2019-08-28 07-41-05](https://user-images.githubusercontent.com/3323703/63831904-916a7b80-c967-11e9-8c48-271763d5c44b.png)

![Screenshot from 2019-08-28 07-41-16](https://user-images.githubusercontent.com/3323703/63831946-a7783c00-c967-11e9-9711-a00711f93325.png)
