### PR TITLE
[WIP] Make i18n machinery opt-in on a per view basis

### DIFF
--- a/tests/functional/test_caching.py
+++ b/tests/functional/test_caching.py
@@ -16,4 +16,7 @@ import pytest
 @pytest.mark.parametrize("path", ["/"])
 def test_basic_views_dont_vary(webtest, path):
     resp = webtest.get(path)
-    assert resp.headers["Vary"] == "Accept-Encoding"
+    assert resp.headers["Vary"] in [
+        "Accept-Encoding, PyPI-Locale",
+        "PyPI-Locale, Accept-Encoding",
+    ]

--- a/tests/unit/cache/origin/test_derivers.py
+++ b/tests/unit/cache/origin/test_derivers.py
@@ -49,7 +49,7 @@ def test_no_origin_cache_found():
     assert request.add_response_callback.calls == []
 
 
-def test_response_hook(monkeypatch):
+def test_response_hook():
     class Cache:
         @staticmethod
         @pretend.call_recorder
@@ -70,16 +70,13 @@ def test_response_hook(monkeypatch):
     )
     info = pretend.stub(options={"renderer": pretend.stub(name="foo.html")})
     derived_view = derivers.html_cache_deriver(view, info)
-    add_vary_callback = pretend.call_recorder(lambda a: None)
-    monkeypatch.setattr(derivers, "add_vary_callback", add_vary_callback)
 
     assert derived_view(context, request) is response
     assert view.calls == [pretend.call(context, request)]
-    assert len(callbacks) == 2
+    assert len(callbacks) == 1
 
     callbacks[0](request, response)
 
     assert cacher.cache.calls == [
         pretend.call(["all-html", "foo.html"], request, response)
     ]
-    assert add_vary_callback.calls == [pretend.call("PyPI-Locale")]

--- a/tests/unit/test_policy.py
+++ b/tests/unit/test_policy.py
@@ -52,7 +52,12 @@ def test_add_policy_view(monkeypatch):
         pretend.call("policy.my-policy", "/policy/my-policy/")
     ]
     assert config.add_view.calls == [
-        pretend.call(md_view, route_name="policy.my-policy", renderer="policy.html")
+        pretend.call(
+            md_view,
+            route_name="policy.my-policy",
+            renderer="policy.html",
+            has_translations=True,
+        )
     ]
     assert markdown_view_factory.calls == [pretend.call(filename="mine.md")]
 

--- a/tests/unit/test_routes.py
+++ b/tests/unit/test_routes.py
@@ -81,6 +81,10 @@ def test_routes(warehouse):
         pretend.call("opensearch.xml", "/opensearch.xml", domain=warehouse),
         pretend.call("index.sitemap.xml", "/sitemap.xml", domain=warehouse),
         pretend.call("bucket.sitemap.xml", "/{bucket}.sitemap.xml", domain=warehouse),
+        pretend.call("sitemap", "/sitemap/", domain=warehouse),
+        pretend.call("help", "/help/", domain=warehouse),
+        pretend.call("security", "/security/", domain=warehouse),
+        pretend.call("sponsors", "/sponsors/", domain=warehouse),
         pretend.call(
             "includes.current-user-indicator",
             "/_includes/current-user-indicator/",
@@ -325,15 +329,6 @@ def test_routes(warehouse):
             domain=warehouse,
         ),
         pretend.call("legacy.docs", docs_route_url),
