### PR TITLE
Make tooltips accessible

### DIFF
--- a/warehouse/static/js/warehouse/index.js
+++ b/warehouse/static/js/warehouse/index.js
@@ -82,28 +82,30 @@ docReady(formUtils.registerFormValidation);
 
 docReady(Statuspage);
 
-// Copy handler for
+// Copy handler for copy tooltips, e.g.
 //   - the pip command on package detail page
 //   - the copy hash on package detail page
 //   - the copy hash on release maintainers page
 docReady(() => {
   let setCopiedTooltip = (e) => {
-    e.trigger.setAttribute("aria-label", "Copied!");
+    e.trigger.setAttribute("data-tooltip-label", "Copied!");
+    e.trigger.setAttribute("role", "alert");
     e.clearSelection();
   };
 
-  new Clipboard(".-js-copy-pip-command").on("success", setCopiedTooltip);
-  new Clipboard(".-js-copy-hash").on("success", setCopiedTooltip);
+  new Clipboard(".copy-tooltip").on("success", setCopiedTooltip);
 
   // Get all elements with class "tooltipped" and bind to focousout and
   // mouseout events. Change the "aria-label" to "original-label" attribute
   // value.
   let setOriginalLabel = (element) => {
-    element.setAttribute("aria-label", element.dataset.originalLabel);
+    element.setAttribute("data-tooltip-label", "Copy to clipboard");
+    element.removeAttribute("role");
+    element.blur();
   };
-  let tooltippedElems = Array.from(document.querySelectorAll(".tooltipped"));
+  let tooltippedElems = Array.from(document.querySelectorAll(".copy-tooltip"));
   tooltippedElems.forEach((element) => {
-    element.addEventListener("focousout",
+    element.addEventListener("focusout",
       setOriginalLabel.bind(undefined, element),
       false
     );

--- a/warehouse/static/sass/base/_typography.scss
+++ b/warehouse/static/sass/base/_typography.scss
@@ -113,7 +113,7 @@ a {
   @include primary-underlined-link;
 
   // Add 'external link' icon to most external links
-  &[target="_blank"]:not(.tooltipped):not(.sponsors__sponsor) {
+  &[target="_blank"]:not(.copy-tooltip):not(.sponsors__sponsor) {
     &::after {
       white-space: nowrap;
       font-size: 0.8rem;

--- a/warehouse/static/sass/blocks/_copy-tooltip.scss
+++ b/warehouse/static/sass/blocks/_copy-tooltip.scss
@@ -8,14 +8,14 @@ $tooltip-text-color: $white !default;
 $tooltip-delay: 0.4s !default;
 $tooltip-duration: 0.1s !default;
 
-.tooltipped {
+.copy-tooltip {
   position: relative;
   cursor: pointer;
 }
 
 // This is the tooltip bubble
-.tooltipped::after {
-  content: attr(aria-label);
+.copy-tooltip::after {
+  content: attr(data-tooltip-label);
   position: absolute;
   z-index: 1000000;
   display: none;
@@ -37,7 +37,7 @@ $tooltip-duration: 0.1s !default;
 }
 
 // This is the tooltip arrow
-.tooltipped::before {
+.copy-tooltip::before {
   position: absolute;
   z-index: 1000001;
   display: none;
@@ -62,10 +62,10 @@ $tooltip-duration: 0.1s !default;
 }
 
 // This will indicate when we'll activate the tooltip
-.tooltipped:hover,
-.tooltipped:active,
-.tooltipped:focus,
-.tooltipped-immediate {
+.copy-tooltip:hover,
+.copy-tooltip:active,
+.copy-tooltip:focus,
+.copy-tooltip-immediate {
   &::before,
   &::after {
     display: inline-block;
@@ -78,9 +78,9 @@ $tooltip-duration: 0.1s !default;
   }
 }
 
-.tooltipped-no-delay:hover,
-.tooltipped-no-delay:active,
-.tooltipped-no-delay:focus {
+.copy-tooltip-no-delay:hover,
+.copy-tooltip-no-delay:active,
+.copy-tooltip-no-delay:focus {
   &::before,
   &::after {
     opacity: 1;
@@ -88,18 +88,18 @@ $tooltip-duration: 0.1s !default;
   }
 }
 
-.tooltipped-multiline:hover,
-.tooltipped-multiline:active,
-.tooltipped-multiline:focus {
+.copy-tooltip-multiline:hover,
+.copy-tooltip-multiline:active,
+.copy-tooltip-multiline:focus {
   &::after {
     display: table-cell;
   }
 }
 
 // Tooltipped south
-.tooltipped-s,
-.tooltipped-se,
-.tooltipped-sw {
+.copy-tooltip-s,
+.copy-tooltip-se,
+.copy-tooltip-sw {
   &::after {
     top: 100%;
     right: 50%;
@@ -115,7 +115,7 @@ $tooltip-duration: 0.1s !default;
   }
 }
 
-.tooltipped-se {
+.copy-tooltip-se {
   &::after {
     right: auto;
     left: 50%;
@@ -123,14 +123,14 @@ $tooltip-duration: 0.1s !default;
   }
 }
 
-.tooltipped-sw::after {
+.copy-tooltip-sw::after {
   margin-right: -($spacing-unit / 2);
 }
 
 // Tooltips above the object
-.tooltipped-n,
-.tooltipped-ne,
-.tooltipped-nw {
+.copy-tooltip-n,
+.copy-tooltip-ne,
+.copy-tooltip-nw {
   &::after {
     right: 50%;
     bottom: 100%;
@@ -146,7 +146,7 @@ $tooltip-duration: 0.1s !default;
   }
 }
 
-.tooltipped-ne {
+.copy-tooltip-ne {
   &::after {
     right: auto;
     left: 50%;
@@ -154,18 +154,18 @@ $tooltip-duration: 0.1s !default;
   }
 }
 
-.tooltipped-nw::after {
+.copy-tooltip-nw::after {
   margin-right: -($spacing-unit / 2);
 }
 
 // Move the tooltip body to the center of the object.
-.tooltipped-s::after,
-.tooltipped-n::after {
+.copy-tooltip-s::after,
+.copy-tooltip-n::after {
   transform: translateX(50%);
 }
 
 // Tooltipped to the left
-.tooltipped-w {
+.copy-tooltip-w {
   &::after {
     right: 100%;
     bottom: 50%;
@@ -182,8 +182,8 @@ $tooltip-duration: 0.1s !default;
   }
 }
 
-// tooltipped to the right
-.tooltipped-e {
+// copy-tooltip to the right
+.copy-tooltip-e {
   &::after {
     bottom: 50%;
     left: 100%;

--- a/warehouse/static/sass/warehouse.scss
+++ b/warehouse/static/sass/warehouse.scss
@@ -75,6 +75,7 @@
 @import "blocks/callout-block";
 @import "blocks/centered-heading";
 @import "blocks/checkbox-tree";
+@import "blocks/copy-tooltip";
 @import "blocks/dark-overlay";
 @import "blocks/dropdown";
 @import "blocks/faq-group";
@@ -109,7 +110,6 @@
 @import "blocks/status-badge";
 @import "blocks/statistics-bar";
 @import "blocks/table";
-@import "blocks/tooltip";
 @import "blocks/totp-form";
 @import "blocks/twofa-login";
 @import "blocks/vertical-tabs";

--- a/warehouse/templates/accounts/register.html
+++ b/warehouse/templates/accounts/register.html
@@ -117,10 +117,7 @@
                   id="show-password" type="checkbox">&nbsp;{% trans %}Show passwords{% endtrans %}
               </label>
             </div>
-            {# the password field needs to be wrapped in a div to properly place tooltips #}
-            <div>
-              {{ form.new_password(placeholder=gettext("Select a password"), required="required", class_="form-group__input", autocomplete="new-password", spellcheck="false", data_target="password.password password-match.passwordMatch password-strength-gauge.password", data_action="input->password-match#checkPasswordsMatch input->password-strength-gauge#checkPasswordStrength", **{"aria-describedby":"password-errors password-strength"}) }}
-            </div>
+            {{ form.new_password(placeholder=gettext("Select a password"), required="required", class_="form-group__input", autocomplete="new-password", spellcheck="false", data_target="password.password password-match.passwordMatch password-strength-gauge.password", data_action="input->password-match#checkPasswordsMatch input->password-strength-gauge#checkPasswordStrength", **{"aria-describedby":"password-errors password-strength"}) }}
             <div id="password-errors">
               {% if form.new_password.errors %}
               <ul class="form-errors" role="alert">

--- a/warehouse/templates/accounts/reset-password.html
+++ b/warehouse/templates/accounts/reset-password.html
@@ -45,10 +45,7 @@
                 id="show-password" type="checkbox", tabindex="4">&nbsp;{% trans %}Show passwords{% endtrans %}
             </label>
           </div>
-          {# the password field needs to be wrapped in a div to properly place tooltips #}
-          <div>
-            {{ form.new_password(placeholder=gettext("Select a new password"), required="required", autocomplete="new-password", spellcheck="false", class_="form-group__input", data_target="password.password password-match.passwordMatch password-strength-gauge.password", data_action="input->password-match#checkPasswordsMatch input->password-strength-gauge#checkPasswordStrength", **{"aria-describedby":"password-errors password-strength"}) }}
-          </div>
+          {{ form.new_password(placeholder=gettext("Select a new password"), required="required", autocomplete="new-password", spellcheck="false", class_="form-group__input", data_target="password.password password-match.passwordMatch password-strength-gauge.password", data_action="input->password-match#checkPasswordsMatch input->password-strength-gauge#checkPasswordStrength", **{"aria-describedby":"password-errors password-strength"}) }}
           {% if form.new_password.errors %}
           <ul id="password-errors" class="form-errors" role="alert">
             {% for error in form.new_password.errors %}

--- a/warehouse/templates/includes/hash-modal.html
+++ b/warehouse/templates/includes/hash-modal.html
@@ -38,7 +38,7 @@
             <th scope="row">SHA256</th>
             <td><code>{{ file.sha256_digest }}</code></td>
             <td class="table__align-right">
-              <button type="button" class="button button--small -js-copy-hash tooltipped tooltipped-w" aria-label="{% trans %}Copy to clipboard{% endtrans %}" data-original-label="{% trans %}Copy to clipboard{% endtrans %}" data-clipboard-text="{{ file.sha256_digest }}">
+              <button type="button" class="button button--small copy-tooltip copy-tooltip-w" data-tooltip-label="{% trans %}Copy to clipboard{% endtrans %}" data-clipboard-text="{{ file.sha256_digest }}">
                 {% trans %}Copy{% endtrans %}
               </button>
             </td>
@@ -47,7 +47,7 @@
             <th scope="row">MD5</th>
             <td><code>{{ file.md5_digest }}</code></td>
             <td class="table__align-right">
-              <button type="button" class="button button--small -js-copy-hash tooltipped tooltipped-w" aria-label="{% trans %}Copy to clipboard{% endtrans %}" data-original-label="{% trans %}Copy to clipboard{% endtrans %}" data-clipboard-text="{{ file.md5_digest }}">
+              <button type="button" class="button button--small copy-tooltip copy-tooltip-w" data-tooltip-label="{% trans %}Copy to clipboard{% endtrans %}" data-clipboard-text="{{ file.md5_digest }}">
                 {% trans %}Copy{% endtrans %}
               </button>
             </td>
@@ -56,7 +56,7 @@
             <th scope="row">BLAKE2-256</th>
             <td><code>{{ file.blake2_256_digest }}</code></td>
             <td class="table__align-right">
-              <button type="button" class="button button--small -js-copy-hash tooltipped tooltipped-w" aria-label="{% trans %}Copy to clipboard{% endtrans %}" data-original-label="{% trans %}Copy to clipboard{% endtrans %}" data-clipboard-text="{{ file.blake2_256_digest }}">
+              <button type="button" class="button button--small copy-tooltip copy-tooltip-w" data-tooltip-label="{% trans %}Copy to clipboard{% endtrans %}" data-clipboard-text="{{ file.blake2_256_digest }}">
                 {% trans %}Copy{% endtrans %}
               </button>
             </td>

--- a/warehouse/templates/manage/account.html
+++ b/warehouse/templates/manage/account.html
@@ -228,7 +228,7 @@
           <div class="modal__body">
             <h3 class="modal__title">{% trans token_description=macaroon.description %}Unique identifier for API token "{{ token_description }}"{% endtrans %}</h3>
             <p><code>{{ macaroon.id }}</code></p>
-            <button type="button" class="button -js-copy-hash tooltipped tooltipped-e" aria-label="{% trans %}Copy to clipboard{% endtrans %}" data-original-label="{% trans %}Copy to clipboard{% endtrans %}" data-clipboard-text="{{ macaroon.id }}">
+            <button type="button" class="button copy-tooltip copy-tooltip-e" data-tooltip-label="{% trans %}Copy to clipboard{% endtrans %}" data-clipboard-text="{{ macaroon.id }}">
               {% trans %}Copy{% endtrans %}
             </button>
           </div>

--- a/warehouse/templates/manage/account/totp-provision.html
+++ b/warehouse/templates/manage/account/totp-provision.html
@@ -54,7 +54,7 @@
       <div class="totp-form__manual-code">
         <p>{% trans %}<strong>No QR scanner?</strong> Manually enter the code instead:{% endtrans %}
           <code>{{ provision_totp_secret }}</code>
-          <button type="button" class="button button--small -js-copy-hash tooltipped tooltipped-w" aria-label="{% trans %}Copy to clipboard{% endtrans %}" data-original-label="{% trans %}Copy to clipboard{% endtrans %}" data-clipboard-text="{{ provision_totp_secret }}">
+          <button type="button" class="button button--small copy-tooltip copy-tooltip-w" data-tooltip-label="{% trans %}Copy to clipboard{% endtrans %}" data-clipboard-text="{{ provision_totp_secret }}">
             {% trans %}Copy{% endtrans %}
           </button>
         </p>

--- a/warehouse/templates/manage/release.html
+++ b/warehouse/templates/manage/release.html
@@ -46,14 +46,7 @@
       <tr>
         <th scope="row">
           <span class="table__mobile-label">{% trans %}Filename, size{% endtrans %}</span>
-          <a href="{{ request.route_url('packaging.file', path=file.path) }}"
-            {% if file.comment_text %}
-              class="tooltipped tooltipped-e"
-              aria-label="{{ file.comment_text|truncate(60, True) }}"
-              data-original-label="{{ file.comment_text|truncate(60, True) }}"
-            {% endif %}
-            title="{% trans %}Download file{% endtrans %}">
-            {{ file.filename }}</a>
+          <a href="{{ request.route_url('packaging.file', path=file.path) }}">{{ file.filename }}</a>
           {% if file.size %}({{ file.size|filesizeformat() }}){% endif %}<br>
         </th>
         <td>

--- a/warehouse/templates/manage/token.html
+++ b/warehouse/templates/manage/token.html
@@ -43,7 +43,7 @@
       <div class="callout-block callout-block--danger no-top-margin">
         <p>{% trans %}For security reasons this token will only appear once. <strong>Copy it now.</strong>{% endtrans %}</p>
       </div>
-      <button type="button" class="button button--primary -js-copy-hash tooltipped tooltipped-e" aria-label="{% trans %}Copy token to clipboard{% endtrans %}" data-original-label="{% trans %}Copy token to clipboard{% endtrans %}" data-clipboard-text="{{ serialized_macaroon }}">
+      <button type="button" class="button button--primary copy-tooltip copy-tooltip-e" aria-label="{% trans %}Copy token to clipboard{% endtrans %}" data-tooltip-label="{% trans %}Copy token to clipboard{% endtrans %}" data-clipboard-text="{{ serialized_macaroon }}">
         {% trans %}Copy token{% endtrans %}
       </button>
       <a href="#remove-API-token--{{ macaroon.id }}" class="button">

--- a/warehouse/templates/packaging/detail.html
+++ b/warehouse/templates/packaging/detail.html
@@ -98,7 +98,7 @@
       {% if files %}
       <p class="package-header__pip-instructions">
         <span id="pip-command">{{ pip_command(release, request.matched_route.name, testPyPI) }}</span>
-        <button type="button" class="-js-copy-pip-command tooltipped tooltipped-s" data-clipboard-target="#pip-command" aria-label="{% trans %}Copy to clipboard{% endtrans %}" data-original-label="{% trans %}Copy to clipboard{% endtrans %}">
+        <button type="button" class="copy-tooltip copy-tooltip-s" data-clipboard-target="#pip-command" data-tooltip-label="{% trans %}Copy to clipboard{% endtrans %}">
           <i class="fa fa-copy" aria-hidden="true"></i>
           <span class="sr-only">{% trans %}Copy PIP instructions{% endtrans %}</span>
         </button>

--- a/warehouse/templates/pages/classifiers.html
+++ b/warehouse/templates/pages/classifiers.html
@@ -34,7 +34,7 @@
       <li>
         <a href="{{ request.route_path('search', _query={'c': classifier.classifier}) }}">{{ classifier.classifier }}</a>
         &nbsp;
-        <button type="button" class="button button--small margin-top margin-bottom -js-copy-hash tooltipped tooltipped-w" aria-label="{% trans %}Copy to clipboard{% endtrans %}" data-original-label="{% trans %}Copy to clipboard{% endtrans %}" data-clipboard-text="{{ classifier.classifier }}">
+        <button type="button" class="button button--small margin-top margin-bottom copy-tooltip copy-tooltip-w" data-tooltip-label="{% trans %}Copy to clipboard{% endtrans %}" data-clipboard-text="{{ classifier.classifier }}">
           {% trans %}Copy{% endtrans %}
         </button>
       </li>

--- a/warehouse/templates/search/results.html
+++ b/warehouse/templates/search/results.html
@@ -84,16 +84,8 @@
           <i class="fa fa-times" aria-hidden="true"></i>
         </button>
         <h2 class="no-top-padding">
-          {% set href = request.route_path('help') + '#trove-classifier' %}
-          {% set label = gettext("What's a trove classifier?") %}
-          {% trans trimmed href=href, aria_label=label, data_original_label=label, classes="tooltipped tooltipped-s" %}
-          Filter by
-          <a href="{{ href }}"
-             class="{{ classes }}"
-             aria-label="{{ aria_label }}"
-             data-original-label="{{ data_original_label }}">
-            classifier
-          </a>
+          {% trans trimmed href=request.route_path('classifiers') %}
+          Filter by <a href="{{ href }}">classifier</a>
           {% endtrans %}
         </h2>
         <form id="classifiers">


### PR DESCRIPTION
Closes #6480 

- Limit the use of tooltips to only 'copy' interactions
- Ensure updated text is announced to screen readers