### PR TITLE
Fix pluralization of front page stats

### DIFF
--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -663,53 +663,29 @@ msgstr ""
 
 #: warehouse/templates/index.html:67
 #, python-format
-msgid ""
-"\n"
-"      %(num_projects_formatted)s project\n"
-"    "
-msgid_plural ""
-"\n"
-"      %(num_projects_formatted)s projects\n"
-"    "
+msgid "%(num_projects_formatted)s project"
+msgid_plural "%(num_projects_formatted)s projects"
 msgstr[0] ""
 msgstr[1] ""
 
 #: warehouse/templates/index.html:74
 #, python-format
-msgid ""
-"\n"
-"      %(num_releases_formatted)s release\n"
-"    "
-msgid_plural ""
-"\n"
-"      %(num_releases_formatted)s releases\n"
-"    "
+msgid "%(num_releases_formatted)s release"
+msgid_plural "%(num_releases_formatted)s releases"
 msgstr[0] ""
 msgstr[1] ""
 
 #: warehouse/templates/index.html:81
 #, python-format
-msgid ""
-"\n"
-"      %(num_files_formatted)s file\n"
-"    "
-msgid_plural ""
-"\n"
-"      %(num_files_formatted)s files\n"
-"    "
+msgid "%(num_files_formatted)s file"
+msgid_plural "%(num_files_formatted)s files"
 msgstr[0] ""
 msgstr[1] ""
 
 #: warehouse/templates/index.html:88
 #, python-format
-msgid ""
-"\n"
-"      %(num_users_formatted)s user\n"
-"    "
-msgid_plural ""
-"\n"
-"      %(num_users_formatted)s users\n"
-"    "
+msgid "%(num_users_formatted)s user"
+msgid_plural "%(num_users_formatted)s users"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -663,23 +663,31 @@ msgstr ""
 
 #: warehouse/templates/index.html:66
 #, python-format
-msgid "%(num_projects)s projects"
-msgstr ""
+msgid "%(num_projects)s project"
+msgid_plural "%(num_projects)s projects"
+msgstr[0] ""
+msgstr[1] ""
 
 #: warehouse/templates/index.html:67
 #, python-format
-msgid "%(num_releases)s releases"
-msgstr ""
+msgid "%(num_releases)s release"
+msgid_plural "%(num_releases)s releases"
+msgstr[0] ""
+msgstr[1] ""
 
 #: warehouse/templates/index.html:68
 #, python-format
-msgid "%(num_files)s files"
-msgstr ""
+msgid "%(num_files)s file"
+msgid_plural "%(num_files)s files"
+msgstr[0] ""
+msgstr[1] ""
 
 #: warehouse/templates/index.html:69
 #, python-format
-msgid "%(num_users)s users"
-msgstr ""
+msgid "%(num_users)s user"
+msgid_plural "%(num_users)s users"
+msgstr[0] ""
+msgstr[1] ""
 
 #: warehouse/templates/index.html:81
 msgid ""

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -230,7 +230,7 @@ msgstr ""
 #: warehouse/templates/includes/accounts/profile-callout.html:18
 #: warehouse/templates/includes/hash-modal.html:23
 #: warehouse/templates/includes/packaging/project-data.html:66
-#: warehouse/templates/index.html:82 warehouse/templates/index.html:86
+#: warehouse/templates/index.html:106 warehouse/templates/index.html:110
 #: warehouse/templates/manage/account.html:152
 #: warehouse/templates/manage/account.html:250
 #: warehouse/templates/manage/account.html:256
@@ -449,7 +449,7 @@ msgstr ""
 msgid "Main menu"
 msgstr ""
 
-#: warehouse/templates/base.html:76 warehouse/templates/index.html:79
+#: warehouse/templates/base.html:76 warehouse/templates/index.html:103
 msgid ""
 "The Python Package Index (PyPI) is a repository of software for the "
 "Python programming language."
@@ -661,65 +661,89 @@ msgstr ""
 msgid "Or <a href=\"%(href)s\">browse projects</a>"
 msgstr ""
 
