### PR TITLE
Make endings of HTTP errors more consistent

### DIFF
--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -788,7 +788,7 @@ class TestFileUpload:
         assert resp.status_code == 403
         assert resp.status == (
             "403 New uploads are temporarily disabled. "
-            "See /the/help/url/ for details"
+            "See /the/help/url/ for more information."
         )
 
     @pytest.mark.parametrize("version", ["2", "3", "-1", "0", "dog", "cat"])
@@ -816,14 +816,16 @@ class TestFileUpload:
                 "'' is an invalid value for Metadata-Version. "
                 "Error: This field is required. "
                 "See "
-                "https://packaging.python.org/specifications/core-metadata",
+                "https://packaging.python.org/specifications/core-metadata"
+                " for more information.",
             ),
             (
                 {"metadata_version": "-1"},
                 "'-1' is an invalid value for Metadata-Version. "
                 "Error: Use a known metadata version. "
                 "See "
-                "https://packaging.python.org/specifications/core-metadata",
+                "https://packaging.python.org/specifications/core-metadata"
+                " for more information.",
             ),
             # name errors.
             (
@@ -831,7 +833,8 @@ class TestFileUpload:
                 "'' is an invalid value for Name. "
                 "Error: This field is required. "
                 "See "
-                "https://packaging.python.org/specifications/core-metadata",
+                "https://packaging.python.org/specifications/core-metadata"
+                " for more information.",
             ),
             (
                 {"metadata_version": "1.2", "name": "foo-"},
@@ -839,7 +842,8 @@ class TestFileUpload:
                 "Error: Start and end with a letter or numeral containing "
                 "only ASCII numeric and '.', '_' and '-'. "
                 "See "
-                "https://packaging.python.org/specifications/core-metadata",
+                "https://packaging.python.org/specifications/core-metadata"
+                " for more information.",
             ),
             # version errors.
             (
@@ -847,7 +851,8 @@ class TestFileUpload:
                 "'' is an invalid value for Version. "
                 "Error: This field is required. "
                 "See "
-                "https://packaging.python.org/specifications/core-metadata",
+                "https://packaging.python.org/specifications/core-metadata"
+                " for more information.",
             ),
             (
                 {"metadata_version": "1.2", "name": "example", "version": "dog"},
@@ -855,7 +860,8 @@ class TestFileUpload:
                 "Error: Start and end with a letter or numeral "
                 "containing only ASCII numeric and '.', '_' and '-'. "
                 "See "
-                "https://packaging.python.org/specifications/core-metadata",
+                "https://packaging.python.org/specifications/core-metadata"
+                " for more information.",
             ),
             # filetype/pyversion errors.
             (
@@ -931,7 +937,8 @@ class TestFileUpload:
                 "'" + "A" * 513 + "' is an invalid value for Summary. "
                 "Error: Field cannot be longer than 512 characters. "
                 "See "
-                "https://packaging.python.org/specifications/core-metadata",
+                "https://packaging.python.org/specifications/core-metadata"
+                " for more information.",
             ),
             (
                 {
@@ -942,12 +949,11 @@ class TestFileUpload:
                     "md5_digest": "a fake md5 digest",
                     "summary": "A\nB",
                 },
-                (
-                    "{!r} is an invalid value for Summary. ".format("A\nB")
-                    + "Error: Use a single line only. "
-                    "See "
-                    "https://packaging.python.org/specifications/core-metadata"
-                ),
+                "{!r} is an invalid value for Summary. ".format("A\nB")
+                + "Error: Use a single line only. "
+                "See "
+                "https://packaging.python.org/specifications/core-metadata"
+                " for more information.",
             ),
             # classifiers are a FieldStorage
             (
@@ -1194,7 +1200,7 @@ class TestFileUpload:
             "403 New project registration temporarily "
             "disabled. See "
             "/the/help/url/ for "
-            "details"
+            "more information."
         )
 
     def test_upload_fails_without_file(self, pyramid_config, db_request):
