### PR TITLE
Fix travis postgres

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,6 @@ addons:
   postgresql: 10
   apt:
     packages:
-    - postgresql-10
-    - postgresql-client-10
     - nasm
     - libgnutls28-dev
 

--- a/bin/tests
+++ b/bin/tests
@@ -1,12 +1,25 @@
 #!/bin/bash
 set -e
-set -x
 
 # Click requires us to ensure we have a well configured environment to run
 # our click commands. So we'll set our environment to ensure our locale is
 # correct.
 export LC_ALL="${ENCODING:-en_US.UTF-8}"
 export LANG="${ENCODING:-en_US.UTF-8}"
+
+# Test the postgres connection
+for arg in "$@"; do
+  shift
+  case "$arg" in
+    "--postgresql-host") export POSTGRES_HOST=$@
+  esac
+done
+
+# Print all the followng commands
+set -x
+
+# Test the postgres connection
+pg_isready -h $POSTGRES_HOST
 
 # Actually run our tests.
 python -m coverage run -m pytest --strict $@


### PR DESCRIPTION
Travis is currently failing with the following error:

```
Job for postgresql@10-main.service failed because the service did not take the steps required by its unit configuration.
See "systemctl status postgresql@10-main.service" and "journalctl -xe" for details.
sudo systemctl start postgresql@10-main
```

This PR fixes that issue based on comments in https://travis-ci.community/t/bionic-postgresql-10-no-longer-starts-up/ and also adds a short-circuit for the tests in the event that the host is not available.