-#: warehouse/templates/index.html:66
-#, python-format
-msgid "%(num_projects_formatted)s project"
-msgid_plural "%(num_projects_formatted)s projects"
-msgstr[0] ""
-msgstr[1] ""
-
 #: warehouse/templates/index.html:67
 #, python-format
-msgid "%(num_releases_formatted)s release"
-msgid_plural "%(num_releases_formatted)s releases"
+msgid ""
+"\n"
+"      %(num_projects_formatted)s project\n"
+"    "
+msgid_plural ""
+"\n"
+"      %(num_projects_formatted)s projects\n"
+"    "
 msgstr[0] ""
 msgstr[1] ""
 
-#: warehouse/templates/index.html:68
+#: warehouse/templates/index.html:74
 #, python-format
-msgid "%(num_files_formatted)s file"
-msgid_plural "%(num_files_formatted)s files"
-msgstr[0] ""
-msgstr[1] ""
-
-#: warehouse/templates/index.html:69
-#, python-format
-msgid "%(num_users_formatted)s user"
-msgid_plural "%(num_users_formatted)s users"
+msgid ""
+"\n"
+"      %(num_releases_formatted)s release\n"
+"    "
+msgid_plural ""
+"\n"
+"      %(num_releases_formatted)s releases\n"
+"    "
 msgstr[0] ""
 msgstr[1] ""
 
 #: warehouse/templates/index.html:81
+#, python-format
+msgid ""
+"\n"
+"      %(num_files_formatted)s file\n"
+"    "
+msgid_plural ""
+"\n"
+"      %(num_files_formatted)s files\n"
+"    "
+msgstr[0] ""
+msgstr[1] ""
+
+#: warehouse/templates/index.html:88
+#, python-format
+msgid ""
+"\n"
+"      %(num_users_formatted)s user\n"
+"    "
+msgid_plural ""
+"\n"
+"      %(num_users_formatted)s users\n"
+"    "
+msgstr[0] ""
+msgstr[1] ""
+
+#: warehouse/templates/index.html:105
 msgid ""
 "PyPI helps you find and install software developed and shared by the "
 "Python community."
 msgstr ""
 
-#: warehouse/templates/index.html:82
+#: warehouse/templates/index.html:106
 msgid "Learn about installing packages</a>."
 msgstr ""
 
-#: warehouse/templates/index.html:85
+#: warehouse/templates/index.html:109
 msgid "Package authors use PyPI to distribute their software."
 msgstr ""
 
-#: warehouse/templates/index.html:86
+#: warehouse/templates/index.html:110
 msgid "Learn how to package your Python code for PyPI</a>."
 msgstr ""
 
-#: warehouse/templates/index.html:96
+#: warehouse/templates/index.html:120
 msgid "Trending projects"
 msgstr ""
 
-#: warehouse/templates/index.html:97
+#: warehouse/templates/index.html:121
 msgid "Trending projects as downloaded by the community"
 msgstr ""
 
-#: warehouse/templates/index.html:107
+#: warehouse/templates/index.html:131
 msgid "New releases"
 msgstr ""
 
-#: warehouse/templates/index.html:108
+#: warehouse/templates/index.html:132
 msgid "Hot off the press: the newest project releases"
 msgstr ""
 

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -664,28 +664,28 @@ msgstr ""
 #: warehouse/templates/index.html:66
 #, python-format
 msgid "%(num_projects)s project"
-msgid_plural "%(num_projects)s projects"
+msgid_plural "%(num_projects_formatted)s projects"
 msgstr[0] ""
 msgstr[1] ""
 
 #: warehouse/templates/index.html:67
 #, python-format
 msgid "%(num_releases)s release"
-msgid_plural "%(num_releases)s releases"
+msgid_plural "%(num_releases_formatted)s releases"
 msgstr[0] ""
 msgstr[1] ""
 
 #: warehouse/templates/index.html:68
 #, python-format
 msgid "%(num_files)s file"
