### PR TITLE
Adding the usage of Github Actions for CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,54 @@
+name: Docker Image CI
+
+on: [push, pull_request]
+
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v1
+      with:
+        python-version: 3.8
+        
+    - name: Install Curl
+      run: sudo apt install libcurl4-openssl-dev libssl-dev
+  
+    - name: Build
+      run: make build
+      
+    - name: Tests
+      if: always()
+      run: make tests
+      
+    - name: Lint
+      if: always()
+      run: make lint
+            
+    - name: Dependencies      
+      if: always()
+      run: make deps
+      
+    - name: Licenses
+      if: always()
+      run: make licenses
+
+    - name: Documentation
+      if: always()
+      run: make docs
+      
+    - name: Translations
+      if: always()
+      run: make translations
+      
+    - name: Static Tests
+      if: always()
+      run: make static_tests
+      
+    - name: Static Pipeline
+      if: always()
+      run: make static_pipeline


### PR DESCRIPTION
This starts work on #7001, to implement Github actions for testing the project. 

Unlike the Travis implementation, this code reuses all of the docker containers. There is also a large amount of usage of the make file in this PR with GH actions.

Limitations:
- Travis allows shows the specific steps clearly in each PR, GH actions does not allow that, unless we used separate jobs (see downsides of this approach below) (also there may be a way to accomplish this, I just didn't figure it out.)
- Travis runs steps after build in parallel, GH actions does not because of the way caching works in Github actions. We _can_ do parallel steps if we build the image and then pass the image as an artifact to other jobs, but I am not sure that is desirable. This would speed up the pipeline a lot, and solve the previous limitation. We could also build in each step, but again, not sure if desirable. 
- Real-time logs after kicking of CI in each step are delayed, haven't experienced this on Travis. 

Advantages:
- Total time seems to be faster than Travis
- Utilizes the existing docker infrastructure much more, hopefully, helps in keeping the environments matched up.
- Seems to be more be faster at reporting back info, build statuses, and kicking of builds. 

Please let me know how I can improve this PR, it's my first one to this repo!

CC: @di 