### PR TITLE
Add email templates for removed file from release

### DIFF
--- a/tests/unit/email/test_init.py
+++ b/tests/unit/email/test_init.py
@@ -1490,6 +1490,218 @@ class TestRemovedReleaseEmail:
         ]
 
 
+class TestRemovedReleaseFileEmail:
+    def test_send_removed_project_release_file_email_to_owner(
+        self, pyramid_request, pyramid_config, monkeypatch
+    ):
+        stub_user = pretend.stub(
+            username="username",
+            name="",
+            email="email@example.com",
+            primary_email=pretend.stub(email="email@example.com", verified=True),
+        )
+        stub_submitter_user = pretend.stub(
+            username="submitterusername",
+            name="",
+            email="submiteremail@example.com",
+            primary_email=pretend.stub(
+                email="submiteremail@example.com", verified=True
+            ),
+        )
+
+        subject_renderer = pyramid_config.testing_add_renderer(
+            "email/removed-project-release-file/subject.txt"
+        )
+        subject_renderer.string_response = "Email Subject"
+        body_renderer = pyramid_config.testing_add_renderer(
+            "email/removed-project-release-file/body.txt"
+        )
+        body_renderer.string_response = "Email Body"
+        html_renderer = pyramid_config.testing_add_renderer(
+            "email/removed-project-release-file/body.html"
+        )
+        html_renderer.string_response = "Email HTML Body"
+
+        send_email = pretend.stub(
+            delay=pretend.call_recorder(lambda *args, **kwargs: None)
+        )
+        pyramid_request.task = pretend.call_recorder(lambda *args, **kwargs: send_email)
+        monkeypatch.setattr(email, "send_email", send_email)
+
+        release = pretend.stub(
+            version="0.0.0",
+            project=pretend.stub(name="test_project"),
+            created=datetime.datetime(2017, 2, 5, 0, 0, 0, 0),
+        )
+
+        result = email.send_removed_project_release_file_email(
+            pyramid_request,
+            [stub_user, stub_submitter_user],
+            file="test-file-0.0.0.tar.gz",
+            release=release,
+            submitter_name=stub_submitter_user.username,
+            submitter_role="Owner",
+            recipient_role="Owner",
+        )
+
+        assert result == {
+            "file": "test-file-0.0.0.tar.gz",
+            "project_name": release.project.name,
+            "release_version": release.version,
+            "submitter_name": stub_submitter_user.username,
+            "submitter_role": "owner",
+            "recipient_role_descr": "an owner",
+        }
+
+        subject_renderer.assert_(project_name="test_project")
+        subject_renderer.assert_(release_version="0.0.0")
+        body_renderer.assert_(file="test-file-0.0.0.tar.gz")
+        body_renderer.assert_(release_version="0.0.0")
+        body_renderer.assert_(project_name="test_project")
+        body_renderer.assert_(submitter_name=stub_submitter_user.username)
+        body_renderer.assert_(submitter_role="owner")
+        body_renderer.assert_(recipient_role_descr="an owner")
+
+        assert pyramid_request.task.calls == [
+            pretend.call(send_email),
+            pretend.call(send_email),
+        ]
+
+        assert send_email.delay.calls == [
+            pretend.call(
+                "username <email@example.com>",
+                attr.asdict(
+                    EmailMessage(
+                        subject="Email Subject",
+                        body_text="Email Body",
+                        body_html=(
+                            "<html>\n<head></head>\n"
+                            "<body><p>Email HTML Body</p></body>\n</html>\n"
+                        ),
+                    ),
+                ),
+            ),
+            pretend.call(
+                "submitterusername <submiteremail@example.com>",
+                attr.asdict(
+                    EmailMessage(
+                        subject="Email Subject",
+                        body_text="Email Body",
+                        body_html=(
+                            "<html>\n<head></head>\n"
+                            "<body><p>Email HTML Body</p></body>\n</html>\n"
+                        ),
+                    )
+                ),
+            ),
+        ]
+
+    def test_send_removed_project_release_file_email_to_maintainer(
+        self, pyramid_request, pyramid_config, monkeypatch
+    ):
+        stub_user = pretend.stub(
+            username="username",
+            name="",
+            email="email@example.com",
+            primary_email=pretend.stub(email="email@example.com", verified=True),
+        )
+        stub_submitter_user = pretend.stub(
+            username="submitterusername",
+            name="",
+            email="submiteremail@example.com",
+            primary_email=pretend.stub(
+                email="submiteremail@example.com", verified=True
+            ),
+        )
+
+        subject_renderer = pyramid_config.testing_add_renderer(
+            "email/removed-project-release-file/subject.txt"
+        )
+        subject_renderer.string_response = "Email Subject"
+        body_renderer = pyramid_config.testing_add_renderer(
+            "email/removed-project-release-file/body.txt"
+        )
+        body_renderer.string_response = "Email Body"
+        html_renderer = pyramid_config.testing_add_renderer(
+            "email/removed-project-release-file/body.html"
+        )
+        html_renderer.string_response = "Email HTML Body"
+
+        send_email = pretend.stub(
+            delay=pretend.call_recorder(lambda *args, **kwargs: None)
+        )
+        pyramid_request.task = pretend.call_recorder(lambda *args, **kwargs: send_email)
+        monkeypatch.setattr(email, "send_email", send_email)
+
+        release = pretend.stub(
+            version="0.0.0",
+            project=pretend.stub(name="test_project"),
+            created=datetime.datetime(2017, 2, 5, 0, 0, 0, 0),
+        )
+
+        result = email.send_removed_project_release_file_email(
+            pyramid_request,
+            [stub_user, stub_submitter_user],
+            file="test-file-0.0.0.tar.gz",
+            release=release,
+            submitter_name=stub_submitter_user.username,
+            submitter_role="Owner",
+            recipient_role="Maintainer",
+        )
+
+        assert result == {
+            "file": "test-file-0.0.0.tar.gz",
+            "project_name": release.project.name,
+            "release_version": release.version,
+            "submitter_name": stub_submitter_user.username,
+            "submitter_role": "owner",
+            "recipient_role_descr": "a maintainer",
+        }
+
+        subject_renderer.assert_(project_name="test_project")
+        subject_renderer.assert_(release_version="0.0.0")
+        body_renderer.assert_(file="test-file-0.0.0.tar.gz")
+        body_renderer.assert_(release_version="0.0.0")
+        body_renderer.assert_(project_name="test_project")
+        body_renderer.assert_(submitter_name=stub_submitter_user.username)
+        body_renderer.assert_(submitter_role="owner")
+        body_renderer.assert_(recipient_role_descr="a maintainer")
+
+        assert pyramid_request.task.calls == [
+            pretend.call(send_email),
+            pretend.call(send_email),
+        ]
+
+        assert send_email.delay.calls == [
+            pretend.call(
+                "username <email@example.com>",
+                attr.asdict(
+                    EmailMessage(
+                        subject="Email Subject",
+                        body_text="Email Body",
+                        body_html=(
+                            "<html>\n<head></head>\n"
+                            "<body><p>Email HTML Body</p></body>\n</html>\n"
+                        ),
+                    ),
+                ),
+            ),
+            pretend.call(
+                "submitterusername <submiteremail@example.com>",
+                attr.asdict(
+                    EmailMessage(
+                        subject="Email Subject",
+                        body_text="Email Body",
+                        body_html=(
+                            "<html>\n<head></head>\n"
+                            "<body><p>Email HTML Body</p></body>\n</html>\n"
+                        ),
+                    )
+                ),
+            ),
+        ]
+
+
 class TestTwoFactorEmail:
     @pytest.mark.parametrize(
         ("action", "method", "pretty_method"),

--- a/warehouse/email/__init__.py
+++ b/warehouse/email/__init__.py
@@ -247,6 +247,24 @@ def send_removed_project_release_email(
     }
 
 
+@_email("removed-project-release-file")
+def send_removed_project_release_file_email(
+    request, user, *, file, release, submitter_name, submitter_role, recipient_role
+):
+    recipient_role_descr = "an owner"
+    if recipient_role == "Maintainer":
+        recipient_role_descr = "a maintainer"
+
+    return {
+        "file": file,
+        "project_name": release.project.name,
+        "release_version": release.version,
+        "submitter_name": submitter_name,
+        "submitter_role": submitter_role.lower(),
+        "recipient_role_descr": recipient_role_descr,
+    }
+
+
 def includeme(config):
     email_sending_class = config.maybe_dotted(config.registry.settings["mail.backend"])
     config.register_service_factory(email_sending_class.create_service, IEmailSender)

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -169,25 +169,25 @@ msgstr ""
 msgid "Email address ${email_address} verified. ${confirm_message}."
 msgstr ""
 
-#: warehouse/manage/views.py:187
+#: warehouse/manage/views.py:188
 msgid "Email ${email_address} added - check your email for a verification link"
 msgstr ""
 
-#: warehouse/manage/views.py:668 warehouse/manage/views.py:704
+#: warehouse/manage/views.py:669 warehouse/manage/views.py:705
 msgid ""
 "You must provision a two factor method before recovery codes can be "
 "generated"
 msgstr ""
 
-#: warehouse/manage/views.py:679
+#: warehouse/manage/views.py:680
 msgid "Recovery codes already generated"
 msgstr ""
 
-#: warehouse/manage/views.py:680
+#: warehouse/manage/views.py:681
 msgid "Generating new recovery codes will invalidate your existing codes."
 msgstr ""
 
-#: warehouse/manage/views.py:730
+#: warehouse/manage/views.py:731
 msgid "Invalid credentials. Try again"
 msgstr ""
 

--- a/warehouse/manage/views.py
+++ b/warehouse/manage/views.py
@@ -40,6 +40,7 @@ from warehouse.email import (
     send_primary_email_change_email,
     send_removed_project_email,
     send_removed_project_release_email,
+    send_removed_project_release_file_email,
     send_two_factor_added_email,
     send_two_factor_removed_email,
 )
@@ -1241,6 +1242,26 @@ class ManageProjectRelease:
                 "filename": release_file.filename,
             },
         )
