### PR TITLE
Re-Authentication for Sensitive Actions/Endpoints

### DIFF
--- a/tests/unit/accounts/test_views.py
+++ b/tests/unit/accounts/test_views.py
@@ -197,8 +197,9 @@ class TestLogin:
         )
 
         pyramid_request.registry.settings = {"sessions.secret": "dummy_secret"}
-        pyramid_request.session.record_auth_timestamp = lambda req, resp: None
-        pyramid_request.session.needs_reauthentication = lambda req: False
+        pyramid_request.session.record_auth_timestamp = pretend.call_recorder(
+            lambda *args: None
+        )
 
         form_obj = pretend.stub(
             validate=pretend.call_recorder(lambda: True),
@@ -251,6 +252,7 @@ class TestLogin:
         assert remember.calls == [pretend.call(pyramid_request, str(user_id))]
         assert pyramid_request.session.invalidate.calls == [pretend.call()]
         assert pyramid_request.session.new_csrf_token.calls == [pretend.call()]
+        assert pyramid_request.session.record_auth_timestamp.calls == [pretend.call()]
 
     @pytest.mark.parametrize(
         # The set of all possible next URLs. Since this set is infinite, we
@@ -278,8 +280,9 @@ class TestLogin:
         pyramid_request.POST["next"] = expected_next_url
         pyramid_request.remote_addr = "0.0.0.0"
 
-        pyramid_request.session.record_auth_timestamp = lambda req, resp: None
-        pyramid_request.session.needs_reauthentication = lambda req: False
+        pyramid_request.session.record_auth_timestamp = pretend.call_recorder(
+            lambda *args: None
+        )
 
         form_obj = pretend.stub(
             validate=pretend.call_recorder(lambda: True),
@@ -300,6 +303,7 @@ class TestLogin:
                 additional={"two_factor_method": None},
             )
         ]
+        assert pyramid_request.session.record_auth_timestamp.calls == [pretend.call()]
 
     def test_redirect_authenticated_user(self):
         pyramid_request = pretend.stub(authenticated_userid=1)

--- a/tests/unit/accounts/test_views.py
+++ b/tests/unit/accounts/test_views.py
@@ -196,6 +196,8 @@ class TestLogin:
             name="unauthenticated_userid",
         )
 
+        pyramid_request.registry.settings = {"sessions.secret": "dummy_secret"}
+
         form_obj = pretend.stub(
             validate=pretend.call_recorder(lambda: True),
             username=pretend.stub(data="theuser"),

--- a/tests/unit/accounts/test_views.py
+++ b/tests/unit/accounts/test_views.py
@@ -197,6 +197,8 @@ class TestLogin:
         )
 
         pyramid_request.registry.settings = {"sessions.secret": "dummy_secret"}
+        pyramid_request.session.record_auth_timestamp = lambda req, resp: None
+        pyramid_request.session.needs_reauthentication = lambda req: False
 
         form_obj = pretend.stub(
             validate=pretend.call_recorder(lambda: True),
@@ -275,6 +277,9 @@ class TestLogin:
         pyramid_request.method = "POST"
         pyramid_request.POST["next"] = expected_next_url
         pyramid_request.remote_addr = "0.0.0.0"
+
+        pyramid_request.session.record_auth_timestamp = lambda req, resp: None
+        pyramid_request.session.needs_reauthentication = lambda req: False
 
         form_obj = pretend.stub(
             validate=pretend.call_recorder(lambda: True),

--- a/tests/unit/manage/test_forms.py
+++ b/tests/unit/manage/test_forms.py
@@ -133,6 +133,15 @@ class TestChangePasswordForm:
         assert form._breach_service is breach_service
 
 
+class TestReAuthenticateForm:
+    def test_creation(self):
+        user_service = pretend.stub()
+
+        form = forms.ReAuthenticateForm(user_service=user_service)
+
+        assert form.user_service is user_service
+
+
 class TestProvisionTOTPForm:
     def test_creation(self):
         totp_secret = pretend.stub()

--- a/tests/unit/manage/test_init.py
+++ b/tests/unit/manage/test_init.py
@@ -13,7 +13,7 @@
 import pretend
 import pytest
 
-from pyramid import renderers, viewderivers
+from pyramid import viewderivers
 
 from warehouse import manage
 
@@ -28,7 +28,7 @@ class TestReAuthView:
         request = pretend.stub(
             matchdict="{}",
             session=pretend.stub(
-                needs_reauthentication=pretend.call_recorder(lambda req: False)
+                needs_reauthentication=pretend.call_recorder(lambda *args: False)
             ),
         )
         response = pretend.stub()
@@ -43,6 +43,9 @@ class TestReAuthView:
 
         assert derived_view(context, request) is response
         assert view.calls == [pretend.call(context, request)]
+        assert request.session.needs_reauthentication.calls == (
+            [pretend.call()] if requires_reauth else []
+        )
 
     def test_reauth(self, monkeypatch):
         context = pretend.stub()
@@ -51,7 +54,7 @@ class TestReAuthView:
             matchdict="{}",
             POST=pretend.stub(),
             session=pretend.stub(
-                needs_reauthentication=pretend.call_recorder(lambda req: True)
+                needs_reauthentication=pretend.call_recorder(lambda *args: True)
             ),
             user=pretend.stub(),
         )
@@ -77,6 +80,7 @@ class TestReAuthView:
 
         assert derived_view(context, request) is not response
         assert view.calls == []
+        assert request.session.needs_reauthentication.calls == [pretend.call()]
 
 
 def test_includeme():

--- a/tests/unit/manage/test_init.py
+++ b/tests/unit/manage/test_init.py
@@ -1,0 +1,93 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pretend
+import pytest
+
+from pyramid import renderers, viewderivers
+
+from warehouse import manage
+
+
+class TestReAuthView:
+    def test_has_options(self):
+        assert set(manage.reauth_view.options) == {"require_reauth"}
+
+    @pytest.mark.parametrize("requires_reauth", [True, False])
+    def test_unneeded_reauth(self, requires_reauth):
+        context = pretend.stub()
+        request = pretend.stub(
+            matchdict="{}",
+            session=pretend.stub(
+                needs_reauthentication=pretend.call_recorder(lambda req: False)
+            ),
+        )
+        response = pretend.stub()
+
+        @pretend.call_recorder
+        def view(context, request):
+            return response
+
+        info = pretend.stub(options={}, exception_only=False)
+        info.options["require_reauth"] = requires_reauth
+        derived_view = manage.reauth_view(view, info)
+
+        assert derived_view(context, request) is response
+        assert view.calls == [pretend.call(context, request)]
+
+    def test_reauth(self, monkeypatch):
+        context = pretend.stub()
+        request = pretend.stub(
+            find_service=pretend.call_recorder(lambda service, context: pretend.stub()),
+            matchdict="{}",
+            POST=pretend.stub(),
+            session=pretend.stub(
+                needs_reauthentication=pretend.call_recorder(lambda req: True)
+            ),
+            user=pretend.stub(),
+        )
+        response = pretend.stub()
+
+        def mock_response(*args, **kwargs):
+            return {"mock_key": "mock_response"}
+
+        def mock_form(*args, **kwargs):
+            return pretend.stub()
+
+        monkeypatch.setattr(manage, "render_to_response", mock_response)
+        monkeypatch.setattr(manage, "ReAuthenticateForm", mock_form)
+
+        @pretend.call_recorder
+        def view(context, request):
+            assert isinstance(request.matchdict_json, str)
+            return response
+
+        info = pretend.stub(options={}, exception_only=False)
+        info.options["require_reauth"] = True
+        derived_view = manage.reauth_view(view, info)
+
+        assert derived_view(context, request) is not response
+        assert view.calls == []
+
+
+def test_includeme():
+    config = pretend.stub(
+        add_view_deriver=pretend.call_recorder(lambda f, over, under: None),
+    )
+
+    manage.includeme(config)
+
+    assert config.add_view_deriver.calls == [
+        pretend.call(
+            manage.reauth_view, over="rendered_view", under=viewderivers.INGRESS
+        )
+    ]

--- a/tests/unit/test_routes.py
+++ b/tests/unit/test_routes.py
@@ -300,6 +300,7 @@ def test_routes(warehouse):
             domain=warehouse,
         ),
         pretend.call("packaging.file", "https://files.example.com/packages/{path}"),
+        pretend.call("reauthenticate", "/reauthenticate/", domain=warehouse),
         pretend.call("ses.hook", "/_/ses-hook/", domain=warehouse),
         pretend.call("rss.updates", "/rss/updates.xml", domain=warehouse),
         pretend.call("rss.packages", "/rss/packages.xml", domain=warehouse),

--- a/tests/unit/test_sessions.py
+++ b/tests/unit/test_sessions.py
@@ -174,11 +174,6 @@ class TestSession:
         session[session._reauth_timestamp_key] = 0
         assert session.needs_reauthentication()
 
-    def test_reauth_needed_bad_value(self):
-        session = Session()
-        session[session._reauth_timestamp_key] = "bad value"
-        assert session.needs_reauthentication()
-
     def test_reauth_needed_no_value(self):
         session = Session()
         assert session.needs_reauthentication()

--- a/tests/unit/test_views.py
+++ b/tests/unit/test_views.py
@@ -26,6 +26,7 @@ from trove_classifiers import classifiers
 from webob.multidict import MultiDict
 
 from warehouse import views