-msgid_plural "%(num_files)s files"
+msgid_plural "%(num_files_formatted)s files"
 msgstr[0] ""
 msgstr[1] ""
 
 #: warehouse/templates/index.html:69
 #, python-format
 msgid "%(num_users)s user"
-msgid_plural "%(num_users)s users"
+msgid_plural "%(num_users_formatted)s users"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -663,28 +663,28 @@ msgstr ""
 
 #: warehouse/templates/index.html:66
 #, python-format
-msgid "%(num_projects)s project"
+msgid "%(num_projects_formatted)s project"
 msgid_plural "%(num_projects_formatted)s projects"
 msgstr[0] ""
 msgstr[1] ""
 
 #: warehouse/templates/index.html:67
 #, python-format
-msgid "%(num_releases)s release"
+msgid "%(num_releases_formatted)s release"
 msgid_plural "%(num_releases_formatted)s releases"
 msgstr[0] ""
 msgstr[1] ""
 
 #: warehouse/templates/index.html:68
 #, python-format
-msgid "%(num_files)s file"
+msgid "%(num_files_formatted)s file"
 msgid_plural "%(num_files_formatted)s files"
 msgstr[0] ""
 msgstr[1] ""
 
 #: warehouse/templates/index.html:69
 #, python-format
-msgid "%(num_users)s user"
+msgid "%(num_users_formatted)s user"
 msgid_plural "%(num_users_formatted)s users"
 msgstr[0] ""
 msgstr[1] ""

--- a/warehouse/templates/index.html
+++ b/warehouse/templates/index.html
@@ -64,10 +64,10 @@
 
 <div class="horizontal-section horizontal-section--grey horizontal-section--thin horizontal-section--statistics">
   <div class="statistics-bar">
-    <p class="statistics-bar__statistic">{% trans num_projects=num_projects, num_projects_formatted=num_projects|format_number %}{{ num_projects }} project{% pluralize num_projects %}{{ num_projects_formatted }} projects{% endtrans %}</p>
-    <p class="statistics-bar__statistic">{% trans num_releases=num_releases, num_releases_formatted=num_releases|format_number %}{{ num_releases }} release{% pluralize num_releases %}{{ num_releases_formatted }} releases{% endtrans %}</p>
-    <p class="statistics-bar__statistic">{% trans num_files=num_files, num_files_formatted=num_files|format_number %}{{ num_files }} file{% pluralize num_files %}{{ num_files_formatted }} files{% endtrans %}</p>
-    <p class="statistics-bar__statistic">{% trans num_users=num_users, num_users_formatted=num_users|format_number %}{{ num_users }} user{% pluralize num_users %}{{ num_users_formatted }} users{% endtrans %}</p>
+    <p class="statistics-bar__statistic">{% trans num_projects=num_projects, num_projects_formatted=num_projects|format_number %}{{ num_projects_formatted }} project{% pluralize num_projects %}{{ num_projects_formatted }} projects{% endtrans %}</p>
+    <p class="statistics-bar__statistic">{% trans num_releases=num_releases, num_releases_formatted=num_releases|format_number %}{{ num_releases_formatted }} release{% pluralize num_releases %}{{ num_releases_formatted }} releases{% endtrans %}</p>
+    <p class="statistics-bar__statistic">{% trans num_files=num_files, num_files_formatted=num_files|format_number %}{{ num_files_formatted }} file{% pluralize num_files %}{{ num_files_formatted }} files{% endtrans %}</p>
+    <p class="statistics-bar__statistic">{% trans num_users=num_users, num_users_formatted=num_users|format_number %}{{ num_users_formatted }} user{% pluralize num_users %}{{ num_users_formatted }} users{% endtrans %}</p>
   </div>
 </div>
 

--- a/warehouse/templates/index.html
+++ b/warehouse/templates/index.html
@@ -64,10 +64,10 @@
 
 <div class="horizontal-section horizontal-section--grey horizontal-section--thin horizontal-section--statistics">
   <div class="statistics-bar">
