### PR TITLE
Implement scheduled checks #7093

### DIFF
--- a/tests/common/checks/scheduled.py
+++ b/tests/common/checks/scheduled.py
@@ -27,7 +27,7 @@ implementation of a scheduled check. This check will generate verdicts if enable
     def __init__(self, db):
         super().__init__(db)
 
-    def scan(self):
+    def scan(self, **kwargs):
         project = self.db.query(Project).first()
         self.add_verdict(
             project_id=project.id,

--- a/tests/common/checks/scheduled.py
+++ b/tests/common/checks/scheduled.py
@@ -31,7 +31,7 @@ implementation of a scheduled check. This check will generate verdicts if enable
         project = self.db.query(Project).first()
         self.add_verdict(
             project_id=project.id,
-            classification=VerdictClassification.benign,
+            classification=VerdictClassification.Benign,
             confidence=VerdictConfidence.High,
             message="Nothing to see here!",
         )

--- a/tests/unit/admin/test_routes.py
+++ b/tests/unit/admin/test_routes.py
@@ -133,8 +133,8 @@ def test_includeme():
             domain=warehouse,
         ),
         pretend.call(
-            "admin.checks.run_backfill",
-            "/admin/checks/{check_name}/run_backfill",
+            "admin.checks.run_evaluation",
+            "/admin/checks/{check_name}/run_evaluation",
             domain=warehouse,
         ),
         pretend.call("admin.verdicts.list", "/admin/verdicts/", domain=warehouse),

--- a/tests/unit/admin/views/test_checks.py
+++ b/tests/unit/admin/views/test_checks.py
@@ -47,6 +47,7 @@ class TestGetCheck:
             "check": check,
             "checks": [check],
             "states": MalwareCheckState,
+            "evaluation_run_size": 10000,
         }
 
     def test_get_check_many_versions(self, db_request):
@@ -57,6 +58,7 @@ class TestGetCheck:
             "check": check2,
             "checks": [check2, check1],
             "states": MalwareCheckState,
+            "evaluation_run_size": 10000,
         }
 
     def test_get_check_not_found(self, db_request):
@@ -196,7 +198,7 @@ class TestRunEvaluation:
             ]
             assert db_request.task.calls == [pretend.call(backfill)]
             assert backfill_recorder.delay.calls == [pretend.call(check.name, 10000)]
-        else:
+        elif check_type == MalwareCheckType.scheduled:
             assert db_request.session.flash.calls == [
                 pretend.call("Running %s now!" % check.name, queue="success",)
             ]
@@ -204,3 +206,5 @@ class TestRunEvaluation:
             assert backfill_recorder.delay.calls == [
                 pretend.call(check.name, manually_triggered=True)
             ]
+        else:
+            raise Exception("Invalid check type: %s" % check_type)

--- a/tests/unit/admin/views/test_checks.py
+++ b/tests/unit/admin/views/test_checks.py
@@ -16,7 +16,8 @@ import pytest
 from pyramid.httpexceptions import HTTPNotFound
 
 from warehouse.admin.views import checks as views
-from warehouse.malware.models import MalwareCheckState
+from warehouse.malware.models import MalwareCheckState, MalwareCheckType
+from warehouse.malware.tasks import backfill, run_check
 
 from ....common.db.malware import MalwareCheckFactory
 
@@ -129,7 +130,7 @@ class TestChangeCheckState:
         assert check.state == initial_state
 
 