+from warehouse.accounts.interfaces import IUserService
 from warehouse.views import (
     current_user_indicator,
     flash_messages,
@@ -38,6 +39,7 @@ from warehouse.views import (
     list_classifiers,
     locale,
     opensearchxml,
+    reauthenticate,
     robotstxt,
     search,
     service_unavailable,
@@ -461,3 +463,48 @@ class TestForceStatus:
     def test_invalid(self):
         with pytest.raises(HTTPNotFound):
             force_status(pretend.stub(matchdict={"status": "599"}))
+
+
+class TestReAuthentication:
+    @pytest.mark.parametrize("next_route", [None, "/manage/accounts", "/projects/"])
+    def test_reauth(self, monkeypatch, pyramid_request, pyramid_services, next_route):
+        user_service = pretend.stub()
+        response = pretend.stub()
+
+        monkeypatch.setattr(views, "HTTPSeeOther", lambda url: response)
+
+        pyramid_services.register_service(IUserService, None, user_service)
+
+        pyramid_request.route_path = lambda *args, **kwargs: pretend.stub()
+        pyramid_request.session.record_auth_timestamp = pretend.call_recorder(
+            lambda *args: None
+        )
+
+        form_obj = pretend.stub(
+            next_route=pretend.stub(data=next_route),
+            next_route_matchdict=pretend.stub(data="{}"),
+            validate=lambda: True,
+        )
+        form_class = pretend.call_recorder(lambda d, **kw: form_obj)
+
+        if next_route is not None:
+            pyramid_request.method = "POST"
+            pyramid_request.POST["next_route"] = next_route
+            pyramid_request.POST["next_route_matchdict"] = "{}"
+
+        _ = reauthenticate(pyramid_request, _form_class=form_class)
+
+        assert pyramid_request.session.record_auth_timestamp.calls == (
+            [pretend.call(pyramid_request, response)] if next_route is not None else []
+        )
+        assert form_class.calls == [
+            pretend.call(
+                pyramid_request.POST,
+                request=pyramid_request,
+                user_service=user_service,
+                check_password_metrics_tags=[
+                    "method:reauth",
+                    "auth_method:reauthenticate_form",
+                ],
+            )
+        ]

--- a/tests/unit/test_views.py
+++ b/tests/unit/test_views.py
@@ -495,7 +495,7 @@ class TestReAuthentication:
         _ = reauthenticate(pyramid_request, _form_class=form_class)
 
         assert pyramid_request.session.record_auth_timestamp.calls == (
-            [pretend.call(pyramid_request, response)] if next_route is not None else []
+            [pretend.call()] if next_route is not None else []
         )
         assert form_class.calls == [
             pretend.call(

--- a/warehouse/accounts/views.py
+++ b/warehouse/accounts/views.py
@@ -55,7 +55,6 @@ from warehouse.email import (
 )
 from warehouse.packaging.models import Project, Release
 from warehouse.rate_limiting.interfaces import IRateLimiter
-from warehouse.utils import crypto
 from warehouse.utils.http import is_safe_url
 
 USER_ID_INSECURE_COOKIE = "user_id__insecure"
@@ -195,7 +194,7 @@ def login(request, redirect_field_name=REDIRECT_FIELD_NAME, _form_class=LoginFor
                     .lower(),
                 )
 
-                request.session.record_auth_timestamp(request, resp)
+                request.session.record_auth_timestamp()
             return resp
 
     return {

--- a/warehouse/accounts/views.py
+++ b/warehouse/accounts/views.py
@@ -53,7 +53,6 @@ from warehouse.email import (
     send_password_change_email,
     send_password_reset_email,
 )
-from warehouse.manage import RE_AUTHENTICATION_KEY
 from warehouse.packaging.models import Project, Release
 from warehouse.rate_limiting.interfaces import IRateLimiter
 from warehouse.utils import crypto
@@ -196,16 +195,7 @@ def login(request, redirect_field_name=REDIRECT_FIELD_NAME, _form_class=LoginFor
                     .lower(),
                 )
 
-                signer = crypto.Signer(
-                    request.registry.settings["sessions.secret"], salt="session"
-                )
-
-                resp.set_cookie(
-                    RE_AUTHENTICATION_KEY,
-                    signer.sign(str(datetime.datetime.now().timestamp())),
-                    max_age=12 * 60 * 60,
-                    httponly=True,
-                )
+                request.session.record_auth_timestamp(request, resp)
             return resp
 
     return {

--- a/warehouse/accounts/views.py
+++ b/warehouse/accounts/views.py
@@ -53,8 +53,10 @@ from warehouse.email import (
     send_password_change_email,
     send_password_reset_email,
 )
+from warehouse.manage import RE_AUTHENTICATION_KEY
 from warehouse.packaging.models import Project, Release
 from warehouse.rate_limiting.interfaces import IRateLimiter
+from warehouse.utils import crypto
 from warehouse.utils.http import is_safe_url
 
 USER_ID_INSECURE_COOKIE = "user_id__insecure"
@@ -192,6 +194,17 @@ def login(request, redirect_field_name=REDIRECT_FIELD_NAME, _form_class=LoginFor
                     )
                     .hexdigest()
                     .lower(),
+                )
+
+                signer = crypto.Signer(
+                    request.registry.settings["sessions.secret"], salt="session"
+                )
+
+                resp.set_cookie(
+                    RE_AUTHENTICATION_KEY,
+                    signer.sign(str(datetime.datetime.now().timestamp())),
+                    max_age=12 * 60 * 60,
+                    httponly=True,
                 )
             return resp
 

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -1,4 +1,4 @@
-#: warehouse/views.py:254
+#: warehouse/views.py:257
 msgid "Locale updated"
 msgstr ""
 
@@ -31,7 +31,7 @@ msgstr ""
 msgid "The password is invalid. Try again."
 msgstr ""
 
-#: warehouse/accounts/forms.py:126 warehouse/accounts/views.py:66
+#: warehouse/accounts/forms.py:126 warehouse/accounts/views.py:67
 msgid "There have been too many unsuccessful login attempts. Try again later."
 msgstr ""
 
@@ -79,121 +79,121 @@ msgstr ""
 msgid "No user found with that username or email"
 msgstr ""
 
-#: warehouse/accounts/views.py:83
+#: warehouse/accounts/views.py:84
 msgid ""
 "Too many emails have been added to this account without verifying them. "
 "Check your inbox and follow the verification links."
 msgstr ""
 
-#: warehouse/accounts/views.py:220 warehouse/accounts/views.py:278
-#: warehouse/accounts/views.py:280 warehouse/accounts/views.py:307
-#: warehouse/accounts/views.py:309 warehouse/accounts/views.py:364
+#: warehouse/accounts/views.py:223 warehouse/accounts/views.py:281
+#: warehouse/accounts/views.py:283 warehouse/accounts/views.py:310
+#: warehouse/accounts/views.py:312 warehouse/accounts/views.py:367
 msgid "Invalid or expired two factor login."
 msgstr ""
 
-#: warehouse/accounts/views.py:272
+#: warehouse/accounts/views.py:275
 msgid "Already authenticated"
 msgstr ""
 
-#: warehouse/accounts/views.py:340
+#: warehouse/accounts/views.py:343
 msgid "Successful WebAuthn assertion"
 msgstr ""
 
-#: warehouse/accounts/views.py:393
+#: warehouse/accounts/views.py:396
 msgid "Recovery code accepted. The supplied code cannot be used again."
 msgstr ""
 
-#: warehouse/accounts/views.py:479
+#: warehouse/accounts/views.py:482
 msgid ""
 "New user registration temporarily disabled. See https://pypi.org/help"
 "#admin-intervention for details."
 msgstr ""
 
-#: warehouse/accounts/views.py:578
+#: warehouse/accounts/views.py:581
 msgid "Expired token: request a new password reset link"
 msgstr ""
 
-#: warehouse/accounts/views.py:580
+#: warehouse/accounts/views.py:583
 msgid "Invalid token: request a new password reset link"
 msgstr ""
 
-#: warehouse/accounts/views.py:582 warehouse/accounts/views.py:665
+#: warehouse/accounts/views.py:585 warehouse/accounts/views.py:668
 msgid "Invalid token: no token supplied"
 msgstr ""
 
-#: warehouse/accounts/views.py:586
+#: warehouse/accounts/views.py:589
 msgid "Invalid token: not a password reset token"
 msgstr ""
 
-#: warehouse/accounts/views.py:591
+#: warehouse/accounts/views.py:594
 msgid "Invalid token: user not found"
 msgstr ""
 
-#: warehouse/accounts/views.py:598
+#: warehouse/accounts/views.py:601
 msgid "Invalid token: user has logged in since this token was requested"
 msgstr ""
 
-#: warehouse/accounts/views.py:607
+#: warehouse/accounts/views.py:610
 msgid ""
 "Invalid token: password has already been changed since this token was "
 "requested"
 msgstr ""
 
-#: warehouse/accounts/views.py:634
+#: warehouse/accounts/views.py:637
 msgid "You have reset your password"
 msgstr ""
 
-#: warehouse/accounts/views.py:661
+#: warehouse/accounts/views.py:664
 msgid "Expired token: request a new email verification link"
 msgstr ""
 
-#: warehouse/accounts/views.py:663
+#: warehouse/accounts/views.py:666
 msgid "Invalid token: request a new email verification link"
 msgstr ""
 
-#: warehouse/accounts/views.py:669
+#: warehouse/accounts/views.py:672
 msgid "Invalid token: not an email verification token"
 msgstr ""
 
-#: warehouse/accounts/views.py:678
+#: warehouse/accounts/views.py:681
 msgid "Email not found"
 msgstr ""
 
-#: warehouse/accounts/views.py:681
+#: warehouse/accounts/views.py:684
 msgid "Email already verified"
 msgstr ""
 
-#: warehouse/accounts/views.py:696
+#: warehouse/accounts/views.py:699
 msgid "You can now set this email as your primary address"
 msgstr ""
 
-#: warehouse/accounts/views.py:700
+#: warehouse/accounts/views.py:703
 msgid "This is your primary address"
 msgstr ""
 
-#: warehouse/accounts/views.py:705
+#: warehouse/accounts/views.py:708
 msgid "Email address ${email_address} verified. ${confirm_message}."
 msgstr ""
 
-#: warehouse/manage/views.py:189
+#: warehouse/manage/views.py:194
 msgid "Email ${email_address} added - check your email for a verification link"
 msgstr ""
 
-#: warehouse/manage/views.py:670 warehouse/manage/views.py:706
+#: warehouse/manage/views.py:681 warehouse/manage/views.py:717
 msgid ""
 "You must provision a two factor method before recovery codes can be "
 "generated"
 msgstr ""
 
-#: warehouse/manage/views.py:681
+#: warehouse/manage/views.py:692
 msgid "Recovery codes already generated"
 msgstr ""
 
-#: warehouse/manage/views.py:682
+#: warehouse/manage/views.py:693
 msgid "Generating new recovery codes will invalidate your existing codes."
 msgstr ""
 
-#: warehouse/manage/views.py:733
+#: warehouse/manage/views.py:744
 msgid "Invalid credentials. Try again"
 msgstr ""
 
@@ -252,63 +252,63 @@ msgstr ""
 #: warehouse/templates/packaging/detail.html:306
 #: warehouse/templates/pages/classifiers.html:25
 #: warehouse/templates/pages/help.html:20
-#: warehouse/templates/pages/help.html:196
-#: warehouse/templates/pages/help.html:203
-#: warehouse/templates/pages/help.html:217
-#: warehouse/templates/pages/help.html:233
-#: warehouse/templates/pages/help.html:237
-#: warehouse/templates/pages/help.html:272
-#: warehouse/templates/pages/help.html:299
-#: warehouse/templates/pages/help.html:304
-#: warehouse/templates/pages/help.html:309
+#: warehouse/templates/pages/help.html:198
+#: warehouse/templates/pages/help.html:205
+#: warehouse/templates/pages/help.html:219
+#: warehouse/templates/pages/help.html:235
+#: warehouse/templates/pages/help.html:239
+#: warehouse/templates/pages/help.html:274
+#: warehouse/templates/pages/help.html:301
+#: warehouse/templates/pages/help.html:306
 #: warehouse/templates/pages/help.html:311
-#: warehouse/templates/pages/help.html:316
-#: warehouse/templates/pages/help.html:317
+#: warehouse/templates/pages/help.html:313
 #: warehouse/templates/pages/help.html:318
-#: warehouse/templates/pages/help.html:322
-#: warehouse/templates/pages/help.html:355
+#: warehouse/templates/pages/help.html:319
+#: warehouse/templates/pages/help.html:320
+#: warehouse/templates/pages/help.html:324
 #: warehouse/templates/pages/help.html:357
-#: warehouse/templates/pages/help.html:360
-#: warehouse/templates/pages/help.html:396
-#: warehouse/templates/pages/help.html:401
-#: warehouse/templates/pages/help.html:407
-#: warehouse/templates/pages/help.html:465
-#: warehouse/templates/pages/help.html:477
-#: warehouse/templates/pages/help.html:483
-#: warehouse/templates/pages/help.html:486
+#: warehouse/templates/pages/help.html:359
+#: warehouse/templates/pages/help.html:362
+#: warehouse/templates/pages/help.html:398
+#: warehouse/templates/pages/help.html:403
+#: warehouse/templates/pages/help.html:409
+#: warehouse/templates/pages/help.html:467
 #: warehouse/templates/pages/help.html:488
+#: warehouse/templates/pages/help.html:494
 #: warehouse/templates/pages/help.html:497
-#: warehouse/templates/pages/help.html:509
-#: warehouse/templates/pages/help.html:515
-#: warehouse/templates/pages/help.html:527
-#: warehouse/templates/pages/help.html:528
-#: warehouse/templates/pages/help.html:533
-#: warehouse/templates/pages/help.html:568
-#: warehouse/templates/pages/help.html:589
-#: warehouse/templates/pages/help.html:601
+#: warehouse/templates/pages/help.html:499
+#: warehouse/templates/pages/help.html:508
+#: warehouse/templates/pages/help.html:520
+#: warehouse/templates/pages/help.html:526
+#: warehouse/templates/pages/help.html:538
+#: warehouse/templates/pages/help.html:539
+#: warehouse/templates/pages/help.html:544
+#: warehouse/templates/pages/help.html:579
+#: warehouse/templates/pages/help.html:600
 #: warehouse/templates/pages/help.html:612
-#: warehouse/templates/pages/help.html:617
-#: warehouse/templates/pages/help.html:625
+#: warehouse/templates/pages/help.html:623
+#: warehouse/templates/pages/help.html:628
 #: warehouse/templates/pages/help.html:636
-#: warehouse/templates/pages/help.html:653
-#: warehouse/templates/pages/help.html:660
-#: warehouse/templates/pages/help.html:668
-#: warehouse/templates/pages/help.html:684
-#: warehouse/templates/pages/help.html:689
-#: warehouse/templates/pages/help.html:694
-#: warehouse/templates/pages/help.html:704
-#: warehouse/templates/pages/help.html:713
-#: warehouse/templates/pages/help.html:727
-#: warehouse/templates/pages/help.html:735
-#: warehouse/templates/pages/help.html:743
-#: warehouse/templates/pages/help.html:751
-#: warehouse/templates/pages/help.html:761
-#: warehouse/templates/pages/help.html:776
-#: warehouse/templates/pages/help.html:791
-#: warehouse/templates/pages/help.html:792
-#: warehouse/templates/pages/help.html:793
-#: warehouse/templates/pages/help.html:794
-#: warehouse/templates/pages/help.html:799
+#: warehouse/templates/pages/help.html:647
+#: warehouse/templates/pages/help.html:664
+#: warehouse/templates/pages/help.html:671
+#: warehouse/templates/pages/help.html:679
+#: warehouse/templates/pages/help.html:695
+#: warehouse/templates/pages/help.html:700
+#: warehouse/templates/pages/help.html:705
+#: warehouse/templates/pages/help.html:715
+#: warehouse/templates/pages/help.html:724
+#: warehouse/templates/pages/help.html:738
+#: warehouse/templates/pages/help.html:746
+#: warehouse/templates/pages/help.html:754
+#: warehouse/templates/pages/help.html:762
+#: warehouse/templates/pages/help.html:772
+#: warehouse/templates/pages/help.html:787
+#: warehouse/templates/pages/help.html:802
+#: warehouse/templates/pages/help.html:803
+#: warehouse/templates/pages/help.html:804
+#: warehouse/templates/pages/help.html:805
+#: warehouse/templates/pages/help.html:810
 #: warehouse/templates/pages/security.html:36
 #: warehouse/templates/pages/sponsor.html:27
 #: warehouse/templates/pages/sponsor.html:33
@@ -421,7 +421,7 @@ msgstr ""
 #: warehouse/templates/base.html:41 warehouse/templates/base.html:55
 #: warehouse/templates/base.html:258
 #: warehouse/templates/includes/current-user-indicator.html:55
-#: warehouse/templates/pages/help.html:99
+#: warehouse/templates/pages/help.html:100
 #: warehouse/templates/pages/sitemap.html:27
 msgid "Help"
 msgstr ""
@@ -730,6 +730,59 @@ msgstr ""
 msgid "Hot off the press: the newest project releases"
 msgstr ""
 
+#: warehouse/templates/accounts/login.html:17
+#: warehouse/templates/accounts/recovery-code.html:17
+#: warehouse/templates/accounts/register.html:17
+#: warehouse/templates/accounts/request-password-reset.html:17
+#: warehouse/templates/accounts/reset-password.html:17
+#: warehouse/templates/accounts/two-factor.html:17
+#: warehouse/templates/manage/account.html:23
+#: warehouse/templates/manage/account/totp-provision.html:22
+#: warehouse/templates/manage/token.html:22 warehouse/templates/re-auth.html:17
+msgid "Error processing form"
+msgstr ""
+
+#: warehouse/templates/accounts/register.html:135
+#: warehouse/templates/accounts/register.html:140
+#: warehouse/templates/accounts/reset-password.html:61
+#: warehouse/templates/accounts/reset-password.html:66
+#: warehouse/templates/manage/account.html:429
+#: warehouse/templates/re-auth.html:18 warehouse/templates/re-auth.html:68
+msgid "Confirm password"
+msgstr ""
+
+#: warehouse/templates/re-auth.html:30
+msgid "Confirm password to continue"
+msgstr ""
+
+#: warehouse/templates/accounts/login.html:69
+#: warehouse/templates/accounts/register.html:110
+#: warehouse/templates/accounts/reset-password.html:38
+#: warehouse/templates/manage/manage_base.html:167
+#: warehouse/templates/re-auth.html:49
+msgid "Password"
+msgstr ""
+
+#: warehouse/templates/accounts/login.html:75
+#: warehouse/templates/re-auth.html:55
+msgid "Your password"
+msgstr ""
+
+#: warehouse/templates/accounts/login.html:92
+#: warehouse/templates/manage/manage_base.html:170
+#: warehouse/templates/re-auth.html:72
+msgid "Show password"
+msgstr ""
+
+#: warehouse/templates/accounts/login.html:96
+#: warehouse/templates/re-auth.html:76
+msgid "Forgot password?"
+msgstr ""
+
+#: warehouse/templates/re-auth.html:80
+msgid "sensitive action"
+msgstr ""
+
 #: warehouse/templates/upload.html:25
 msgid "This URL is an API endpoint for uploading files to PyPI."
 msgstr ""
@@ -747,18 +800,6 @@ msgstr ""
 msgid ""
 "Otherwise, we suggest you <a href=\"%(href)s\">go to the PyPI "
 "homepage</a>."
-msgstr ""
-
-#: warehouse/templates/accounts/login.html:17
-#: warehouse/templates/accounts/recovery-code.html:17
-#: warehouse/templates/accounts/register.html:17
-#: warehouse/templates/accounts/request-password-reset.html:17
-#: warehouse/templates/accounts/reset-password.html:17
-#: warehouse/templates/accounts/two-factor.html:17
-#: warehouse/templates/manage/account.html:23
-#: warehouse/templates/manage/account/totp-provision.html:22
-#: warehouse/templates/manage/token.html:22
-msgid "Error processing form"
 msgstr ""
 
 #: warehouse/templates/accounts/login.html:30
@@ -804,26 +845,6 @@ msgstr ""
 
 #: warehouse/templates/accounts/login.html:54
 msgid "Your username"
-msgstr ""
-
-#: warehouse/templates/accounts/login.html:69
-#: warehouse/templates/accounts/register.html:110
-#: warehouse/templates/accounts/reset-password.html:38
-#: warehouse/templates/manage/manage_base.html:167
-msgid "Password"
-msgstr ""
-
-#: warehouse/templates/accounts/login.html:75
-msgid "Your password"
-msgstr ""
-
-#: warehouse/templates/accounts/login.html:92
-#: warehouse/templates/manage/manage_base.html:170
-msgid "Show password"
-msgstr ""
-
-#: warehouse/templates/accounts/login.html:96
-msgid "Forgot password?"
 msgstr ""
 
 #: warehouse/templates/accounts/logout.html:16
@@ -962,14 +983,6 @@ msgstr ""
 
 #: warehouse/templates/accounts/register.html:120
 msgid "Select a password"
-msgstr ""
-
-#: warehouse/templates/accounts/register.html:135
-#: warehouse/templates/accounts/register.html:140
-#: warehouse/templates/accounts/reset-password.html:61
-#: warehouse/templates/accounts/reset-password.html:66
-#: warehouse/templates/manage/account.html:429
-msgid "Confirm password"
 msgstr ""
 
 #: warehouse/templates/accounts/register.html:157
@@ -1550,7 +1563,7 @@ msgstr ""
 
 #: warehouse/templates/includes/packaging/project-data.html:84
 #: warehouse/templates/includes/packaging/project-data.html:86
-#: warehouse/templates/pages/help.html:519
+#: warehouse/templates/pages/help.html:530
 msgid "Maintainer:"
 msgstr ""
 
@@ -2798,7 +2811,7 @@ msgid ""
 msgstr ""
 
 #: warehouse/templates/manage/roles.html:25
-#: warehouse/templates/pages/help.html:518
+#: warehouse/templates/pages/help.html:529
 msgid "There are two possible roles for collaborators:"
 msgstr ""
 
@@ -2809,7 +2822,7 @@ msgid "Maintainer"
 msgstr ""
 
 #: warehouse/templates/manage/roles.html:28
-#: warehouse/templates/pages/help.html:519
+#: warehouse/templates/pages/help.html:530
 msgid ""
 "Can upload releases for a package. Cannot add collaborators. Cannot "
 "delete files, releases, or the project."
@@ -2822,7 +2835,7 @@ msgid "Owner"
 msgstr ""
 
 #: warehouse/templates/manage/roles.html:30
-#: warehouse/templates/pages/help.html:520
+#: warehouse/templates/pages/help.html:531
 msgid ""
 "Can upload releases. Can add other collaborators. Can delete files, "
 "releases, or the entire project."
@@ -3501,162 +3514,166 @@ msgstr ""
 msgid "How can I use API tokens to authenticate with PyPI?"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:67
-msgid "How can I run a mirror of PyPI?"
+#: warehouse/templates/pages/help.html:66
+msgid "Why do certain actions require me to confirm my password?"
 msgstr ""
 
 #: warehouse/templates/pages/help.html:68
-msgid "Does PyPI have APIs I can use?"
+msgid "How can I run a mirror of PyPI?"
 msgstr ""
 
 #: warehouse/templates/pages/help.html:69
-msgid "How do I get notified when a new version of a project is released?"
+msgid "Does PyPI have APIs I can use?"
 msgstr ""
 
 #: warehouse/templates/pages/help.html:70
+msgid "How do I get notified when a new version of a project is released?"
+msgstr ""
+
+#: warehouse/templates/pages/help.html:71
 msgid ""
 "Where can I see statistics about PyPI, downloads, and project/package "
 "usage?"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:72
+#: warehouse/templates/pages/help.html:73
 msgid "I forgot my PyPI password. Can you help me?"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:73
+#: warehouse/templates/pages/help.html:74
 msgid "I've lost access to my PyPI account. Can you help me?"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:74
+#: warehouse/templates/pages/help.html:75
 msgid ""
 "Why am I getting a \"Invalid or non-existent authentication "
 "information.\" error when uploading files?"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:75
+#: warehouse/templates/pages/help.html:76
 msgid ""
 "Why am I getting \"No matching distribution found\" or \"Could not fetch "
 "URL\" errors during <code>pip install</code>?"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:76
+#: warehouse/templates/pages/help.html:77
 msgid "I am having trouble using the PyPI website. Can you help me?"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:77
+#: warehouse/templates/pages/help.html:78
 msgid "Why can't I manually upload files to PyPI, through the browser interface?"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:78
+#: warehouse/templates/pages/help.html:79
 msgid "How can I publish my private packages to PyPI?"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:79
+#: warehouse/templates/pages/help.html:80
 msgid "Why did my package or user registration get blocked?"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:80
+#: warehouse/templates/pages/help.html:81
 msgid "How do I get a file size limit exemption or increase for my project?"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:82
+#: warehouse/templates/pages/help.html:83
 msgid ""
 "Why am I getting a \"Filename or contents already exists\" or \"Filename "
 "has been previously used\" error?"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:83
+#: warehouse/templates/pages/help.html:84
 msgid "Why isn't my desired project name available?"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:84
+#: warehouse/templates/pages/help.html:85
 msgid "How do I claim an abandoned or previously registered project name?"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:85
+#: warehouse/templates/pages/help.html:86
 msgid "What collaborator roles are available for a project on PyPI?"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:86
+#: warehouse/templates/pages/help.html:87
 msgid "How do I become an owner/maintainer of a project on PyPI?"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:87
+#: warehouse/templates/pages/help.html:88
 msgid "How can I upload a project description in a different format?"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:88
+#: warehouse/templates/pages/help.html:89
 msgid "How do I request a new trove classifier?"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:89
+#: warehouse/templates/pages/help.html:90
 msgid "Where can I report a bug or provide feedback about PyPI?"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:91
+#: warehouse/templates/pages/help.html:92
 msgid "Who maintains PyPI?"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:92
+#: warehouse/templates/pages/help.html:93
 msgid "What powers PyPI?"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:93
+#: warehouse/templates/pages/help.html:94
 msgid "Can I depend on PyPI being available?"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:94
+#: warehouse/templates/pages/help.html:95
 msgid "How can I contribute to PyPI?"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:95
+#: warehouse/templates/pages/help.html:96
 msgid "How do I keep up with upcoming changes to PyPI?"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:96
+#: warehouse/templates/pages/help.html:97
 msgid ""
 "What does the \"beta feature\" badge mean? What are Warehouse's current "
 "beta features?"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:97
+#: warehouse/templates/pages/help.html:98
 msgid "How do I pronounce \"PyPI\"?"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:104
+#: warehouse/templates/pages/help.html:105
 msgid "Common questions"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:107
-#: warehouse/templates/pages/help.html:184
+#: warehouse/templates/pages/help.html:108
+#: warehouse/templates/pages/help.html:186
 msgid "Basics"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:118
+#: warehouse/templates/pages/help.html:119
 msgid "My Account"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:132
-#: warehouse/templates/pages/help.html:474
+#: warehouse/templates/pages/help.html:134
+#: warehouse/templates/pages/help.html:485
 msgid "Integrating"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:142
-#: warehouse/templates/pages/help.html:501
+#: warehouse/templates/pages/help.html:144
+#: warehouse/templates/pages/help.html:512
 msgid "Administration of projects on PyPI"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:155
-#: warehouse/templates/pages/help.html:550
+#: warehouse/templates/pages/help.html:157
+#: warehouse/templates/pages/help.html:561
 msgid "Troubleshooting"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:171
-#: warehouse/templates/pages/help.html:680
+#: warehouse/templates/pages/help.html:173
+#: warehouse/templates/pages/help.html:691
 msgid "About"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:187
+#: warehouse/templates/pages/help.html:189
 #, python-format
 msgid ""
 "\n"
@@ -3680,7 +3697,7 @@ msgid ""
 "        "
 msgstr ""
 
-#: warehouse/templates/pages/help.html:196
+#: warehouse/templates/pages/help.html:198
 #, python-format
 msgid ""
 "To learn how to install a file from PyPI, visit the <a "
@@ -3690,7 +3707,7 @@ msgid ""
 "rel=\"noopener\">Python Packaging User Guide</a>."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:203
+#: warehouse/templates/pages/help.html:205
 #, python-format
 msgid ""
 "For full instructions on configuring, packaging and distributing your "
@@ -3700,7 +3717,7 @@ msgid ""
 "target=\"_blank\" rel=\"noopener\">Python Packaging User Guide</a>."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:210
+#: warehouse/templates/pages/help.html:212
 #, python-format
 msgid ""
 "Classifiers are used to categorize projects on PyPI. See <a "
@@ -3708,7 +3725,7 @@ msgid ""
 "as a list of valid classifiers."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:217
+#: warehouse/templates/pages/help.html:219
 #, python-format
 msgid ""
 "A yanked release is a release that is always ignored by an installer, "
@@ -3719,31 +3736,31 @@ msgid ""
 "information."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:224
+#: warehouse/templates/pages/help.html:226
 msgid "My account"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:227
+#: warehouse/templates/pages/help.html:229
 msgid ""
 "Currently, PyPI requires a verified email address to perform the "
 "following operations:"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:229
+#: warehouse/templates/pages/help.html:231
 msgid "Register a new project."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:230
+#: warehouse/templates/pages/help.html:232
 msgid "Upload a new version or file."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:232
+#: warehouse/templates/pages/help.html:234
 msgid ""
 "The list of activities that require a verified email address is likely to"
 " grow over time."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:233
+#: warehouse/templates/pages/help.html:235
 #, python-format
 msgid ""
 "This policy will allow us to enforce a key policy of <a href=\"%(href)s\""
@@ -3753,7 +3770,7 @@ msgid ""
 " create many accounts in an automated fashion."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:234
+#: warehouse/templates/pages/help.html:236
 #, python-format
 msgid ""
 "You can manage your account's email addresses in your <a "
@@ -3762,7 +3779,7 @@ msgid ""
 "began enforcing this policy."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:237
+#: warehouse/templates/pages/help.html:239
 #, python-format
 msgid ""
 "<p> PyPI itself has not suffered a breach. This is a protective measure "
@@ -3788,7 +3805,7 @@ msgid ""
 "href=\"%(reset_pwd_href)s\">reset your password</a>. </p>"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:272
+#: warehouse/templates/pages/help.html:274
 #, python-format
 msgid ""
 "<p> Two factor authentication (2FA) makes your account more secure by "
@@ -3807,7 +3824,7 @@ msgid ""
 "rel=\"noopener\">discuss.python.org</a>.</p>"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:299
+#: warehouse/templates/pages/help.html:301
 #, python-format
 msgid ""
 "PyPI users can set up two-factor authentication using any authentication "
@@ -3816,21 +3833,21 @@ msgid ""
 "password\">TOTP</abbr> standard</a>."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:300
+#: warehouse/templates/pages/help.html:302
 msgid ""
 "<abbr title=\"time-based one-time password\">TOTP</abbr> authentication "
 "applications generate a regularly changing authentication code to use "
 "when logging into your account."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:301
+#: warehouse/templates/pages/help.html:303
 msgid ""
 "Because <abbr title=\"time-based one-time password\">TOTP</abbr> is an "
 "open standard, there are many applications that are compatible with your "
 "PyPI account. Popular applications include:"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:304
+#: warehouse/templates/pages/help.html:306
 #, python-format
 msgid ""
 "Google Authenticator for <a href=\"%(android_href)s\" title=\"%(title)s\""
@@ -3839,14 +3856,14 @@ msgid ""
 "rel=\"noopener\">iOS</a>"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:307
 #: warehouse/templates/pages/help.html:309
-#: warehouse/templates/pages/help.html:314
+#: warehouse/templates/pages/help.html:311
 #: warehouse/templates/pages/help.html:316
+#: warehouse/templates/pages/help.html:318
 msgid "(proprietary)"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:311
+#: warehouse/templates/pages/help.html:313
 #, python-format
 msgid ""
 "Duo Mobile for <a href=\"%(android_href)s\" title=\"%(title)s\" "
@@ -3855,12 +3872,12 @@ msgid ""
 "rel=\"noopener\">iOS</a>"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:317
-#: warehouse/templates/pages/help.html:318
+#: warehouse/templates/pages/help.html:319
+#: warehouse/templates/pages/help.html:320
 msgid "(open source)"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:322
+#: warehouse/templates/pages/help.html:324
 #, python-format
 msgid ""
 "Some password managers (e.g. <a href=\"%(href)s\" title=\"%(title)s\" "
@@ -3869,70 +3886,70 @@ msgid ""
 "up one application per account."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:330
+#: warehouse/templates/pages/help.html:332
 msgid ""
 "To set up <abbr title=\"two factor authentication\">2FA</abbr> with an "
 "authentication application:"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:332
+#: warehouse/templates/pages/help.html:334
 msgid ""
 "Open an authentication (<abbr title=\"time-based one-time "
 "password\">TOTP</abbr>) application"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:333
+#: warehouse/templates/pages/help.html:335
 msgid ""
 "Log in to your PyPI account, go to your account settings, and choose "
 "\"Add <abbr title=\"two factor authentication\">2FA</abbr> with "
 "authentication application\""
 msgstr ""
 
-#: warehouse/templates/pages/help.html:334
+#: warehouse/templates/pages/help.html:336
 msgid ""
 "PyPI will generate a secret key, specific to your account. This is "
 "displayed as a QR code, and as a text code."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:335
+#: warehouse/templates/pages/help.html:337
 msgid ""
 "Scan the QR code with your authentication application, or type it in "
 "manually. The method of input will depend on the application you have "
 "chosen."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:336
+#: warehouse/templates/pages/help.html:338
 msgid ""
 "Your application will generate an authentication code - use this to "
 "verify your set up on PyPI"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:339
+#: warehouse/templates/pages/help.html:341
 msgid ""
 "The PyPI server and your application now share your PyPI secret key, "
 "allowing your application to generate valid authentication codes for your"
 " PyPI account."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:341
-#: warehouse/templates/pages/help.html:383
+#: warehouse/templates/pages/help.html:343
+#: warehouse/templates/pages/help.html:385
 msgid "Next time you log in to PyPI you'll need to:"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:343
-#: warehouse/templates/pages/help.html:435
+#: warehouse/templates/pages/help.html:345
+#: warehouse/templates/pages/help.html:437
 msgid "Provide your username and password, as normal"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:344
+#: warehouse/templates/pages/help.html:346
 msgid "Open your authentication application to generate an authentication code"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:345
+#: warehouse/templates/pages/help.html:347
 msgid "Use this code to finish logging into PyPI"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:351
+#: warehouse/templates/pages/help.html:353
 msgid ""
 "A security device is a USB key or <a href=\"#utfdevices\">other "
 "device</a> that generates a one-time password and sends that password to "
@@ -3940,11 +3957,11 @@ msgid ""
 "user."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:353
+#: warehouse/templates/pages/help.html:355
 msgid "To set up two factor authentication with a <em>USB key</em>, you'll need:"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:355
+#: warehouse/templates/pages/help.html:357
 #, python-format
 msgid ""
 "To use a <a href=\"%(href)s\" title=\"%(title)s\" target=\"_blank\" "
@@ -3953,11 +3970,11 @@ msgid ""
 "the standard implemented by PyPI."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:356
+#: warehouse/templates/pages/help.html:358
 msgid "To be running JavaScript on your browser"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:357
+#: warehouse/templates/pages/help.html:359
 #, python-format
 msgid ""
 "To use a USB key that adheres to the <a href=\"%(href)s\" "
@@ -3965,7 +3982,7 @@ msgid ""
 "specification</a>:"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:360
+#: warehouse/templates/pages/help.html:362
 #, python-format
 msgid ""
 "Popular keys include <a href=\"%(yubikey_href)s\" title=\"%(title)s\" "
@@ -3975,17 +3992,17 @@ msgid ""
 "title=\"%(title)s\" target=\"_blank\" rel=\"noopener\">Thetis</a>."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:367
+#: warehouse/templates/pages/help.html:369
 msgid ""
 "Note that some older Yubico USB keys <strong>do not follow the FIDO "
 "specification</strong>, and will therefore not work with PyPI"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:372
+#: warehouse/templates/pages/help.html:374
 msgid "Follow these steps:"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:374
+#: warehouse/templates/pages/help.html:376
 msgid ""
 "\n"
 "          <li>Log in to your PyPI account, go to your account settings, "
@@ -3999,13 +4016,13 @@ msgid ""
 "          "
 msgstr ""
 
-#: warehouse/templates/pages/help.html:381
+#: warehouse/templates/pages/help.html:383
 msgid ""
 "Once complete, your USB key will be registered to your PyPI account and "
 "can be used during the log in process."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:385
+#: warehouse/templates/pages/help.html:387
 msgid ""
 "\n"
 "          <li>Provide your username and password, as normal</li>\n"
@@ -4014,7 +4031,7 @@ msgid ""
 "          "
 msgstr ""
 
-#: warehouse/templates/pages/help.html:396
+#: warehouse/templates/pages/help.html:398
 #, python-format
 msgid ""
 "There is a growing ecosystem of <a href=\"%(href)s\" title=\"%(title)s\" "
@@ -4022,7 +4039,7 @@ msgid ""
 "and can therefore be used with PyPI."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:401
+#: warehouse/templates/pages/help.html:403
 #, python-format
 msgid ""
 "Emerging solutions include biometric (facial and fingerprint) scanners "
@@ -4031,7 +4048,7 @@ msgid ""
 "rel=\"noopener\">mobile phones to act as security devices</a>."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:407
+#: warehouse/templates/pages/help.html:409
 #, python-format
 msgid ""
 "As PyPI's two factor implementation follows the <a href=\"%(href)s\" "
@@ -4040,14 +4057,14 @@ msgid ""
 " take advantage of any future developments in this field."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:416
+#: warehouse/templates/pages/help.html:418
 msgid ""
 "If you lose access to your <a href=\"#totp\">authentication "
 "application</a> or <a href=\"#utfkey\">security device</a>, you can use "
 "these codes to sign into PyPI."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:419
+#: warehouse/templates/pages/help.html:421
 msgid ""
 "Recovery codes are <strong>one time use</strong>. They are not a "
 "substitute for a <a href=\"#totp\">authentication application</a> or <a "
@@ -4055,53 +4072,53 @@ msgid ""
 "recovery. After using a recovery code to sign in, it becomes inactive."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:425
+#: warehouse/templates/pages/help.html:427
 msgid "To provision recovery codes:"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:427
+#: warehouse/templates/pages/help.html:429
 msgid ""
 "Log in to your PyPI account, go to your account settings, and choose "
 "\"Generate recovery codes\""
 msgstr ""
 
-#: warehouse/templates/pages/help.html:428
+#: warehouse/templates/pages/help.html:430
 msgid ""
 "Securely store the displayed recovery codes! Consider printing them out "
 "and storing them in a safe location or saving them in a password manager."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:431
+#: warehouse/templates/pages/help.html:433
 msgid ""
 "If you lose access to your stored recovery codes or use all of them, you "
 "can get new ones by selecting \"Regenerate recovery codes\" in your "
 "account settings."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:433
+#: warehouse/templates/pages/help.html:435
 msgid "To sign in with a recovery code:"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:436
+#: warehouse/templates/pages/help.html:438
 msgid ""
 "When prompted for two factor authentication, select \"Login using "
 "recovery codes\""
 msgstr ""
 
-#: warehouse/templates/pages/help.html:437
+#: warehouse/templates/pages/help.html:439
 msgid ""
 "As each code can be used only once, you might want to mark the code as "
 "used"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:438
+#: warehouse/templates/pages/help.html:440
 msgid ""
 "If you have few recovery codes remaining, you may also want to generate a"
 " new set using the \"Regenerate recovery codes\" button in your account "
 "settings."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:443
+#: warehouse/templates/pages/help.html:445
 msgid ""
 "\n"
 "          <p>API tokens provide an alternative way (instead of username "
@@ -4116,41 +4133,41 @@ msgid ""
 "        "
 msgstr ""
 
-#: warehouse/templates/pages/help.html:450
+#: warehouse/templates/pages/help.html:452
 msgid "To make an API token:"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:453
+#: warehouse/templates/pages/help.html:455
 msgid "Verify your email address"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:453
+#: warehouse/templates/pages/help.html:455
 #, python-format
 msgid "(check your <a href=\"%(href)s\">account settings</a>)"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:454
+#: warehouse/templates/pages/help.html:456
 #, python-format
 msgid ""
 "In your <a href=\"%(href)s\">account settings</a>, go to the API tokens "
 "section and select \"Add API token\""
 msgstr ""
 
-#: warehouse/templates/pages/help.html:457
+#: warehouse/templates/pages/help.html:459
 msgid "To use an API token:"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:460
+#: warehouse/templates/pages/help.html:462
 msgid "Set your username to <code>__token__</code>"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:461
+#: warehouse/templates/pages/help.html:463
 msgid ""
 "Set your password to the token value, including the <code>pypi-</code> "
 "prefix"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:465
+#: warehouse/templates/pages/help.html:467
 #, python-format
 msgid ""
 "Where you edit or add these values will depend on your individual use "
@@ -4162,22 +4179,37 @@ msgid ""
 "rel=\"noopener\"><code>.travis.yml</code> if you are using Travis</a>)."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:469
+#: warehouse/templates/pages/help.html:471
 msgid ""
 "Advanced users may wish to inspect their token by decoding it with "
 "base64, and checking the output against the unique identifier displayed "
 "on PyPI."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:477
+#: warehouse/templates/pages/help.html:475
+msgid ""
+"\n"
+"          <p>PyPI asks you to confirm your password before you want to "
+"perform a <i>sensitive action</i>. Sensitive actions include things like "
+"adding or removing maintainers, deleting distributions, generating API "
+"tokens, and setting up 2FA.</p>\n"
+"          <p>You'll only have to re-confirm your password if it's been "
+"more than an hour since you last confirmed it.</p>\n"
+"          <p><strong>We strongly recommend you only perform such actions "
+"on your personal, password-protected computer.</strong></p>\n"
+"\n"
+"        "
+msgstr ""
+
+#: warehouse/templates/pages/help.html:488
 msgid "Yes, including RSS feeds of new packages and new releases."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:477
+#: warehouse/templates/pages/help.html:488
 msgid "See the API reference."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:480
+#: warehouse/templates/pages/help.html:491
 #, python-format
 msgid ""
 "If you need to run your own mirror of PyPI, the <a "
@@ -4186,7 +4218,7 @@ msgid ""
 "terabyte—and growing!"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:483
+#: warehouse/templates/pages/help.html:494
 #, python-format
 msgid ""
 "You can subscribe to the <a href=\"%(rss_href)s\" title=\"%(title)s\" "
@@ -4197,7 +4229,7 @@ msgid ""
 "target=\"_blank\" rel=\"noopener\">GitHub apps</a>."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:486
+#: warehouse/templates/pages/help.html:497
 #, python-format
 msgid ""
 "You can <a href=\"%(href)s\" title=\"%(title)s\" target=\"_blank\" "
@@ -4205,7 +4237,7 @@ msgid ""
 "dataset on Google BigQuery</a>."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:488
+#: warehouse/templates/pages/help.html:499
 #, python-format
 msgid ""
 "<a href=\"%(libs_io_href)s\" title=\"%(title)s\" target=\"_blank\" "
@@ -4220,7 +4252,7 @@ msgid ""
 "rel=\"noopener\">other relevant factors</a>."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:497
+#: warehouse/templates/pages/help.html:508
 #, python-format
 msgid ""
 "For recent statistics on uptime and performance, see <a href=\"%(href)s\""
@@ -4228,7 +4260,7 @@ msgid ""
 "page</a>."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:504
+#: warehouse/templates/pages/help.html:515
 #, python-format
 msgid ""
 "PyPI does not support publishing private packages. If you need to publish"
@@ -4236,7 +4268,7 @@ msgid ""
 "run your own deployment of the <a href=\"%(href)s\">devpi project</a>."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:507
+#: warehouse/templates/pages/help.html:518
 msgid ""
 "Your publishing tool may return an error that your new project can't be "
 "created with your desired name, despite no evidence of a project or "
@@ -4244,7 +4276,7 @@ msgid ""
 "reasons this may occur:"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:509
+#: warehouse/templates/pages/help.html:520
 #, python-format
 msgid ""
 "The project name conflicts with a <a href=\"%(href)s\" "
@@ -4252,7 +4284,7 @@ msgid ""
 "Library</a> module from any major version from 2.5 to present."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:510
+#: warehouse/templates/pages/help.html:521
 #, python-format
 msgid ""
 "The project name has been explicitly prohibited by the PyPI "
@@ -4261,13 +4293,13 @@ msgid ""
 "with a malicious package."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:511
+#: warehouse/templates/pages/help.html:522
 msgid ""
 "The project name has been registered by another user, but no releases "
 "have been created."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:515
+#: warehouse/templates/pages/help.html:526
 #, python-format
 msgid ""
 "Follow the <a href=\"%(href)s\" title=\"%(title)s\" target=\"_blank\" "
@@ -4275,11 +4307,11 @@ msgid ""
 "title=\"Python enhancement proposal\">PEP</abbr> 541."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:520
+#: warehouse/templates/pages/help.html:531
 msgid "Owner:"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:523
+#: warehouse/templates/pages/help.html:534
 msgid ""
 "Only the current owners of a project have the ability to add new owners "
 "or maintainers. If you need to request ownership, you should contact the "
@@ -4288,12 +4320,12 @@ msgid ""
 "project page."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:524
+#: warehouse/templates/pages/help.html:535
 #, python-format
 msgid "If the owner is unresponsive, see <a href=\"%(href)s\">%(anchor_text)s</a>"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:527
+#: warehouse/templates/pages/help.html:538
 #, python-format
 msgid ""
 "By default, an upload's description will render with <a href=\"%(href)s\""
@@ -4304,7 +4336,7 @@ msgid ""
 "the alternate format."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:528
+#: warehouse/templates/pages/help.html:539
 #, python-format
 msgid ""
 "Refer to the <a href=\"%(href)s\" title=\"%(title)s\" target=\"_blank\" "
@@ -4312,7 +4344,7 @@ msgid ""
 "available formats."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:529
+#: warehouse/templates/pages/help.html:540
 #, python-format
 msgid ""
 "PyPI will reject uploads if the description fails to render. To check a "
@@ -4321,7 +4353,7 @@ msgid ""
 "renderer used by PyPI."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:533
+#: warehouse/templates/pages/help.html:544
 #, python-format
 msgid ""
 "If you can't upload your project's release to PyPI because you're hitting"
@@ -4334,59 +4366,59 @@ msgid ""
 "rel=\"noopener\">file an issue</a> and tell us:</p>"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:541
+#: warehouse/templates/pages/help.html:552
 msgid "A link to your project on PyPI (or Test PyPI)"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:542
+#: warehouse/templates/pages/help.html:553
 msgid "The size of your release, in megabytes"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:543
+#: warehouse/templates/pages/help.html:554
 msgid "Which index/indexes you need the increase for (PyPI, Test PyPI, or both)"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:544
+#: warehouse/templates/pages/help.html:555
 msgid ""
 "A brief description of your project, including the reason for the "
 "additional size."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:553
+#: warehouse/templates/pages/help.html:564
 msgid ""
 "If you've forgotten your PyPI password but you remember your email "
 "address or username, follow these steps to reset your password:"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:555
+#: warehouse/templates/pages/help.html:566
 #, python-format
 msgid "Go to <a href=\"%(href)s\">reset your password</a>."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:556
+#: warehouse/templates/pages/help.html:567
 msgid "Enter the email address or username you used for PyPI and submit the form."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:557
+#: warehouse/templates/pages/help.html:568
 msgid "You'll receive an email with a password reset link."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:562
+#: warehouse/templates/pages/help.html:573
 msgid "If you've lost access to your PyPI account due to:"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:564
+#: warehouse/templates/pages/help.html:575
 msgid "Lost access to the email address associated with your account"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:565
+#: warehouse/templates/pages/help.html:576
 msgid ""
 "Lost two factor authentication <a href=\"#totp\">application</a>, <a "
 "href=\"#utfkey\">device</a>, and <a href=\"#recoverycodes\">recovery "
 "codes</a>"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:568
+#: warehouse/templates/pages/help.html:579
 #, python-format
 msgid ""
 "You can proceed to <a href=\"%(href)s\" title=\"%(title)s\" "
@@ -4394,42 +4426,42 @@ msgid ""
 "request assistance with account recovery."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:575
+#: warehouse/templates/pages/help.html:586
 msgid "If you are using a username and password for uploads:"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:577
+#: warehouse/templates/pages/help.html:588
 msgid "Ensure that your username and password are correct."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:578
+#: warehouse/templates/pages/help.html:589
 msgid ""
 "Ensure that your username and password do not contain any trailing "
 "characters such as newlines."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:580
+#: warehouse/templates/pages/help.html:591
 msgid "If you are using an <a href=\"#apitoken\">API Token</a> for uploads:"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:582
+#: warehouse/templates/pages/help.html:593
 msgid "Ensure that your API Token is valid and has not been revoked."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:583
+#: warehouse/templates/pages/help.html:594
 msgid ""
 "Ensure that your API Token is <a href=\"#apitoken\">properly "
 "formatted</a> and does not contain any trailing characters such as "
 "newlines."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:585
+#: warehouse/templates/pages/help.html:596
 msgid ""
 "In both cases, remember that PyPI and TestPyPI each require you to create"
 " an account, so your credentials may be different."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:589
+#: warehouse/templates/pages/help.html:600
 #, python-format
 msgid ""
 "Transport Layer Security, or TLS, is part of how we make sure connections"
@@ -4441,7 +4473,7 @@ msgid ""
 "target=\"_blank\" rel=\"noopener\">Learn why on the PSF blog</a>."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:596
+#: warehouse/templates/pages/help.html:607
 #, python-format
 msgid ""
 "If you are having trouble with <code>%(command)s</code> and get a "
@@ -4450,7 +4482,7 @@ msgid ""
 "information:"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:598
+#: warehouse/templates/pages/help.html:609
 msgid ""
 "If you see an error like <code>There was a problem confirming the ssl "
 "certificate</code> or <code>tlsv1 alert protocol version</code> or "
@@ -4458,7 +4490,7 @@ msgid ""
 "PyPI with a newer TLS support library."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:599
+#: warehouse/templates/pages/help.html:610
 msgid ""
 "The specific steps you need to take will depend on your operating system "
 "version, where your installation of Python originated (python.org, your "
@@ -4466,7 +4498,7 @@ msgid ""
 " Python, <code>setuptools</code>, and <code>pip</code>."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:601
+#: warehouse/templates/pages/help.html:612
 #, python-format
 msgid ""
 "For help, go to <a href=\"%(irc_href)s\" title=\"%(title)s\" "
@@ -4479,7 +4511,7 @@ msgid ""
 "and the output of <code>%(command)s</code>."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:612
+#: warehouse/templates/pages/help.html:623
 #, python-format
 msgid ""
 "We take <a href=\"%(href)s\" title=\"%(title)s\" target=\"_blank\" "
@@ -4487,7 +4519,7 @@ msgid ""
 "website easy to use for everyone."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:617
+#: warehouse/templates/pages/help.html:628
 #, python-format
 msgid ""
 "If you are experiencing an accessibility problem, <a href=\"%(href)s\" "
@@ -4495,7 +4527,7 @@ msgid ""
 " GitHub</a>, so we can try to fix the problem, for you and others."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:625
+#: warehouse/templates/pages/help.html:636
 #, python-format
 msgid ""
 "In a previous version of PyPI, it used to be possible for maintainers to "
@@ -4505,7 +4537,7 @@ msgid ""
 "rel=\"noopener\">use twine to upload your project to PyPI</a>."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:634
+#: warehouse/templates/pages/help.html:645
 msgid ""
 "Spammers return to PyPI with some regularity hoping to place their Search"
 " Engine Optimized phishing, scam, and click-farming content on the site. "
@@ -4514,7 +4546,7 @@ msgid ""
 "prime target."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:636
+#: warehouse/templates/pages/help.html:647
 #, python-format
 msgid ""
 "When the PyPI administrators are overwhelmed by spam <strong>or</strong> "
@@ -4525,29 +4557,29 @@ msgid ""
 "have updated it with reasoning for the intervention."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:645
+#: warehouse/templates/pages/help.html:656
 msgid "PyPI will return these errors for one of these reasons:"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:647
+#: warehouse/templates/pages/help.html:658
 msgid "Filename has been used and file exists"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:648
+#: warehouse/templates/pages/help.html:659
 msgid "Filename has been used but file no longer exists"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:649
+#: warehouse/templates/pages/help.html:660
 msgid "A file with the exact same content exists"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:651
+#: warehouse/templates/pages/help.html:662
 msgid ""
 "PyPI does not allow for a filename to be reused, even once a project has "
 "been deleted and recreated."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:653
+#: warehouse/templates/pages/help.html:664
 #, python-format
 msgid ""
 "To avoid this situation, <a href=\"%(test_pypi_href)s\" "
@@ -4556,7 +4588,7 @@ msgid ""
 "href=\"%(pypi_href)s\">pypi.org</a>."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:660
+#: warehouse/templates/pages/help.html:671
 #, python-format
 msgid ""
 "If you would like to request a new trove classifier file a pull request "
@@ -4565,7 +4597,7 @@ msgid ""
 " to include a brief justification of why it is important."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:668
+#: warehouse/templates/pages/help.html:679
 #, python-format
 msgid ""
 "If you're experiencing an issue with PyPI itself, we welcome "
@@ -4576,14 +4608,14 @@ msgid ""
 " first check that a similar issue does not already exist."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:675
+#: warehouse/templates/pages/help.html:686
 msgid ""
 "If you are having an issue is with a specific package installed from "
 "PyPI, you should reach out to the maintainers of that project directly "
 "instead."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:684
+#: warehouse/templates/pages/help.html:695
 #, python-format
 msgid ""
 "PyPI is powered by the Warehouse project; <a href=\"%(href)s\" "
@@ -4593,7 +4625,7 @@ msgid ""
 "Group (PackagingWG)."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:689
+#: warehouse/templates/pages/help.html:700
 #, python-format
 msgid ""
 "The <a href=\"%(href)s\" title=\"%(title)s\" target=\"_blank\" "
@@ -4602,7 +4634,7 @@ msgid ""
 "Python packaging."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:694
+#: warehouse/templates/pages/help.html:705
 #, python-format
 msgid ""
 "The <a href=\"%(packaging_wg_href)s\" title=\"%(title)s\" "
@@ -4615,7 +4647,7 @@ msgid ""
 "Warehouse's security and accessibility."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:704
+#: warehouse/templates/pages/help.html:715
 #, python-format
 msgid ""
 "PyPI is powered by <a href=\"%(warehouse_href)s\" title=\"%(title)s\" "
@@ -4624,14 +4656,14 @@ msgid ""
 " sponsors</a>."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:711
+#: warehouse/templates/pages/help.html:722
 msgid ""
 "As of April 16, 2018, PyPI.org is at \"production\" status, meaning that "
 "it has moved out of beta and replaced the old site (pypi.python.org). It "
 "is now robust, tested, and ready for expected browser and API traffic."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:713
+#: warehouse/templates/pages/help.html:724
 #, python-format
 msgid ""
 "PyPI is heavily cached and distributed via <abbr title=\"content delivery"
@@ -4648,7 +4680,7 @@ msgid ""
 "href=\"%(private_index_href)s\">private index</a>."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:727
+#: warehouse/templates/pages/help.html:738
 #, python-format
 msgid ""
 "We have a huge amount of work to do to continue to maintain and improve "
@@ -4656,22 +4688,22 @@ msgid ""
 "target=\"_blank\" rel=\"noopener\">the Warehouse project</a>)."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:732
+#: warehouse/templates/pages/help.html:743
 msgid "Financial:"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:732
+#: warehouse/templates/pages/help.html:743
 #, python-format
 msgid ""
 "We would deeply appreciate <a href=\"%(href)s\">your donations to fund "
 "development and maintenance</a>."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:733
+#: warehouse/templates/pages/help.html:744
 msgid "Development:"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:733
+#: warehouse/templates/pages/help.html:744
 msgid ""
 "Warehouse is open source, and we would love to see some new faces working"
 " on the project. You <strong>do not</strong> need to be an experienced "
@@ -4679,7 +4711,7 @@ msgid ""
 " you make your first open source pull request!"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:735
+#: warehouse/templates/pages/help.html:746
 #, python-format
 msgid ""
 "If you have skills in Python, ElasticSearch, HTML, SCSS, JavaScript, or "
@@ -4693,7 +4725,7 @@ msgid ""
 "here."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:743
+#: warehouse/templates/pages/help.html:754
 #, python-format
 msgid ""
 "Issues are grouped into <a href=\"%(href)s\" title=\"%(title)s\" "
@@ -4703,11 +4735,11 @@ msgid ""
 "we can guide you through the contribution process."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:750
+#: warehouse/templates/pages/help.html:761
 msgid "Stay updated:"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:751
+#: warehouse/templates/pages/help.html:762
 #, python-format
 msgid ""
 "You can also follow the ongoing development of the project on the <a "
@@ -4717,7 +4749,7 @@ msgid ""
 "rel=\"noopener\">Python packaging forum on Discourse</a>."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:761
+#: warehouse/templates/pages/help.html:772
 #, python-format
 msgid ""
 "Changes to PyPI are generally announced on both the <a "
@@ -4731,7 +4763,7 @@ msgid ""
 "the \"pypi\" label."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:771
+#: warehouse/templates/pages/help.html:782
 msgid ""
 "When Warehouse's maintainers are deploying new features, at first we mark"
 " them with a small \"beta feature\" symbol to tell you: this should "
@@ -4739,11 +4771,11 @@ msgid ""
 "functionality."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:772
+#: warehouse/templates/pages/help.html:783
 msgid "Currently, no features are in beta."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:776
+#: warehouse/templates/pages/help.html:787
 #, python-format
 msgid ""
 "\"PyPI\" should be pronounced like \"pie pea eye\", specifically with the"
@@ -4753,39 +4785,39 @@ msgid ""
 "implementation of the Python language."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:788
+#: warehouse/templates/pages/help.html:799
 msgid "Resources"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:789
+#: warehouse/templates/pages/help.html:800
 msgid "Looking for something else? Perhaps these links will help:"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:791
+#: warehouse/templates/pages/help.html:802
 msgid "Python Packaging User Guide"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:792
+#: warehouse/templates/pages/help.html:803
 msgid "Python documentation"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:793
+#: warehouse/templates/pages/help.html:804
 msgid "(main Python website)"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:794
+#: warehouse/templates/pages/help.html:805
 msgid "Python community page"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:794
+#: warehouse/templates/pages/help.html:805
 msgid "(lists IRC channels, mailing lists, etc.)"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:797
+#: warehouse/templates/pages/help.html:808
 msgid "Contact"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:799
+#: warehouse/templates/pages/help.html:810
 #, python-format
 msgid ""
 "The <a href=\"%(pypa_href)s\" title=\"%(title)s\" target=\"_blank\" "

--- a/warehouse/manage/__init__.py
+++ b/warehouse/manage/__init__.py
@@ -10,11 +10,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import datetime
 import functools
 import json
-
-import msgpack
 
 from pyramid import viewderivers
 from pyramid.renderers import render_to_response
@@ -30,7 +27,7 @@ def reauth_view(view, info):
         def wrapped(context, request):
             request.matchdict_json = json.dumps(request.matchdict)
 
-            if request.session.needs_reauthentication(request):
+            if request.session.needs_reauthentication():
                 user_service = request.find_service(IUserService, context=None)
 
                 form = ReAuthenticateForm(

--- a/warehouse/manage/__init__.py
+++ b/warehouse/manage/__init__.py
@@ -15,65 +15,34 @@ import functools
 
 import msgpack
 import msgpack.exceptions
-import redis
 
 from pyramid import viewderivers
 from pyramid.renderers import render_to_response
 
+from warehouse.accounts import REDIRECT_FIELD_NAME
 from warehouse.accounts.interfaces import IUserService
 from warehouse.manage.forms import ReAuthenticateForm  # TODO: move to accounts yea
 from warehouse.utils import crypto
 from warehouse.utils.http import is_safe_url
 from warehouse.utils.msgpack import object_encode
 
-RE_AUTHENTICATION_KEY = "session_reauth__time"
-
 
 class ReAuthenticationView(object):
-    cookie_name = "session_id"
-    max_age = 60 * 60
-
     def __init__(self, request):
         self.request = request
-        self.redis = redis.StrictRedis.from_url(
-            request.registry.settings["sessions.url"]
-        )
-        self.signer = crypto.Signer(
-            request.registry.settings["sessions.secret"], salt="session"
-        )
-
-        self.response_call = lambda: None
-
-    def check_session_cookie(self):
-        def response_call():
-            user_service = self.request.find_service(IUserService, context=None)
-
-            form = ReAuthenticateForm(
-                self.request.POST, request=self.request, user_service=user_service,
-            )  # TODO: fill in next parameter somewhere here yeah?
-
-            return render_to_response(
-                "re-auth.html",
-                {"form": form, "user": self.request.user},
-                request=self.request,
-            )
-
-        self.response_call = response_call
-
-        return self._is_valid_ttl(self.request.session._sid)
-
-    def _is_valid_ttl(self, session_id):
-        try:
-            auth_time = float(
-                self.signer.unsign(self.request.cookies.get(RE_AUTHENTICATION_KEY))
-            )
-            current_time = datetime.datetime.now().timestamp()
-            return current_time - auth_time < self.max_age
-        except (crypto.BadSignature, ValueError):
-            return False
 
     def __call__(self):
-        return self.response_call()
+        user_service = self.request.find_service(IUserService, context=None)
+
+        form = ReAuthenticateForm(
+            self.request.POST, request=self.request, user_service=user_service,
+        )
+
+        return render_to_response(
+            "re-auth.html",
+            {"form": form, "user": self.request.user},
+            request=self.request,
+        )
 
 
 # test to make sure that they're being called with the gated action
@@ -84,12 +53,13 @@ def reauth_view(view, info):
 
         @functools.wraps(view)
         def wrapped(context, request):
+            print(f"REQUEST REDIRECT: {request.matched_route.name}")
             re_auth_view = ReAuthenticationView(request)
 
-            if re_auth_view.check_session_cookie():
-                return view(context, request)
+            if request.session.needs_reauthentication(request):
+                return re_auth_view()
 
-            return re_auth_view()
+            return view(context, request)
 
         return wrapped
 

--- a/warehouse/manage/__init__.py
+++ b/warehouse/manage/__init__.py
@@ -12,40 +12,15 @@
 
 import datetime
 import functools
+import json
 
 import msgpack
-import msgpack.exceptions
 
 from pyramid import viewderivers
 from pyramid.renderers import render_to_response
 
-from warehouse.accounts import REDIRECT_FIELD_NAME
 from warehouse.accounts.interfaces import IUserService
 from warehouse.manage.forms import ReAuthenticateForm  # TODO: move to accounts yea
-from warehouse.utils import crypto
-from warehouse.utils.http import is_safe_url
-from warehouse.utils.msgpack import object_encode
-
-
-class ReAuthenticationView(object):
-    def __init__(self, request):
-        self.request = request
-
-    def __call__(self):
-        user_service = self.request.find_service(IUserService, context=None)
-
-        form = ReAuthenticateForm(
-            self.request.POST, request=self.request, user_service=user_service,
-        )
-
-        return render_to_response(
-            "re-auth.html",
-            {"form": form, "user": self.request.user},
-            request=self.request,
-        )
-
-
-# test to make sure that they're being called with the gated action
 
 
 def reauth_view(view, info):
@@ -53,11 +28,20 @@ def reauth_view(view, info):
 
         @functools.wraps(view)
         def wrapped(context, request):
-            print(f"REQUEST REDIRECT: {request.matched_route.name}")
-            re_auth_view = ReAuthenticationView(request)
+            request.matchdict_json = json.dumps(request.matchdict)
 
             if request.session.needs_reauthentication(request):
-                return re_auth_view()
+                user_service = request.find_service(IUserService, context=None)
+
+                form = ReAuthenticateForm(
+                    request.POST, request=request, user_service=user_service,
+                )
+
+                return render_to_response(
+                    "re-auth.html",
+                    {"form": form, "user": request.user},
+                    request=request,
+                )
 
             return view(context, request)
 

--- a/warehouse/manage/__init__.py
+++ b/warehouse/manage/__init__.py
@@ -10,6 +10,96 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import datetime
+import functools
+
+import msgpack
+import msgpack.exceptions
+import redis
+
+from pyramid import viewderivers
+from pyramid.renderers import render_to_response
+
+from warehouse.accounts.interfaces import IUserService
+from warehouse.manage.forms import ReAuthenticateForm  # TODO: move to accounts yea
+from warehouse.utils import crypto
+from warehouse.utils.http import is_safe_url
+from warehouse.utils.msgpack import object_encode
+
+RE_AUTHENTICATION_KEY = "session_reauth__time"
+
+
+class ReAuthenticationView(object):
+    cookie_name = "session_id"
+    max_age = 60 * 60
+
+    def __init__(self, request):
+        self.request = request
+        self.redis = redis.StrictRedis.from_url(
+            request.registry.settings["sessions.url"]
+        )
+        self.signer = crypto.Signer(
+            request.registry.settings["sessions.secret"], salt="session"
+        )
+
+        self.response_call = lambda: None
+
+    def check_session_cookie(self):
+        def response_call():
+            user_service = self.request.find_service(IUserService, context=None)
+
+            form = ReAuthenticateForm(
+                self.request.POST, request=self.request, user_service=user_service,
+            )  # TODO: fill in next parameter somewhere here yeah?
+
+            return render_to_response(
+                "re-auth.html",
+                {"form": form, "user": self.request.user},
+                request=self.request,
+            )
+
+        self.response_call = response_call
+
+        return self._is_valid_ttl(self.request.session._sid)
+
+    def _is_valid_ttl(self, session_id):
+        try:
+            auth_time = float(
+                self.signer.unsign(self.request.cookies.get(RE_AUTHENTICATION_KEY))
+            )
+            current_time = datetime.datetime.now().timestamp()
+            return current_time - auth_time < self.max_age
+        except (crypto.BadSignature, ValueError):
+            return False
+
+    def __call__(self):
+        return self.response_call()
+
+
+# test to make sure that they're being called with the gated action
+
+
+def reauth_view(view, info):
+    if info.options.get("require_reauth"):
+
+        @functools.wraps(view)
+        def wrapped(context, request):
+            re_auth_view = ReAuthenticationView(request)
+
+            if re_auth_view.check_session_cookie():
+                return view(context, request)
+
+            return re_auth_view()
+
+        return wrapped
+
+    return view
+
+
+reauth_view.options = {"require_reauth"}
+
 
 def includeme(config):
-    pass
+    config.add_view_deriver(
+        reauth_view, over="rendered_view", under=viewderivers.INGRESS
+    )

--- a/warehouse/manage/forms.py
+++ b/warehouse/manage/forms.py
@@ -115,6 +115,14 @@ class ConfirmPasswordForm(UsernameMixin, PasswordMixin, forms.Form):
         self.user_service = user_service
 
 
+class ReAuthenticateForm(PasswordMixin, forms.Form):
+    __params__ = ["password"]
+
+    def __init__(self, *args, user_service, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.user_service = user_service
+
+
 class DeleteTOTPForm(ConfirmPasswordForm):
     # TODO: delete?
     pass

--- a/warehouse/manage/forms.py
+++ b/warehouse/manage/forms.py
@@ -116,7 +116,10 @@ class ConfirmPasswordForm(UsernameMixin, PasswordMixin, forms.Form):
 
 
 class ReAuthenticateForm(PasswordMixin, forms.Form):
-    __params__ = ["password"]
+    __params__ = ["username", "password", "next_route"]
+
+    username = wtforms.StringField(validators=[wtforms.validators.DataRequired()])
+    next_route = wtforms.StringField(validators=[wtforms.validators.DataRequired()])
 
     def __init__(self, *args, user_service, **kwargs):
         super().__init__(*args, **kwargs)

--- a/warehouse/manage/forms.py
+++ b/warehouse/manage/forms.py
@@ -116,10 +116,13 @@ class ConfirmPasswordForm(UsernameMixin, PasswordMixin, forms.Form):
 
 
 class ReAuthenticateForm(PasswordMixin, forms.Form):
-    __params__ = ["username", "password", "next_route"]
+    __params__ = ["username", "password", "next_route", "next_route_matchdict"]
 
     username = wtforms.StringField(validators=[wtforms.validators.DataRequired()])
     next_route = wtforms.StringField(validators=[wtforms.validators.DataRequired()])
+    next_route_matchdict = wtforms.StringField(
+        validators=[wtforms.validators.DataRequired()]
+    )
 
     def __init__(self, *args, user_service, **kwargs):
         super().__init__(*args, **kwargs)

--- a/warehouse/manage/views.py
+++ b/warehouse/manage/views.py
@@ -111,6 +111,7 @@ def user_projects(request):
     require_methods=False,
     permission="manage:user",
     has_translations=True,
+    require_reauth=True,
 )
 class ManageAccountViews:
     def __init__(self, request):
@@ -944,6 +945,7 @@ def get_user_role_in_project(project, user, request):
     require_methods=["POST"],
     permission="manage:project",
     has_translations=True,
+    require_reauth=False,
 )
 def delete_project(project, request):
     if request.flags.enabled(AdminFlagValue.DISALLOW_DELETION):
@@ -986,6 +988,7 @@ def delete_project(project, request):
     require_methods=["POST"],
     permission="manage:project",
     has_translations=True,
+    require_reauth=False,
 )
 def destroy_project_docs(project, request):
     confirm_project(project, request, fail_route="manage.project.documentation")
@@ -1005,6 +1008,7 @@ def destroy_project_docs(project, request):
     uses_session=True,
     permission="manage:project",
     has_translations=True,
+    require_reauth=False,
 )
 def manage_project_releases(project, request):
     # Get the counts for all the files for this project, grouped by the
@@ -1049,6 +1053,7 @@ def manage_project_releases(project, request):
     require_methods=False,
     permission="manage:project",
     has_translations=True,
+    require_reauth=False,
 )
 class ManageProjectRelease:
     def __init__(self, release, request):
@@ -1063,7 +1068,11 @@ class ManageProjectRelease:
             "files": self.release.files.all(),
         }
 
-    @view_config(request_method="POST", request_param=["confirm_yank_version"])
+    @view_config(
+        request_method="POST",
+        request_param=["confirm_yank_version"],
+        require_reauth=False,
+    )
     def yank_project_release(self):
         version = self.request.POST.get("confirm_yank_version")
         yanked_reason = self.request.POST.get("yanked_reason", "")
@@ -1143,7 +1152,11 @@ class ManageProjectRelease:
             )
         )
 
