### PR TITLE
Fix #8188 - incorrect stats in testpypi

### DIFF
--- a/warehouse/views.py
+++ b/warehouse/views.py
@@ -405,15 +405,6 @@ def stats(request):
     )
     # Move top packages into a dict to make JSON more self describing
 
-    print("TOP PACKAGES:")
-    print(top_100_packages)
-    print("TOP PACKAGES WITH ZERO_SIZE:")
-    zero_package = ('zero_size_package', 0)
-    none_package = ('none_package', None)
-    top_100_packages.append(zero_package)
-    top_100_packages.append(none_package)
-    print(top_100_packages)
-
     top_packages = {
         pkg_name: {"size": int(pkg_bytes)}
         for pkg_name, pkg_bytes in top_100_packages if pkg_bytes not in [0, None]

--- a/warehouse/views.py
+++ b/warehouse/views.py
@@ -404,9 +404,19 @@ def stats(request):
         .all()
     )
     # Move top packages into a dict to make JSON more self describing
+
+    print("TOP PACKAGES:")
+    print(top_100_packages)
+    print("TOP PACKAGES WITH ZERO_SIZE:")
+    zero_package = ('zero_size_package', 0)
+    none_package = ('none_package', None)
+    top_100_packages.append(zero_package)
+    top_100_packages.append(none_package)
+    print(top_100_packages)
+
     top_packages = {
-        pkg_name: {"size": int(pkg_bytes) if pkg_bytes is not None else 0}
-        for pkg_name, pkg_bytes in top_100_packages
+        pkg_name: {"size": int(pkg_bytes)}
+        for pkg_name, pkg_bytes in top_100_packages if pkg_bytes not in [0, None]
     }
 
     return {"total_packages_size": total_size, "top_packages": top_packages}

--- a/warehouse/views.py
+++ b/warehouse/views.py
@@ -399,16 +399,14 @@ def stats(request):
     top_100_packages = (
         request.db.query(Project)
         .with_entities(Project.name, Project.total_size)
-        .filter(Project.total_size > 0)
         .order_by(Project.total_size.desc().nullslast())
         .limit(100)
         .all()
     )
     # Move top packages into a dict to make JSON more self describing
     top_packages = {
-        pkg_name: {"size": int(pkg_bytes)}
+        pkg_name: {"size": int(pkg_bytes) if pkg_bytes is not None else 0}
         for pkg_name, pkg_bytes in top_100_packages
-        if pkg_bytes is not None
     }
 
     return {"total_packages_size": total_size, "top_packages": top_packages}

--- a/warehouse/views.py
+++ b/warehouse/views.py
@@ -399,6 +399,7 @@ def stats(request):
     top_100_packages = (
         request.db.query(Project)
         .with_entities(Project.name, Project.total_size)
+        .filter(Project.total_size > 0)
         .order_by(Project.total_size.desc())
         .limit(100)
         .all()

--- a/warehouse/views.py
+++ b/warehouse/views.py
@@ -408,7 +408,7 @@ def stats(request):
     top_packages = {
         pkg_name: {"size": int(pkg_bytes)}
         for pkg_name, pkg_bytes in top_100_packages
-        if pkg_bytes not in [0, None]
+        if pkg_bytes is not None
     }
 
     return {"total_packages_size": total_size, "top_packages": top_packages}

--- a/warehouse/views.py
+++ b/warehouse/views.py
@@ -400,7 +400,7 @@ def stats(request):
         request.db.query(Project)
         .with_entities(Project.name, Project.total_size)
         .filter(Project.total_size > 0)
-        .order_by(Project.total_size.desc())
+        .order_by(Project.total_size.desc().nullslast())
         .limit(100)
         .all()
     )

--- a/warehouse/views.py
+++ b/warehouse/views.py
@@ -406,7 +406,8 @@ def stats(request):
     # Move top packages into a dict to make JSON more self describing
     top_packages = {
         pkg_name: {"size": int(pkg_bytes)}
-        for pkg_name, pkg_bytes in top_100_packages if pkg_bytes not in [0, None]
+        for pkg_name, pkg_bytes in top_100_packages
+        if pkg_bytes not in [0, None]
     }
 
     return {"total_packages_size": total_size, "top_packages": top_packages}

--- a/warehouse/views.py
+++ b/warehouse/views.py
@@ -404,7 +404,6 @@ def stats(request):
         .all()
     )
     # Move top packages into a dict to make JSON more self describing
-
     top_packages = {
         pkg_name: {"size": int(pkg_bytes)}
         for pkg_name, pkg_bytes in top_100_packages if pkg_bytes not in [0, None]


### PR DESCRIPTION
Closes #8188.

I've made a small modification to the view that collects packages stats so that now it'll not display any packages that are of size 0.

I've tested it locally:
- Before fix, after adding a zero size package to display:
![before](https://user-images.githubusercontent.com/34001701/86533518-74cd9700-beda-11ea-91bb-0bacfedb6d4a.png)
- After fix:
![after](https://user-images.githubusercontent.com/34001701/86533523-78f9b480-beda-11ea-96fd-067c43a8b797.png)

I've also tested and linted locally with make.
