### PR TITLE
Fix example .pypirc for project tokens

### DIFF
--- a/warehouse/templates/manage/token.html
+++ b/warehouse/templates/manage/token.html
@@ -89,6 +89,11 @@
       {% endtrans %}
     </p>
     <pre class="code-block">
+[distutils]
+  index-servers =
+    pypi
+    PROJECT_NAME
+
 [pypi]
   username = __token__
   password = # {% trans %}either a user-scoped token or a project-scoped token you want to set as the default{% endtrans %}

--- a/warehouse/templates/manage/token.html
+++ b/warehouse/templates/manage/token.html
@@ -99,6 +99,7 @@
   password = # {% trans %}either a user-scoped token or a project-scoped token you want to set as the default{% endtrans %}
 
 [PROJECT_NAME]
+  repository = https://upload.pypi.org/legacy/
   username = __token__
   password = # {% trans %}a project token{% endtrans %} </pre>
     <p>


### PR DESCRIPTION
Per my comment in https://github.com/pypa/twine/issues/496#issuecomment-578461036, it seems a "project" repository must be defined in `index-servers` in order to be usable by twine.

This is just a quick fix, mostly to surface the issue to the Warehouse maintainers. I did it via the GitHub UI, without setting up a development environment.