### PR TITLE
Add reload interval to hupper to allow time for gunicorn to shutdown

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
         # working on pypi-theme, this is a private repository due to the fact
         # that other people's IP is contained in it.
         #THEME_REPO:
-    command: hupper -w 'warehouse/locale/**/*.mo' -m gunicorn.app.wsgiapp -b 0.0.0.0:8000 -c gunicorn.conf.py warehouse.wsgi:application
+    command: hupper --reload-interval 3 -w 'warehouse/locale/**/*.mo' -m gunicorn.app.wsgiapp -b 0.0.0.0:8000 -c gunicorn.conf.py warehouse.wsgi:application
     env_file: dev/environment
     volumes:
       # We specify all of these directories instead of just . because we want to


### PR DESCRIPTION
Fixes https://github.com/pypa/warehouse/issues/6578

Add [`reload_interval`](https://docs.pylonsproject.org/projects/hupper/en/latest/api.html#hupper.start_reloader) to the web command. Seems to solve the issue for me but it would be good to do some further testing.