### PR TITLE
Use threadlocals less

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,14 +30,14 @@ from pytest_postgresql.factories import DatabaseJanitor, get_config
 from sqlalchemy import event
 
 from warehouse import admin, config, static
-from warehouse.accounts import services as account_services, views as account_views
+from warehouse.accounts import services as account_services
 from warehouse.macaroons import services as macaroon_services
 from warehouse.manage import views as manage_views
 from warehouse.metrics import IMetricsService
 
 from .common.db import Session
 
-L10N_TAGGED_MODULES = [account_views, manage_views]
+L10N_TAGGED_MODULES = [manage_views]
 
 
 def pytest_collection_modifyitems(items):
@@ -101,6 +101,12 @@ def pyramid_services(metrics):
 def pyramid_request(pyramid_services):
     dummy_request = pyramid.testing.DummyRequest()
     dummy_request.find_service = pyramid_services.find_service
+
+    def localize(message, **kwargs):
+        ts = TranslationString(message, **kwargs)
+        return ts.interpolate()
+
+    dummy_request._ = localize
 
     return dummy_request
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,12 +32,9 @@ from sqlalchemy import event
 from warehouse import admin, config, static
 from warehouse.accounts import services as account_services
 from warehouse.macaroons import services as macaroon_services
-from warehouse.manage import views as manage_views
 from warehouse.metrics import IMetricsService
 
 from .common.db import Session
-
-L10N_TAGGED_MODULES = [manage_views]
 
 
 def pytest_collection_modifyitems(items):
@@ -336,13 +333,3 @@ def monkeypatch_session():
     m = MonkeyPatch()
     yield m
     m.undo()
-
-
-@pytest.fixture(scope="session", autouse=True)
-def dummy_localize(monkeypatch_session):
-    def localize(message, **kwargs):
-        ts = TranslationString(message, **kwargs)
-        return ts.interpolate()
-
-    for mod in L10N_TAGGED_MODULES:
-        monkeypatch_session.setattr(mod, "_", localize)

--- a/tests/unit/accounts/test_views.py
+++ b/tests/unit/accounts/test_views.py
@@ -41,7 +41,7 @@ from ...common.db.accounts import EmailFactory, UserFactory
 class TestFailedLoginView:
     def test_too_many_failed_logins(self):
         exc = TooManyFailedLogins(resets_in=datetime.timedelta(seconds=600))
-        request = pretend.stub(localizer=pretend.stub(translate=lambda tsf: tsf()))
+        request = pretend.stub(_=lambda message: message)
 
         resp = views.failed_logins(exc, request)
 
@@ -53,7 +53,7 @@ class TestFailedLoginView:
 
     def test_too_many_emails_added(self):
         exc = TooManyEmailsAdded(resets_in=datetime.timedelta(seconds=600))
-        request = pretend.stub(localizer=pretend.stub(translate=lambda tsf: tsf()))
+        request = pretend.stub(_=lambda message: message)
 
         resp = views.unverified_emails(exc, request)
 

--- a/tests/unit/accounts/test_views.py
+++ b/tests/unit/accounts/test_views.py
@@ -39,11 +39,10 @@ from ...common.db.accounts import EmailFactory, UserFactory
 
 
 class TestFailedLoginView:
-    def test_too_many_failed_logins(self):
+    def test_too_many_failed_logins(self, pyramid_request):
         exc = TooManyFailedLogins(resets_in=datetime.timedelta(seconds=600))
-        request = pretend.stub(_=lambda message: message)
 
-        resp = views.failed_logins(exc, request)
+        resp = views.failed_logins(exc, pyramid_request)
 
         assert resp.status == "429 Too Many Failed Login Attempts"
         assert resp.detail == (
@@ -51,11 +50,10 @@ class TestFailedLoginView:
         )
         assert dict(resp.headers).get("Retry-After") == "600"
 
-    def test_too_many_emails_added(self):
+    def test_too_many_emails_added(self, pyramid_request):
         exc = TooManyEmailsAdded(resets_in=datetime.timedelta(seconds=600))
-        request = pretend.stub(_=lambda message: message)
 
-        resp = views.unverified_emails(exc, request)
+        resp = views.unverified_emails(exc, pyramid_request)
 
         assert resp.status == "429 Too Many Requests"
         assert resp.detail == (
@@ -658,72 +656,70 @@ class TestTwoFactor:
         ]
         assert result == {"totp_form": form_obj}
 
