### PR TITLE
Use `confirm_password_modal` in token API page deletion

### DIFF
--- a/warehouse/templates/manage/token.html
+++ b/warehouse/templates/manage/token.html
@@ -59,7 +59,7 @@
         <p>{% trans %}Applications or scripts using this token will no longer have access to PyPI.{% endtrans %}</p>
       {% endset %}
 
-      {{ confirm_modal(title=title, label=gettext("Username"), confirm_name="username", confirm_string=user.username, confirm_button_label=confirm_button_label, slug=slug, extra_fields=extra_fields, custom_warning_text=token_warning_text, confirm_string_in_title=False) }}
+      {{ confirm_password_modal(title=title, slug=slug, confirm_button_label=confirm_button_label, extra_fields=extra_fields, custom_warning_text=token_warning_text) }}
     </div>
 
     <h2>{% trans %}Using this token{% endtrans %}</h2>


### PR DESCRIPTION
Fixes https://github.com/pypa/warehouse/issues/6818

Turns out I'd missed the token API confirmation page when changing from requesting the username to requesting the password in a previous PR.

![delete_api_token_from_confirmation](https://user-images.githubusercontent.com/6739793/66719714-414a5a00-edeb-11e9-96ca-2c1f0fc8fd4c.gif)