@@ -1553,7 +1559,8 @@ class TestFileUpload:
         assert resp.status_code == 400
         assert resp.status == (
             "400 Invalid file extension: Use .egg, .tar.gz, .whl or .zip "
-            "extension. (https://www.python.org/dev/peps/pep-0527)"
+            "extension. See https://www.python.org/dev/peps/pep-0527 "
+            "for more information."
         )
 
     def test_upload_fails_for_second_sdist(self, pyramid_config, db_request):
@@ -1877,7 +1884,7 @@ class TestFileUpload:
         assert resp.status_code == 400
         assert resp.status == (
             "400 File too large. Limit for project 'foobar' is 60 MB. "
-            "See /the/help/url/"
+            "See /the/help/url/ for more information."
         )
 
     def test_upload_fails_with_too_large_signature(self, pyramid_config, db_request):
@@ -1960,7 +1967,7 @@ class TestFileUpload:
         assert resp.status == (
             "400 This filename has already been used, use a "
             "different version. "
-            "See /the/help/url/"
+            "See /the/help/url/ for more information."
         )
 
     def test_upload_noop_with_existing_filename_same_content(
@@ -2060,7 +2067,9 @@ class TestFileUpload:
 
         assert db_request.help_url.calls == [pretend.call(_anchor="file-name-reuse")]
         assert resp.status_code == 400
-        assert resp.status == "400 File already exists. See /the/help/url/"
+        assert resp.status == (
+            "400 File already exists. See /the/help/url/ for more information."
+        )
 
     def test_upload_fails_with_diff_filename_same_blake2(
         self, pyramid_config, db_request
@@ -2115,7 +2124,9 @@ class TestFileUpload:
 
         assert db_request.help_url.calls == [pretend.call(_anchor="file-name-reuse")]
         assert resp.status_code == 400
-        assert resp.status == "400 File already exists. See /the/help/url/"
+        assert resp.status == (
+            "400 File already exists. See /the/help/url/ for more information."
+        )
 
     def test_upload_fails_with_wrong_filename(self, pyramid_config, db_request):
         pyramid_config.testing_securitypolicy(userid=1)
@@ -2191,7 +2202,8 @@ class TestFileUpload:
         assert resp.status_code == 400
         assert resp.status == (
             "400 Invalid file extension: Use .egg, .tar.gz, .whl or .zip "
-            "extension. (https://www.python.org/dev/peps/pep-0527)"
+            "extension. See https://www.python.org/dev/peps/pep-0527 "
+            "for more information."
         )
 
     @pytest.mark.parametrize("character", ["/", "\\"])
@@ -3106,7 +3118,7 @@ class TestFileUpload:
                     "400 User {!r} does not have a verified primary email "
                     "address. Please add a verified primary email before "
                     "attempting to upload to PyPI. See /the/help/url/ for "
-                    "more information.for more information."
+                    "more information."
                 ).format(user.username)
             )
 
@@ -3157,7 +3169,7 @@ class TestFileUpload:
         resp = excinfo.value
 
         assert resp.status_code == 403
-        assert resp.status == ("403 Read-only mode: Uploads are temporarily disabled")
+        assert resp.status == ("403 Read-only mode: Uploads are temporarily disabled.")
 
     def test_fails_without_user(self, pyramid_config, pyramid_request):
         pyramid_request.flags = pretend.stub(enabled=lambda *a: False)