-    ]
-
-    assert config.add_template_view.calls == [
-        pretend.call("sitemap", "/sitemap/", "pages/sitemap.html"),
-        pretend.call("help", "/help/", "pages/help.html"),
-        pretend.call("security", "/security/", "pages/security.html"),
-        pretend.call(
-            "sponsors", "/sponsors/", "warehouse:templates/pages/sponsors.html"
-        ),
     ]
 
     assert config.add_redirect.calls == [

--- a/tests/unit/test_views.py
+++ b/tests/unit/test_views.py
@@ -28,6 +28,7 @@ from warehouse import views
 from warehouse.views import (
     classifiers,
     current_user_indicator,
+    faq,
     flash_messages,
     forbidden,
     forbidden_include,
@@ -39,8 +40,11 @@ from warehouse.views import (
     opensearchxml,
     robotstxt,
     search,
+    security,
     service_unavailable,
     session_notifications,
+    sitemap,
+    sponsors,
     stats,
 )
 
@@ -169,6 +173,26 @@ class TestServiceUnavailableView:
         assert resp.status_code == 503
         assert resp.content_type == "text/html"
         assert resp.body == b"A 503 Error"
+
+
+def test_sitemap(pyramid_request):
+    assert sitemap(pyramid_request) == {}
+    assert pyramid_request.response.content_type == "text/html"
+
+
+def test_help(pyramid_request):
+    assert faq(pyramid_request) == {}
+    assert pyramid_request.response.content_type == "text/html"
+
+
+def test_security(pyramid_request):
+    assert security(pyramid_request) == {}
+    assert pyramid_request.response.content_type == "text/html"
+
+
+def test_sponsors(pyramid_request):
+    assert sponsors(pyramid_request) == {}
+    assert pyramid_request.response.content_type == "text/html"
 
 
 def test_robotstxt(pyramid_request):

--- a/warehouse/accounts/views.py
+++ b/warehouse/accounts/views.py
@@ -246,6 +246,7 @@ def two_factor_and_totp_validate(request, _form_class=TOTPAuthenticationForm):
     request_method="GET",
     route_name="accounts.webauthn-authenticate.options",
     renderer="json",
+    has_translations=True,
 )
 def webauthn_authentication_options(request):
     if request.authenticated_userid is not None:
@@ -272,6 +273,7 @@ def webauthn_authentication_options(request):
     request_param=WebAuthnAuthenticationForm.__params__,
     route_name="accounts.webauthn-authenticate.validate",
     renderer="json",
+    has_translations=True,
 )
 def webauthn_authentication_validate(request):
     if request.authenticated_userid is not None:
@@ -470,6 +472,7 @@ def request_password_reset(request, _form_class=RequestPasswordResetForm):
     uses_session=True,
     require_csrf=True,
     require_methods=False,
+    has_translations=True,
 )
 def reset_password(request, _form_class=ResetPasswordForm):
     if request.authenticated_userid is not None:
@@ -549,7 +552,10 @@ def reset_password(request, _form_class=ResetPasswordForm):
 
 
 @view_config(
-    route_name="accounts.verify-email", uses_session=True, permission="manage:user"
+    route_name="accounts.verify-email",
+    uses_session=True,
+    permission="manage:user",
+    has_translations=True,
 )
 def verify_email(request):
     token_service = request.find_service(ITokenService, name="email")

--- a/warehouse/accounts/views.py
+++ b/warehouse/accounts/views.py
@@ -58,7 +58,7 @@ from warehouse.utils.http import is_safe_url
 USER_ID_INSECURE_COOKIE = "user_id__insecure"
 
 
-@view_config(context=TooManyFailedLogins)
+@view_config(context=TooManyFailedLogins, has_translations=True)
 def failed_logins(exc, request):
     resp = HTTPTooManyRequests(
         _("There have been too many unsuccessful login attempts. Try again later."),
@@ -80,6 +80,7 @@ def failed_logins(exc, request):
     decorator=[
         origin_cache(1 * 24 * 60 * 60, stale_if_error=1 * 24 * 60 * 60)  # 1 day each.
     ],
+    has_translations=True,
 )
 def profile(user, request):
     if user.username != request.matchdict.get("username", user.username):
@@ -102,6 +103,7 @@ def profile(user, request):
     uses_session=True,
     require_csrf=True,
     require_methods=False,
+    has_translations=True,
 )
 def login(request, redirect_field_name=REDIRECT_FIELD_NAME, _form_class=LoginForm):
     # TODO: Logging in should reset request.user
@@ -190,6 +192,7 @@ def login(request, redirect_field_name=REDIRECT_FIELD_NAME, _form_class=LoginFor
     uses_session=True,
     require_csrf=True,
     require_methods=False,
+    has_translations=True,
 )
 def two_factor_and_totp_validate(request, _form_class=TOTPAuthenticationForm):
     if request.authenticated_userid is not None:
@@ -377,6 +380,7 @@ def logout(request, redirect_field_name=REDIRECT_FIELD_NAME):
     uses_session=True,
     require_csrf=True,
     require_methods=False,
