### PR TITLE
Adding pluralization to the statistics block

### DIFF
--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -663,23 +663,31 @@ msgstr ""
 
 #: warehouse/templates/index.html:66
 #, python-format
-msgid "%(num_projects)s projects"
-msgstr ""
+msgid "%(num_projects)s project"
+msgid_plural "%(num_projects)s projects"
+msgstr[0] ""
+msgstr[1] ""
 
 #: warehouse/templates/index.html:67
 #, python-format
-msgid "%(num_releases)s releases"
-msgstr ""
+msgid "%(num_releases)s release"
+msgid_plural "%(num_releases)s releases"
+msgstr[0] ""
+msgstr[1] ""
 
 #: warehouse/templates/index.html:68
 #, python-format
-msgid "%(num_files)s files"
-msgstr ""
+msgid "%(num_files)s file"
+msgid_plural "%(num_files)s files"
+msgstr[0] ""
+msgstr[1] ""
 
 #: warehouse/templates/index.html:69
 #, python-format
-msgid "%(num_users)s users"
-msgstr ""
+msgid "%(num_users)s user"
+msgid_plural "%(num_users)s users"
+msgstr[0] ""
+msgstr[1] ""
 
 #: warehouse/templates/index.html:81
 msgid ""

--- a/warehouse/templates/index.html
+++ b/warehouse/templates/index.html
@@ -64,10 +64,10 @@
 
 <div class="horizontal-section horizontal-section--grey horizontal-section--thin horizontal-section--statistics">
   <div class="statistics-bar">
-    <p class="statistics-bar__statistic">{% trans num_projects=num_projects|format_number %}{{ num_projects }} projects{% endtrans %}</p>
-    <p class="statistics-bar__statistic">{% trans num_releases=num_releases|format_number %}{{ num_releases }} releases{% endtrans %}</p>
-    <p class="statistics-bar__statistic">{% trans num_files=num_files|format_number %}{{ num_files }} files{% endtrans %}</p>
-    <p class="statistics-bar__statistic">{% trans num_users=num_users|format_number %}{{ num_users }} users{% endtrans %}</p>
+    <p class="statistics-bar__statistic">{% trans num_projects=num_projects|format_number %}{{ num_projects }} project{% pluralize %}{{ num_projects }} projects{% endtrans %}</p>
+    <p class="statistics-bar__statistic">{% trans num_releases=num_releases|format_number %}{{ num_releases }} release{% pluralize %}{{ num_releases }} releases{% endtrans %}</p>
+    <p class="statistics-bar__statistic">{% trans num_files=num_files|format_number %}{{ num_files }} file{% pluralize %}{{ num_files }} files{% endtrans %}</p>
+    <p class="statistics-bar__statistic">{% trans num_users=num_users|format_number %}{{ num_users }} user{% pluralize %}{{ num_users }} users{% endtrans %}</p>
   </div>
 </div>
 


### PR DESCRIPTION
The statistics block on main page always uses the plural form for the displayed messages. This change makes the message dependent on the actual number of statistics items.