### PR TITLE
Pin Hupper version to 1.7

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,3 +1,3 @@
-hupper==1.7
+hupper==1.7  # Pinned until https://github.com/Pylons/hupper/issues/54 is resolved
 pip-tools>=1.0
 pyramid_debugtoolbar>=2.5

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,3 +1,3 @@
-hupper>=0.4.0
+hupper==1.7
 pip-tools>=1.0
 pyramid_debugtoolbar>=2.5


### PR DESCRIPTION
Fixes #6578 

Hupper [introduced reloading pressing the Enter key on version 1.8](https://github.com/Pylons/hupper/blob/master/CHANGES.rst#18-2019-06-11) which does not work well with our Docker Compose dev environment.

This PR pins the version to 1.7 just before this change.