### PR TITLE
extend user account security history to show 90 days of events

### DIFF
--- a/tests/unit/accounts/test_models.py
+++ b/tests/unit/accounts/test_models.py
@@ -94,7 +94,7 @@ class TestUser:
             user=user,
             tag="bar",
             ip_address="0.0.0.0",
-            time=datetime.datetime.now() - datetime.timedelta(days=15),
+            time=datetime.datetime.now() - datetime.timedelta(days=91),
         )
 
         assert len(user.events) == 2

--- a/warehouse/accounts/models.py
+++ b/warehouse/accounts/models.py
@@ -141,10 +141,10 @@ class User(SitemapMixin, db.Model):
     @property
     def recent_events(self):
         session = orm.object_session(self)
-        last_fortnight = datetime.datetime.now() - datetime.timedelta(days=14)
+        last_ninety = datetime.datetime.now() - datetime.timedelta(days=90)
         return (
             session.query(UserEvent)
-            .filter((UserEvent.user_id == self.id) & (UserEvent.time >= last_fortnight))
+            .filter((UserEvent.user_id == self.id) & (UserEvent.time >= last_ninety))
             .order_by(UserEvent.time.desc())
             .all()
         )


### PR DESCRIPTION
Fourteen days is a bit short.