### PR TITLE
Add pointer to pypi-support on faq page

### DIFF
--- a/warehouse/templates/pages/help.html
+++ b/warehouse/templates/pages/help.html
@@ -40,6 +40,13 @@
         provision <a href="#recoverycodes">recovery codes</a>.
       {% endtrans %}
     </p>
+    <p>
+      {% trans %}
+        In the worst case wherein you've lost access to your account
+        and don't have recovery codes, you can raise an <a href="https://github.com/pypa/pypi-support/issues/new?labels=account-recovery&template=account-recovery.md&title=Account+recovery+request">account recovery request</a>
+        on the <a href="https://github.com/pypa/pypi-support">pypi-support</a> repository on GitHub.
+      {% endtrans %}
+    </p>
   </div>
 {% endmacro %}
 


### PR DESCRIPTION
Added a pointer to the pypi-support repo in case someone loses access to their authenticator app and don't have recovery codes.