-    @view_config(request_method="POST", request_param=["confirm_unyank_version"])
+    @view_config(
+        request_method="POST",
+        request_param=["confirm_unyank_version"],
+        require_reauth=False,
+    )
     def unyank_project_release(self):
         version = self.request.POST.get("confirm_unyank_version")
         if not version:
@@ -1220,7 +1233,11 @@ class ManageProjectRelease:
             )
         )
 
-    @view_config(request_method="POST", request_param=["confirm_delete_version"])
+    @view_config(
+        request_method="POST",
+        request_param=["confirm_delete_version"],
+        require_reauth=False,
+    )
     def delete_project_release(self):
         if self.request.flags.enabled(AdminFlagValue.DISALLOW_DELETION):
             self.request.session.flash(
@@ -1313,7 +1330,9 @@ class ManageProjectRelease:
         )
 
     @view_config(
-        request_method="POST", request_param=["confirm_project_name", "file_id"]
+        request_method="POST",
+        request_param=["confirm_project_name", "file_id"],
+        require_reauth=False,
     )
     def delete_project_release_file(self):
         def _error(message):
@@ -1418,6 +1437,7 @@ class ManageProjectRelease:
     require_methods=False,
     permission="manage:project",
     has_translations=True,
+    require_reauth=False,
 )
 def manage_project_roles(project, request, _form_class=CreateRoleForm):
     user_service = request.find_service(IUserService, context=None)
