### PR TITLE
token revocation: disable autocomplete for hidden macaroon_id field

### DIFF
--- a/warehouse/templates/manage/account.html
+++ b/warehouse/templates/manage/account.html
@@ -208,7 +208,7 @@
       {% set action=request.route_path('manage.account.token') %}
       {% set confirm_button_label=gettext("Remove API token") %}
       {% set extra_fields %}
-        <input type="text" name="macaroon_id" value="{{ macaroon.id }}" autocomplete="off" hidden>
+        <input type="hidden" name="macaroon_id" value="{{ macaroon.id }}" autocomplete="off">
       {% endset %}
       {% set token_warning_text %}
         <p>{% trans %}Applications or scripts using this token will no longer have access to PyPI.{% endtrans %}</p>
@@ -460,7 +460,7 @@
               {% set action=request.route_path('manage.account.webauthn-provision.delete') %}
               {% set slug="disable-webauthn-" + credential.id | string %}
               {% set extra_fields %}
-                <input type="text" name="label" value="{{ credential.label }}" autocomplete="off" hidden>
+                <input type="hidden" name="label" value="{{ credential.label }}" autocomplete="off">
               {% endset %}
               {{ confirm_modal(title=title, label=gettext("Device name"), confirm_name="device_name", confirm_string=credential.label, confirm_button_label=confirm_button_label, slug=slug, extra_fields=extra_fields, action=action, warning=False, confirm_string_in_title=False) }}
             </td>

--- a/warehouse/templates/manage/account.html
+++ b/warehouse/templates/manage/account.html
@@ -208,7 +208,7 @@
       {% set action=request.route_path('manage.account.token') %}
       {% set confirm_button_label=gettext("Remove API token") %}
       {% set extra_fields %}
-        <input type="text" name="macaroon_id" value="{{ macaroon.id }}" hidden>
+        <input type="text" name="macaroon_id" value="{{ macaroon.id }}" autocomplete="off" hidden>
       {% endset %}
       {% set token_warning_text %}
         <p>{% trans %}Applications or scripts using this token will no longer have access to PyPI.{% endtrans %}</p>
@@ -460,7 +460,7 @@
               {% set action=request.route_path('manage.account.webauthn-provision.delete') %}
               {% set slug="disable-webauthn-" + credential.id | string %}
               {% set extra_fields %}
-                <input type="text" name="label" value="{{ credential.label }}" hidden>
+                <input type="text" name="label" value="{{ credential.label }}" autocomplete="off" hidden>
               {% endset %}
               {{ confirm_modal(title=title, label=gettext("Device name"), confirm_name="device_name", confirm_string=credential.label, confirm_button_label=confirm_button_label, slug=slug, extra_fields=extra_fields, action=action, warning=False, confirm_string_in_title=False) }}
             </td>

--- a/warehouse/templates/manage/token.html
+++ b/warehouse/templates/manage/token.html
@@ -53,7 +53,7 @@
       {% set title=gettext("Remove API token") + " - " + macaroon.description %}
       {% set confirm_button_label=gettext("Remove API token") %}
       {% set extra_fields %}
-        <input type="text" name="macaroon_id" value="{{ macaroon.id }}" hidden>
+        <input type="text" name="macaroon_id" value="{{ macaroon.id }}" autocomplete="off" hidden>
       {% endset %}
       {% set token_warning_text %}
         <p>{% trans %}Applications or scripts using this token will no longer have access to PyPI.{% endtrans %}</p>

--- a/warehouse/templates/manage/token.html
+++ b/warehouse/templates/manage/token.html
@@ -53,7 +53,7 @@
       {% set title=gettext("Remove API token") + " - " + macaroon.description %}
       {% set confirm_button_label=gettext("Remove API token") %}
       {% set extra_fields %}
-        <input type="text" name="macaroon_id" value="{{ macaroon.id }}" autocomplete="off" hidden>
+        <input type="hidden" name="macaroon_id" value="{{ macaroon.id }}" autocomplete="off">
       {% endset %}
       {% set token_warning_text %}
         <p>{% trans %}Applications or scripts using this token will no longer have access to PyPI.{% endtrans %}</p>


### PR DESCRIPTION
as discovered in #7143, some password managers are being overzealous and filling this input as the username.