### PR TITLE
Normalize language names

### DIFF
--- a/warehouse/i18n/__init__.py
+++ b/warehouse/i18n/__init__.py
@@ -23,8 +23,8 @@ from warehouse.cache.http import add_vary
 # https://github.com/django/django/blob/master/django/conf/locale/__init__.py
 KNOWN_LOCALES = {
     "en": "English",  # English
-    "es": "español",  # Spanish
-    "fr": "français",  # French
+    "es": "Español",  # Spanish
+    "fr": "Français",  # French
     "ja": "日本語",  # Japanese
     "pt_BR": "Português Brasileiro",  # Brazilian Portugeuse
     "uk": "Українська",  # Ukrainian


### PR DESCRIPTION
All locale names are capitalized, except for Spanish and French. I think it makes sense to have the same style for them too.