### PR TITLE
Multiple celery queues

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -2,5 +2,4 @@ release: bin/release
 web: bin/start-web python -m gunicorn.app.wsgiapp -c gunicorn.conf.py warehouse.wsgi:application
 web-uploads: bin/start-web python -m gunicorn.app.wsgiapp -c gunicorn-uploads.conf.py warehouse.wsgi:application
 worker: bin/start-worker celery -A warehouse worker -Q default -l info --max-tasks-per-child 32
-worker-malware: bin/start-worker celery -A warehouse worker -Q malware -l info --max-tasks-per-child 32
 worker-beat: bin/start-worker celery -A warehouse beat -S redbeat.RedBeatScheduler -l info

--- a/Procfile
+++ b/Procfile
@@ -1,5 +1,6 @@
 release: bin/release
 web: bin/start-web python -m gunicorn.app.wsgiapp -c gunicorn.conf.py warehouse.wsgi:application
 web-uploads: bin/start-web python -m gunicorn.app.wsgiapp -c gunicorn-uploads.conf.py warehouse.wsgi:application
-worker: bin/start-worker celery -A warehouse worker -l info --max-tasks-per-child 32
+worker: bin/start-worker celery -A warehouse worker -Q default -l info --max-tasks-per-child 32
+worker-malware: bin/start-worker celery -A warehouse worker -Q malware -l info --max-tasks-per-child 32
 worker-beat: bin/start-worker celery -A warehouse beat -S redbeat.RedBeatScheduler -l info

--- a/dev/environment
+++ b/dev/environment
@@ -7,7 +7,7 @@ WAREHOUSE_TOKEN=insecuretoken
 
 AWS_ACCESS_KEY_ID=foo
 AWS_SECRET_ACCESS_KEY=foo
-BROKER_URL=sqs://localstack:4576/warehouse-dev?region=us-east-1
+BROKER_URL=sqs://localstack:4576/?region=us-east-1&queue_name_prefix=warehouse-dev
 
 DATABASE_URL=postgresql://postgres@db/warehouse
 

--- a/tests/unit/test_tasks.py
+++ b/tests/unit/test_tasks.py
@@ -468,11 +468,8 @@ def test_includeme(env, ssl, broker_url, expected_url, transport_options):
         "task_serializer": "json",
         "accept_content": ["json", "msgpack"],
         "task_queue_ha_policy": "all",
-        "task_queues": (
-            Queue("default", routing_key="task.#"),
-            Queue("malware", routing_key="malware.#"),
-        ),
-        "task_routes": ([("warehouse.malware.tasks.*", {"queue": "malware"})]),
+        "task_queues": (Queue("default", routing_key="task.#"),),
+        "task_routes": ([]),
         "REDBEAT_REDIS_URL": (config.registry.settings["celery.scheduler_url"]),
     }.items():
         assert app.conf[key] == value

--- a/warehouse/tasks.py
+++ b/warehouse/tasks.py
@@ -21,6 +21,7 @@ import pyramid_retry
 import transaction
 import venusian
 
+from kombu import Queue
 from pyramid.threadlocal import get_current_request
 
 from warehouse.config import Environment
@@ -158,7 +159,6 @@ def _add_periodic_task(config, schedule, func, args=(), kwargs=(), name=None, **
 def includeme(config):
     s = config.registry.settings
 
-    queue_name = "celery"
     broker_transport_options = {}
 
     broker_url = s["celery.broker_url"]
@@ -169,8 +169,10 @@ def includeme(config):
         # so we'll just remove them from here.
         broker_url = urllib.parse.urlunparse(parsed_url[:2] + ("", "", "", ""))
 
-        if parsed_url.path:
-            queue_name = parsed_url.path[1:]
+        if "queue_name_prefix" in parsed_query:
+            broker_transport_options["queue_name_prefix"] = (
+                parsed_query["queue_name_prefix"][0] + "-"
+            )
 
         if "region" in parsed_query:
             broker_transport_options["region"] = parsed_query["region"][0]
@@ -183,8 +185,14 @@ def includeme(config):
         broker_url=broker_url,
         broker_use_ssl=s["warehouse.env"] == Environment.production,
         broker_transport_options=broker_transport_options,
-        task_default_queue=queue_name,
+        task_default_queue="default",
+        task_default_routing_key="task.default",
         task_queue_ha_policy="all",
+        task_queues=(
+            Queue("default", routing_key="task.#"),
+            Queue("malware", routing_key="malware.#"),
+        ),
+        task_routes=([("warehouse.malware.tasks.*", {"queue": "malware"})]),
         task_serializer="json",
         worker_disable_rate_limits=True,
         REDBEAT_REDIS_URL=s["celery.scheduler_url"],

--- a/warehouse/tasks.py
+++ b/warehouse/tasks.py
@@ -188,11 +188,8 @@ def includeme(config):
         task_default_queue="default",
         task_default_routing_key="task.default",
         task_queue_ha_policy="all",
-        task_queues=(
-            Queue("default", routing_key="task.#"),
-            Queue("malware", routing_key="malware.#"),
-        ),
-        task_routes=([("warehouse.malware.tasks.*", {"queue": "malware"})]),
+        task_queues=(Queue("default", routing_key="task.#"),),
+        task_routes=([]),
         task_serializer="json",
         worker_disable_rate_limits=True,
         REDBEAT_REDIS_URL=s["celery.scheduler_url"],


### PR DESCRIPTION
This enables us to add additional Celery queues, primarily in support of malware detection. Though it would also allow us to further separate various tasks as needed.

Adding a queue is effectively the reverse of https://github.com/pypa/warehouse/commit/d733bb053fd53c834ffc38f73ffcb930329742d2