+    has_translations=True,
 )
 def register(request, _form_class=RegistrationForm):
     if request.authenticated_userid is not None:

--- a/warehouse/cache/origin/derivers.py
+++ b/warehouse/cache/origin/derivers.py
@@ -12,7 +12,6 @@
 
 import functools
 
-from warehouse.cache.http import add_vary_callback
 from warehouse.cache.origin.interfaces import IOriginCache
 
 
@@ -29,9 +28,6 @@ def html_cache_deriver(view, info):
                 request.add_response_callback(
                     functools.partial(cacher.cache, ["all-html", renderer.name])
                 )
-                # This is a custom header set in our VCL based on the _LOCALE_
-                # cookie value
-                request.add_response_callback(add_vary_callback("PyPI-Locale"))
 
             return view(context, request)
 

--- a/warehouse/i18n/__init__.py
+++ b/warehouse/i18n/__init__.py
@@ -16,6 +16,7 @@ from babel.core import Locale
 from pyramid import viewderivers
 from pyramid.i18n import TranslationStringFactory, default_locale_negotiator
 from pyramid.threadlocal import get_current_request
+
 from warehouse.cache.http import add_vary
 
 KNOWN_LOCALES = {

--- a/warehouse/i18n/__init__.py
+++ b/warehouse/i18n/__init__.py
@@ -10,9 +10,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import functools
+
 from babel.core import Locale
+from pyramid import viewderivers
 from pyramid.i18n import TranslationStringFactory, default_locale_negotiator
 from pyramid.threadlocal import get_current_request
+from warehouse.cache.http import add_vary
 
 KNOWN_LOCALES = {
     "en": "English",
@@ -83,6 +87,69 @@ def localize(message, **kwargs):
     return LazyString(_localize, message, **kwargs)
 
 
+class InvalidLocalizer:
+    def _fail(self):
+        raise RuntimeError("Cannot use localizer without has_translations=True")
+
+    @property
+    def locale_name(self):
+        self._fail()
+
+    def pluralize(self, *args, **kwargs):
+        self._fail()
+
+    def translate(self, *args, **kwargs):
+        self._fail()
+
+
+def translated_view(view, info):
+    if info.options.get("has_translations"):
+        # If this page can be translated, then we'll add a Vary: PyPI-Locale
+        #   Vary header.
+        # Note: This will give weird results if hitting PyPI directly instead of through
+        #       the Fastly VCL which sets PyPI-Locale.
+        return add_vary("PyPI-Locale")(view)
+    elif info.exception_only:
+        return view
+    else:
+        # If we're not using translations on this view, then we'll wrap the view
+        # with a wrapper that just ensures that the localizer cannot be used.
+        @functools.wraps(view)
+        def wrapped(context, request):
+            # This whole method is a little bit of an odd duck, we want to make
+            # sure that we don't actually *access* request.localizer, because
+            # doing so triggers the machinery to create a new localizer. So
+            # instead we will dig into the request object __dict__ to
+            # effectively do the same thing, just without triggering an access
+            # on request.localizer.
+
+            # Save the original session so that we can restore it once the
+            # inner views have been called.
+            nothing = object()
+            original_localizer = request.__dict__.get("localizer", nothing)
+
+            # This particular view hasn't been set to allow access to the
+            # translations, so we'll just assign an InvalidLocalizer to
+            # request.localizer
+            request.__dict__["localizer"] = InvalidLocalizer()
+
+            try:
+                # Invoke the real view
+                return view(context, request)
+            finally:
+                # Restore the original session so that things like
+                # pyramid_debugtoolbar can access it.
+                if original_localizer is nothing:
+                    del request.__dict__["localizer"]
+                else:
+                    request.__dict__["localizer"] = original_localizer
+
+        return wrapped
+
+
+translated_view.options = {"has_translations"}
+
+
 def includeme(config):
     # Add the request attributes
     config.add_request_method(_locale, name="locale", reify=True)
@@ -103,3 +170,7 @@ def includeme(config):
 
     jglobals = config.get_settings().setdefault("jinja2.globals", {})
     jglobals.setdefault("KNOWN_LOCALES", "warehouse.i18n:KNOWN_LOCALES")
+
+    config.add_view_deriver(
+        translated_view, over="rendered_view", under=viewderivers.INGRESS
+    )

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Warehouse VERSION\n"
 "Report-Msgid-Bugs-To: https://github.com/pypa/warehouse/issues/new\n"
-"POT-Creation-Date: 2019-10-16 11:27-0400\n"
+"POT-Creation-Date: 2019-10-17 13:29-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -90,93 +90,93 @@ msgstr ""
 msgid "No user found with that username or email"
 msgstr ""
 
-#: warehouse/accounts/views.py:201 warehouse/accounts/views.py:254
-#: warehouse/accounts/views.py:255 warehouse/accounts/views.py:280
-#: warehouse/accounts/views.py:281
+#: warehouse/accounts/views.py:204 warehouse/accounts/views.py:258
+#: warehouse/accounts/views.py:259 warehouse/accounts/views.py:285
+#: warehouse/accounts/views.py:286
 msgid "Invalid or expired two factor login."
 msgstr ""
 
-#: warehouse/accounts/views.py:249
+#: warehouse/accounts/views.py:253
 msgid "Already authenticated"
 msgstr ""
 
-#: warehouse/accounts/views.py:312
+#: warehouse/accounts/views.py:317
 msgid "Successful WebAuthn assertion"
 msgstr ""
 
-#: warehouse/accounts/views.py:391
+#: warehouse/accounts/views.py:397
 msgid ""
 "New user registration temporarily disabled. See https://pypi.org/help"
 "#admin-intervention for details."
 msgstr ""
 
-#: warehouse/accounts/views.py:486
+#: warehouse/accounts/views.py:493
 msgid "Expired token: request a new password reset link"
 msgstr ""
 
-#: warehouse/accounts/views.py:488
+#: warehouse/accounts/views.py:495
 msgid "Invalid token: request a new password reset link"
 msgstr ""
 
-#: warehouse/accounts/views.py:490 warehouse/accounts/views.py:565
+#: warehouse/accounts/views.py:497 warehouse/accounts/views.py:575
 msgid "Invalid token: no token supplied"
 msgstr ""
 
-#: warehouse/accounts/views.py:494
+#: warehouse/accounts/views.py:501
 msgid "Invalid token: not a password reset token"
 msgstr ""
 
-#: warehouse/accounts/views.py:499
+#: warehouse/accounts/views.py:506
 msgid "Invalid token: user not found"
 msgstr ""
 
-#: warehouse/accounts/views.py:506
+#: warehouse/accounts/views.py:513
 msgid "Invalid token: user has logged in since this token was requested"
 msgstr ""
 
-#: warehouse/accounts/views.py:513
+#: warehouse/accounts/views.py:520
 msgid ""
 "Invalid token: password has already been changed since this token was "
 "requested"
 msgstr ""
 
-#: warehouse/accounts/views.py:539
+#: warehouse/accounts/views.py:546
 msgid "You have reset your password"
 msgstr ""
 
-#: warehouse/accounts/views.py:561
+#: warehouse/accounts/views.py:571
 msgid "Expired token: request a new email verification link"
 msgstr ""
 
-#: warehouse/accounts/views.py:563
+#: warehouse/accounts/views.py:573
 msgid "Invalid token: request a new email verification link"
 msgstr ""
 
-#: warehouse/accounts/views.py:569
+#: warehouse/accounts/views.py:579
 msgid "Invalid token: not an email verification token"
 msgstr ""
 
-#: warehouse/accounts/views.py:578
+#: warehouse/accounts/views.py:588
 msgid "Email not found"
 msgstr ""
 
-#: warehouse/accounts/views.py:581
+#: warehouse/accounts/views.py:591
 msgid "Email already verified"
 msgstr ""
 
-#: warehouse/accounts/views.py:593
+#: warehouse/accounts/views.py:603
 msgid "You can now set this email as your primary address"
 msgstr ""
 
-#: warehouse/accounts/views.py:595
+#: warehouse/accounts/views.py:605
 msgid "This is your primary address"
 msgstr ""
 
-#: warehouse/accounts/views.py:600
+#: warehouse/accounts/views.py:610
 msgid "Email address ${email_address} verified. ${confirm_message}."
 msgstr ""
 
-#: warehouse/manage/views.py:169
+#: warehouse/manage/views.py:170
 msgid "Email ${email_address} added - check your email for a verification link"
 msgstr ""
 
@@ -712,7 +712,7 @@ msgstr ""
 #: warehouse/templates/accounts/profile.html:32
 #: warehouse/templates/accounts/register.html:89
 #: warehouse/templates/manage/account.html:269
-#: warehouse/templates/manage/roles.html:136
+#: warehouse/templates/manage/roles.html:140
 msgid "Username"
 msgstr ""
 
@@ -734,8 +734,8 @@ msgstr ""
 #: warehouse/templates/manage/account.html:404
 #: warehouse/templates/manage/account/totp-provision.html:69
 #: warehouse/templates/manage/account/webauthn-provision.html:44
-#: warehouse/templates/manage/roles.html:133
-#: warehouse/templates/manage/roles.html:145
+#: warehouse/templates/manage/roles.html:137
+#: warehouse/templates/manage/roles.html:149
 #: warehouse/templates/manage/token.html:123
 #: warehouse/templates/manage/token.html:140
 msgid "(required)"
@@ -1497,16 +1497,6 @@ msgstr ""
 msgid "Classifiers"
 msgstr ""
 
-#: warehouse/templates/legacy/api/simple/detail.html:17
-#: warehouse/templates/legacy/api/simple/detail.html:20
-#, python-format
-msgid "Links for %(project_name)s"
-msgstr ""
-
-#: warehouse/templates/legacy/api/simple/index.html:17
-msgid "Simple index"
-msgstr ""
-
 #: warehouse/templates/manage/account.html:33
 msgid "Verified*"
 msgstr ""
@@ -1789,7 +1779,7 @@ msgstr ""
 
 #: warehouse/templates/manage/account.html:442
 #: warehouse/templates/manage/account.html:457
-#: warehouse/templates/manage/roles.html:117
+#: warehouse/templates/manage/roles.html:121
 msgid "Remove"
 msgstr ""
 
@@ -2226,7 +2216,7 @@ msgstr ""
 #: warehouse/templates/manage/journal.html:37
 #: warehouse/templates/manage/journal.html:52
 #: warehouse/templates/manage/roles.html:37
-#: warehouse/templates/manage/roles.html:131
+#: warehouse/templates/manage/roles.html:135
 msgid "User"
 msgstr ""
 
@@ -2576,7 +2566,8 @@ msgid "There are two possible roles for collaborators:"
 msgstr ""
 
 #: warehouse/templates/manage/roles.html:27
-#: warehouse/templates/manage/roles.html:80
+#: warehouse/templates/manage/roles.html:73
+#: warehouse/templates/manage/roles.html:84
 msgid "Maintainer"
 msgstr ""
 
@@ -2588,7 +2579,8 @@ msgid ""
 msgstr ""
 
 #: warehouse/templates/manage/roles.html:29
-#: warehouse/templates/manage/roles.html:80
+#: warehouse/templates/manage/roles.html:71
+#: warehouse/templates/manage/roles.html:84
 msgid "Owner"
 msgstr ""
 
@@ -2605,30 +2597,30 @@ msgid "Users who can manage %(project_name)s"
 msgstr ""
 
 #: warehouse/templates/manage/roles.html:38
-#: warehouse/templates/manage/roles.html:78
-#: warehouse/templates/manage/roles.html:143
+#: warehouse/templates/manage/roles.html:82
+#: warehouse/templates/manage/roles.html:147
 msgid "Role"
 msgstr ""
 
-#: warehouse/templates/manage/roles.html:86
+#: warehouse/templates/manage/roles.html:90
 msgid "Save role"
 msgstr ""
 
-#: warehouse/templates/manage/roles.html:87
+#: warehouse/templates/manage/roles.html:91
 msgid "Save"
 msgstr ""
 
-#: warehouse/templates/manage/roles.html:111
+#: warehouse/templates/manage/roles.html:115
 msgid "Cannot remove yourself as owner"
 msgstr ""
 
-#: warehouse/templates/manage/roles.html:114
+#: warehouse/templates/manage/roles.html:118
 #, python-format
 msgid "Remove %(user)s from this project"
 msgstr ""
 
-#: warehouse/templates/manage/roles.html:126
-#: warehouse/templates/manage/roles.html:154
+#: warehouse/templates/manage/roles.html:130
+#: warehouse/templates/manage/roles.html:158
 msgid "Add collaborator"
 msgstr ""
 

--- a/warehouse/manage/views.py
+++ b/warehouse/manage/views.py
@@ -106,6 +106,7 @@ def user_projects(request):
     require_csrf=True,
     require_methods=False,
     permission="manage:user",
+    has_translations=True,
 )
 class ManageAccountViews:
     def __init__(self, request):
@@ -368,6 +369,7 @@ class ManageAccountViews:
     require_methods=False,
     permission="manage:user",
     http_cache=0,
+    has_translations=True,
 )
 class ProvisionTOTPViews:
     def __init__(self, request):
