### PR TITLE
Invalidate Two Factor state after login

### DIFF
--- a/tests/unit/accounts/test_services.py
+++ b/tests/unit/accounts/test_services.py
@@ -762,6 +762,16 @@ class TestTokenService:
         token = token_service.dumps({"foo": "bar"})
         assert token_service.loads(token) == {"foo": "bar"}
 
+    def test_loads_return_timestamp(self, token_service):
+        sign_time = datetime.datetime.utcnow()
+        with freezegun.freeze_time(sign_time):
+            token = token_service.dumps({"foo": "bar"})
+
+        assert token_service.loads(token, return_timestamp=True) == (
+            {"foo": "bar"},
+            sign_time.replace(microsecond=0),
+        )
+
     @pytest.mark.parametrize("token", ["", None])
     def test_loads_token_is_none(self, token_service, token):
         with pytest.raises(TokenMissing):

--- a/warehouse/accounts/services.py
+++ b/warehouse/accounts/services.py
@@ -566,19 +566,14 @@ class TokenService:
             raise TokenMissing
 
         try:
-            if return_timestamp:
-                data, timestamp = self.serializer.loads(
-                    token, max_age=self.max_age, return_timestamp=True
-                )
-            else:
-                data = self.serializer.loads(token, max_age=self.max_age)
+            data = self.serializer.loads(
+                token, max_age=self.max_age, return_timestamp=return_timestamp
+            )
         except SignatureExpired:
             raise TokenExpired
         except BadData:  #  Catch all other exceptions
             raise TokenInvalid
 
-        if return_timestamp:
-            return data, timestamp
         return data
 
 

--- a/warehouse/accounts/services.py
+++ b/warehouse/accounts/services.py
@@ -561,17 +561,24 @@ class TokenService:
     def dumps(self, data):
         return self.serializer.dumps({key: str(value) for key, value in data.items()})
 
-    def loads(self, token):
+    def loads(self, token, return_timestamp=False):
         if not token:
             raise TokenMissing
 
         try:
-            data = self.serializer.loads(token, max_age=self.max_age)
+            if return_timestamp:
+                data, timestamp = self.serializer.loads(
+                    token, max_age=self.max_age, return_timestamp=True
+                )
+            else:
+                data = self.serializer.loads(token, max_age=self.max_age)
         except SignatureExpired:
             raise TokenExpired
         except BadData:  #  Catch all other exceptions
             raise TokenInvalid
 
+        if return_timestamp:
+            return data, timestamp
         return data
 
 


### PR DESCRIPTION
Currently our Two Factor Auth state is carried in the query string and expires after 300s, but this state remains reusable after a login is complete.

This checks against the last login for the user and refuses Two Factor attempts if the user has logged in since the token was created.

Thanks to @Julian for the report that led to this discovery!