+
+        submitter_role = get_user_role_in_project(
+            project_name, self.request.user.username, self.request
+        )
+        contributors = get_project_contributors(project_name, self.request)
+
+        for contributor in contributors:
+            contributor_role = get_user_role_in_project(
+                project_name, contributor.username, self.request
+            )
+
+            send_removed_project_release_file_email(
+                self.request,
+                contributor,
+                file=release_file.filename,
+                release=self.release,
+                submitter_name=self.request.user.username,
+                submitter_role=submitter_role,
+                recipient_role=contributor_role,
+            )
 
         self.request.db.delete(release_file)
 

--- a/warehouse/templates/email/removed-project-release-file/body.html
+++ b/warehouse/templates/email/removed-project-release-file/body.html
@@ -1,0 +1,41 @@
+{#
+ # Licensed under the Apache License, Version 2.0 (the "License");
+ # you may not use this file except in compliance with the License.
+ # You may obtain a copy of the License at
+ #
+ # http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+-#}
+{% extends "email/_base/body.html" %}
+
+{% block extra_style %}
+ul.collaborator-details {
+list-style-type: none;
+}
+{% endblock %}
+
+{% block content %}
+<p>
+  <ul class="removed-project-release-file">
+    <li>The file {{ file }} from release {{ release_version }} of the {{ project_name }} project has been deleted.</li>
+    <li><strong>Deleted by:</strong> {{ submitter_name }} with a role:
+      {{ submitter_role }}.
+    </li>
+  </ul>
+</p>
+
+<p>If this was a mistake, you can email <a
+    href="mailto:admin@pypi.org">admin@pypi.org</a> to communicate with the PyPI administrators.</p>
+{% endblock %}
+
+{% block reason %}
+
+<p>
+You are receiving this because you are {{ recipient_role_descr }} of this project.</p>
+
+{% endblock %}

--- a/warehouse/templates/email/removed-project-release-file/body.txt
+++ b/warehouse/templates/email/removed-project-release-file/body.txt
@@ -1,0 +1,27 @@
+{#
+ # Licensed under the Apache License, Version 2.0 (the "License");
+ # you may not use this file except in compliance with the License.
+ # You may obtain a copy of the License at
+ #
+ # http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+-#}
+
+{% extends "email/_base/body.txt" %}
+
+{% block content %}
+  The file {{ file }} from release {{ release_version }} of the {{ project_name }} project has been deleted.
+
+  Deleted by: {{ submitter_name }} with a role: {{ submitter_role }}.
+
+  If this was a mistake, you can email admin@pypi.org to communicate with the PyPI administrators.
+{% endblock %}
+
+{% block reason %}
+    You are receiving this because you are {{ recipient_role_descr }} of this project.
+{% endblock %}

--- a/warehouse/templates/email/removed-project-release-file/subject.txt
+++ b/warehouse/templates/email/removed-project-release-file/subject.txt
@@ -1,0 +1,17 @@
+{#
+ # Licensed under the Apache License, Version 2.0 (the "License");
+ # you may not use this file except in compliance with the License.
+ # You may obtain a copy of the License at
+ #
+ # http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+-#}
+
+{% extends "email/_base/subject.txt" %}
+
+{% block subject %}File deleted for {{ project_name }} {{ release_version }}{% endblock %}


### PR DESCRIPTION
Until now, when there are multiple contributors on a single
the project, if one of them deletes a file from certain release
the other contributors don't get any notification,
which is problematic.

Connected with issue https://github.com/pypa/warehouse/issues/5714

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>