@@ -1517,6 +1537,7 @@ def manage_project_roles(project, request, _form_class=CreateRoleForm):
     require_methods=["POST"],
     permission="manage:project",
     has_translations=True,
+    require_reauth=False,
 )
 def change_project_role(project, request, _form_class=ChangeRoleForm):
     form = _form_class(request.POST)
@@ -1569,6 +1590,7 @@ def change_project_role(project, request, _form_class=ChangeRoleForm):
     require_methods=["POST"],
     permission="manage:project",
     has_translations=True,
+    require_reauth=False,
 )
 def delete_project_role(project, request):
     try:

--- a/warehouse/manage/views.py
+++ b/warehouse/manage/views.py
@@ -1008,7 +1008,7 @@ def destroy_project_docs(project, request):
     uses_session=True,
     permission="manage:project",
     has_translations=True,
-    require_reauth=False,
+    require_reauth=True,
 )
 def manage_project_releases(project, request):
     # Get the counts for all the files for this project, grouped by the
@@ -1053,7 +1053,7 @@ def manage_project_releases(project, request):
     require_methods=False,
     permission="manage:project",
     has_translations=True,
-    require_reauth=False,
+    require_reauth=True,
 )
 class ManageProjectRelease:
     def __init__(self, release, request):
@@ -1437,7 +1437,7 @@ class ManageProjectRelease:
     require_methods=False,
     permission="manage:project",
     has_translations=True,
