### PR TITLE
warehouse: Remove <form> on WebAuth provision

### DIFF
--- a/warehouse/static/js/warehouse/utils/webauthn.js
+++ b/warehouse/static/js/warehouse/utils/webauthn.js
@@ -205,6 +205,19 @@ export const ProvisionWebAuthn = () => {
       return;
     });
   });
+
+  const labelInput = document.getElementById("webauthn-provision-label");
+
+  if (labelInput === null) {
+    return;
+  }
+
+  labelInput.addEventListener("keyup", async (event) => {
+    if (event.keyCode === 13) {
+      event.preventDefault();
+      document.getElementById("webauthn-provision-begin").click();
+    }
+  });
 };
 
 export const AuthenticateWebAuthn = () => {

--- a/warehouse/static/js/warehouse/utils/webauthn.js
+++ b/warehouse/static/js/warehouse/utils/webauthn.js
@@ -205,19 +205,6 @@ export const ProvisionWebAuthn = () => {
       return;
     });
   });
-
-  const labelInput = document.getElementById("webauthn-provision-label");
-
-  if (labelInput === null) {
-    return;
-  }
-
-  labelInput.addEventListener("keyup", async (event) => {
-    if (event.keyCode === 13) {
-      event.preventDefault();
-      document.getElementById("webauthn-provision-begin").click();
-    }
-  });
 };
 
 export const AuthenticateWebAuthn = () => {

--- a/warehouse/templates/manage/account/webauthn-provision.html
+++ b/warehouse/templates/manage/account/webauthn-provision.html
@@ -33,30 +33,28 @@
   <p>Enable JavaScript to set up two factor authentication with a security device (e.g. USB key)</p>
 </noscript>
 
-<form>
-  <div class="form-group">
-    <label for="webauthn-provision-label" class="form-group__label">
-      Name your device to begin
-      <span class="form-group__required">(required)</span>
-    </label>
-    <input id="webauthn-provision-label" type="text" name="label" class="form-group__input" aria-describedby="webauthn-errors">
-    <p class="form-group__help-text">PyPI supports adding multiple security devices.<br>Please give this device a name. 64 characters or fewer. All Unicode is valid, including spaces.</p>
-    <ul id="webauthn-errors" class="form-errors margin-top--large">
-      <li id="webauthn-browser-support" class="hidden">
-        <a href="https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredential#Browser_compatibility" title="External link" target="_blank" rel="noopener">Upgrade your browser</a> to set up two factor authentication with a security device (e.g. USB key)
-      </li>
-    </ul>
-  </div>
-  <div>
-    <button
-      type="button"
-      id="webauthn-provision-begin"
-      class="button button--primary"
-      value="{{ request.session.get_csrf_token() }}"
-      disabled>Set up security device
-    </button>
-  </div>
-</form>
+<div class="form-group">
+  <label for="webauthn-provision-label" class="form-group__label">
+    Name your device to begin
+    <span class="form-group__required">(required)</span>
+  </label>
+  <input id="webauthn-provision-label" type="text" name="label" class="form-group__input" aria-describedby="webauthn-errors">
+  <p class="form-group__help-text">PyPI supports adding multiple security devices.<br>Please give this device a name. 64 characters or fewer. All Unicode is valid, including spaces.</p>
+  <ul id="webauthn-errors" class="form-errors margin-top--large">
+    <li id="webauthn-browser-support" class="hidden">
+      <a href="https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredential#Browser_compatibility" title="External link" target="_blank" rel="noopener">Upgrade your browser</a> to set up two factor authentication with a security device (e.g. USB key)
+    </li>
+  </ul>
+</div>
+<div>
+  <button
+    type="submit"
+    id="webauthn-provision-begin"
+    class="button button--primary"
+    value="{{ request.session.get_csrf_token() }}"
+    disabled>Set up security device
+  </button>
+</div>
 
 <br>
 


### PR DESCRIPTION
`<form>` was introduced in #6524, but was causing some weird routing when submitted via the return key rather than a direct button press (probably because `<form>` defaults to `GET`). It's also unfortunately still nonfunctional with `method="POST"`, since we still need to perform the relevant WebAuthn operations in JavaScript.