@@ -510,6 +512,7 @@ class ProvisionTOTPViews:
     require_methods=False,
     permission="manage:user",
     http_cache=0,
+    has_translations=True,
 )
 class ProvisionWebAuthnViews:
     def __init__(self, request):
@@ -620,6 +623,7 @@ class ProvisionWebAuthnViews:
     permission="manage:user",
     renderer="manage/token.html",
     route_name="manage.account.token",
+    has_translations=True,
 )
 class ProvisionMacaroonViews:
     def __init__(self, request):
@@ -760,6 +764,7 @@ class ProvisionMacaroonViews:
     renderer="manage/projects.html",
     uses_session=True,
     permission="manage:user",
+    has_translations=True,
 )
 def manage_projects(request):
     def _key(project):
@@ -788,6 +793,7 @@ def manage_projects(request):
     renderer="manage/settings.html",
     uses_session=True,
     permission="manage:project",
+    has_translations=True,
 )
 def manage_project_settings(project, request):
     return {"project": project}
@@ -799,6 +805,7 @@ def manage_project_settings(project, request):
     uses_session=True,
     require_methods=["POST"],
     permission="manage:project",
+    has_translations=True,
 )
 def delete_project(project, request):
     if request.flags.enabled(AdminFlagValue.DISALLOW_DELETION):