-class TestRunBackfill:
+class TestRunEvaluation:
     @pytest.mark.parametrize(
         ("check_state", "message"),
         [
@@ -152,15 +153,21 @@ class TestRunBackfill:
         )
 
         db_request.route_path = pretend.call_recorder(
-            lambda *a, **kw: "/admin/checks/%s/run_backfill" % check.name
+            lambda *a, **kw: "/admin/checks/%s/run_evaluation" % check.name
         )
 
-        views.run_backfill(db_request)
+        views.run_evaluation(db_request)
 
         assert db_request.session.flash.calls == [pretend.call(message, queue="error")]
 
-    def test_sucess(self, db_request):
-        check = MalwareCheckFactory.create(state=MalwareCheckState.Enabled)
+    @pytest.mark.parametrize(
+        ("check_type"), [MalwareCheckType.EventHook, MalwareCheckType.Scheduled]
+    )
+    def test_success(self, db_request, check_type):
+
+        check = MalwareCheckFactory.create(
+            check_type=check_type, state=MalwareCheckState.Enabled
+        )
         db_request.matchdict["check_name"] = check.name
 
         db_request.session = pretend.stub(
@@ -168,7 +175,7 @@ class TestRunBackfill:
         )
 
         db_request.route_path = pretend.call_recorder(
-            lambda *a, **kw: "/admin/checks/%s/run_backfill" % check.name
+            lambda *a, **kw: "/admin/checks/%s/run_evaluation" % check.name
         )
 
         backfill_recorder = pretend.stub(
@@ -177,13 +184,23 @@ class TestRunBackfill:
 
         db_request.task = pretend.call_recorder(lambda *a, **kw: backfill_recorder)
 
-        views.run_backfill(db_request)
+        views.run_evaluation(db_request)
 
-        assert db_request.session.flash.calls == [
-            pretend.call(
-                "Running %s on 10000 %ss!" % (check.name, check.hooked_object.value),
-                queue="success",
-            )
-        ]
-
-        assert backfill_recorder.delay.calls == [pretend.call(check.name, 10000)]
+        if check_type == MalwareCheckType.EventHook:
+            assert db_request.session.flash.calls == [
+                pretend.call(
+                    "Running %s on 10000 %ss!"
+                    % (check.name, check.hooked_object.value),
+                    queue="success",
+                )
+            ]
+            assert db_request.task.calls == [pretend.call(backfill)]
+            assert backfill_recorder.delay.calls == [pretend.call(check.name, 10000)]
+        else:
+            assert db_request.session.flash.calls == [
+                pretend.call("Running %s now!" % check.name, queue="success",)
+            ]
+            assert db_request.task.calls == [pretend.call(run_check)]
+            assert backfill_recorder.delay.calls == [
+                pretend.call(check.name, manually_triggered=True)
+            ]

--- a/tests/unit/admin/views/test_checks.py
+++ b/tests/unit/admin/views/test_checks.py
@@ -138,11 +138,11 @@ class TestRunEvaluation:
         [
             (
                 MalwareCheckState.Disabled,
-                "Check must be in 'enabled' or 'evaluation' state to run a backfill.",
+                "Check must be in 'enabled' or 'evaluation' state to manually execute.",
             ),
             (
                 MalwareCheckState.WipedOut,
-                "Check must be in 'enabled' or 'evaluation' state to run a backfill.",
+                "Check must be in 'enabled' or 'evaluation' state to manually execute.",
             ),
         ],
     )
@@ -198,7 +198,7 @@ class TestRunEvaluation:
             ]
             assert db_request.task.calls == [pretend.call(backfill)]
             assert backfill_recorder.delay.calls == [pretend.call(check.name, 10000)]
-        elif check_type == MalwareCheckType.scheduled:
+        elif check_type == MalwareCheckType.Scheduled:
             assert db_request.session.flash.calls == [
                 pretend.call("Running %s now!" % check.name, queue="success",)
             ]

--- a/tests/unit/malware/test_init.py
+++ b/tests/unit/malware/test_init.py
@@ -14,9 +14,12 @@ from collections import defaultdict
 
 import pretend
 
+from celery.schedules import crontab
+
 from warehouse import malware
 from warehouse.malware import utils
 from warehouse.malware.interfaces import IMalwareCheckService
+from warehouse.malware.tasks import run_check
 
 from ...common import checks as test_checks
 from ...common.db.accounts import UserFactory
