### PR TITLE
Catch all PyMacaroons exceptions

### DIFF
--- a/tests/unit/macaroons/test_services.py
+++ b/tests/unit/macaroons/test_services.py
@@ -165,10 +165,12 @@ class TestDatabaseMacaroonService:
         [
             IndexError,
             TypeError,
+            UnicodeDecodeError,
             ValueError,
             binascii.Error,
             struct.error,
             MacaroonDeserializationException,
+            Exception,  # https://github.com/ecordell/pymacaroons/issues/50
         ],
     )
     def test_deserialize_raw_macaroon(self, monkeypatch, macaroon_service, exception):

--- a/warehouse/macaroons/services.py
+++ b/warehouse/macaroons/services.py
@@ -10,10 +10,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import binascii
 import datetime
 import json
-import struct
 import uuid
 
 import pymacaroons
@@ -77,12 +75,8 @@ class DatabaseMacaroonService:
         try:
             return pymacaroons.Macaroon.deserialize(raw_macaroon)
         except (
-            IndexError,
-            TypeError,
-            ValueError,
-            binascii.Error,
-            struct.error,
             MacaroonDeserializationException,
+            Exception,  # https://github.com/ecordell/pymacaroons/issues/50
         ):
             raise InvalidMacaroon("malformed macaroon")
 


### PR DESCRIPTION
Per https://github.com/ecordell/pymacaroons/issues/50, deserializing a macaroon can raise a generic `Exception`, so this PR catches _any_ exception from `pymacaroons.Macaroon.deserialize`.