@@ -3172,7 +3184,7 @@ class TestFileUpload:
         assert resp.status_code == 403
         assert resp.status == (
             "403 Invalid or non-existent authentication information. "
-            "See /the/help/url/ for details"
+            "See /the/help/url/ for more information."
         )
 
 

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -735,14 +735,14 @@ def file_upload(request):
     # If we're in read-only mode, let upload clients know
     if request.flags.enabled(AdminFlagValue.READ_ONLY):
         raise _exc_with_message(
-            HTTPForbidden, "Read-only mode: Uploads are temporarily disabled"
+            HTTPForbidden, "Read-only mode: Uploads are temporarily disabled."
         )
 
     if request.flags.enabled(AdminFlagValue.DISALLOW_NEW_UPLOAD):
         raise _exc_with_message(
             HTTPForbidden,
             "New uploads are temporarily disabled. "
-            "See {projecthelp} for details".format(
+            "See {projecthelp} for more information.".format(
                 projecthelp=request.help_url(_anchor="admin-intervention")
             ),
         )
@@ -757,7 +757,7 @@ def file_upload(request):
         raise _exc_with_message(
             HTTPForbidden,
             "Invalid or non-existent authentication information. "
-            "See {projecthelp} for details".format(
+            "See {projecthelp} for more information.".format(
                 projecthelp=request.help_url(_anchor="invalid-auth")
             ),
         )
@@ -775,7 +775,6 @@ def file_upload(request):
                 "User {!r} does not have a verified primary email address. "
                 "Please add a verified primary email before attempting to "
                 "upload to PyPI. See {project_help} for more information."
-                "for more information."
             ).format(
                 request.user.username,
                 project_help=request.help_url(_anchor="verified-email"),
@@ -832,6 +831,7 @@ def file_upload(request):
                     + "Error: {} ".format(form.errors[field_name][0])
                     + "See "
                     "https://packaging.python.org/specifications/core-metadata"
+                    + " for more information."
                 )
             else:
                 error_message = "Invalid value for {field}. Error: {msgs[0]}".format(
@@ -866,7 +866,7 @@ def file_upload(request):
                 HTTPForbidden,
                 (
                     "New project registration temporarily disabled. "
-                    "See {projecthelp} for details"
+                    "See {projecthelp} for more information."
                 ).format(projecthelp=request.help_url(_anchor="admin-intervention")),
             ) from None
 
@@ -882,8 +882,7 @@ def file_upload(request):
                 HTTPBadRequest,
                 (
                     "The name {name!r} isn't allowed. "
-                    "See {projecthelp} "
-                    "for more information."
+                    "See {projecthelp} for more information."
                 ).format(
                     name=form.name.data,
                     projecthelp=request.help_url(_anchor="project-name"),
@@ -1163,7 +1162,8 @@ def file_upload(request):
         raise _exc_with_message(
             HTTPBadRequest,
             "Invalid file extension: Use .egg, .tar.gz, .whl or .zip "
-            "extension. (https://www.python.org/dev/peps/pep-0527)",
+            "extension. See https://www.python.org/dev/peps/pep-0527 "
+            "for more information.",
         )
 
     # Make sure that our filename matches the project that it is being uploaded
@@ -1208,7 +1208,8 @@ def file_upload(request):
                             name=project.name, limit=file_size_limit // (1024 * 1024)
                         )
                         + "See "
-                        + request.help_url(_anchor="file-size-limit"),
+                        + request.help_url(_anchor="file-size-limit")
+                        + " for more information.",
                     )
                 fp.write(chunk)
                 for hasher in file_hashes.values():
@@ -1250,7 +1251,8 @@ def file_upload(request):
                 # ref: https://github.com/pypa/warehouse/issues/3482
                 # ref: https://github.com/pypa/twine/issues/332
                 "File already exists. See "
-                + request.help_url(_anchor="file-name-reuse"),
+                + request.help_url(_anchor="file-name-reuse")
+                + " for more information.",
             )
 
         # Check to see if the file that was uploaded exists in our filename log
@@ -1261,7 +1263,9 @@ def file_upload(request):
                 HTTPBadRequest,
                 "This filename has already been used, use a "
                 "different version. "
-                "See " + request.help_url(_anchor="file-name-reuse"),
+                "See "
+                + request.help_url(_anchor="file-name-reuse")
+                + " for more information.",
             )
 
         # Check to see if uploading this file would create a duplicate sdist


### PR DESCRIPTION
I noticed these when writing up https://github.com/pypa/twine/issues/587

- Add missing periods
- Use "for more information" on all URLs (since it seemed to be the more common pattern)