### PR TITLE
Add icon for change log etc project URL

### DIFF
--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -249,7 +249,7 @@ msgstr ""
 #: warehouse/templates/manage/release.html:161
 #: warehouse/templates/manage/releases.html:123
 #: warehouse/templates/manage/releases.html:156
-#: warehouse/templates/packaging/detail.html:304
+#: warehouse/templates/packaging/detail.html:306
 #: warehouse/templates/pages/classifiers.html:25
 #: warehouse/templates/pages/help.html:20
 #: warehouse/templates/pages/help.html:196
@@ -1378,7 +1378,7 @@ msgstr ""
 #: warehouse/templates/manage/account.html:230
 #: warehouse/templates/manage/account/recovery_codes-provision.html:61
 #: warehouse/templates/manage/account/totp-provision.html:57
-#: warehouse/templates/packaging/detail.html:105
+#: warehouse/templates/packaging/detail.html:107
 #: warehouse/templates/pages/classifiers.html:37
 msgid "Copy to clipboard"
 msgstr ""
@@ -1978,7 +1978,7 @@ msgstr ""
 
 #: warehouse/templates/manage/account.html:568
 #: warehouse/templates/manage/release.html:58
-#: warehouse/templates/packaging/detail.html:336
+#: warehouse/templates/packaging/detail.html:338
 msgid "None"
 msgstr ""
 
@@ -2443,7 +2443,7 @@ msgstr ""
 
 #: warehouse/templates/manage/projects.html:67
 #: warehouse/templates/manage/releases.html:88
-#: warehouse/templates/packaging/detail.html:346
+#: warehouse/templates/packaging/detail.html:348
 msgid "View"
 msgstr ""
 
@@ -2486,8 +2486,8 @@ msgstr ""
 
 #: warehouse/templates/manage/release.html:37
 #: warehouse/templates/manage/release.html:48
-#: warehouse/templates/packaging/detail.html:310
-#: warehouse/templates/packaging/detail.html:321
+#: warehouse/templates/packaging/detail.html:312
+#: warehouse/templates/packaging/detail.html:323
 msgid "Filename, size"
 msgstr ""
 
@@ -2498,15 +2498,15 @@ msgstr ""
 
 #: warehouse/templates/manage/release.html:39
 #: warehouse/templates/manage/release.html:57
-#: warehouse/templates/packaging/detail.html:312
-#: warehouse/templates/packaging/detail.html:332
+#: warehouse/templates/packaging/detail.html:314
+#: warehouse/templates/packaging/detail.html:334
 msgid "Python version"
 msgstr ""
 
 #: warehouse/templates/manage/release.html:40
 #: warehouse/templates/manage/release.html:61
-#: warehouse/templates/packaging/detail.html:313
-#: warehouse/templates/packaging/detail.html:340
+#: warehouse/templates/packaging/detail.html:315
+#: warehouse/templates/packaging/detail.html:342
 msgid "Upload date"
 msgstr ""
 
@@ -3214,119 +3214,119 @@ msgid ""
 " not work with PyPI."
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:89
+#: warehouse/templates/packaging/detail.html:91
 #, python-format
 msgid "RSS: latest releases for %(project_name)s"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:107
+#: warehouse/templates/packaging/detail.html:109
 msgid "Copy PIP instructions"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:117
+#: warehouse/templates/packaging/detail.html:119
 msgid "This release has been yanked"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:123
+#: warehouse/templates/packaging/detail.html:125
 #, python-format
 msgid "Stable version available (%(version)s)"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:127
+#: warehouse/templates/packaging/detail.html:129
 #, python-format
 msgid "Newer version available (%(version)s)"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:131
+#: warehouse/templates/packaging/detail.html:133
 msgid "Latest version"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:136
+#: warehouse/templates/packaging/detail.html:138
 #, python-format
 msgid "Released: %(release_date)s"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:148
+#: warehouse/templates/packaging/detail.html:150
 msgid "No project description provided"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:161
+#: warehouse/templates/packaging/detail.html:163
 msgid "Navigation"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:162
-#: warehouse/templates/packaging/detail.html:192
+#: warehouse/templates/packaging/detail.html:164
+#: warehouse/templates/packaging/detail.html:194
 #, python-format
 msgid "Navigation for %(project)s"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:165
-#: warehouse/templates/packaging/detail.html:195
+#: warehouse/templates/packaging/detail.html:167
+#: warehouse/templates/packaging/detail.html:197
 msgid "Project description. Focus will be moved to the description."
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:167
-#: warehouse/templates/packaging/detail.html:197
-#: warehouse/templates/packaging/detail.html:225
+#: warehouse/templates/packaging/detail.html:169
+#: warehouse/templates/packaging/detail.html:199
+#: warehouse/templates/packaging/detail.html:227
 msgid "Project description"
