### PR TITLE
Use change log icon for history URLs

### DIFF
--- a/warehouse/templates/packaging/detail.html
+++ b/warehouse/templates/packaging/detail.html
@@ -21,7 +21,7 @@
    {% set icon = "fas fa-cloud-download-alt" %}
 {% elif name|lower in ["home", "homepage", "home page"] %}
   {% set icon = "fas fa-home" %}
-{% elif name|lower in ["changelog", "change log", "changes", "release notes", "news", "what's new"] %}
+{% elif name|lower in ["changelog", "change log", "changes", "release notes", "news", "what's new", "history"] %}
   {% set icon = "fas fa-gift" %}
 {% elif name.lower().startswith(("docs", "documentation")) or parsed.netloc in ["readthedocs.io", "readthedocs.org", "rtfd.io", "rtfd.org"] or parsed.netloc.endswith((".readthedocs.io", ".readthedocs.org", ".rtfd.io", ".rtfd.org")) or parsed.netloc.startswith(("docs.", "documentation.")) %}
   {% set icon = "fas fa-book" %}


### PR DESCRIPTION
Related to #7882, some projects call their change logs by the name "History".