### PR TITLE
Update links to distutils-sig from pypa-dev

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,8 +23,8 @@ If you run into bugs, you can file them in our `issue tracker`_.
 
 You can also join the chat channels ``#pypa`` (general packaging
 discussion and user support) and ``#pypa-dev`` (discussion about
-development of packaging tools) `on Freenode`_, or the `pypa-dev
-mailing list`_, to ask questions or get involved.
+development of packaging tools) `on Freenode`_, or the `distutils-sig mailing
+list`_, to ask questions or get involved.
 
 Testing
 ----------
@@ -51,7 +51,7 @@ rooms, and mailing lists is expected to follow the `PyPA Code of Conduct`_.
 .. _`issue tracker`: https://github.com/pypa/warehouse/issues
 .. _`pypi.org`: https://pypi.org/
 .. _`on Freenode`: https://webchat.freenode.net/?channels=%23pypa-dev,pypa
-.. _`pypa-dev mailing list`: https://groups.google.com/forum/#!forum/pypa-dev
+.. _`distutils-sig mailing list`: https://mail.python.org/mailman3/lists/distutils-sig.python.org/
 .. _`Running tests and linters section`: https://warehouse.readthedocs.io/development/getting-started/#running-tests-and-linters
 .. _BrowserStack: https://browserstack.com/
 .. _`supported browsers`: https://warehouse.readthedocs.io/development/frontend/#browser-support

--- a/docs/development/getting-started.rst
+++ b/docs/development/getting-started.rst
@@ -23,7 +23,7 @@ improve the process:
 - For bug reports or general problems, file an issue on `GitHub`_;
 - For real-time chat with other PyPA developers, join ``#pypa-dev`` `on
   Freenode`_;
-- For longer-form questions or discussion, message the `pypa-dev mailing
+- For longer-form questions or discussion, message the `distutils-sig mailing
   list`_.
 
 .. _dev-env-install:
@@ -606,7 +606,7 @@ Talk with us
 ^^^^^^^^^^^^
 
 You can find us via a `GitHub`_ issue, ``#pypa`` or ``#pypa-dev`` `on
-Freenode`_, or the `pypa-dev mailing list`_, to ask questions or get
+Freenode`_, or the `distutils-sig mailing list`_, to ask questions or get
 involved. And you can meet us in person at `packaging sprints`_.
 
 Learn about Warehouse and packaging
@@ -630,6 +630,6 @@ Resources to help you learn Warehouse's context:
 .. _`open issues that are labelled "good first issue"`: https://github.com/pypa/warehouse/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22
 .. _`GitHub`: https://github.com/pypa/warehouse
 .. _`on Freenode`: https://webchat.freenode.net/?channels=%23pypa-dev,pypa
-.. _`pypa-dev mailing list`: https://groups.google.com/forum/#!forum/pypa-dev
+.. _`distutils-sig mailing list`: https://mail.python.org/mailman3/lists/distutils-sig.python.org/
 .. _`Test PyPI`: https://test.pypi.org/
 .. _`packaging sprints`: https://wiki.python.org/psf/PackagingSprints

--- a/docs/development/index.rst
+++ b/docs/development/index.rst
@@ -16,7 +16,7 @@ check out `"What to put in your bug report"`_ for guidance.
 
 You can also join ``#pypa`` (general packaging discussion and user support) and
 ``#pypa-dev`` (discussion about development of packaging tools) `on Freenode`_,
-or the `pypa-dev mailing list`_, to ask questions or get involved.
+or the `distutils-sig mailing list`_, to ask questions or get involved.
 
 
 .. toctree::
@@ -35,4 +35,4 @@ or the `pypa-dev mailing list`_, to ask questions or get involved.
 .. _`GitHub`: https://github.com/pypa/warehouse
 .. _`"What to put in your bug report"`: http://www.contribution-guide.org/#what-to-put-in-your-bug-report
 .. _`on Freenode`: https://webchat.freenode.net/?channels=%23pypa-dev,pypa
-.. _`pypa-dev mailing list`: https://groups.google.com/forum/#!forum/pypa-dev
+.. _`distutils-sig mailing list`: https://mail.python.org/mailman3/lists/distutils-sig.python.org/


### PR DESCRIPTION
This PR replaces references to the decomissioned pypa-dev google group with the distutils-sig mailing list. Closes #8012 . Thanks @brainwane for the approachable first issue :)