### PR TITLE
Increase default count for scan_iter to 1000

### DIFF
--- a/warehouse/legacy/api/xmlrpc/cache/fncache.py
+++ b/warehouse/legacy/api/xmlrpc/cache/fncache.py
@@ -76,7 +76,7 @@ class RedisLru(object):
 
     def purge(self, tag):
         try:
-            keys = self.conn.scan_iter(":".join([self.name, tag, "*"]))
+            keys = self.conn.scan_iter(":".join([self.name, tag, "*"]), count=1000)
             pipeline = self.conn.pipeline()
             for key in keys:
                 pipeline.delete(key)


### PR DESCRIPTION
Default for `SCAN` is 10.