@@ -825,6 +832,7 @@ def delete_project(project, request):
     uses_session=True,
     require_methods=["POST"],
     permission="manage:project",
+    has_translations=True,
 )
 def destroy_project_docs(project, request):
     confirm_project(project, request, fail_route="manage.project.documentation")
@@ -843,6 +851,7 @@ def destroy_project_docs(project, request):
     renderer="manage/releases.html",
     uses_session=True,
     permission="manage:project",
+    has_translations=True,
 )
 def manage_project_releases(project, request):
     # Get the counts for all the files for this project, grouped by the
@@ -886,6 +895,7 @@ def manage_project_releases(project, request):
     require_csrf=True,
     require_methods=False,
     permission="manage:project",
+    has_translations=True,
 )
 class ManageProjectRelease:
     def __init__(self, release, request):
@@ -1060,6 +1070,7 @@ class ManageProjectRelease:
     uses_session=True,
     require_methods=False,
     permission="manage:project",
+    has_translations=True,
 )
 def manage_project_roles(project, request, _form_class=CreateRoleForm):
     user_service = request.find_service(IUserService, context=None)
@@ -1162,6 +1173,7 @@ def manage_project_roles(project, request, _form_class=CreateRoleForm):
     uses_session=True,
     require_methods=["POST"],
     permission="manage:project",