-    <p class="statistics-bar__statistic">{% trans num_projects=num_projects|format_number %}{{ num_projects }} projects{% endtrans %}</p>
-    <p class="statistics-bar__statistic">{% trans num_releases=num_releases|format_number %}{{ num_releases }} releases{% endtrans %}</p>
-    <p class="statistics-bar__statistic">{% trans num_files=num_files|format_number %}{{ num_files }} files{% endtrans %}</p>
-    <p class="statistics-bar__statistic">{% trans num_users=num_users|format_number %}{{ num_users }} users{% endtrans %}</p>
+    <p class="statistics-bar__statistic">{% trans num_projects=num_projects|format_number %}{{ num_projects }} project{% pluralize %}{{ num_projects }} projects{% endtrans %}</p>
+    <p class="statistics-bar__statistic">{% trans num_releases=num_releases|format_number %}{{ num_releases }} release{% pluralize %}{{ num_releases }} releases{% endtrans %}</p>
+    <p class="statistics-bar__statistic">{% trans num_files=num_files|format_number %}{{ num_files }} file{% pluralize %}{{ num_files }} files{% endtrans %}</p>
+    <p class="statistics-bar__statistic">{% trans num_users=num_users|format_number %}{{ num_users }} user{% pluralize %}{{ num_users }} users{% endtrans %}</p>
   </div>
 </div>
 

--- a/warehouse/templates/index.html
+++ b/warehouse/templates/index.html
@@ -64,10 +64,34 @@
 
 <div class="horizontal-section horizontal-section--grey horizontal-section--thin horizontal-section--statistics">
   <div class="statistics-bar">
-    <p class="statistics-bar__statistic">{% trans num_projects=num_projects, num_projects_formatted=num_projects|format_number %}{{ num_projects_formatted }} project{% pluralize num_projects %}{{ num_projects_formatted }} projects{% endtrans %}</p>
-    <p class="statistics-bar__statistic">{% trans num_releases=num_releases, num_releases_formatted=num_releases|format_number %}{{ num_releases_formatted }} release{% pluralize num_releases %}{{ num_releases_formatted }} releases{% endtrans %}</p>
-    <p class="statistics-bar__statistic">{% trans num_files=num_files, num_files_formatted=num_files|format_number %}{{ num_files_formatted }} file{% pluralize num_files %}{{ num_files_formatted }} files{% endtrans %}</p>
-    <p class="statistics-bar__statistic">{% trans num_users=num_users, num_users_formatted=num_users|format_number %}{{ num_users_formatted }} user{% pluralize num_users %}{{ num_users_formatted }} users{% endtrans %}</p>
+    <p class="statistics-bar__statistic">
+    {% trans num_projects=num_projects, num_projects_formatted=num_projects|format_number %}
+      {{ num_projects_formatted }} project
+    {% pluralize num_projects %}
+      {{ num_projects_formatted }} projects
+    {% endtrans %}
+    </p>
+    <p class="statistics-bar__statistic">
+    {% trans num_releases=num_releases, num_releases_formatted=num_releases|format_number %}
+      {{ num_releases_formatted }} release
+    {% pluralize num_releases %}
+      {{ num_releases_formatted }} releases
+    {% endtrans %}
+    </p>
+    <p class="statistics-bar__statistic">
+    {% trans num_files=num_files, num_files_formatted=num_files|format_number %}
+      {{ num_files_formatted }} file
+    {% pluralize num_files %}
+      {{ num_files_formatted }} files
+    {% endtrans %}
+    </p>
+    <p class="statistics-bar__statistic">
+    {% trans num_users=num_users, num_users_formatted=num_users|format_number %}
+      {{ num_users_formatted }} user
+    {% pluralize num_users %}
+      {{ num_users_formatted }} users
+    {% endtrans %}
+    </p>
   </div>
 </div>
 

