### PR TITLE
Match RSS version with content, mark as 2.0

### DIFF
--- a/warehouse/templates/rss/base.xml
+++ b/warehouse/templates/rss/base.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE rss PUBLIC "-//Netscape Communications//DTD RSS 0.91//EN" "http://www.rssboard.org/rss-0.91.dtd">
-<rss version="0.91">
+<rss version="2.0">
   <channel>
     <title>{% block title %}{% endblock %}</title>
     <link>{% block channel_link %}{{ request.route_url('index') }}{% endblock %}</link>


### PR DESCRIPTION
Ref http://www.rssboard.org/rss-specification (and elsewhere).

While the unmodified files pass various "RSS validators" out there (including the W3C one), those validators apparently fail to actually validate the content per the DTD -- they would not validate, because they're using the 2.0, not 0.91 structure. For 2.0 there's no DTD, http://www.rssboard.org/convert-rss-0-91-to-rss-2-0