-    require_reauth=False,
+    require_reauth=True,
 )
 def manage_project_roles(project, request, _form_class=CreateRoleForm):
     user_service = request.find_service(IUserService, context=None)

--- a/warehouse/manage/views.py
+++ b/warehouse/manage/views.py
@@ -164,7 +164,11 @@ class ManageAccountViews:
 
         return {**self.default_response, "save_account_form": form}
 
-    @view_config(request_method="POST", request_param=AddEmailForm.__params__)
+    @view_config(
+        request_method="POST",
+        request_param=AddEmailForm.__params__,
+        require_reauth=True,
+    )
     def add_email(self):
         form = AddEmailForm(
             self.request.POST,
@@ -197,7 +201,9 @@ class ManageAccountViews:
 
         return {**self.default_response, "add_email_form": form}
 
-    @view_config(request_method="POST", request_param=["delete_email_id"])
+    @view_config(
+        request_method="POST", request_param=["delete_email_id"], require_reauth=True
+    )
     def delete_email(self):
         try:
             email = (
@@ -229,7 +235,9 @@ class ManageAccountViews:
             )
         return self.default_response
 
-    @view_config(request_method="POST", request_param=["primary_email_id"])
+    @view_config(
+        request_method="POST", request_param=["primary_email_id"], require_reauth=True
+    )
     def change_primary_email(self):
         previous_primary_email = self.request.user.primary_email
         try:
@@ -330,7 +338,9 @@ class ManageAccountViews:
 
         return {**self.default_response, "change_password_form": form}
 
-    @view_config(request_method="POST", request_param=DeleteTOTPForm.__params__)
+    @view_config(
+        request_method="POST", request_param=DeleteTOTPForm.__params__
+    )  # TODO: gate_action instead of confirm pass form
     def delete_account(self):
         confirm_password = self.request.params.get("confirm_password")
         if not confirm_password:

--- a/warehouse/manage/views.py
+++ b/warehouse/manage/views.py
@@ -754,6 +754,7 @@ class ProvisionRecoveryCodesViews:
     renderer="manage/token.html",
     route_name="manage.account.token",
     has_translations=True,
+    require_reauth=True,
 )
 class ProvisionMacaroonViews:
     def __init__(self, request):