-msgstr ""
-
-#: warehouse/templates/packaging/detail.html:171
-#: warehouse/templates/packaging/detail.html:207
-msgid "Release history. Focus will be moved to the history panel."
 msgstr ""
 
 #: warehouse/templates/packaging/detail.html:173
 #: warehouse/templates/packaging/detail.html:209
-#: warehouse/templates/packaging/detail.html:247
-msgid "Release history"
+msgid "Release history. Focus will be moved to the history panel."
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:178
-#: warehouse/templates/packaging/detail.html:214
-msgid "Download files. Focus will be moved to the project files."
+#: warehouse/templates/packaging/detail.html:175
+#: warehouse/templates/packaging/detail.html:211
+#: warehouse/templates/packaging/detail.html:249
+msgid "Release history"
 msgstr ""
 
 #: warehouse/templates/packaging/detail.html:180
 #: warehouse/templates/packaging/detail.html:216
-#: warehouse/templates/packaging/detail.html:303
+msgid "Download files. Focus will be moved to the project files."
+msgstr ""
+
+#: warehouse/templates/packaging/detail.html:182
+#: warehouse/templates/packaging/detail.html:218
+#: warehouse/templates/packaging/detail.html:305
 msgid "Download files"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:201
+#: warehouse/templates/packaging/detail.html:203
 msgid "Project details. Focus will be moved to the project details."
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:203
-#: warehouse/templates/packaging/detail.html:239
+#: warehouse/templates/packaging/detail.html:205
+#: warehouse/templates/packaging/detail.html:241
 msgid "Project details"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:232
+#: warehouse/templates/packaging/detail.html:234
 msgid "The author of this package has not provided a project description"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:249
+#: warehouse/templates/packaging/detail.html:251
 msgid "Release notifications"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:250
+#: warehouse/templates/packaging/detail.html:252
 msgid "RSS feed"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:262
+#: warehouse/templates/packaging/detail.html:264
 msgid "This version"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:282
+#: warehouse/templates/packaging/detail.html:284
 msgid "pre-release"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:287
+#: warehouse/templates/packaging/detail.html:289
 msgid "yanked"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:304
+#: warehouse/templates/packaging/detail.html:306
 #, python-format
 msgid ""
 "Download the file for your platform. If you're not sure which to choose, "
@@ -3334,18 +3334,18 @@ msgid ""
 "target=\"_blank\" rel=\"noopener\">installing packages</a>."
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:307
+#: warehouse/templates/packaging/detail.html:309
 #, python-format
 msgid "Files for %(project_name)s, version %(version)s"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:311
-#: warehouse/templates/packaging/detail.html:328
+#: warehouse/templates/packaging/detail.html:313
+#: warehouse/templates/packaging/detail.html:330
 msgid "File type"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:314
-#: warehouse/templates/packaging/detail.html:344
+#: warehouse/templates/packaging/detail.html:316
+#: warehouse/templates/packaging/detail.html:346
 msgid "Hashes"
 msgstr ""
 

--- a/warehouse/templates/packaging/detail.html
+++ b/warehouse/templates/packaging/detail.html
@@ -21,6 +21,8 @@
    {% set icon = "fas fa-cloud-download-alt" %}
 {% elif name|lower in ["home", "homepage", "home page"] %}
   {% set icon = "fas fa-home" %}
+{% elif name|lower in ["changelog", "change log", "changes", "release notes", "news", "what's new"] %}
+  {% set icon = "fas fa-gift" %}
 {% elif name.lower().startswith(("docs", "documentation")) or parsed.netloc in ["readthedocs.io", "readthedocs.org", "rtfd.io", "rtfd.org"] or parsed.netloc.endswith((".readthedocs.io", ".readthedocs.org", ".rtfd.io", ".rtfd.org")) or parsed.netloc.startswith(("docs.", "documentation.")) %}
   {% set icon = "fas fa-book" %}
 {% elif name.lower().startswith(("bug", "issue", "tracker", "report")) %}


### PR DESCRIPTION
Getting to package change logs, release notes or the like is currently a manual task, as links to them are not defined just about anywhere except perhapse in description prose. I think it would be good to promote adding them.

For example, when I see a new release from a project RSS feed being made, I go to PyPI and... start manually sifting through pages here and there to find what's changed in the release. Would be very nice to have a direct link in project links for that.

Although this is beyond PyPI, adding a recognizable specific icon could be a step towards that direction.
