### PR TITLE
update account and recovery code faq text, simplify translations strings

### DIFF
--- a/warehouse/templates/accounts/recovery-code.html
+++ b/warehouse/templates/accounts/recovery-code.html
@@ -55,8 +55,8 @@
             <input type="submit" value="{% trans %}Verify{% endtrans %}" class="button button--primary">
           </div>
 
+          <p>{% trans %}PyPI allows for generating recovery codes to be stored securely offline in the event that your device or application is lost. Enter one of these codes in the form to verify your identity. Once used, the recovery code will no longer be valid.{% endtrans %}</p>
           {% trans trimmed href='/help/#recovery_code' %}
-          <p>PyPI allows for generating recovery codes to be stored securely offline in the event that your device or application is lost. Enter one of these codes in the form to verify your identity. Once used, the recovery code will no longer be valid.</p>
           <p>Not working? <a href="{{ href }}">Get help</a>.</p>
           {% endtrans %}
         </form>

--- a/warehouse/templates/pages/help.html
+++ b/warehouse/templates/pages/help.html
@@ -34,10 +34,15 @@
       {% endtrans %}
     </p>
     <p>
-      {% trans %}
-        We recommend that all PyPI users set up <em>at least two</em>
-        supported two factor authentication methods and
-        provision <a href="#recoverycodes">recovery codes</a>.
+      {% trans trimmed %}
+        We recommend that all PyPI users set up <em>at least two</em> supported two factor authentication methods
+        and provision <a href="#recoverycodes">recovery codes</a>.
+      {% endtrans %}
+    </p>
+    <p>
+      {% trans trimmed %}
+        If you've lost access to all two factor methods for your account and do not have <a href="#recoverycodes">recovery codes</a>,
+        you can request help <a href="#account-recovery">with account recovery</a>.
       {% endtrans %}
     </p>
   </div>
@@ -64,6 +69,7 @@
 {% macro statistics() %}{% trans %}Where can I see statistics about PyPI, downloads, and project/package usage?{% endtrans %}{% endmacro %}
 
 {% macro login_problem() %}{% trans %}I forgot my PyPI password. Can you help me?{% endtrans %}{% endmacro %}
+{% macro account_recovery() %}{% trans %}I've lost access to my PyPI account. Can you help me?{% endtrans %}{% endmacro %}
 {% macro invalid_auth() %}{% trans %}Why am I getting a "Invalid or non-existent authentication information." error when uploading files?{% endtrans %}{% endmacro %}
 {% macro tls_deprecation() %}{% trans %}Why am I getting "No matching distribution found" or "Could not fetch URL" errors during <code>pip install</code>?{% endtrans %}{% endmacro %}
 {% macro accessibility() %}{% trans %}I am having trouble using the PyPI website. Can you help me?{% endtrans %}{% endmacro %}
@@ -148,6 +154,7 @@
         <ul>
           <li><a href="#uploading">{{ uploading() }}</a></li>
           <li><a href="#login-problem">{{ login_problem() }}</a></li>
+          <li><a href="#account-recovery">{{ account_recovery() }}</a></li>
           <li><a href="#invalid-auth">{{ invalid_auth() }}</a></li>
           <li><a href="#tls-deprecation">{{ tls_deprecation() }}</a></li>
           <li><a href="#accessibility">{{ accessibility() }}</a></li>
@@ -396,26 +403,31 @@
 
         <h3 id="recoverycodes">{{ recoverycodes() }}</h3>
 
-        {% trans %}
-          <p>If you lose access to your <a href="#totp">authentication application</a> or <a href="#utfkey">security device</a>, you can use these codes to sign into PyPI.</a>
-          <p>Recovery codes are <strong>one time use</strong>. They are not a substitute for a <a href="#totp">authentication application</a> or <a href="#utfkey">security device</a> and should only be used for recovery. After using a recovery code to sign in, it becomes inactive.</p>
+        <p>
+          {% trans %}If you lose access to your <a href="#totp">authentication application</a> or <a href="#utfkey">security device</a>, you can use these codes to sign into PyPI.{% endtrans %}
+        </p>
+        <p>
+          {% trans trimmed %}
+            Recovery codes are <strong>one time use</strong>. They are not a substitute for a <a href="#totp">authentication application</a> or <a href="#utfkey">security device</a>
+            and should only be used for recovery. After using a recovery code to sign in, it becomes inactive.
+          {% endtrans %}
+        </p>
 