@@ -165,10 +168,17 @@ def test_includeme(monkeypatch):
         registry=pretend.stub(
             settings={"malware_check.backend": "TestMalwareCheckService"}
         ),
+        add_periodic_task=pretend.call_recorder(lambda *a, **kw: None),
     )
 
     malware.includeme(config)
 
     assert config.register_service_factory.calls == [
         pretend.call(malware_check_class.create_service, IMalwareCheckService)
+    ]
+
+    assert config.add_periodic_task.calls == [
+        pretend.call(
+            crontab(minute="0", hour="*/8"), run_check, args=("ExampleScheduledCheck",)
+        )
     ]

--- a/tests/unit/malware/test_tasks.py
+++ b/tests/unit/malware/test_tasks.py
@@ -150,9 +150,8 @@ class TestBackfill:
     )
     def test_run(self, db_session, num_objects, num_runs, monkeypatch):
         monkeypatch.setattr(tasks, "checks", test_checks)
-        files = []
         for i in range(num_objects):
-            files.append(FileFactory.create())
+            FileFactory.create()
 
         MalwareCheckFactory.create(
             name="ExampleHookedCheck", state=MalwareCheckState.Enabled
@@ -175,10 +174,7 @@ class TestBackfill:
             pretend.call("Running backfill on %d Files." % num_runs)
         ]
 
-        assert enqueue_recorder.delay.calls == [
-            pretend.call("ExampleHookedCheck", files[i].id, manually_triggered=True)
-            for i in range(num_runs)
-        ]
+        assert len(enqueue_recorder.delay.calls) == num_runs
 
 
 class TestSyncChecks:

--- a/tests/unit/malware/test_tasks.py
+++ b/tests/unit/malware/test_tasks.py
@@ -43,7 +43,7 @@ class TestRunCheck:
     def test_evaluation_run(self, db_session, monkeypatch, manually_triggered):
         monkeypatch.setattr(tasks, "checks", test_checks)
         MalwareCheckFactory.create(
-            name="ExampleScheduledCheck", state=MalwareCheckState.evaluation
+            name="ExampleScheduledCheck", state=MalwareCheckState.Evaluation
         )
         ProjectFactory.create()
         task = pretend.stub()

--- a/tests/unit/malware/test_tasks.py
+++ b/tests/unit/malware/test_tasks.py
@@ -85,10 +85,7 @@ manually triggered to run."
         file = FileFactory.create()
 
         tasks.run_check(
-            task,
-            request,
-            "ExampleHookedCheck",
-            obj_id=file.id,
+            task, request, "ExampleHookedCheck", obj_id=file.id,
         )
 
         assert request.log.info.calls == [

--- a/tests/unit/malware/test_tasks.py
+++ b/tests/unit/malware/test_tasks.py
@@ -14,8 +14,6 @@ import celery
 import pretend
 import pytest
 
-from sqlalchemy.orm.exc import NoResultFound
-
 from warehouse.malware import tasks
 from warehouse.malware.models import MalwareCheck, MalwareCheckState, MalwareVerdict
 
@@ -34,45 +32,89 @@ class TestRunCheck:
             name="ExampleHookedCheck", state=MalwareCheckState.Enabled
         )
         task = pretend.stub()
-        tasks.run_check(task, db_request, "ExampleHookedCheck", file0.id)
+        tasks.run_check(task, db_request, "ExampleHookedCheck", obj_id=file0.id)
 
         assert db_request.route_url.calls == [
             pretend.call("packaging.file", path=file0.path)
         ]
         assert db_request.db.query(MalwareVerdict).one()
 
