### PR TITLE
Add Brazilian Portuguese support

### DIFF
--- a/warehouse/i18n/__init__.py
+++ b/warehouse/i18n/__init__.py
@@ -14,7 +14,8 @@ from babel.core import Locale
 from pyramid.i18n import TranslationStringFactory, default_locale_negotiator
 from pyramid.threadlocal import get_current_request
 
-KNOWN_LOCALES = {"en": "English"}
+KNOWN_LOCALES = {"en": "English",
+                 "pt_BR": "Brazilian Portugese"}
 
 LOCALE_ATTR = "_LOCALE_"
 

--- a/warehouse/i18n/__init__.py
+++ b/warehouse/i18n/__init__.py
@@ -14,7 +14,7 @@ from babel.core import Locale
 from pyramid.i18n import TranslationStringFactory, default_locale_negotiator
 from pyramid.threadlocal import get_current_request
 
-KNOWN_LOCALES = {"en": "English", "pt_BR": "Brazilian Portugese"}
+KNOWN_LOCALES = {"en": "English", "pt_BR": "Portuguese (Brazil)"}
 
 LOCALE_ATTR = "_LOCALE_"
 

--- a/warehouse/i18n/__init__.py
+++ b/warehouse/i18n/__init__.py
@@ -14,8 +14,7 @@ from babel.core import Locale
 from pyramid.i18n import TranslationStringFactory, default_locale_negotiator
 from pyramid.threadlocal import get_current_request
 
-KNOWN_LOCALES = {"en": "English",
-                 "pt_BR": "Brazilian Portugese"}
+KNOWN_LOCALES = {"en": "English", "pt_BR": "Brazilian Portugese"}
 
 LOCALE_ATTR = "_LOCALE_"
 

--- a/warehouse/templates/base.html
+++ b/warehouse/templates/base.html
@@ -327,8 +327,7 @@
       </div>
     </footer>
 
-    <!-- TODO: Remove this check once a non-English translation is available. -->
-    {% if KNOWN_LOCALES|length > 1 %}
+
     <div class="language-switcher">
       <form action="{{ request.route_path('locale') }}">
         <ul>
@@ -340,7 +339,7 @@
         </ul>
       </form>
     </div>
-    {% endif %}
+
 
     {% include "warehouse:templates/includes/sponsors.html" %}
 


### PR DESCRIPTION
We now have 100% string translation for Brazilian
Portugese via Weblate.

Fixes #6744.