+    has_translations=True,
 )
 def change_project_role(project, request, _form_class=ChangeRoleForm):
     # TODO: This view was modified to handle deleting multiple roles for a
@@ -1265,6 +1277,7 @@ def change_project_role(project, request, _form_class=ChangeRoleForm):
     uses_session=True,
     require_methods=["POST"],
     permission="manage:project",
+    has_translations=True,
 )
 def delete_project_role(project, request):
     # TODO: This view was modified to handle deleting multiple roles for a
@@ -1317,6 +1330,7 @@ def delete_project_role(project, request):
     renderer="manage/history.html",
     uses_session=True,
     permission="manage:project",
+    has_translations=True,
 )
 def manage_project_history(project, request):
     try:
@@ -1350,6 +1364,7 @@ def manage_project_history(project, request):
     renderer="manage/journal.html",
     uses_session=True,
     permission="manage:project",
+    has_translations=True,
 )
 def manage_project_journal(project, request):
     try:
@@ -1383,6 +1398,7 @@ def manage_project_journal(project, request):
     renderer="manage/documentation.html",
     uses_session=True,
     permission="manage:project",
+    has_translations=True,
 )
 def manage_project_documentation(project, request):
     return {"project": project}

--- a/warehouse/packaging/views.py
+++ b/warehouse/packaging/views.py
@@ -29,6 +29,7 @@ from warehouse.utils import readme
             1 * 24 * 60 * 60, stale_if_error=5 * 24 * 60 * 60  # 1 day, 5 days stale
         )
     ],