-    def test_disabled_check(self, db_request, monkeypatch):
+    @pytest.mark.parametrize(("manually_triggered"), [True, False])
+    def test_evaluation_run(self, db_session, monkeypatch, manually_triggered):
+        monkeypatch.setattr(tasks, "checks", test_checks)
+        MalwareCheckFactory.create(
+            name="ExampleScheduledCheck", state=MalwareCheckState.evaluation
+        )
+        ProjectFactory.create()
+        task = pretend.stub()
+
+        request = pretend.stub(
+            db=db_session,
+            log=pretend.stub(info=pretend.call_recorder(lambda *args, **kwargs: None)),
+        )
+
+        tasks.run_check(
+            task,
+            request,
+            "ExampleScheduledCheck",
+            manually_triggered=manually_triggered,
+        )
+
+        if manually_triggered:
+            assert db_session.query(MalwareVerdict).one()
+        else:
+            assert request.log.info.calls == [
+                pretend.call(
+                    "ExampleScheduledCheck is in the `evaluation` state and must be \
+manually triggered to run."
+                )
+            ]
+            assert db_session.query(MalwareVerdict).all() == []
+
+    def test_disabled_check(self, db_session, monkeypatch):
         monkeypatch.setattr(tasks, "checks", test_checks)
         MalwareCheckFactory.create(
             name="ExampleHookedCheck", state=MalwareCheckState.Disabled
         )
         task = pretend.stub()
+        request = pretend.stub(
+            db=db_session,
+            log=pretend.stub(info=pretend.call_recorder(lambda *args, **kwargs: None)),
+        )
 
         file = FileFactory.create()
 
-        with pytest.raises(NoResultFound):
-            tasks.run_check(task, db_request, "ExampleHookedCheck", file.id)
+        tasks.run_check(
+            task,
+            request,
+            "ExampleHookedCheck",
+            obj_id=file.id,
+        )
+
+        assert request.log.info.calls == [
+            pretend.call("Check ExampleHookedCheck isn't active. Aborting.")
+        ]
 
     def test_missing_check(self, db_request, monkeypatch):
         monkeypatch.setattr(tasks, "checks", test_checks)
         task = pretend.stub()
 
-        file = FileFactory.create()
-
         with pytest.raises(AttributeError):
-            tasks.run_check(task, db_request, "DoesNotExistCheck", file.id)
+            tasks.run_check(
+                task, db_request, "DoesNotExistCheck",
+            )
 
     def test_retry(self, db_session, monkeypatch):
+        monkeypatch.setattr(tasks, "checks", test_checks)
         exc = Exception("Scan failed")
 
         def scan(self, **kwargs):
             raise exc
 
-        monkeypatch.setattr(tasks, "checks", test_checks)
         monkeypatch.setattr(tasks.checks.ExampleHookedCheck, "scan", scan)
 
         MalwareCheckFactory.create(
-            name="ExampleHookedCheck", state=MalwareCheckState.Evaluation
+            name="ExampleHookedCheck", state=MalwareCheckState.Enabled
         )
 
         task = pretend.stub(
@@ -87,7 +129,7 @@ class TestRunCheck:
         file = FileFactory.create()
 
         with pytest.raises(celery.exceptions.Retry):
-            tasks.run_check(task, request, "ExampleHookedCheck", file.id)
+            tasks.run_check(task, request, "ExampleHookedCheck", obj_id=file.id)
 
         assert request.log.error.calls == [
             pretend.call("Error executing check ExampleHookedCheck: Scan failed")
@@ -134,7 +176,8 @@ class TestBackfill:
         ]
 
         assert enqueue_recorder.delay.calls == [
-            pretend.call("ExampleHookedCheck", files[i].id) for i in range(num_runs)
+            pretend.call("ExampleHookedCheck", files[i].id, manually_triggered=True)
+            for i in range(num_runs)
         ]
 
 
@@ -142,6 +185,7 @@ class TestSyncChecks:
     def test_no_updates(self, db_session, monkeypatch):
         monkeypatch.setattr(tasks, "checks", test_checks)
         monkeypatch.setattr(tasks.checks.ExampleScheduledCheck, "version", 2)
+
         MalwareCheckFactory.create(
             name="ExampleHookedCheck", state=MalwareCheckState.Disabled
         )

--- a/warehouse/admin/routes.py
+++ b/warehouse/admin/routes.py
@@ -140,8 +140,8 @@ def includeme(config):
         domain=warehouse,
     )
     config.add_route(
-        "admin.checks.run_backfill",
-        "/admin/checks/{check_name}/run_backfill",
+        "admin.checks.run_evaluation",
+        "/admin/checks/{check_name}/run_evaluation",
         domain=warehouse,
     )
     config.add_route("admin.verdicts.list", "/admin/verdicts/", domain=warehouse)