@@ -785,7 +786,7 @@ class ProvisionMacaroonViews:
     def manage_macaroons(self):
         return self.default_response
 
-    @view_config(request_method="POST")
+    @view_config(request_method="POST", require_reauth=True)
     def create_macaroon(self):
         if not self.request.user.has_primary_verified_email:
             self.request.session.flash(
@@ -842,7 +843,11 @@ class ProvisionMacaroonViews:
 
         return {**response, "create_macaroon_form": form}
 
-    @view_config(request_method="POST", request_param=DeleteMacaroonForm.__params__)
+    @view_config(
+        request_method="POST",
+        request_param=DeleteMacaroonForm.__params__,
+        require_reauth=True,
+    )
     def delete_macaroon(self):
         form = DeleteMacaroonForm(
             password=self.request.POST["confirm_password"],
@@ -924,6 +929,7 @@ def manage_projects(request):
     uses_session=True,
     permission="manage:project",
     has_translations=True,
+    require_reauth=True,
 )
 def manage_project_settings(project, request):
     return {"project": project}
@@ -945,7 +951,7 @@ def get_user_role_in_project(project, user, request):
     require_methods=["POST"],
     permission="manage:project",
     has_translations=True,
-    require_reauth=False,
+    require_reauth=True,
 )
 def delete_project(project, request):
     if request.flags.enabled(AdminFlagValue.DISALLOW_DELETION):
