### PR TITLE
Remove 'beta' badge for API tokens on account settings page

### DIFF
--- a/warehouse/templates/manage/account.html
+++ b/warehouse/templates/manage/account.html
@@ -483,7 +483,7 @@
   <hr>
 
   <section id="api-tokens">
-    <h2>{% trans %}API tokens{% endtrans %} <span class="badge badge--warning">{% trans %}Beta feature{% endtrans %}</span></h2>
+    <h2>{% trans %}API tokens{% endtrans %}</h2>
     <p>{% trans %}API tokens provide an alternative way to authenticate when uploading packages to PyPI.{% endtrans %} <a href="/help#apitoken">{% trans %}Learn more about API tokens{% endtrans %}</a>.</p>
 
     {% if user.macaroons|length > 0 %}


### PR DESCRIPTION
Hello! Just a quick PR getting rid of this-

![image](https://user-images.githubusercontent.com/1244307/72662718-677f2780-39e2-11ea-8279-1dd4a6bd504e.png)

This was declared as out-of-beta in https://github.com/pypa/warehouse/issues/5661#issuecomment-575779320