### PR TITLE
Upgrade Node.js version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python: 3.7.3
 
 env:
   global:
-    - TRAVIS_NODE_VERSION=8.9.4
+    - TRAVIS_NODE_VERSION=10.19.0
 
 dist: xenial
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # our static assets with. It is important that the steps in this remain the
 # same as the steps in Dockerfile.static, EXCEPT this may include additional
 # steps appended onto the end.
-FROM node:8.15.1 as static
+FROM node:10.19.0 as static
 
 WORKDIR /opt/warehouse/src/
 

--- a/Dockerfile.static
+++ b/Dockerfile.static
@@ -1,4 +1,4 @@
-FROM node:8.15.1 as static
+FROM node:10.19.0 as static
 
 WORKDIR /opt/warehouse/src/
 

--- a/docs/development/frontend.rst
+++ b/docs/development/frontend.rst
@@ -14,7 +14,7 @@ Building
 
 Static files should be automatically built when ``make serve`` is running;
 however, you can trigger a manual build of them by installing
-`NodeJS 8.x <https://nodejs.org/en/download/releases/>`_, installing
+`NodeJS 10.x <https://nodejs.org/en/download/releases/>`_, installing
 the dependencies using ``npm install`` and then running ``gulp dist``.
 
 If you're in a POSIX environment you may find


### PR DESCRIPTION
Our current Node.js version is [no longer supported](https://nodejs.org/en/about/releases/). I chose Node.js 10.19.0 since it's the smallest version jump in [the official Docker images](https://hub.docker.com/_/node/).

This does mean you'll have to rebuild your images from scratch, sorry about that 😅 