### PR TITLE
Improve URLs parsing

### DIFF
--- a/tests/unit/packaging/test_models.py
+++ b/tests/unit/packaging/test_models.py
@@ -243,6 +243,7 @@ class TestRelease:
                     ]
                 ),
             ),
+            # project_urls has more priority than home_page and download_url
             (
                 "https://example.com/home/",
                 "https://example.com/download/",
@@ -256,6 +257,22 @@ class TestRelease:
                         ("Homepage", "https://example.com/home2/"),
                         ("Source Code", "https://example.com/source-code/"),
                         ("Download", "https://example.com/download2/"),
+                    ]
+                ),
+            ),
+            # ignore invalid links
+            (
+                None,
+                None,
+                [
+                    " ,https://example.com/home/",
+                    ",https://example.com/home/",
+                    "https://example.com/home/",
+                    "Download,https://example.com/download/",
+                ],
+                OrderedDict(
+                    [
+                        ("Download", "https://example.com/download/"),
                     ]
                 ),
             ),

--- a/tests/unit/packaging/test_models.py
+++ b/tests/unit/packaging/test_models.py
@@ -270,11 +270,7 @@ class TestRelease:
                     "https://example.com/home/",
                     "Download,https://example.com/download/",
                 ],
-                OrderedDict(
-                    [
-                        ("Download", "https://example.com/download/"),
-                    ]
-                ),
+                OrderedDict([("Download", "https://example.com/download/")]),
             ),
         ],
     )

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -420,23 +420,23 @@ class Release(db.Model):
 
         if self.home_page:
             _urls["Homepage"] = self.home_page
+        if self.download_url:
+            _urls["Download"] = self.download_url
 
         for urlspec in self.project_urls:
-            name, url = [x.strip() for x in urlspec.split(",", 1)]
-            _urls[name] = url
-
-        if self.download_url and "Download" not in _urls:
-            _urls["Download"] = self.download_url
+            name, _, url = urlspec.partition(",")
+            name = name.strip()
+            if name:
+                _urls[name] = url.strip()
 
         return _urls
 
     @property
     def github_repo_info_url(self):
-        for parsed in [urlparse(url) for url in self.urls.values()]:
-            segments = parsed.path.strip("/").rstrip("/").split("/")
-            if (
-                parsed.netloc == "github.com" or parsed.netloc == "www.github.com"
-            ) and len(segments) >= 2:
+        for url in self.urls.values():
+            parsed = urlparse(url)
+            segments = parsed.path.strip("/").split("/")
+            if parsed.netloc in {"github.com", "www.github.com"} and len(segments) >= 2:
                 user_name, repo_name = segments[:2]
                 return f"https://api.github.com/repos/{user_name}/{repo_name}"
 

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -426,8 +426,9 @@ class Release(db.Model):
         for urlspec in self.project_urls:
             name, _, url = urlspec.partition(",")
             name = name.strip()
-            if name:
-                _urls[name] = url.strip()
+            url = url.strip()
+            if name and url:
+                _urls[name] = url
 
         return _urls
 


### PR DESCRIPTION
A few small non-breaking changes to make `Release.urls` parsing a bit more readable and reliable. The most important thing is replacing `split` to `partition` to handle cases with missed link name:

+ `Example,https://exampe.com` - correct
+ `,https://exampe.com` - ignore
+ `https://exampe.com` - ignore

Tests inside