--- a/warehouse/admin/templates/admin/malware/checks/detail.html
+++ b/warehouse/admin/templates/admin/malware/checks/detail.html
@@ -42,7 +42,7 @@
             <td>{{ c.version }}</td>
             <td>{{ c.state.value }}</td>
             {% if check.check_type.value == "event_hook" %}
-            <td>{{ c.hooked_object }}</td>
+            <td>{{ c.hooked_object.value }}</td>
             {% else %}
 	    <td><pre>{{ c.schedule }}</pre></td>
             {% endif %}
@@ -83,7 +83,7 @@
       <input name="csrf_token" type="hidden" value="{{ request.session.get_csrf_token() }}">
       <div class="box-body">
 	{% if check.check_type.value == "event_hook" %}
-	<p>Run this check against 10,000 {{ check.hooked_object.value }}s, selected at random. This is used to evaluate the efficacy of a check.</p>
+	<p>Run this check against {{ evaluation_run_size }} {{ check.hooked_object.value }}s, selected at random. This is used to evaluate the efficacy of a check.</p>
 	{% else %}
 	<p>Execute this check now.</p>
         {% endif %}

--- a/warehouse/admin/templates/admin/malware/checks/detail.html
+++ b/warehouse/admin/templates/admin/malware/checks/detail.html
@@ -30,12 +30,22 @@
           <tr>
             <th>Version</th>
             <th>State</th>
+            {% if check.check_type.value == "event_hook" %}
+            <th>Hooked Object</th>
+            {% else %}
+            <th>Schedule</th>
+            {% endif %}
             <th>Created</th>
           </tr>
           {% for c in checks %}
           <tr>
             <td>{{ c.version }}</td>
             <td>{{ c.state.value }}</td>
+            {% if check.check_type.value == "event_hook" %}
+            <td>{{ c.hooked_object }}</td>
+            {% else %}
+	    <td><pre>{{ c.schedule }}</pre></td>
+            {% endif %}
             <td>{{ c.created }}</td>
           </tr>
           {% endfor %}
@@ -69,10 +79,14 @@
     <div class="box-header with-border">
       <h3 class="box-title">Run Evaluation</h3>
     </div>
-    <form method="POST" action="{{ request.route_path('admin.checks.run_backfill', check_name=check.name) }}">
+    <form method="POST" action="{{ request.route_path('admin.checks.run_evaluation', check_name=check.name) }}">
       <input name="csrf_token" type="hidden" value="{{ request.session.get_csrf_token() }}">
       <div class="box-body">
-        <p>Run this check against 10,000 {{ check.hooked_object.value }}s, selected at random. This is used to evaluate the efficacy of a check.</p>
+	{% if check.check_type.value == "event_hook" %}
+	<p>Run this check against 10,000 {{ check.hooked_object.value }}s, selected at random. This is used to evaluate the efficacy of a check.</p>
+	{% else %}
+	<p>Execute this check now.</p>
+        {% endif %}
         <div class="pull-right col-sm-4">
           <button type="submit" class="btn btn-primary pull-right">Run</button>
         </div>

--- a/warehouse/admin/templates/admin/malware/checks/index.html
+++ b/warehouse/admin/templates/admin/malware/checks/index.html
@@ -26,7 +26,7 @@
       <tr>
         <th>Check Name</th>
         <th>State</th>
-        <th>Revisions</th>
+        <th>Type</th>
         <th>Last Modified</th>
         <th>Description</th>
       </tr>
@@ -38,7 +38,7 @@
           </a>
         </td>
         <td>{{ check.state.value }}</td>
