### PR TITLE
Add gravatar to the current user indicator

### DIFF
--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -420,14 +420,14 @@ msgstr ""
 
 #: warehouse/templates/base.html:41 warehouse/templates/base.html:55
 #: warehouse/templates/base.html:258
-#: warehouse/templates/includes/current-user-indicator.html:54
+#: warehouse/templates/includes/current-user-indicator.html:55
 #: warehouse/templates/pages/help.html:99
 #: warehouse/templates/pages/sitemap.html:27
 msgid "Help"
 msgstr ""
 
 #: warehouse/templates/base.html:42 warehouse/templates/base.html:56
-#: warehouse/templates/includes/current-user-indicator.html:60
+#: warehouse/templates/includes/current-user-indicator.html:61
 msgid "Sponsor"
 msgstr ""
 
@@ -452,7 +452,7 @@ msgid "Menu"
 msgstr ""
 
 #: warehouse/templates/base.html:54
-#: warehouse/templates/includes/current-user-indicator.html:24
+#: warehouse/templates/includes/current-user-indicator.html:25
 msgid "Main menu"
 msgstr ""
 
@@ -828,7 +828,7 @@ msgstr ""
 
 #: warehouse/templates/accounts/logout.html:16
 #: warehouse/templates/accounts/logout.html:25
-#: warehouse/templates/includes/current-user-indicator.html:68
+#: warehouse/templates/includes/current-user-indicator.html:69
 msgid "Log out"
 msgstr ""
 
@@ -1294,25 +1294,25 @@ msgid ""
 " link to verify your email address</a>."
 msgstr ""
 
-#: warehouse/templates/includes/current-user-indicator.html:29
+#: warehouse/templates/includes/current-user-indicator.html:30
 msgid "Admin"
 msgstr ""
 
-#: warehouse/templates/includes/current-user-indicator.html:36
+#: warehouse/templates/includes/current-user-indicator.html:37
 #: warehouse/templates/manage/manage_base.html:32
 #: warehouse/templates/manage/manage_base.html:52
 #: warehouse/templates/manage/projects.html:18
 msgid "Your projects"
 msgstr ""
 
-#: warehouse/templates/includes/current-user-indicator.html:42
+#: warehouse/templates/includes/current-user-indicator.html:43
 #: warehouse/templates/manage/account.html:17
 #: warehouse/templates/manage/manage_base.html:38
 #: warehouse/templates/manage/manage_base.html:58
 msgid "Account settings"
 msgstr ""
 
-#: warehouse/templates/includes/current-user-indicator.html:48
+#: warehouse/templates/includes/current-user-indicator.html:49
 msgid "Public profile"
 msgstr ""
 

--- a/warehouse/static/sass/blocks/_horizontal-menu.scss
+++ b/warehouse/static/sass/blocks/_horizontal-menu.scss
@@ -52,16 +52,19 @@
 
     &--with-icon {
       .fa {
-        margin-right: 3px;
+        margin-right: 5px;
+      }
+
+      img.fa {
+        border-radius: 10%;
+      }
+
+      &:hover {
+        .fa {
+          opacity: 0.8;
+        }
       }
     }
-  }
-
-  &__btn {
-    display: inline-block;
-    padding: 8px 10px;
-    @include link-without-underline;
-    @include link-focus-state($white);
   }
 
   &--light {
@@ -69,27 +72,7 @@
       color: $white;
 
       &:hover {
-        text-decoration: underline;
         text-decoration-color: $transparent-white;
-      }
-    }
-
-    .horizontal-menu__btn {
-      color: $white;
-
-      &:hover {
-        .icn {
-          opacity: 0.8;
-        }
-      }
-
-      img.icn {
-        border-radius: 10%;
-        margin: 0px 5px;
-      }
-
-      @media only screen and (max-width: $small-tablet) {
-        padding: 25px 10px;
       }
     }
   }
@@ -100,24 +83,6 @@
 
       &:hover {
         text-decoration: underline;
-      }
-
-      @media only screen and (max-width: $small-tablet) {
-        padding: 25px 10px;
-      }
-    }
-
-    .horizontal-menu__btn {
-      padding: 32px ($spacing-unit / 2);
-
-      &:hover {
-        .icn {
-          opacity: 0.8;
-        }
-      }
-
-      img.icn {
-        border-radius: 10%;
       }
 
       @media only screen and (max-width: $small-tablet) {

--- a/warehouse/static/sass/blocks/_horizontal-menu.scss
+++ b/warehouse/static/sass/blocks/_horizontal-menu.scss
@@ -57,12 +57,39 @@
     }
   }
 
+  &__btn {
+    display: inline-block;
+    padding: 8px 10px;
+    @include link-without-underline;
+    @include link-focus-state($white);
+  }
+
   &--light {
     .horizontal-menu__link {
       color: $white;
 
       &:hover {
+        text-decoration: underline;
         text-decoration-color: $transparent-white;
+      }
+    }
+
+    .horizontal-menu__btn {
+      color: $white;
+
+      &:hover {
+        .icn {
+          opacity: 0.8;
+        }
+      }
+
+      img.icn {
+        border-radius: 10%;
+        margin: 0px 5px;
+      }
+
+      @media only screen and (max-width: $small-tablet) {
+        padding: 25px 10px;
       }
     }
   }
