### PR TITLE
Fix flake8 on warehouse/accounts/services.py

### DIFF
--- a/warehouse/accounts/services.py
+++ b/warehouse/accounts/services.py
@@ -13,12 +13,10 @@
 import collections
 import functools
 import hashlib
-import hmac
 import logging
 import os
 import secrets
 import urllib.parse
-import uuid
 
 import requests
 
@@ -106,7 +104,6 @@ class DatabaseUserService:
     @functools.lru_cache()
     def find_userid_by_email(self, email):
         try:
-            # flake8: noqa
             user_id = (self.db.query(Email.user_id).filter(Email.email == email).one())[
                 0
             ]
@@ -596,7 +593,7 @@ class TokenService:
             )
         except SignatureExpired:
             raise TokenExpired
-        except BadData:  #  Catch all other exceptions
+        except BadData:  # Catch all other exceptions
             raise TokenInvalid
 
         return data
@@ -645,7 +642,10 @@ class TokenServiceFactory:
 @implementer(IPasswordBreachedService)
 class HaveIBeenPwnedPasswordBreachedService:
 
-    _failure_message_preamble = "This password appears in a security breach or has been compromised and cannot be used."
+    _failure_message_preamble = (
+        "This password appears in a security breach or has been "
+        "compromised and cannot be used."
+    )
 
     def __init__(
         self,


### PR DESCRIPTION
The comment `# flake8: noqa` was disabling flake8 for the whole file. It seem not to be used elsewhere in the codebase (pfhew 😅 )

Discovered in https://github.com/pypa/warehouse/pull/7124#discussion_r460312963