### PR TITLE
Use the same message for "too many failed logins" error

### DIFF
--- a/warehouse/accounts/forms.py
+++ b/warehouse/accounts/forms.py
@@ -115,8 +115,8 @@ class PasswordMixin:
             except TooManyFailedLogins:
                 raise wtforms.validators.ValidationError(
                     _(
-                        "There have been too many unsuccessful login attempts, "
-                        "try again later."
+                        "There have been too many unsuccessful login attempts. "
+                        "Try again later."
                     )
                 ) from None
 

--- a/warehouse/accounts/views.py
+++ b/warehouse/accounts/views.py
@@ -57,7 +57,7 @@ USER_ID_INSECURE_COOKIE = "user_id__insecure"
 @view_config(context=TooManyFailedLogins)
 def failed_logins(exc, request):
     resp = HTTPTooManyRequests(
-        _("There have been too many unsuccessful login attempts. " "Try again later."),
+        _("There have been too many unsuccessful login attempts. Try again later."),
         retry_after=exc.resets_in.total_seconds(),
     )
 


### PR DESCRIPTION
These duplicated messages I've caught in Weblate and this PR aimed to reduce translators' work.