@@ -73,6 +100,24 @@
 
       &:hover {
         text-decoration: underline;
+      }
+
+      @media only screen and (max-width: $small-tablet) {
+        padding: 25px 10px;
+      }
+    }
+
+    .horizontal-menu__btn {
+      padding: 32px ($spacing-unit / 2);
+
+      &:hover {
+        .icn {
+          opacity: 0.8;
+        }
+      }
+
+      img.icn {
+        border-radius: 10%;
       }
 
       @media only screen and (max-width: $small-tablet) {

--- a/warehouse/static/sass/blocks/_horizontal-menu.scss
+++ b/warehouse/static/sass/blocks/_horizontal-menu.scss
@@ -52,15 +52,17 @@
 
     &--with-icon {
       .fa {
-        margin-right: 5px;
+        margin-right: 3px;
       }
 
-      img.fa {
+      .user-image {
+        margin-right: 5px;
         border-radius: 10%;
       }
 
       &:hover {
-        .fa {
+        .fa,
+        .user-image {
           opacity: 0.8;
         }
       }

--- a/warehouse/templates/includes/current-user-indicator.html
+++ b/warehouse/templates/includes/current-user-indicator.html
@@ -15,10 +15,11 @@
   {% if request.user %}
   <div id="user-indicator" class="horizontal-menu horizontal-menu--light horizontal-menu--tall">
     <nav aria-label="{% trans %}Main navigation{% endtrans %}" class="dropdown dropdown--on-menu dropdown--with-icons">
-      <button type="button" class="horizontal-menu__link dropdown__trigger" aria-haspopup="true" aria-expanded="false" aria-label="{% trans %}View menu{% endtrans %}">
+      <button type="button" class="horizontal-menu__btn horizontal-menu__link dropdown__trigger" aria-haspopup="true" aria-expanded="false" aria-label="{% trans %}View menu{% endtrans %}">
+        <img class="icn" src="{{ gravatar(request, request.user.email, size=40) }}" alt="User Image">
         {{ request.user.username }}
         <span class="dropdown__trigger-caret">
-          <i class="fa fa-caret-down" aria-hidden="true"></i>
+          <i class="icn fa fa-caret-down" aria-hidden="true"></i>
         </span>
       </button>
       <ul class="dropdown__content" aria-hidden="true" aria-label="{% trans %}Main menu{% endtrans %}">

--- a/warehouse/templates/includes/current-user-indicator.html
+++ b/warehouse/templates/includes/current-user-indicator.html
@@ -15,11 +15,11 @@
   {% if request.user %}
   <div id="user-indicator" class="horizontal-menu horizontal-menu--light horizontal-menu--tall">
     <nav aria-label="{% trans %}Main navigation{% endtrans %}" class="dropdown dropdown--on-menu dropdown--with-icons">
-      <button type="button" class="horizontal-menu__btn horizontal-menu__link dropdown__trigger" aria-haspopup="true" aria-expanded="false" aria-label="{% trans %}View menu{% endtrans %}">
-        <img class="icn" src="{{ gravatar(request, request.user.email, size=40) }}" alt="User Image">
+      <button type="button" class="horizontal-menu__link--with-icon horizontal-menu__link dropdown__trigger" aria-haspopup="true" aria-expanded="false" aria-label="{% trans %}View menu{% endtrans %}">
+        <img class="fa" src="{{ gravatar(request, request.user.email, size=40) }}" alt="User Image">
         {{ request.user.username }}
         <span class="dropdown__trigger-caret">
-          <i class="icn fa fa-caret-down" aria-hidden="true"></i>
+          <i class="fa fa-caret-down" aria-hidden="true"></i>
         </span>
       </button>
       <ul class="dropdown__content" aria-hidden="true" aria-label="{% trans %}Main menu{% endtrans %}">

--- a/warehouse/templates/includes/current-user-indicator.html
+++ b/warehouse/templates/includes/current-user-indicator.html
@@ -16,7 +16,7 @@
   <div id="user-indicator" class="horizontal-menu horizontal-menu--light horizontal-menu--tall">
     <nav aria-label="{% trans %}Main navigation{% endtrans %}" class="dropdown dropdown--on-menu dropdown--with-icons">
       <button type="button" class="horizontal-menu__link--with-icon horizontal-menu__link dropdown__trigger" aria-haspopup="true" aria-expanded="false" aria-label="{% trans %}View menu{% endtrans %}">
-        <img class="fa" src="{{ gravatar(request, request.user.email, size=40) }}" alt="User Image">
+        <img class="user-image" src="{{ gravatar(request, request.user.email, size=40) }}" alt="User Image">
         {{ request.user.username }}
         <span class="dropdown__trigger-caret">
           <i class="fa fa-caret-down" aria-hidden="true"></i>


### PR DESCRIPTION
As per the feature request in #6462, the user's gravatar is now present next to their username in the top-right user menu action. Resolves #6462 

Initially, the plan was to replace the username with the gravatar and move the username into the drop-down menu as a `Welcome, <username>` message. However, since most users have the [default gravatar](https://secure.gravatar.com/avatar/default), its background color is almost identical to the webpage's header making the indicator a little confusing as it just shows up as a white circle in the top-right. Here's the updated user indicator:

<img src="https://user-images.githubusercontent.com/27223486/83801207-5de31d00-a66e-11ea-9a90-ae21f59a75fa.gif" width="250" height="413" alt="custom_grav"/> <img src="https://user-images.githubusercontent.com/27223486/83793287-f4f5a800-a661-11ea-97d8-1113274f7ed0.gif" width="250" height="413" alt="default_grav"/>