+    has_translations=True,
 )
 def project_detail(project, request):
     if project.name != request.matchdict.get("name", project.name):
@@ -57,6 +58,7 @@ def project_detail(project, request):
             1 * 24 * 60 * 60, stale_if_error=5 * 24 * 60 * 60  # 1 day, 5 days stale
         )
     ],
+    has_translations=True,
 )
 def release_detail(release, request):
     project = release.project
@@ -133,6 +135,7 @@ def release_detail(release, request):
     renderer="includes/manage-project-button.html",
     uses_session=True,
     permission="manage:project",
+    has_translations=True,
 )
 def edit_project_button(project, request):
     return {"project": project}

--- a/warehouse/policy.py
+++ b/warehouse/policy.py
@@ -50,6 +50,7 @@ def add_policy_view(config, name, filename):
         markdown_view_factory(filename=filename),
         route_name="policy.{}".format(name),
         renderer="policy.html",
+        has_translations=True,
     )
 
 

--- a/warehouse/routes.py
+++ b/warehouse/routes.py
@@ -34,16 +34,10 @@ def includeme(config):
     config.add_route("bucket.sitemap.xml", "/{bucket}.sitemap.xml", domain=warehouse)
 
     # Some static, template driven pages
-    config.add_template_view("sitemap", "/sitemap/", "pages/sitemap.html")
-    config.add_template_view("help", "/help/", "pages/help.html")
-    config.add_template_view("security", "/security/", "pages/security.html")
-    config.add_template_view(
-        "sponsors",
-        "/sponsors/",
-        # Use the full resource path here to make it able to be overridden by
-        # pypi-theme.
-        "warehouse:templates/pages/sponsors.html",
-    )
+    config.add_route("sitemap", "/sitemap/", domain=warehouse)
+    config.add_route("help", "/help/", domain=warehouse)
+    config.add_route("security", "/security/", domain=warehouse)
+    config.add_route("sponsors", "/sponsors/", domain=warehouse)
 
     # Our legal policies
     config.add_policy("terms-of-use", "terms.md")

--- a/warehouse/templates/legacy/api/simple/detail.html
+++ b/warehouse/templates/legacy/api/simple/detail.html
@@ -14,10 +14,10 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>{% trans project_name=project.name %}Links for {{ project_name }}{% endtrans %}</title>
+    <title>Links for {{ project.name }}</title>
   </head>
   <body>
-    <h1>{% trans project_name=project.name %}Links for {{ project_name }}{% endtrans %}</h1>
+    <h1>Links for {{ project.name }}</h1>
     {% for file in files -%}
     <a href="{{ request.route_url('packaging.file', path=file.path) }}#sha256={{ file.sha256_digest }}"{% if file.release.requires_python %} data-requires-python="{{ file.release.requires_python }}"{% endif %}>{{ file.filename }}</a><br/>
     {% endfor -%}

--- a/warehouse/templates/legacy/api/simple/index.html
+++ b/warehouse/templates/legacy/api/simple/index.html
@@ -14,7 +14,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>{% trans %}Simple index{% endtrans %}</title>
+    <title>Simple index</title>
   </head>
   <body>
     {% for project in projects -%}

--- a/warehouse/templates/manage/roles.html
+++ b/warehouse/templates/manage/roles.html
@@ -67,7 +67,11 @@
         </th>
         <td>
         {% if role.user == request.user %}
