### PR TITLE
Yank updates

### DIFF
--- a/tests/unit/packaging/test_views.py
+++ b/tests/unit/packaging/test_views.py
@@ -106,6 +106,35 @@ class TestProjectDetail:
         assert resp is response
         assert release_detail.calls == [pretend.call(release, db_request)]
 
+    def test_prefers_non_yanked_release(self, monkeypatch, db_request):
+        project = ProjectFactory.create()
+
+        ReleaseFactory.create(project=project, version="2.0", yanked=True)
+        release = ReleaseFactory.create(project=project, version="1.0")
+
+        response = pretend.stub()
+        release_detail = pretend.call_recorder(lambda ctx, request: response)
+        monkeypatch.setattr(views, "release_detail", release_detail)
+
+        resp = views.project_detail(project, db_request)
+
+        assert resp is response
+        assert release_detail.calls == [pretend.call(release, db_request)]
+
+    def test_only_yanked_release(self, monkeypatch, db_request):
+        project = ProjectFactory.create()
+
+        release = ReleaseFactory.create(project=project, version="1.0", yanked=True)
+
+        response = pretend.stub()
+        release_detail = pretend.call_recorder(lambda ctx, request: response)
+        monkeypatch.setattr(views, "release_detail", release_detail)
+
+        resp = views.project_detail(project, db_request)
+
+        assert resp is response
+        assert release_detail.calls == [pretend.call(release, db_request)]
+
 
 class TestReleaseDetail:
     def test_normalizing_name_redirects(self, db_request):

--- a/warehouse/admin/templates/admin/projects/release_detail.html
+++ b/warehouse/admin/templates/admin/projects/release_detail.html
@@ -51,6 +51,10 @@
           <td>Created via</td>
           <td><code>{{ release.uploaded_via }}</code></td>
         </tr>
+        <tr>
+          <td>Yanked</td>
+          <td>{{ release.yanked }}</td>
+        </tr>
       </table>
     </div>
   </div>

--- a/warehouse/admin/templates/admin/projects/releases_list.html
+++ b/warehouse/admin/templates/admin/projects/releases_list.html
@@ -43,6 +43,7 @@
       <tr>
         <th>Release version</th>
         <th>Created</th>
+        <th>Yanked</th>
         <th>Uploader</th>
         <th>Author email</th>
       </tr>
@@ -51,6 +52,7 @@
       <tr>
         <td><a href="{{ request.route_path('admin.project.release', project_name=release.project.normalized_name, version=release.version) }}">{{ release.project.name }}-{{ release.version }}</a></td>
         <td>{{ release.created }}</td>
+        <td>{{ release.yanked }}</td>
         <td>
           {% if release.uploader %}
           <a href="{{ request.route_path('admin.user.detail', user_id=release.uploader.id) }}">{{ release.uploader.username }}</a>

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -3218,7 +3218,7 @@ msgstr ""
 msgid "Copy PIP instructions"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:114
+#: warehouse/templates/packaging/detail.html:113
 msgid "This release has been yanked"
 msgstr ""
 
@@ -3227,12 +3227,12 @@ msgstr ""
 msgid "Stable version available (%(version)s)"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:124
+#: warehouse/templates/packaging/detail.html:123
 #, python-format
 msgid "Newer version available (%(version)s)"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:128
+#: warehouse/templates/packaging/detail.html:127
 msgid "Latest version"
 msgstr ""
 

--- a/warehouse/packaging/views.py
+++ b/warehouse/packaging/views.py
@@ -36,6 +36,7 @@ def project_detail(project, request):
         return HTTPMovedPermanently(request.current_route_path(name=project.name))
 
     try:
+        # Try to find a non-yanked release
         release = (
             request.db.query(Release)
             .filter(Release.project == project, Release.yanked.is_(False))
@@ -43,10 +44,25 @@ def project_detail(project, request):
             .limit(1)
             .one()
         )
+        return release_detail(release, request)
     except NoResultFound:
-        raise HTTPNotFound
+        pass
 
-    return release_detail(release, request)
+    try:
+        # Fall back on the latest yanked release if it exists
+        release = (
+            request.db.query(Release)
+            .filter(Release.project == project)
+            .order_by(Release.is_prerelease.nullslast(), Release._pypi_ordering.desc())
+            .limit(1)
+            .one()
+        )
+        return release_detail(release, request)
+    except NoResultFound:
+        pass
+
+    # We didn't find any releases
+    raise HTTPNotFound
 
 
 @view_config(

--- a/warehouse/templates/packaging/detail.html
+++ b/warehouse/templates/packaging/detail.html
@@ -107,18 +107,17 @@
     </div>
 
     <div class="package-header__right">
-      {% if release.version|parse_version > latest_version.version|parse_version %}
-      {% if release.yanked %}
+    {% if release.yanked %}
       <a class="status-badge status-badge--bad" href="{{ request.route_path('packaging.project', name=release.project.name) }}">
         <span>
           {% trans %}This release has been yanked{% endtrans %}<br>
         </span>
       </a>
-      {% else %}
+    {% else %}
+      {% if release.version|parse_version > latest_version.version|parse_version %}
       <a class="status-badge status-badge--warn" href="{{ request.route_path('packaging.project', name=release.project.name) }}">
         <span>{% trans version=latest_version.version %}Stable version available ({{ version }}){% endtrans %}</span>
       </a>
-      {% endif %}
       {% elif release.version|parse_version != latest_version.version|parse_version %}
       <a class="status-badge status-badge--bad" href="{{ request.route_path('packaging.project', name=release.project.name) }}">
         <span>{% trans version=latest_version.version %}Newer version available ({{ version }}){% endtrans %}</span>
@@ -128,6 +127,7 @@
         <span>{% trans %}Latest version{% endtrans %}</span>
       </a>
       {% endif %}
+    {% endif %}
       <p class="package-header__date">
         {% trans release_date=humanize(release.created) %}Released: {{ release_date }}{% endtrans %}
       </p>


### PR DESCRIPTION
This PR:

* displays the yanked status of a release in the admin UI
* ensures that if only yanked releases are available

Fixes https://sentry.io/organizations/python-software-foundation/issues/1504635020/