-          <p><strong>To provision recovery codes:</strong></p>
-          <ol>
-            <li>Log in to your PyPI account, go to your account settings, and choose "Generate recovery codes"</li>
-            <li>Securely store the displayed recovery codes! Consider printing them out and storing them in a safe location or saving them in a password manager.</li>
-          </ol>
+        <p><strong>{% trans %}To provision recovery codes:{% endtrans %}</strong></p>
+        <ol>
+          <li>{% trans %}Log in to your PyPI account, go to your account settings, and choose "Generate recovery codes"{% endtrans %}</li>
+          <li>{% trans %}Securely store the displayed recovery codes! Consider printing them out and storing them in a safe location or saving them in a password manager.{% endtrans %}</li>
+        </ol>
 
-          <p>If you lose access to your stored recovery codes or use all of them, you can get new ones by selecting "Regenerate recovery codes" in your account settings.</p>
+        <p>{% trans %}If you lose access to your stored recovery codes or use all of them, you can get new ones by selecting "Regenerate recovery codes" in your account settings.{% endtrans %}</p>
 
-          <p><strong>To sign in with a recovery code:</strong></p>
-          <ol>
-            <li>Provide your username and password, as normal</li>
-            <li>When prompted for Two-Factor Authentication, select "Login using a Recovery Code"</li>
-            <li>As each code can be used only once, you might want to mark the code as used</li>
-            <li>If you have few recovery codes remaining, you may also want to generate a new set using the "Regenerate recovery codes" button in your account settings.</li>
-          </ol>
-        {% endtrans %}
+        <p><strong>{% trans %}To sign in with a recovery code:{% endtrans %}</strong></p>
+        <ol>
+          <li>{% trans %}Provide your username and password, as normal{% endtrans %}</li>
+          <li>{% trans %}When prompted for Two-Factor Authentication, select "Login using a Recovery Code"{% endtrans %}</li>
+          <li>{% trans %}As each code can be used only once, you might want to mark the code as used{% endtrans %}</li>
+          <li>{% trans %}If you have few recovery codes remaining, you may also want to generate a new set using the "Regenerate recovery codes" button in your account settings.{% endtrans %}</li>
+        </ol>
 
         <h3 id="apitoken">{{ apitoken() }}</h3>
 
@@ -534,8 +546,20 @@
           <li>{% trans href=request.route_path('accounts.reset-password') %}Go to <a href="{{ href }}">reset your password</a>.{% endtrans %}</li>
           <li>{% trans %}Enter the email address or username you used for PyPI and submit the form.{% endtrans %}</li>
           <li>{% trans %}You'll receive an email with a password reset link.{% endtrans %}</li>
-          <li>{% trans href='https://github.com/pypa/pypi-support/issues/new?labels=account-recovery&template=account-recovery.md&title=Account+recovery+request', title=gettext('External link') %}If you no longer have access to the email address associated with your account, <a href="{{ href }}" title="{{ title }}" target="_blank" rel="noopener">file an issue on our tracker</a>.{% endtrans %}</li>
         </ol>
+        {{ code_of_conduct() }}
+
+        <h3 id="account-recovery">{{ account_recovery() }}</h3>
+        <p>{% trans %}If you've lost access to your PyPI account due to:{% endtrans %}</p>
+        <ul>
+          <li>{% trans %}Lost access to the email address associated with your account{% endtrans %}</li>
+          <li>{% trans %}Lost two factor authentication <a href="#totp">application</a>, <a href="#utfkey">device</a>, and <a href="#recoverycodes">recovery codes</a>{% endtrans %}</li>
+        </ul>
+        <p>
+          {% trans trimmed href='https://github.com/pypa/pypi-support/issues/new?labels=account-recovery&template=account-recovery.md&title=Account+recovery+request', title=gettext('External link') %}
+            You can proceed to, <a href="{{ href }}" title="{{ title }}" target="_blank" rel="noopener">file an issue on our tracker</a> to request assistance with account recovery.
+          {% endtrans %}
+        </p>
         {{ code_of_conduct() }}
 
         <h3 id="invalid-auth">{{ invalid_auth() }}</h3>


### PR DESCRIPTION
tidies up some of the longer strings from #5800, adds notes for account recovery to two factor auth sections.