### PR TITLE
Autofocus for the search field

### DIFF
--- a/warehouse/templates/index.html
+++ b/warehouse/templates/index.html
@@ -51,7 +51,7 @@
 
     <form class="search-form search-form--large search-form--fullwidth" action="{{ request.route_path('search') }}" role="search">
       <label for="search" class="sr-only">{% trans %}Search PyPI{% endtrans %}</label>
-      <input id="search" class="search-form__search large-input" type="text" name="q" placeholder="{% trans %}Search projects{% endtrans %}" autocomplete="off" autocapitalize="off" spellcheck="false">
+      <input id="search" class="search-form__search large-input" type="text" name="q" placeholder="{% trans %}Search projects{% endtrans %}" autocomplete="off" autocapitalize="off" spellcheck="false" autofocus>
       <button type="submit" class="search-form__button">
         <i class="fa fa-search" aria-hidden="true"></i>
         <span class="sr-only">{% trans %}Search{% endtrans %}</span>


### PR DESCRIPTION
I guess the primary use case of the warehouse is searching or looking libs or applications. Having the search field focused right from the start would speed this task up tremendously.