### PR TITLE
do not pass pybabel errors silently

### DIFF
--- a/babel.cfg
+++ b/babel.cfg
@@ -2,3 +2,4 @@
 [jinja2: **.html]
 encoding = utf-8
 extensions=jinja2.ext.autoescape,jinja2.ext.with_
+silent=False


### PR DESCRIPTION
As discovered in #6850, [pybabel was silently passing errors](https://github.com/pallets/jinja/blob/81b32242e5bdaa226bb8e4e7d67118d717fad005/jinja2/utils.py#L143-L145) accessing our custom jinja extension, leading to missed strings in our `messages.pot`.

This causes pybabel to bubble those errors up!