### PR TITLE
Add additional email validation

### DIFF
--- a/tests/unit/accounts/test_forms.py
+++ b/tests/unit/accounts/test_forms.py
@@ -299,9 +299,10 @@ class TestRegistrationForm:
         assert not form.validate()
         assert form.email.errors.pop() == "This field is required."
 
-    def test_invalid_email_error(self, pyramid_config):
+    @pytest.mark.parametrize("email", ["bad", "foo]bar@example.com"])
+    def test_invalid_email_error(self, pyramid_config, email):
         form = forms.RegistrationForm(
-            data={"email": "bad"},
+            data={"email": email},
             user_service=pretend.stub(
                 find_userid_by_email=pretend.call_recorder(lambda _: None)
             ),


### PR DESCRIPTION
We later try to turn the address into an `Address`, so we should do it as soon as possible in the validation of the form to determine whether it will fail later or not.

(Also moves the domain checking up earlier in the validation so we can bail out before needing to make an additional query).