-          {{ role.role_name }}
+          {% if role.role_name == "Owner" %}
+              {% trans %}Owner{% endtrans %}
+          {% elif role.role_name == "Maintainer" %}
+              {% trans %}Maintainer{% endtrans %}
+          {% endif %}
         {% else %}
           <form class="table__change-role" method="POST" action="{{ request.route_path('manage.project.change_role', project_name=project.name) }}">
             <input name="csrf_token" type="hidden" value="{{ request.session.get_csrf_token() }}">

--- a/warehouse/views.py
+++ b/warehouse/views.py
@@ -166,6 +166,7 @@ def opensearchxml(request):
             keys=["all-projects", "trending"],
         )
     ],
+    has_translations=True,
 )
 def index(request):
     project_ids = [

--- a/warehouse/views.py
+++ b/warehouse/views.py
@@ -10,6 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 import collections
 import re
 
@@ -119,6 +120,34 @@ def forbidden_include(exc, request):
 @view_config(context=DatabaseNotAvailable)
 def service_unavailable(exc, request):
     return httpexception_view(HTTPServiceUnavailable(), request)
+
+
+@view_config(route_name="sitemap", renderer="pages/sitemap.html", has_translations=True)
+def sitemap(request):
+    return {}
+
+
+@view_config(route_name="help", renderer="pages/help.html", has_translations=True)
+def faq(request):
+    return {}
+
+
+@view_config(
+    route_name="security", renderer="pages/security.html", has_translations=True
+)
+def security(request):
+    return {}
+
+
+@view_config(
+    route_name="sponsors",
+    # Use the full resource path here to make it able to be overridden by
+    # pypi-theme.
+    renderer="warehouse:templates/pages/sponsors.html",
+    has_translations=True,
+)
+def sponsors(request):
+    return {}
 
 
 @view_config(
@@ -251,7 +280,9 @@ def locale(request):
     return resp
 
 
-@view_config(route_name="classifiers", renderer="pages/classifiers.html")
+@view_config(
+    route_name="classifiers", renderer="pages/classifiers.html", has_translations=True
+)
 def classifiers(request):
     classifiers = (
         request.db.query(Classifier.classifier)
@@ -273,6 +304,7 @@ def classifiers(request):
             keys=["all-projects"],
         )
     ],
+    has_translations=True,
 )
 def search(request):
     metrics = request.find_service(IMetricsService, context=None)
@@ -396,6 +428,7 @@ def search(request):
             stale_if_error=1 * 24 * 60 * 60,  # 1 day
         ),
     ],
+    has_translations=True,
 )
 @view_config(
     route_name="stats.json",
@@ -433,6 +466,7 @@ def stats(request):
     route_name="includes.current-user-indicator",
     renderer="includes/current-user-indicator.html",
     uses_session=True,
+    has_translations=True,
 )
 def current_user_indicator(request):
     return {}
@@ -442,6 +476,7 @@ def current_user_indicator(request):
     route_name="includes.flash-messages",
     renderer="includes/flash-messages.html",
     uses_session=True,
+    has_translations=True,
 )
 def flash_messages(request):
     return {}
@@ -451,6 +486,7 @@ def flash_messages(request):
     route_name="includes.session-notifications",
     renderer="includes/session-notifications.html",
     uses_session=True,
+    has_translations=True,
 )
 def session_notifications(request):
     return {}


### PR DESCRIPTION
This is basically the exact same problem as with sessions, we need to know what responses will vary based on the locale or not-- so we'll use the same solution. We won't allow access to the ``request.localizer`` unless a view has been configured with ``has_translations=True``, and when it does, it will add a ``Vary: PyPI-Locale`` to the response.

This also removes translations from the ``/simple/`` index, as that's an API and not a UI page and thus shouldn't be translated.

TODO:
- [x] Revert the parts of https://github.com/pypa/warehouse/pull/6802 that add the ``PyPI-Locale`` header.
- [x] Audit the existing views and add ``has_translations=True`` to all of the ones that expect to be translated.
- [x] Edit the VCL to replace ``Vary: PyPI-Locale`` with ``Vary: Cookie``.
- [x] Write Tests.

