### PR TITLE
Upgrade NPM in travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ install:
   - 'rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm install $TRAVIS_NODE_VERSION'
   - pip install -U pip setuptools wheel
   - pip install -r requirements/main.txt -r requirements/deploy.txt -r requirements/docs.txt -r requirements/lint.txt -r requirements/tests.txt
+  - npm i -g npm
   - npm install
 
 script:


### PR DESCRIPTION
This is causing failures now that the Travis base image does not have a `python2` shim. (e.g. https://travis-ci.org/pypa/warehouse/jobs/640023381)