### PR TITLE
Use provided nvm on Travis and cache node version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ cache:
     - node_modules/
 
 install:
-  - 'rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm install $TRAVIS_NODE_VERSION'
+  - nvm install $TRAVIS_NODE_VERSION
   - pip install -U pip setuptools wheel
   - pip install -r requirements/main.txt -r requirements/deploy.txt -r requirements/docs.txt -r requirements/lint.txt -r requirements/tests.txt
   - npm i -g npm

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ services:
 cache:
   directories:
     - ~/.cache/pip
+    - ~/.nvm/versions/
     - node_modules/
 
 install:


### PR DESCRIPTION
This was added in #936 but I think it's no longer necessary, it was upgrading us the latest version of `nvm` by cloning from source every time, but currently that just means that we get 0.35.3 instead of 0.34.0.

In addition, this was downloading the Node distribution from nodejs.org every single time for every build, and I was noticing a lot of timeouts happening lately causing jobs to need to be restarted, and this download just generally being slow. Now that we're not removing `~/.nvm` on every build, adding `~/.nvm/versions/` to the cache ensures that this no longer needs to happen.

At in this PR, it takes our average test run from 4m 56s to 3m 23s.