### PR TITLE
Do not hide text in 'view hashes' button

### DIFF
--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -2415,6 +2415,7 @@ msgstr ""
 
 #: warehouse/templates/manage/projects.html:67
 #: warehouse/templates/manage/releases.html:75
+#: warehouse/templates/packaging/detail.html:312
 msgid "View"
 msgstr ""
 
@@ -3226,10 +3227,6 @@ msgstr ""
 #: warehouse/templates/packaging/detail.html:280
 #: warehouse/templates/packaging/detail.html:310
 msgid "Hashes"
-msgstr ""
-
-#: warehouse/templates/packaging/detail.html:312
-msgid "View <span>hashes</span>"
 msgstr ""
 
 #: warehouse/templates/pages/classifiers.html:22

--- a/warehouse/static/sass/blocks/_table.scss
+++ b/warehouse/static/sass/blocks/_table.scss
@@ -176,16 +176,6 @@
       @include mobile-friendly-table;
       margin-bottom: ($spacing-unit / 2);
     }
-
-    @media only screen and (max-width: $mobile) {
-      .table__mobile-label--hashes {
-        display: none;
-      }
-
-      td .button span {
-        display: inline;
-      }
-    }
   }
 
   &--releases {

--- a/warehouse/templates/packaging/detail.html
+++ b/warehouse/templates/packaging/detail.html
@@ -318,7 +318,7 @@
                   <td class="table__align-right">
                     <span class="table__mobile-label table__mobile-label--hashes">{% trans %}Hashes{% endtrans %}</span>
                     <a href="#copy-hash-modal-{{ file.id }}" class="button button--small button--primary">
-                      {% trans %}View <span>hashes</span>{% endtrans %}
+                      {% trans %}View{% endtrans %}
                     </a>
                   </td>
                 </tr>


### PR DESCRIPTION
Closes #7457 

Ensures full text of button is always displayed, allowing it to be easily translated.

## Mobile

![Screenshot from 2020-02-28 21-55-09](https://user-images.githubusercontent.com/3323703/75590435-39771380-5a75-11ea-8275-7c28e57adf0f.png)

## Desktop
![Screenshot from 2020-02-28 21-54-54](https://user-images.githubusercontent.com/3323703/75590436-3aa84080-5a75-11ea-8a8d-f59b04e7658d.png)
