### PR TITLE
add PEP 541 link

### DIFF
--- a/warehouse/templates/pages/help.html
+++ b/warehouse/templates/pages/help.html
@@ -465,7 +465,7 @@
         </ul>
 
         <h3 id="project-name-claim">{{ project_name_claim() }}</h3>
-        <p>{% trans href='', title=gettext('External link') %}Follow the <a href="{{ href }}" title="{{ title }}" target="_blank" rel="noopener">"How to request a name transfer"</a> section of <abbr title="Python enhancement proposal">PEP</abbr> 541.{% endtrans %}</p>
+        <p>{% trans href='https://www.python.org/dev/peps/pep-0541/#how-to-request-a-name-transfer', title=gettext('External link') %}Follow the <a href="{{ href }}" title="{{ title }}" target="_blank" rel="noopener">"How to request a name transfer"</a> section of <abbr title="Python enhancement proposal">PEP</abbr> 541.{% endtrans %}</p>
 
         <h3 id="collaborator-roles">{{ collaborator_roles() }}</h3>
         <p>{% trans %}There are two possible roles for collaborators:{% endtrans %}</p>


### PR DESCRIPTION
As documentation says:
> Follow the "How to request a name transfer" section of PEP 541.

add link for "How to request a name transfer" section of PEP 541.