--- a/warehouse/templates/index.html
+++ b/warehouse/templates/index.html
@@ -64,10 +64,10 @@
 
 <div class="horizontal-section horizontal-section--grey horizontal-section--thin horizontal-section--statistics">
   <div class="statistics-bar">
-    <p class="statistics-bar__statistic">{% trans num_projects=num_projects|format_number %}{{ num_projects }} project{% pluralize %}{{ num_projects }} projects{% endtrans %}</p>
-    <p class="statistics-bar__statistic">{% trans num_releases=num_releases|format_number %}{{ num_releases }} release{% pluralize %}{{ num_releases }} releases{% endtrans %}</p>
-    <p class="statistics-bar__statistic">{% trans num_files=num_files|format_number %}{{ num_files }} file{% pluralize %}{{ num_files }} files{% endtrans %}</p>
-    <p class="statistics-bar__statistic">{% trans num_users=num_users|format_number %}{{ num_users }} user{% pluralize %}{{ num_users }} users{% endtrans %}</p>
+    <p class="statistics-bar__statistic">{% trans num_projects=num_projects, num_projects_formatted=num_projects|format_number %}{{ num_projects }} project{% pluralize num_projects %}{{ num_projects_formatted }} projects{% endtrans %}</p>
+    <p class="statistics-bar__statistic">{% trans num_releases=num_releases, num_releases_formatted=num_releases|format_number %}{{ num_releases }} release{% pluralize num_releases %}{{ num_releases_formatted }} releases{% endtrans %}</p>
+    <p class="statistics-bar__statistic">{% trans num_files=num_files, num_files_formatted=num_files|format_number %}{{ num_files }} file{% pluralize num_files %}{{ num_files_formatted }} files{% endtrans %}</p>
+    <p class="statistics-bar__statistic">{% trans num_users=num_users, num_users_formatted=num_users|format_number %}{{ num_users }} user{% pluralize num_users %}{{ num_users_formatted }} users{% endtrans %}</p>
   </div>
 </div>
 

--- a/warehouse/templates/index.html
+++ b/warehouse/templates/index.html
@@ -65,28 +65,28 @@
 <div class="horizontal-section horizontal-section--grey horizontal-section--thin horizontal-section--statistics">
   <div class="statistics-bar">
     <p class="statistics-bar__statistic">
-    {% trans num_projects=num_projects, num_projects_formatted=num_projects|format_number %}
+    {% trans trimmed num_projects=num_projects, num_projects_formatted=num_projects|format_number %}
       {{ num_projects_formatted }} project
     {% pluralize num_projects %}
       {{ num_projects_formatted }} projects
     {% endtrans %}
     </p>
     <p class="statistics-bar__statistic">
-    {% trans num_releases=num_releases, num_releases_formatted=num_releases|format_number %}
+    {% trans trimmed num_releases=num_releases, num_releases_formatted=num_releases|format_number %}
       {{ num_releases_formatted }} release
     {% pluralize num_releases %}
       {{ num_releases_formatted }} releases
     {% endtrans %}
     </p>
     <p class="statistics-bar__statistic">
-    {% trans num_files=num_files, num_files_formatted=num_files|format_number %}
+    {% trans trimmed num_files=num_files, num_files_formatted=num_files|format_number %}
       {{ num_files_formatted }} file
     {% pluralize num_files %}
       {{ num_files_formatted }} files
     {% endtrans %}
     </p>
     <p class="statistics-bar__statistic">
-    {% trans num_users=num_users, num_users_formatted=num_users|format_number %}
+    {% trans trimmed num_users=num_users, num_users_formatted=num_users|format_number %}
       {{ num_users_formatted }} user
     {% pluralize num_users %}
       {{ num_users_formatted }} users


### PR DESCRIPTION
Initial change caused issues as `pluralize` was trying to interpret a formatted number instead of an integer: https://sentry.io/share/issue/dd54ac64ea7d4550855117f85a460a85/

Jinja docs say that we can pass a different value to `pluralize`: https://jinja.palletsprojects.com/en/2.11.x/templates/#i18n