### PR TITLE
Fix typo in help.html

### DIFF
--- a/warehouse/templates/pages/help.html
+++ b/warehouse/templates/pages/help.html
@@ -86,7 +86,7 @@
 {% macro availability() %}{% trans %}Can I depend on PyPI being available?{% endtrans %}{% endmacro %}
 {% macro contributing() %}{% trans %}How can I contribute to PyPI?{% endtrans %}{% endmacro %}
 {% macro upcoming_changes() %}{% trans %}How do I keep up with upcoming changes to PyPI?{% endtrans %}{% endmacro %}
-{% macro beta_badge() %}{% trans %}What does the "beta feature" badge mean? What are Warehouse\'s current beta features?{% endtrans %}{% endmacro %}
+{% macro beta_badge() %}{% trans %}What does the "beta feature" badge mean? What are Warehouse's current beta features?{% endtrans %}{% endmacro %}
 {% macro pronunciation() %}{% trans %}How do I pronounce "PyPI"?{% endtrans %}{% endmacro %}
 
 {% block title %}{% trans %}Help{% endtrans %}{% endblock %}


### PR DESCRIPTION
Fixes a small typo in the help doc