@@ -988,7 +994,7 @@ def delete_project(project, request):
     require_methods=["POST"],
     permission="manage:project",
     has_translations=True,
-    require_reauth=False,
+    require_reauth=True,
 )
 def destroy_project_docs(project, request):
     confirm_project(project, request, fail_route="manage.project.documentation")
@@ -1071,7 +1077,7 @@ class ManageProjectRelease:
     @view_config(
         request_method="POST",
         request_param=["confirm_yank_version"],
-        require_reauth=False,
+        require_reauth=True,
     )
     def yank_project_release(self):
         version = self.request.POST.get("confirm_yank_version")
@@ -1155,7 +1161,7 @@ class ManageProjectRelease:
     @view_config(
         request_method="POST",
         request_param=["confirm_unyank_version"],
-        require_reauth=False,
+        require_reauth=True,
     )
     def unyank_project_release(self):
         version = self.request.POST.get("confirm_unyank_version")
@@ -1236,7 +1242,7 @@ class ManageProjectRelease:
     @view_config(
         request_method="POST",
         request_param=["confirm_delete_version"],
-        require_reauth=False,
+        require_reauth=True,
     )
     def delete_project_release(self):
         if self.request.flags.enabled(AdminFlagValue.DISALLOW_DELETION):
@@ -1332,7 +1338,7 @@ class ManageProjectRelease:
     @view_config(
         request_method="POST",
         request_param=["confirm_project_name", "file_id"],
-        require_reauth=False,
+        require_reauth=True,
     )
     def delete_project_release_file(self):
         def _error(message):
@@ -1537,7 +1543,7 @@ def manage_project_roles(project, request, _form_class=CreateRoleForm):
     require_methods=["POST"],
     permission="manage:project",
     has_translations=True,
