### PR TITLE
redistribute sitemap buckets

### DIFF
--- a/tests/unit/sitemap/test_views.py
+++ b/tests/unit/sitemap/test_views.py
@@ -47,9 +47,9 @@ def test_sitemap_index(db_request):
 
     assert sitemap.sitemap_index(db_request) == {
         "buckets": [
-            sitemap.Bucket("0", modified=project.created),
-            sitemap.Bucket("1", modified=users[0].date_joined),
-            sitemap.Bucket("5", modified=None),
+            sitemap.Bucket("0a", modified=project.created),
+            sitemap.Bucket("1f", modified=users[0].date_joined),
+            sitemap.Bucket("52", modified=None),
         ]
     }
     assert db_request.response.content_type == "text/xml"
@@ -66,7 +66,7 @@ def test_sitemap_bucket(db_request):
     expected_iter = iter(expected)
     db_request.route_url = pretend.call_recorder(lambda *a, **kw: next(expected_iter))
 
-    db_request.matchdict["bucket"] = "0"
+    db_request.matchdict["bucket"] = "0a"
 
     ProjectFactory.create(
         name="foobar", created=(datetime.utcnow() - timedelta(days=15))
@@ -86,13 +86,13 @@ def test_sitemap_bucket_too_many(monkeypatch, db_request):
     )
 
     db_request.route_url = pretend.call_recorder(lambda *a, **kw: "/")
-    db_request.matchdict["bucket"] = "5"
+    db_request.matchdict["bucket"] = "52"
 
     monkeypatch.setattr(sitemap, "SITEMAP_MAXSIZE", 2)
 
     for _ in range(3):
         p = ProjectFactory.create(created=(datetime.utcnow() - timedelta(days=15)))
-        p.sitemap_bucket = "5"
+        p.sitemap_bucket = "52"
 
     db_request.db.flush()
 

--- a/warehouse/migrations/versions/c4cb2d15dada_redistribute_sitemap_buckets.py
+++ b/warehouse/migrations/versions/c4cb2d15dada_redistribute_sitemap_buckets.py
@@ -1,0 +1,83 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+redistribute sitemap buckets
+
+Revision ID: c4cb2d15dada
+Revises: d15f020ee3df
+Create Date: 2020-04-07 16:59:56.333491
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "c4cb2d15dada"
+down_revision = "d15f020ee3df"
+
+
+def upgrade():
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION sitemap_bucket(text) RETURNS text AS $$
+                SELECT substring(
+                    encode(digest($1, 'sha512'), 'hex')
+                    from 1
+                    for 2
+                )
+            $$
+            LANGUAGE SQL
+            IMMUTABLE
+            RETURNS NULL ON NULL INPUT;
+    """
+    )
+    op.execute(
+        """
+        UPDATE users
+        SET sitemap_bucket = sitemap_bucket(username)
+        """
+    )
+    op.execute(
+        """
+        UPDATE projects
+        SET sitemap_bucket = sitemap_bucket(name)
+        """
+    )
+
+
+def downgrade():
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION sitemap_bucket(text) RETURNS text AS $$
+                SELECT substring(
+                    encode(digest($1, 'sha512'), 'hex')
+                    from 1
+                    for 1
+                )
+            $$
+            LANGUAGE SQL
+            IMMUTABLE
+            RETURNS NULL ON NULL INPUT;
+    """
+    )
+    op.execute(
+        """
+        UPDATE users
+        SET sitemap_bucket = sitemap_bucket(username)
+        """
+    )
+    op.execute(
+        """
+        UPDATE projects
+        SET sitemap_bucket = sitemap_bucket(name)
+        """
+    )

--- a/warehouse/migrations/versions/c4cb2d15dada_redistribute_sitemap_buckets.py
+++ b/warehouse/migrations/versions/c4cb2d15dada_redistribute_sitemap_buckets.py
@@ -17,8 +17,6 @@ Revises: d15f020ee3df
 Create Date: 2020-04-07 16:59:56.333491
 """
 
-import sqlalchemy as sa
-
 from alembic import op
 
 revision = "c4cb2d15dada"


### PR DESCRIPTION
while researching for #7765 i noticed that each bucket on PyPI is currently up to ~40,000 entries.

max allowed is 50,000 so this will keep it from sneaking up on us and give us... "plenty" of headroom for growth!