-    def test_two_factor_token_missing_userid(self):
+    def test_two_factor_token_missing_userid(self, pyramid_request):
         token_service = pretend.stub(
             loads=pretend.call_recorder(lambda *a, **kw: ({}, None))
         )
 
-        request = pretend.stub(
-            session=pretend.stub(flash=pretend.call_recorder(lambda *a, **kw: None)),
-            authenticated_userid=None,
-            route_path=pretend.call_recorder(lambda p: "redirect_to"),
-            find_service=lambda interface, **kwargs: {ITokenService: token_service}[
-                interface
-            ],
-            query_string=pretend.stub(),
+        pyramid_request.session = pretend.stub(
+            flash=pretend.call_recorder(lambda *a, **kw: None)
         )
-        result = views.two_factor_and_totp_validate(request)
+        pyramid_request.route_path = pretend.call_recorder(lambda p: "redirect_to")
+        pyramid_request.find_service = lambda interface, **kwargs: {
+            ITokenService: token_service
+        }[interface]
+        pyramid_request.query_string = pretend.stub()
+        result = views.two_factor_and_totp_validate(pyramid_request)
 
         assert token_service.loads.calls == [
-            pretend.call(request.query_string, return_timestamp=True)
+            pretend.call(pyramid_request.query_string, return_timestamp=True)
         ]
-        assert request.route_path.calls == [pretend.call("accounts.login")]
-        assert request.session.flash.calls == [
+        assert pyramid_request.route_path.calls == [pretend.call("accounts.login")]
+        assert pyramid_request.session.flash.calls == [
             pretend.call("Invalid or expired two factor login.", queue="error")
         ]
 
         assert isinstance(result, HTTPSeeOther)
         assert result.headers["Location"] == "redirect_to"
 
-    def test_two_factor_token_invalid(self):
+    def test_two_factor_token_invalid(self, pyramid_request):
         token_service = pretend.stub(loads=pretend.raiser(TokenException))
-        request = pretend.stub(
-            session=pretend.stub(flash=pretend.call_recorder(lambda *a, **kw: None)),
-            authenticated_userid=None,
-            route_path=pretend.call_recorder(lambda p: "redirect_to"),
-            find_service=lambda interface, **kwargs: {ITokenService: token_service}[
-                interface
-            ],
-            query_string=pretend.stub(),
-        )
 
-        result = views.two_factor_and_totp_validate(request)
+        pyramid_request.session = pretend.stub(
+            flash=pretend.call_recorder(lambda *a, **kw: None)
+        )
+        pyramid_request.find_service = lambda interface, **kwargs: {
+            ITokenService: token_service
+        }[interface]
+        pyramid_request.route_path = pretend.call_recorder(lambda p: "redirect_to")
+
+        result = views.two_factor_and_totp_validate(pyramid_request)
 
         assert isinstance(result, HTTPSeeOther)
         assert result.headers["Location"] == "redirect_to"
-        assert request.session.flash.calls == [
+        assert pyramid_request.session.flash.calls == [
             pretend.call("Invalid or expired two factor login.", queue="error")
         ]
 
 
 class TestWebAuthn:
-    def test_webauthn_get_options_already_authenticated(self):
-        request = pretend.stub(authenticated_userid=pretend.stub())
+    def test_webauthn_get_options_already_authenticated(self, pyramid_request):
+        request = pretend.stub(authenticated_userid=pretend.stub(), _=lambda a: a)
         result = views.webauthn_authentication_options(request)
 
         assert result == {"fail": {"errors": ["Already authenticated"]}}
 
-    def test_webauthn_get_options_invalid_token(self, monkeypatch):
+    def test_webauthn_get_options_invalid_token(self, monkeypatch, pyramid_request):
         _get_two_factor_data = pretend.raiser(TokenException)
         monkeypatch.setattr(views, "_get_two_factor_data", _get_two_factor_data)
 
-        request = pretend.stub(
-            session=pretend.stub(flash=pretend.call_recorder(lambda *a, **kw: None)),
-            authenticated_userid=None,
+        pyramid_request.session = pretend.stub(
+            flash=pretend.call_recorder(lambda *a, **kw: None)
         )
-        result = views.webauthn_authentication_options(request)
 
-        assert request.session.flash.calls == [
+        result = views.webauthn_authentication_options(pyramid_request)
+
+        assert pyramid_request.session.flash.calls == [
             pretend.call("Invalid or expired two factor login.", queue="error")
         ]
         assert result == {"fail": {"errors": ["Invalid or expired two factor login."]}}
@@ -760,17 +756,17 @@ class TestWebAuthn:
 
         assert result == {"fail": {"errors": ["Already authenticated"]}}
 
-    def test_webauthn_validate_invalid_token(self, monkeypatch):
+    def test_webauthn_validate_invalid_token(self, monkeypatch, pyramid_request):
         _get_two_factor_data = pretend.raiser(TokenException)
         monkeypatch.setattr(views, "_get_two_factor_data", _get_two_factor_data)
 
-        request = pretend.stub(
-            session=pretend.stub(flash=pretend.call_recorder(lambda *a, **kw: None)),
-            authenticated_userid=None,
+        pyramid_request.session = pretend.stub(
+            flash=pretend.call_recorder(lambda *a, **kw: None)
         )
-        result = views.webauthn_authentication_validate(request)
 
-        assert request.session.flash.calls == [
+        result = views.webauthn_authentication_validate(pyramid_request)
+
+        assert pyramid_request.session.flash.calls == [
             pretend.call("Invalid or expired two factor login.", queue="error")
         ]
         assert result == {"fail": {"errors": ["Invalid or expired two factor login."]}}
@@ -810,7 +806,7 @@ class TestWebAuthn:
 
         assert result == {"fail": {"errors": ["Fake validation failure"]}}
 
-    def test_webauthn_validate(self, monkeypatch):
+    def test_webauthn_validate(self, monkeypatch, pyramid_request):
         _get_two_factor_data = pretend.call_recorder(
             lambda r: {"redirect_to": "foobar", "userid": 1}
         )
@@ -827,23 +823,11 @@ class TestWebAuthn:
                 lambda *a: pretend.stub()
             ),
         )
-
-        request = pretend.stub(
-            authenticated_userid=None,
-            POST={},
-            session=pretend.stub(
-                get_webauthn_challenge=pretend.call_recorder(lambda: "not_real"),
-                clear_webauthn_challenge=pretend.call_recorder(lambda: pretend.stub()),
-            ),
-            find_service=lambda *a, **kw: user_service,
-            host_url=pretend.stub(),
-            registry=pretend.stub(settings=pretend.stub(get=lambda *a: pretend.stub())),
-            rp_id=pretend.stub(),
-            domain=pretend.stub(),
-            response=pretend.stub(
-                set_cookie=pretend.call_recorder(lambda *a: pretend.stub())
-            ),
+        pyramid_request.session = pretend.stub(
+            get_webauthn_challenge=pretend.call_recorder(lambda: "not_real"),
+            clear_webauthn_challenge=pretend.call_recorder(lambda: pretend.stub()),
         )
+        pyramid_request.find_service = lambda *a, **kw: user_service
 
         form_obj = pretend.stub(
             validate=pretend.call_recorder(lambda: True),
@@ -853,14 +837,16 @@ class TestWebAuthn:
         form_class = pretend.call_recorder(lambda *a, **kw: form_obj)
         monkeypatch.setattr(views, "WebAuthnAuthenticationForm", form_class)
 
-        result = views.webauthn_authentication_validate(request)
+        result = views.webauthn_authentication_validate(pyramid_request)
 
-        assert _get_two_factor_data.calls == [pretend.call(request)]
+        assert _get_two_factor_data.calls == [pretend.call(pyramid_request)]
         assert _login_user.calls == [
-            pretend.call(request, 1, two_factor_method="webauthn")
+            pretend.call(pyramid_request, 1, two_factor_method="webauthn")
         ]
-        assert request.session.get_webauthn_challenge.calls == [pretend.call()]
-        assert request.session.clear_webauthn_challenge.calls == [pretend.call()]
+        assert pyramid_request.session.get_webauthn_challenge.calls == [pretend.call()]
+        assert pyramid_request.session.clear_webauthn_challenge.calls == [
+            pretend.call()
+        ]
 
         assert result == {
             "success": "Successful WebAuthn assertion",
@@ -881,24 +867,22 @@ class TestRecoveryCode:
         assert isinstance(result, HTTPSeeOther)
         assert result.headers["Location"] == "redirect_to"
 
-    def test_two_factor_token_invalid(self):
+    def test_two_factor_token_invalid(self, pyramid_request):
         token_service = pretend.stub(loads=pretend.raiser(TokenException))
-        request = pretend.stub(
-            session=pretend.stub(flash=pretend.call_recorder(lambda *a, **kw: None)),
-            authenticated_userid=None,
-            route_path=pretend.call_recorder(lambda p: "redirect_to"),
-            find_service=lambda interface, **kwargs: {ITokenService: token_service}[
-                interface
-            ],
-            query_string=pretend.stub(),
+        pyramid_request.session = pretend.stub(
+            flash=pretend.call_recorder(lambda *a, **kw: None)
         )
+        pyramid_request.route_path = pretend.call_recorder(lambda p: "redirect_to")
+        pyramid_request.find_service = lambda interface, **kwargs: {
+            ITokenService: token_service
+        }[interface]
 
-        result = views.recovery_code(request)
+        result = views.recovery_code(pyramid_request)
 
         assert isinstance(result, HTTPSeeOther)
-        assert request.route_path.calls == [pretend.call("accounts.login")]
+        assert pyramid_request.route_path.calls == [pretend.call("accounts.login")]
         assert result.headers["Location"] == "redirect_to"
-        assert request.session.flash.calls == [
+        assert pyramid_request.session.flash.calls == [
             pretend.call("Invalid or expired two factor login.", queue="error")
         ]
 
@@ -1076,23 +1060,21 @@ class TestRecoveryCode:
         ]
         assert result == {"form": form_obj}
 
-    def test_recovery_code_auth_invalid_token(self):
+    def test_recovery_code_auth_invalid_token(self, pyramid_request):
         token_service = pretend.stub(loads=pretend.raiser(TokenException))
-        request = pretend.stub(
-            session=pretend.stub(flash=pretend.call_recorder(lambda *a, **kw: None)),
-            authenticated_userid=None,
-            route_path=pretend.call_recorder(lambda p: "redirect_to"),
-            find_service=lambda interface, **kwargs: {ITokenService: token_service}[
-                interface
-            ],
-            query_string=pretend.stub(),
+        pyramid_request.session = pretend.stub(
+            flash=pretend.call_recorder(lambda *a, **kw: None)
         )
+        pyramid_request.route_path = pretend.call_recorder(lambda p: "redirect_to")
+        pyramid_request.find_service = lambda interface, **kwargs: {
+            ITokenService: token_service
+        }[interface]
 
-        result = views.recovery_code(request)
+        result = views.recovery_code(pyramid_request)
 
         assert isinstance(result, HTTPSeeOther)
         assert result.headers["Location"] == "redirect_to"
-        assert request.session.flash.calls == [
+        assert pyramid_request.session.flash.calls == [
             pretend.call("Invalid or expired two factor login.", queue="error")
         ]
 

--- a/tests/unit/i18n/test_init.py
+++ b/tests/unit/i18n/test_init.py
@@ -138,7 +138,7 @@ def test_includeme():
     config = pretend.stub(
         add_translation_dirs=pretend.call_recorder(lambda s: None),
         set_locale_negotiator=pretend.call_recorder(lambda f: None),
-        add_request_method=pretend.call_recorder(lambda f, name, reify: None),
+        add_request_method=pretend.call_recorder(lambda f, name, reify=False: None),
         get_settings=lambda: config_settings,
         add_view_deriver=pretend.call_recorder(lambda f, over, under: None),
     )
@@ -148,7 +148,8 @@ def test_includeme():
     assert config.add_translation_dirs.calls == [pretend.call("warehouse:locale/")]
     assert config.set_locale_negotiator.calls == [pretend.call(i18n._negotiate_locale)]
     assert config.add_request_method.calls == [
-        pretend.call(i18n._locale, name="locale", reify=True)
+        pretend.call(i18n._locale, name="locale", reify=True),
+        pretend.call(i18n._localize, name="_"),
     ]
     assert config.add_view_deriver.calls == [
         pretend.call(

--- a/warehouse/accounts/views.py
+++ b/warehouse/accounts/views.py
@@ -53,7 +53,6 @@ from warehouse.email import (
     send_password_change_email,
     send_password_reset_email,
 )
-from warehouse.i18n import localize as _
 from warehouse.packaging.models import Project, Release
 from warehouse.rate_limiting.interfaces import IRateLimiter
 from warehouse.utils.http import is_safe_url
@@ -217,7 +216,9 @@ def two_factor_and_totp_validate(request, _form_class=TOTPAuthenticationForm):
     try:
         two_factor_data = _get_two_factor_data(request)
     except TokenException:
-        request.session.flash(_("Invalid or expired two factor login."), queue="error")
+        request.session.flash(
+            request._("Invalid or expired two factor login."), queue="error"
+        )
         return HTTPSeeOther(request.route_path("accounts.login"))
 
     userid = two_factor_data.get("userid")
@@ -268,13 +269,15 @@ def two_factor_and_totp_validate(request, _form_class=TOTPAuthenticationForm):
 )
 def webauthn_authentication_options(request):
     if request.authenticated_userid is not None:
-        return {"fail": {"errors": [_("Already authenticated")]}}
+        return {"fail": {"errors": [request._("Already authenticated")]}}
 
     try:
         two_factor_data = _get_two_factor_data(request)
     except TokenException:
-        request.session.flash(_("Invalid or expired two factor login."), queue="error")
-        return {"fail": {"errors": [_("Invalid or expired two factor login.")]}}
+        request.session.flash(
+            request._("Invalid or expired two factor login."), queue="error"
+        )
+        return {"fail": {"errors": [request._("Invalid or expired two factor login.")]}}
 
     userid = two_factor_data.get("userid")
     user_service = request.find_service(IUserService, context=None)
@@ -300,8 +303,10 @@ def webauthn_authentication_validate(request):
     try:
         two_factor_data = _get_two_factor_data(request)
     except TokenException:
-        request.session.flash(_("Invalid or expired two factor login."), queue="error")
-        return {"fail": {"errors": [_("Invalid or expired two factor login.")]}}
+        request.session.flash(
+            request._("Invalid or expired two factor login."), queue="error"
+        )
+        return {"fail": {"errors": [request._("Invalid or expired two factor login.")]}}
 
     redirect_to = two_factor_data.get("redirect_to")
     userid = two_factor_data.get("userid")
@@ -332,7 +337,7 @@ def webauthn_authentication_validate(request):
             .lower(),
         )
         return {
-            "success": _("Successful WebAuthn assertion"),
+            "success": request._("Successful WebAuthn assertion"),
             "redirect_to": redirect_to,
         }
 
@@ -355,7 +360,9 @@ def recovery_code(request, _form_class=RecoveryCodeAuthenticationForm):
     try:
         two_factor_data = _get_two_factor_data(request)
     except TokenException:
-        request.session.flash(_("Invalid or expired two factor login."), queue="error")
+        request.session.flash(
+            request._("Invalid or expired two factor login."), queue="error"
+        )
         return HTTPSeeOther(request.route_path("accounts.login"))
 
     userid = two_factor_data.get("userid")
@@ -383,7 +390,9 @@ def recovery_code(request, _form_class=RecoveryCodeAuthenticationForm):
             )
 
             request.session.flash(
-                _("Recovery code accepted. The supplied code cannot be used again."),
+                request._(
+                    "Recovery code accepted. The supplied code cannot be used again."
+                ),
                 queue="success",
             )
 
@@ -467,7 +476,7 @@ def register(request, _form_class=RegistrationForm):
 
     if request.flags.enabled(AdminFlagValue.DISALLOW_NEW_USER_REGISTRATION):
         request.session.flash(
-            _(
+            request._(
                 "New user registration temporarily disabled. "
                 "See https://pypi.org/help#admin-intervention for details."
             ),
@@ -566,34 +575,36 @@ def reset_password(request, _form_class=ResetPasswordForm):
         token = request.params.get("token")
         data = token_service.loads(token)
     except TokenExpired:
-        return _error(_("Expired token: request a new password reset link"))
+        return _error(request._("Expired token: request a new password reset link"))
     except TokenInvalid:
-        return _error(_("Invalid token: request a new password reset link"))
+        return _error(request._("Invalid token: request a new password reset link"))
     except TokenMissing:
-        return _error(_("Invalid token: no token supplied"))
+        return _error(request._("Invalid token: no token supplied"))
 
     # Check whether this token is being used correctly
     if data.get("action") != "password-reset":
-        return _error(_("Invalid token: not a password reset token"))
+        return _error(request._("Invalid token: not a password reset token"))
 
     # Check whether a user with the given user ID exists
     user = user_service.get_user(uuid.UUID(data.get("user.id")))
     if user is None:
-        return _error(_("Invalid token: user not found"))
+        return _error(request._("Invalid token: user not found"))
 
     # Check whether the user has logged in since the token was created
     last_login = data.get("user.last_login")
     if str(user.last_login) > last_login:
         # TODO: track and audit this, seems alertable
         return _error(
-            _("Invalid token: user has logged in since " "this token was requested")
+            request._(
+                "Invalid token: user has logged in since " "this token was requested"
+            )
         )
 
     # Check whether the password has been changed since the token was created
     password_date = data.get("user.password_date")
     if str(user.password_date) > password_date:
         return _error(
-            _(
+            request._(
                 "Invalid token: password has already been changed since this "
                 "token was requested"
             )
@@ -619,7 +630,9 @@ def reset_password(request, _form_class=ResetPasswordForm):
         send_password_change_email(request, user)
 
         # Flash a success message
-        request.session.flash(_("You have reset your password"), queue="success")
+        request.session.flash(
+            request._("You have reset your password"), queue="success"
+        )
 
         # Redirect to account login.
         return HTTPSeeOther(request.route_path("accounts.login"))
@@ -645,15 +658,15 @@ def verify_email(request):
         token = request.params.get("token")
         data = token_service.loads(token)
     except TokenExpired:
-        return _error(_("Expired token: request a new email verification link"))
+        return _error(request._("Expired token: request a new email verification link"))
     except TokenInvalid:
-        return _error(_("Invalid token: request a new email verification link"))
+        return _error(request._("Invalid token: request a new email verification link"))
     except TokenMissing:
-        return _error(_("Invalid token: no token supplied"))
+        return _error(request._("Invalid token: no token supplied"))
 
     # Check whether this token is being used correctly
     if data.get("action") != "email-verify":
-        return _error(_("Invalid token: not an email verification token"))
+        return _error(request._("Invalid token: not an email verification token"))
 
     try:
         email = (
@@ -662,10 +675,10 @@ def verify_email(request):
             .one()
         )
     except NoResultFound:
-        return _error(_("Email not found"))
+        return _error(request._("Email not found"))
 
     if email.verified:
-        return _error(_("Email already verified"))
+        return _error(request._("Email already verified"))
 
     email.verified = True
     email.unverify_reason = None
@@ -680,14 +693,16 @@ def verify_email(request):
     email_limiter.clear(request.remote_addr)
 
     if not email.primary:
-        confirm_message = _("You can now set this email as your primary address")
+        confirm_message = request._(
+            "You can now set this email as your primary address"
+        )
     else:
-        confirm_message = _("This is your primary address")
+        confirm_message = request._("This is your primary address")
 
     request.user.is_active = True
 
     request.session.flash(
-        _(
+        request._(
             "Email address ${email_address} verified. ${confirm_message}.",
             mapping={"email_address": email.email, "confirm_message": confirm_message},
         ),

--- a/warehouse/accounts/views.py
+++ b/warehouse/accounts/views.py
@@ -64,7 +64,9 @@ USER_ID_INSECURE_COOKIE = "user_id__insecure"
 @view_config(context=TooManyFailedLogins, has_translations=True)
 def failed_logins(exc, request):
     resp = HTTPTooManyRequests(
-        _("There have been too many unsuccessful login attempts. Try again later."),
+        request._(
+            "There have been too many unsuccessful login attempts. Try again later."
+        ),
         retry_after=exc.resets_in.total_seconds(),
     )
 
@@ -79,7 +81,7 @@ def failed_logins(exc, request):
 @view_config(context=TooManyEmailsAdded, has_translations=True)
 def unverified_emails(exc, request):
     return HTTPTooManyRequests(
-        _(
+        request._(
             "Too many emails have been added to this account without verifying "
             "them. Check your inbox and follow the verification links."
         ),

--- a/warehouse/i18n/__init__.py
+++ b/warehouse/i18n/__init__.py
@@ -86,12 +86,24 @@ def _negotiate_locale(request):
     )
 
 
-def localize(message, **kwargs):
-    def _localize(message, **kwargs):
-        request = get_current_request()
-        return request.localizer.translate(_translation_factory(message, **kwargs))
+def _localize(request, message, **kwargs):
+    """
+    To be used on the request directly, e.g. `request._(message)`
+    """
+    return request.localizer.translate(_translation_factory(message, **kwargs))
 
-    return LazyString(_localize, message, **kwargs)
+
+def localize(message, **kwargs):
+    """
+    To be used when we don't have the request context, e.g.
+    `from warehouse.i18n import localize as _`
+    """
+
+    def _lazy_localize(message, **kwargs):
+        request = get_current_request()
+        return _localize(request, message, **kwargs)
+
+    return LazyString(_lazy_localize, message, **kwargs)
 
 
 class InvalidLocalizer:
@@ -160,6 +172,7 @@ translated_view.options = {"has_translations"}
 def includeme(config):
     # Add the request attributes
     config.add_request_method(_locale, name="locale", reify=True)
+    config.add_request_method(_localize, name="_")
 
     # Register our translation directory.
     config.add_translation_dirs("warehouse:locale/")

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -31,7 +31,7 @@ msgstr ""
 msgid "The password is invalid. Try again."
 msgstr ""
 
-#: warehouse/accounts/forms.py:126 warehouse/accounts/views.py:67
+#: warehouse/accounts/forms.py:126 warehouse/accounts/views.py:66
 msgid "There have been too many unsuccessful login attempts. Try again later."
 msgstr ""
 
@@ -79,117 +79,117 @@ msgstr ""
 msgid "No user found with that username or email"
 msgstr ""
 
-#: warehouse/accounts/views.py:82
+#: warehouse/accounts/views.py:83
 msgid ""
 "Too many emails have been added to this account without verifying them. "
 "Check your inbox and follow the verification links."
 msgstr ""
 
-#: warehouse/accounts/views.py:218 warehouse/accounts/views.py:274
-#: warehouse/accounts/views.py:275 warehouse/accounts/views.py:301
-#: warehouse/accounts/views.py:302 warehouse/accounts/views.py:356
+#: warehouse/accounts/views.py:220 warehouse/accounts/views.py:278
+#: warehouse/accounts/views.py:280 warehouse/accounts/views.py:307
+#: warehouse/accounts/views.py:309 warehouse/accounts/views.py:364
 msgid "Invalid or expired two factor login."
 msgstr ""
 
-#: warehouse/accounts/views.py:269
+#: warehouse/accounts/views.py:272
 msgid "Already authenticated"
 msgstr ""
 
-#: warehouse/accounts/views.py:333
+#: warehouse/accounts/views.py:340
 msgid "Successful WebAuthn assertion"
 msgstr ""
 
-#: warehouse/accounts/views.py:384
+#: warehouse/accounts/views.py:393
 msgid "Recovery code accepted. The supplied code cannot be used again."
 msgstr ""
 
-#: warehouse/accounts/views.py:468
+#: warehouse/accounts/views.py:479
 msgid ""
 "New user registration temporarily disabled. See https://pypi.org/help"
 "#admin-intervention for details."
 msgstr ""
 
-#: warehouse/accounts/views.py:567
+#: warehouse/accounts/views.py:578
 msgid "Expired token: request a new password reset link"
 msgstr ""
 
-#: warehouse/accounts/views.py:569
+#: warehouse/accounts/views.py:580
 msgid "Invalid token: request a new password reset link"
 msgstr ""
 
-#: warehouse/accounts/views.py:571 warehouse/accounts/views.py:650
+#: warehouse/accounts/views.py:582 warehouse/accounts/views.py:665
 msgid "Invalid token: no token supplied"
 msgstr ""
 
-#: warehouse/accounts/views.py:575
+#: warehouse/accounts/views.py:586
 msgid "Invalid token: not a password reset token"
 msgstr ""
 
-#: warehouse/accounts/views.py:580
+#: warehouse/accounts/views.py:591
 msgid "Invalid token: user not found"
 msgstr ""
 
-#: warehouse/accounts/views.py:587
+#: warehouse/accounts/views.py:598
 msgid "Invalid token: user has logged in since this token was requested"
 msgstr ""
 
-#: warehouse/accounts/views.py:594
+#: warehouse/accounts/views.py:607
 msgid ""
 "Invalid token: password has already been changed since this token was "
 "requested"
 msgstr ""
 
-#: warehouse/accounts/views.py:620
+#: warehouse/accounts/views.py:634
 msgid "You have reset your password"
 msgstr ""
 
-#: warehouse/accounts/views.py:646
+#: warehouse/accounts/views.py:661
 msgid "Expired token: request a new email verification link"
 msgstr ""
 
-#: warehouse/accounts/views.py:648
+#: warehouse/accounts/views.py:663
 msgid "Invalid token: request a new email verification link"
 msgstr ""
 
-#: warehouse/accounts/views.py:654
+#: warehouse/accounts/views.py:669
 msgid "Invalid token: not an email verification token"
 msgstr ""
 
-#: warehouse/accounts/views.py:663
+#: warehouse/accounts/views.py:678
 msgid "Email not found"
 msgstr ""
 
-#: warehouse/accounts/views.py:666
+#: warehouse/accounts/views.py:681
 msgid "Email already verified"
 msgstr ""
 
-#: warehouse/accounts/views.py:681
+#: warehouse/accounts/views.py:696
 msgid "You can now set this email as your primary address"
 msgstr ""
 
-#: warehouse/accounts/views.py:683
+#: warehouse/accounts/views.py:700
 msgid "This is your primary address"
 msgstr ""
 
-#: warehouse/accounts/views.py:688
+#: warehouse/accounts/views.py:705
 msgid "Email address ${email_address} verified. ${confirm_message}."
 msgstr ""
 
-#: warehouse/manage/views.py:188
+#: warehouse/manage/views.py:187
 msgid "Email ${email_address} added - check your email for a verification link"
 msgstr ""
 
-#: warehouse/manage/views.py:669 warehouse/manage/views.py:705
+#: warehouse/manage/views.py:668 warehouse/manage/views.py:704
 msgid ""
 "You must provision a two factor method before recovery codes can be "
 "generated"
 msgstr ""
 
-#: warehouse/manage/views.py:680
+#: warehouse/manage/views.py:679
 msgid "Recovery codes already generated"
 msgstr ""
 
-#: warehouse/manage/views.py:681
+#: warehouse/manage/views.py:680
 msgid "Generating new recovery codes will invalidate your existing codes."
 msgstr ""
 

--- a/warehouse/manage/views.py
+++ b/warehouse/manage/views.py
@@ -42,7 +42,6 @@ from warehouse.email import (
     send_two_factor_added_email,
     send_two_factor_removed_email,
 )
-from warehouse.i18n import localize as _
 from warehouse.macaroons.interfaces import IMacaroonService
 from warehouse.manage.forms import (
     AddEmailForm,
@@ -185,7 +184,7 @@ class ManageAccountViews:
             send_email_verification_email(self.request, (self.request.user, email))
 
             self.request.session.flash(
-                _(
+                self.request._(
                     "Email ${email_address} added - check your email for "
                     "a verification link",
                     mapping={"email_address": email.email},
@@ -666,7 +665,7 @@ class ProvisionRecoveryCodesViews:
     def recovery_codes_generate(self):
         if not self.user_service.has_two_factor(self.request.user.id):
             self.request.session.flash(
-                _(
+                self.request._(
                     "You must provision a two factor method before recovery "
                     "codes can be generated"
                 ),
@@ -677,8 +676,8 @@ class ProvisionRecoveryCodesViews:
         if self.user_service.has_recovery_codes(self.request.user.id):
             return {
                 "recovery_codes": None,
-                "_error": _("Recovery codes already generated"),
-                "_message": _(
+                "_error": self.request._("Recovery codes already generated"),
+                "_message": self.request._(
                     "Generating new recovery codes will invalidate your existing codes."
                 ),
             }
@@ -702,7 +701,7 @@ class ProvisionRecoveryCodesViews:
     def recovery_codes_regenerate(self):
         if not self.user_service.has_two_factor(self.request.user.id):
             self.request.session.flash(
-                _(
+                self.request._(
                     "You must provision a two factor method before recovery "
                     "codes can be generated"
                 ),
@@ -728,7 +727,9 @@ class ProvisionRecoveryCodesViews:
                 )
             }
 
-        self.request.session.flash(_("Invalid credentials. Try again"), queue="error")
+        self.request.session.flash(
+            self.request._("Invalid credentials. Try again"), queue="error"
+        )
         return HTTPSeeOther(self.request.route_path("manage.account"))
 
 


### PR DESCRIPTION
Fixes the issue mentioned at https://github.com/pypa/warehouse/pull/7560#discussion_r406576642.

Previously these views were using threadlocals/`get_current_request` to get access to the localizer, which apparently just outright fails for exception view.

 Instead, we should use the current request directly. This also removes the need for weird monkeypatching of the localizer during testing.

Currently `warehouse.i18n.localize` needs to stick around for translating fields on the forms in `accounts/forms.py` which doesn't currently have access to the request, see https://github.com/pypa/warehouse/issues/6825#issuecomment-611880836.