-    require_reauth=False,
+    require_reauth=True,
 )
 def change_project_role(project, request, _form_class=ChangeRoleForm):
     form = _form_class(request.POST)
@@ -1590,7 +1596,7 @@ def change_project_role(project, request, _form_class=ChangeRoleForm):
     require_methods=["POST"],
     permission="manage:project",
     has_translations=True,
-    require_reauth=False,
+    require_reauth=True,
 )
 def delete_project_role(project, request):
     try:

--- a/warehouse/routes.py
+++ b/warehouse/routes.py
@@ -296,6 +296,9 @@ def includeme(config):
     )
     config.add_route("packaging.file", files_url)
 
+    # Re-Authentication Route
+    config.add_route("reauthenticate", "/reauthenticate/", domain=warehouse)
+
     # SES Webhooks
     config.add_route("ses.hook", "/_/ses-hook/", domain=warehouse)
 

--- a/warehouse/sessions.py
+++ b/warehouse/sessions.py
@@ -83,7 +83,7 @@ def _changed_method(method):
 
 @implementer(ISession)
 class Session(dict):
-    time_to_reauth = 60 * 60  # 1 hour
+    time_to_reauth = 30  # 60 * 60  # 1 hour
 
     _csrf_token_key = "_csrf_token"
     _flash_key = "_flash_messages"

--- a/warehouse/sessions.py
+++ b/warehouse/sessions.py
@@ -147,7 +147,7 @@ class Session(dict):
 
     def record_auth_timestamp(self, request, response):
         auth_signer = crypto.TimestampSigner(
-            request.registry.settings["sessions.secret"], salt="session"
+            request.registry.settings["sessions.secret"], salt=self._sid
         )
 
         response.set_cookie(
@@ -159,7 +159,7 @@ class Session(dict):
 
     def needs_reauthentication(self, request):
         reauth_signer = crypto.TimestampSigner(
-            request.registry.settings["sessions.secret"], salt="session"
+            request.registry.settings["sessions.secret"], salt=self._sid
         )
 
         try:

--- a/warehouse/sessions.py
+++ b/warehouse/sessions.py
@@ -83,7 +83,7 @@ def _changed_method(method):
 
 @implementer(ISession)
 class Session(dict):
-    time_to_reauth = 30  # 60 * 60  # 1 hour
+    time_to_reauth = 60 * 60  # 1 hour
 
     _csrf_token_key = "_csrf_token"
     _flash_key = "_flash_messages"
@@ -154,12 +154,9 @@ class Session(dict):
         if reauth_timestamp is None:
             return True
 
-        try:
-            auth_time = float(reauth_timestamp)
-            current_time = datetime.datetime.now().timestamp()
-            return current_time - auth_time >= self.time_to_reauth
-        except (ValueError, TypeError):
-            return True
+        auth_time = float(reauth_timestamp)
+        current_time = datetime.datetime.now().timestamp()
+        return current_time - auth_time >= self.time_to_reauth
 
     # Flash Messages Methods
     def _get_flash_queue_key(self, queue):

--- a/warehouse/templates/pages/help.html
+++ b/warehouse/templates/pages/help.html
@@ -63,6 +63,7 @@
 {% macro utfdevices() %}{% trans %}What devices (other than a USB key) can I use as a security device?{% endtrans %}{% endmacro %}
 {% macro recoverycodes() %}{% trans %}How does two factor authentication with a recovery code work? How do I set it up on PyPI?{% endtrans %}{% endmacro %}
 {% macro apitoken() %}{% trans %}How can I use API tokens to authenticate with PyPI?{% endtrans %}{% endmacro %}
+{% macro sensitiveactions() %}{% trans %}Why do certain actions require me to confirm my password?{% endtrans %}{% endmacro %}
 
 {% macro mirroring() %}{% trans %}How can I run a mirror of PyPI?{% endtrans %}{% endmacro %}
 {% macro APIs() %}{% trans %}Does PyPI have APIs I can use?{% endtrans %}{% endmacro %}
@@ -125,6 +126,7 @@
           <li><a href="#utfdevices">{{ utfdevices() }}</a></li>
           <li><a href="#recoverycodes">{{ recoverycodes() }}</a></li>
           <li><a href="#apitoken">{{ apitoken() }}</a></li>
+          <li><a href="#sensitiveactions">{{ sensitiveactions() }}</a></li>
         </ul>
       </section>
 
@@ -467,6 +469,15 @@
           {% endtrans %}
         </p>
         <p>{% trans %}Advanced users may wish to inspect their token by decoding it with base64, and checking the output against the unique identifier displayed on PyPI.{% endtrans %}</p>
+
+        <h3 id="sensitiveactions">{{ sensitiveactions() }}</h3>
+
+        {% trans %}
+          <p>PyPI asks you to confirm your password before you want to perform a <i>sensitive action</i>. Sensitive actions include things like adding or removing maintainers, deleting distributions, generating API tokens, and setting up 2FA.</p>
+          <p>You'll only have to re-confirm your password if it's been more than an hour since you last confirmed it.</p>
+          <p><strong>We strongly recommend you only perform such actions on your personal, password-protected computer.</strong></p>
+
+        {% endtrans %}
 
       </section>
 

--- a/warehouse/templates/re-auth.html
+++ b/warehouse/templates/re-auth.html
@@ -32,6 +32,7 @@
          <form method="POST" action="{{ request.route_path('reauthenticate') }}">
            <input name="csrf_token" type="hidden" value="{{ request.session.get_csrf_token() }}">
            <input name="next_route" type="hidden" value="{{ request.matched_route.name }}">
+           <input name="next_route_matchdict" type="hidden" value="{{ request.matchdict_json }}">
            <input name="username" type="hidden" value="{{ request.user.username }}">
    
            {% if form.errors.__all__ %}

--- a/warehouse/templates/re-auth.html
+++ b/warehouse/templates/re-auth.html
@@ -29,8 +29,10 @@
        <div class="site-container">
          <h1 class="page-title">{% trans title=title %}Confirm password to continue{% endtrans %}</h1>
    
-         <form method="POST" action="{{ request.current_route_path() }}">
+         <form method="POST" action="{{ request.route_path('reauthenticate') }}">
            <input name="csrf_token" type="hidden" value="{{ request.session.get_csrf_token() }}">
+           <input name="next_route" type="hidden" value="{{ request.matched_route.name }}">
+           <input name="username" type="hidden" value="{{ request.user.username }}">
    
            {% if form.errors.__all__ %}
            <ul class="form-errors" role="alert">

--- a/warehouse/templates/re-auth.html
+++ b/warehouse/templates/re-auth.html
@@ -1,0 +1,85 @@
+{#
+    # Licensed under the Apache License, Version 2.0 (the "License");
+    # you may not use this file except in compliance with the License.
+    # You may obtain a copy of the License at
+    #
+    # http://www.apache.org/licenses/LICENSE-2.0
+    #
+    # Unless required by applicable law or agreed to in writing, software
+    # distributed under the License is distributed on an "AS IS" BASIS,
+    # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    # See the License for the specific language governing permissions and
+    # limitations under the License.
+   -#}
+   {% extends "base.html" %}
+   
+   {% block title %}
+     {% if form.errors %}{% trans %}Error processing form{% endtrans %} -{% endif %}
+     {% trans %}Confirm password{% endtrans %}
+   {% endblock %}
+   
+   {% block content %}
+     {% if testPyPI %}
+       {% set title = "TestPyPI" %}
+     {% else %}
+       {% set title = "PyPI" %}
+     {% endif %}
+   
+     <div class="horizontal-section">
+       <div class="site-container">
+         <h1 class="page-title">{% trans title=title %}Confirm password to continue{% endtrans %}</h1>
+   
+         <form method="POST" action="{{ request.current_route_path() }}">
+           <input name="csrf_token" type="hidden" value="{{ request.session.get_csrf_token() }}">
+   
+           {% if form.errors.__all__ %}
+           <ul class="form-errors" role="alert">
+             {% for error in form.errors.__all__ %}
+             <li>{{ error }}</li>
+             {% endfor %}
+           </ul>
+           {% endif %}
+   
+           <div data-controller="password" class="form-group">
+             <div>
+               <label for="password" class="form-group__label">
+                 {% trans %}Password{% endtrans %}
+                 {% if form.password.flags.required %}
+                 <span class="form-group__required">{% trans %}{% endtrans %}</span>
+                 {% endif %}
+               </label>
+             </div>
+             {{ form.password(placeholder=gettext("Your password"), required="required", class_="form-group__field", autocomplete="current-password", spellcheck="false", data_target="password.password", **{"aria-describedby":"password-errors"}) }}
+             <div id="password-errors">
+               {% if form.password.errors %}
+               <ul class="form-errors" role="alert">
+                 {% for error in form.password.errors %}
+                 <li>{{ error }}</li>
+                 {% endfor %}
+               </ul>
+               {% endif %}
+             </div>
+             <div class="form-group">
+               <div class="split-layout margin-top--large margin-bottom--large">
+                 <div>
+                   <input type="submit" value="{% trans %}Confirm password{% endtrans %}" class="button button--primary">
+                 </div>
+                 <label for="show-password">
+                   <input data-action="change->password#togglePasswords" data-target="password.showPassword"
+                     id="show-password" type="checkbox">&nbsp;{% trans %}Show password{% endtrans %}
+                 </label>
+               </div>
+               <span>
+                 <a href="{{request.route_url('accounts.request-password-reset')}}">{% trans %}Forgot password?{% endtrans %}</a>
+               </span>
+             </div>
+             <span>
+                <b>Tip:</b> you are about to perform a <a href="{{request.route_url('help')}}">{% trans %}sensitive action{% endtrans %}</a>. If you are not on a personal computer, make sure to log out once you're done with your session.
+                We won't ask you to confirm your password again for the next hour.
+             </span>
+           </div>
+         </form>
+       </div>
+     </div>
+   {% endblock %}
+   

--- a/warehouse/views.py
+++ b/warehouse/views.py
@@ -494,6 +494,6 @@ def reauthenticate(request, _form_class=ReAuthenticateForm):
     resp = HTTPSeeOther(redirect_to)
 
     if request.method == "POST" and form.validate():
-        request.session.record_auth_timestamp(request, resp)
+        request.session.record_auth_timestamp()
 
     return resp

--- a/warehouse/views.py
+++ b/warehouse/views.py
@@ -12,7 +12,7 @@
 
 
 import collections
-import datetime
+import json
 
 import elasticsearch
 
@@ -54,7 +54,6 @@ from warehouse.manage.forms import ReAuthenticateForm
 from warehouse.metrics import IMetricsService
 from warehouse.packaging.models import File, Project, Release, release_classifiers
 from warehouse.search.queries import SEARCH_FILTER_ORDER, get_es_query
-from warehouse.utils import crypto
 from warehouse.utils.http import is_safe_url
 from warehouse.utils.paginate import ElasticsearchPage, paginate_url_factory
 from warehouse.utils.row_counter import RowCount
@@ -485,7 +484,12 @@ def reauthenticate(request, _form_class=ReAuthenticateForm):
         ],
     )
 
-    redirect_to = request.route_path(form.next_route.data or "manage.projects")
+    if form.next_route.data and form.next_route_matchdict.data:
+        redirect_to = request.route_path(
+            form.next_route.data, **json.loads(form.next_route_matchdict.data)
+        )
+    else:
+        redirect_to = request.route_path("manage.projects")
 
     resp = HTTPSeeOther(redirect_to)
 


### PR DESCRIPTION
Implements https://github.com/pypa/warehouse/issues/8139.

Whenever a "sensitive" endpoint is hit, we check to see how long it has been since the user last authenticated. We do this by recording the timestamp of each authentication for a given session in Redis. If it has been less than specified period of time (1 hour by default), we perform the action normally, otherwise we first display a password confirmation page:

![Screen Shot 2020-06-30 at 12 36 20 AM](https://user-images.githubusercontent.com/13244482/86097585-b9d07400-ba69-11ea-9f9c-22d1134806df.png)

Once the user re-authenticates, the timestamp of is recorded in the session (and subsequently in Redis), they are redirected to their original destination, and the user won't be asked to re-authenticate again for another hour for such sensitive endpoints.

Below is a draft checklist of endpoints that should require re-authentication:

- [x] /manage/account/
  - [x] adding emails
  - [x] deleting emails
  - [x] changing primary email
  - [ ] deleting account (should reauthenticate every time, modal view already exists doing this)
- [x] /manage/project/[project_name]/releases/
  - [x] adding collaborators
  - [x] removing collaborators
  - [x] changing collaborator roles
  - [x] yanking releases
  - [x] unyanking releases
  - [x] deleting releases
  - [x] deleting files
- [x] /manage/project/[project_name]/collaborators/
- [x] /manage/project/[project_name]/settings/
  - [x] generating API tokens
  - [x] deleting API tokens
  - [x] deleting projects