### PR TITLE
Update help link to remove decommissioned mailing list

### DIFF
--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -4719,8 +4719,8 @@ msgid ""
 "You can also follow the ongoing development of the project on the <a "
 "href=\"%(mailing_list_href)s\" title=\"%(title)s\" target=\"_blank\" "
 "rel=\"noopener\">distutils-sig mailing list</a> and the <a "
-"href=\"%(message_group_href)s\" title=\"%(title)s\" target=\"_blank\" "
-"rel=\"noopener\">PyPA Dev message group</a>."
+"href=\"%(discourse_forum_href)s\" title=\"%(title)s\" target=\"_blank\" "
+"rel=\"noopener\">Python packaging forum on Discourse</a>."
 msgstr ""
 
 #: warehouse/templates/pages/help.html:761

--- a/warehouse/templates/pages/help.html
+++ b/warehouse/templates/pages/help.html
@@ -748,10 +748,10 @@
         </p>
         <p>
           <strong>{% trans %}Stay updated:{% endtrans %}</strong>
-          {% trans trimmed mailing_list_href='https://mail.python.org/mailman/listinfo/distutils-sig', message_group_href='https://groups.google.com/forum/#!forum/pypa-dev', title=gettext('External link') %}
+          {% trans trimmed mailing_list_href='https://mail.python.org/mailman/listinfo/distutils-sig', discourse_forum_href='https://discuss.python.org/c/packaging', title=gettext('External link') %}
             You can also follow the ongoing development of the project on the
             <a href="{{ mailing_list_href }}" title="{{ title }}" target="_blank" rel="noopener">distutils-sig mailing list</a>
-            and the <a href="{{ message_group_href }}" title="{{ title }}" target="_blank" rel="noopener">PyPA Dev message group</a>.
+            and the <a href="{{ discourse_forum_href }}" title="{{ title }}" target="_blank" rel="noopener">Python packaging forum on Discourse</a>.
           {% endtrans %}
         </p>
         {{ code_of_conduct() }}


### PR DESCRIPTION
Per https://groups.google.com/d/msg/pypa-dev/rUNsfIbruHM/LCEx-CB5AgAJ
the pypa-dev Google Group is now decommissioned.
Instead, in the FAQ, we point users to Discourse.

Signed-off-by: Sumana Harihareswara <sh@changeset.nyc>