### PR TITLE
GitHub Actions CI

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,60 @@
+name: 'Setup'
+description: 'Set up CI environment'
+runs:
+  using: "composite"
+  steps:
+    - name: Check out repository
+      uses: actions/checkout@v2
+
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.8.2
+
+    - name: Cache Python dependencies
+      uses: actions/cache@v2
+      env:
+        cache-name: warehouse-cache-pip
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-${{ github.job }}-${{ env.cache-name }}-${{ hashFiles('requirements.txt', 'requirements/*.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ github.job }}-${{ env.cache-name }}-
+          ${{ runner.os }}-${{ github.job }}-
+          ${{ runner.os }}-
+
+    - name: Install Python dependencies
+      run: |
+        pip install -U pip setuptools wheel
+        pip install -r requirements.txt
+        pip install -r requirements/dev.txt
+
+    - uses: actions/setup-node@v2
+      with:
+        node-version: 14.4.0
+
+    - name: Cache Node dependencies
+      uses: actions/cache@v2
+      env:
+        cache-name: warehouse-cache-npm-modules-static
+      with:
+        path: |
+          ~/.npm
+          **/node_modules
+        key: ${{ runner.os }}-build-${{ github.job }}-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-build-${{ github.job }}-${{ env.cache-name }}-
+          ${{ runner.os }}-build-${{ github.job }}-
+          ${{ runner.os }}-build-
+          ${{ runner.os }}-
+
+    - name: Install Node dependencies
+      run: npm ci
+
+    - name: Check versions
+      run: |
+        node -v
+        npm -v
+        python --version
+
+    - run: echo "Setup success!"
+      shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,11 @@
+on: [push]
+
+jobs:
+  hello_world_job:
+    runs-on: ubuntu-latest
+    name: A job to say hello
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ./.github/actions/setup
+    - run: echo Done
+      shell: bash


### PR DESCRIPTION
Testing Warehouse using GitHub Actions. We run all of our jobs in parallel using the native `ubuntu-latest` Docker containers provided by GitHub Actions.

- The testing job runs inside of a PostgreSQL [service container](https://docs.github.com/en/actions/configuring-and-managing-workflows/about-service-containers), specifically `postgres:10.1` instead of `postgres:latest`.
- ~Ideally we would cache Docker containers with GitHub Package Registry instead of Docker Hub (because of [faster build time when compared to other caching methods](https://dev.to/dtinth/caching-docker-builds-in-github-actions-which-approach-is-the-fastest-a-research-18ei)), however it doesn't yet seem possible to use for container actions because accessing even public packages on GitHub Package Registry requires an extra authentication step (see https://github.community/t/docker-pull-from-public-github-package-registry-fail-with-no-basic-auth-credentials-error/16358 for ongoing discussion). In case GitHub fixes this and allows a simpler integration of Actions and Package Registry, I've left the (skipped) job in [.github/workflows/main.yml](https://github.com/callmecampos/warehouse/blob/github-actions-ci/.github/workflows/main.yml#L55-L101).~
- We use GitHub Actions' native caching action to cache pip dependencies and node modules for the following jobs: `test`, `lint`, `deps`, `static-tests`, `static-pipeline`.

Resolves #7001. You can see the latest runs with runtimes at the bottom of this PR, or in the Checks tab.

~This won't yet be able to run on pypa/warehouse since the secret environment variables for Docker Hub haven't been set up in this repo, only in my fork.~ This now runs fine on pypa/warehouse.