-        <td>{{ check.version }}</td>
+        <td>{{ check.check_type.value }}</td>
         <td>{{ check.created }}</td>
         <td>{{ check.short_description }}</td>
       </tr>

--- a/warehouse/admin/views/checks.py
+++ b/warehouse/admin/views/checks.py
@@ -82,7 +82,7 @@ def run_evaluation(request):
             request.route_path("admin.checks.detail", check_name=check.name)
         )
 
-    if check.check_type == MalwareCheckType.event_hook:
+    if check.check_type == MalwareCheckType.EventHook:
         request.session.flash(
             f"Running {check.name} on {EVALUATION_RUN_SIZE} {check.hooked_object.value}s\
 !",

--- a/warehouse/admin/views/checks.py
+++ b/warehouse/admin/views/checks.py
@@ -14,8 +14,8 @@ from pyramid.httpexceptions import HTTPNotFound, HTTPSeeOther
 from pyramid.view import view_config
 from sqlalchemy.orm.exc import NoResultFound
 
-from warehouse.malware.models import MalwareCheck, MalwareCheckState
-from warehouse.malware.tasks import backfill, remove_verdicts
+from warehouse.malware.models import MalwareCheck, MalwareCheckState, MalwareCheckType
+from warehouse.malware.tasks import backfill, remove_verdicts, run_check
 
 
 @view_config(
@@ -56,32 +56,36 @@ def get_check(request):
 
 
 @view_config(
-    route_name="admin.checks.run_backfill",
+    route_name="admin.checks.run_evaluation",
     permission="admin",
     request_method="POST",
     uses_session=True,
     require_methods=False,
     require_csrf=True,
 )
-def run_backfill(request):
+def run_evaluation(request):
     check = get_check_by_name(request.db, request.matchdict["check_name"])
-    num_objects = 10000
 
     if check.state not in (MalwareCheckState.Enabled, MalwareCheckState.Evaluation):
         request.session.flash(
-            f"Check must be in 'enabled' or 'evaluation' state to run a backfill.",
+            f"Check must be in 'enabled' or 'evaluation' state to manually execute.",
             queue="error",
         )
         return HTTPSeeOther(
             request.route_path("admin.checks.detail", check_name=check.name)
         )
 
-    request.session.flash(
-        f"Running {check.name} on {num_objects} {check.hooked_object.value}s!",
-        queue="success",
-    )
+    if check.check_type == MalwareCheckType.event_hook:
+        num_objects = 10000
+        request.session.flash(
+            f"Running {check.name} on {num_objects} {check.hooked_object.value}s!",
+            queue="success",
+        )
+        request.task(backfill).delay(check.name, num_objects)
 
-    request.task(backfill).delay(check.name, num_objects)
+    else:
+        request.session.flash(f"Running {check.name} now!", queue="success")
+        request.task(run_check).delay(check.name, manually_triggered=True)
 
     return HTTPSeeOther(
         request.route_path("admin.checks.detail", check_name=check.name)

--- a/warehouse/malware/__init__.py
+++ b/warehouse/malware/__init__.py
@@ -10,9 +10,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import inspect
+
+from celery.schedules import crontab
+
+import warehouse.malware.checks as checks
+
 from warehouse import db
 from warehouse.malware import utils
 from warehouse.malware.interfaces import IMalwareCheckService
+from warehouse.malware.tasks import run_check
 
 
 @db.listens_for(db.Session, "after_flush")
@@ -57,3 +64,12 @@ def includeme(config):
     config.register_service_factory(
         malware_check_class.create_service, IMalwareCheckService
     )
+
+    # Add scheduled tasks for every scheduled Malware Check.
+    all_checks = inspect.getmembers(checks, inspect.isclass)
+    for check_obj in all_checks:
+        check = check_obj[1]
+        if check.check_type == "scheduled":
+            config.add_periodic_task(
+                crontab(**check.schedule), run_check, args=(check_obj[0],)
+            )

--- a/warehouse/malware/checks/base.py
+++ b/warehouse/malware/checks/base.py
@@ -18,7 +18,7 @@ class MalwareCheckBase:
     def __init__(self, db):
         self.db = db
         self._name = self.__class__.__name__
-        self._load_check_id()
+        self._load_check_fields()
         self._verdicts = []
 
     @classmethod
@@ -26,7 +26,7 @@ class MalwareCheckBase:
         """
         Prepares some context for scanning the given object.
         """
-        kwargs = {}
+        kwargs = {"obj_id": obj_id}
 
         model = getattr(models, cls.hooked_object)
         kwargs["obj"] = request.db.query(model).get(obj_id)
@@ -60,9 +60,9 @@ class MalwareCheckBase:
         backfill on the entire corpus.
         """
 
-    def _load_check_id(self):
-        (self.id,) = (
-            self.db.query(MalwareCheck.id)
+    def _load_check_fields(self):
+        self.id, self.state = (
+            self.db.query(MalwareCheck.id, MalwareCheck.state)
             .filter(MalwareCheck.name == self._name)
             .filter(
                 MalwareCheck.state.in_(

--- a/warehouse/malware/tasks.py
+++ b/warehouse/malware/tasks.py
@@ -32,7 +32,7 @@ def run_check(task, request, check_name, obj_id=None, manually_triggered=False):
 
     # Don't run scheduled checks if they are in evaluation mode, unless manually
     # triggered.
-    if check.state == MalwareCheckState.evaluation and not manually_triggered:
+    if check.state == MalwareCheckState.Evaluation and not manually_triggered:
         request.log.info(
             "%s is in the `evaluation` state and must be manually triggered to run."
             % check_name

--- a/warehouse/malware/tasks.py
+++ b/warehouse/malware/tasks.py
@@ -12,6 +12,8 @@
 
 import inspect
 
+from sqlalchemy.orm.exc import NoResultFound
+
 import warehouse.malware.checks as checks
 import warehouse.packaging.models as packaging_models
 
@@ -21,11 +23,30 @@ from warehouse.tasks import task
 
 
 @task(bind=True, ignore_result=True, acks_late=True, retry_backoff=True)
-def run_check(task, request, check_name, obj_id):
-    check = getattr(checks, check_name)(request.db)
+def run_check(task, request, check_name, obj_id=None, manually_triggered=False):
     try:
+        check = getattr(checks, check_name)(request.db)
+    except NoResultFound:
+        request.log.info("Check %s isn't active. Aborting." % check_name)
+        return
+
+    # Don't run scheduled checks if they are in evaluation mode, unless manually
+    # triggered.
+    if check.state == MalwareCheckState.evaluation and not manually_triggered:
+        request.log.info(
+            "%s is in the `evaluation` state and must be manually triggered to run."
+            % check_name
+        )
+        return
+
+    kwargs = {}
+
+    # Hooked checks require `obj_id`s.
+    if obj_id is not None:
         kwargs = check.prepare(request, obj_id)
-        check.run(obj_id=obj_id, **kwargs)
+
+    try:
+        check.run(**kwargs)
     except Exception as exc:
         request.log.error("Error executing check %s: %s" % (check_name, str(exc)))
         raise task.retry(exc=exc)
@@ -43,7 +64,7 @@ def backfill(task, request, check_name, num_objects):
     request.log.info("Running backfill on %d %ss." % (num_objects, check.hooked_object))
 
     for (elem_id,) in query:
-        request.task(run_check).delay(check_name, elem_id)
+        request.task(run_check).delay(check_name, elem_id, manually_triggered=True)
 
 
 @task(bind=True, ignore_result=True, acks_late=True)


### PR DESCRIPTION
- Rename `run_backfill` to `run_evaluation` in admin malware view
- Modify `run` and `scan` method signatures to accept `**kwargs`
- Extend `run_check` to accomodate scheduled check functionality