### PR TITLE
Add project removal JournalEntrys for nuked users

### DIFF
--- a/warehouse/admin/views/users.py
+++ b/warehouse/admin/views/users.py
@@ -184,6 +184,15 @@ def user_delete(request):
             .subquery()
         )
     )
+    for project in projects:
+        request.db.add(
+            JournalEntry(
+                name=project.name,
+                action="remove project",
+                submitted_by=request.user,
+                submitted_from=request.remote_addr,
+            )
+        )
     projects.delete(synchronize_session=False)
 
     # Update all journals to point to `deleted-user` instead


### PR DESCRIPTION
Fixes #7154. 

We can't use `remove_project` here because that's designed to remove a single project, it's better to batch all the deletions with `projects.delete()`, so we'll just add all the necessary `JournalEntry`s here before deleting instead.