### PR TITLE
#7782 render the null public email correctly

### DIFF
--- a/warehouse/templates/accounts/profile.html
+++ b/warehouse/templates/accounts/profile.html
@@ -33,7 +33,7 @@
               &nbsp;&nbsp;
               <span class="break">{{ user.username }}</span>
             </p>
-            {% if user.public_email %}
+            {% if user.public_email is defined and user.public_email is sameas true and user.public_email|length %}
             {% csi request.route_url("includes.profile-public-email", username=user.username), 'p' %}
             {% endcsi %}
             {% endif %}

--- a/warehouse/templates/accounts/profile.html
+++ b/warehouse/templates/accounts/profile.html
@@ -33,7 +33,7 @@
               &nbsp;&nbsp;
               <span class="break">{{ user.username }}</span>
             </p>
-            {% if user.public_email is defined and user.public_email is sameas true and user.public_email|length %}
+            {% if user.public_email is defined and user.public_email is not none and user.public_email|length %}
             {% csi request.route_url("includes.profile-public-email", username=user.username), 'p' %}
             {% endcsi %}
             {% endif %}


### PR DESCRIPTION
For #7782

I added some checks to help filter out conditions for this. Without knowing the data returned from the admin user query, it's hard to pinpoint the issue but I suspect that it's returning a string with blanks like " ". I'd love to connect and discuss ways to test this locally but I was having trouble connecting and altering the database from shell.