### PR TITLE
Add language switcher UI

### DIFF
--- a/warehouse/static/sass/blocks/_language-switcher.scss
+++ b/warehouse/static/sass/blocks/_language-switcher.scss
@@ -1,0 +1,69 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+  Language switcher found on the site footer.
+
+  <div class="language-switcher">
+    <ul>
+      <li><button type="button" class="language-swticher__selected">Selected language</button><li>
+      <li><button type="button">Other language</button></li>
+    </ul>
+  </div>
+*/
+
+.language-switcher {
+  background-color: lighten($primary-color, 1);
+  border-top: 1px solid darken($primary-color, 2);
+  color: $white;
+  padding: ($spacing-unit / 2) 0;
+  width: 100%;
+  text-align: center;
+  font-size: $small-font-size;
+
+  ul {
+    list-style-type: none;
+
+    li {
+      display: inline-block;
+      margin: 0 ($spacing-unit / 4);
+    }
+
+    button {
+      color: $white;
+      border: 0;
+      background-color: transparent;
+      padding: 0;
+      background-position: 0 1.3em;
+      background-repeat: repeat-x;
+      background-size: 100% 1.5px;
+      @include white-underlined-link;
+    }
+
+    button.language-switcher__selected {
+      pointer-events: none;
+      @include link-without-underline;
+
+      &:before {
+        font-family: "Font Awesome 5 Free";
+        font-weight: 900;
+        content: "\f105";
+        margin-right: 4px;
+        color: $white;
+        position: relative;
+        top: 0.5px;
+      }
+    }
+  }
+}

--- a/warehouse/static/sass/warehouse.scss
+++ b/warehouse/static/sass/warehouse.scss
@@ -88,6 +88,7 @@
 @import "blocks/homepage-banner";
 @import "blocks/horizontal-menu";
 @import "blocks/horizontal-section";
+@import "blocks/language-switcher";
 @import "blocks/large-input";
 @import "blocks/lede-paragraph";
 @import "blocks/mobile-search-bar";

--- a/warehouse/templates/base.html
+++ b/warehouse/templates/base.html
@@ -332,6 +332,14 @@
       </div>
     </footer>
 
+    <div class="language-switcher">
+      <ul>
+        <li><button type="button" class="language-switcher__selected">English</button></li>
+        <li><button type="button">Français</button></li>
+        <li><button type="button">中文</button></li>
+      </ul>
+    </div>
+
     {% include "warehouse:templates/includes/sponsors.html" %}
 
     {% endblock body %}


### PR DESCRIPTION
Closes #6455 

Adds a language switcher list in the PyPI footer:

![lang-switch](https://user-images.githubusercontent.com/3323703/64731069-5e33fa80-d4d8-11e9-947b-69ba79781b44.png)


Blocked by https://github.com/pypa/warehouse/pull/6535

@woodruffw I'm assigning this PR to you, as it's done on my side, and just needs to be hooked in as you see fit

Note: the language names should *not* be translated.