### PR TITLE
Drop unnecessary comma after "You can proceed to"

### DIFF
--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -4246,7 +4246,7 @@ msgstr ""
 #: warehouse/templates/pages/help.html:559
 #, python-format
 msgid ""
-"You can proceed to, <a href=\"%(href)s\" title=\"%(title)s\" "
+"You can proceed to <a href=\"%(href)s\" title=\"%(title)s\" "
 "target=\"_blank\" rel=\"noopener\">file an issue on our tracker</a> to "
 "request assistance with account recovery."
 msgstr ""

--- a/warehouse/templates/pages/help.html
+++ b/warehouse/templates/pages/help.html
@@ -557,7 +557,7 @@
         </ul>
         <p>
           {% trans trimmed href='https://github.com/pypa/pypi-support/issues/new?labels=account-recovery&template=account-recovery.md&title=Account+recovery+request', title=gettext('External link') %}
-            You can proceed to, <a href="{{ href }}" title="{{ title }}" target="_blank" rel="noopener">file an issue on our tracker</a> to request assistance with account recovery.
+            You can proceed to <a href="{{ href }}" title="{{ title }}" target="_blank" rel="noopener">file an issue on our tracker</a> to request assistance with account recovery.
           {% endtrans %}
         </p>
         {{ code_of_conduct() }}


### PR DESCRIPTION
It seems incorrect that it's there.