### PR TITLE
Generic events

### DIFF
--- a/tests/common/db/accounts.py
+++ b/tests/common/db/accounts.py
@@ -14,7 +14,7 @@ import datetime
 
 import factory
 
-from warehouse.accounts.models import Email, User, UserEvent
+from warehouse.accounts.models import Email, User
 
 from .base import WarehouseFactory
 
@@ -42,9 +42,9 @@ class UserFactory(WarehouseFactory):
 
 class UserEventFactory(WarehouseFactory):
     class Meta:
-        model = UserEvent
+        model = User.Event
 
-    user = factory.SubFactory(User)
+    source = factory.SubFactory(User)
 
 
 class EmailFactory(WarehouseFactory):

--- a/tests/common/db/packaging.py
+++ b/tests/common/db/packaging.py
@@ -25,7 +25,6 @@ from warehouse.packaging.models import (
     JournalEntry,
     ProhibitedProjectName,
     Project,
-    ProjectEvent,
     Release,
     Role,
     RoleInvitation,
@@ -48,9 +47,9 @@ class ProjectFactory(WarehouseFactory):
 
 class ProjectEventFactory(WarehouseFactory):
     class Meta:
-        model = ProjectEvent
+        model = Project.Event
 
-    project = factory.SubFactory(ProjectFactory)
+    source = factory.SubFactory(ProjectFactory)
 
 
 class DescriptionFactory(WarehouseFactory):

--- a/tests/unit/accounts/test_models.py
+++ b/tests/unit/accounts/test_models.py
@@ -102,9 +102,9 @@ class TestUser:
 
     def test_recent_events(self, db_session):
         user = DBUserFactory.create()
-        recent_event = DBUserEventFactory(user=user, tag="foo", ip_address="0.0.0.0")
+        recent_event = DBUserEventFactory(source=user, tag="foo", ip_address="0.0.0.0")
         stale_event = DBUserEventFactory(
-            user=user,
+            source=user,
             tag="bar",
             ip_address="0.0.0.0",
             time=datetime.datetime.now() - datetime.timedelta(days=91),

--- a/tests/unit/manage/test_views.py
+++ b/tests/unit/manage/test_views.py
@@ -48,7 +48,6 @@ from warehouse.packaging.models import (
     File,
     JournalEntry,
     Project,
-    ProjectEvent,
     Role,
     RoleInvitation,
     User,
@@ -2556,12 +2555,9 @@ class TestManageProjectSettings:
         assert result.status_code == 303
         assert result.headers["Location"] == "/foo/bar/"
 
-        event = (
-            db_request.db.query(ProjectEvent)
-            .join(ProjectEvent.project)
-            .filter(ProjectEvent.project_id == project.id)
-            .one()
-        )
+        events = project.events
+        assert len(events) == 1
+        event = events[0]
         assert event.tag == tag
         assert event.additional == {"modified_by": db_request.user.username}
 
@@ -4460,13 +4456,13 @@ class TestManageProjectHistory:
     def test_get(self, db_request):
         project = ProjectFactory.create()
         older_event = ProjectEventFactory.create(
-            project=project,
+            source=project,
             tag="fake:event",
             ip_address="0.0.0.0",
             time=datetime.datetime(2017, 2, 5, 17, 18, 18, 462_634),
         )
         newer_event = ProjectEventFactory.create(
-            project=project,
+            source=project,
             tag="fake:event",
             ip_address="0.0.0.0",
             time=datetime.datetime(2018, 2, 5, 17, 18, 18, 462_634),
@@ -4510,13 +4506,13 @@ class TestManageProjectHistory:
         total_items = items_per_page + 2
         for _ in range(total_items):
             ProjectEventFactory.create(
-                project=project, tag="fake:event", ip_address="0.0.0.0"
+                source=project, tag="fake:event", ip_address="0.0.0.0"
             )
         events_query = (
-            db_request.db.query(ProjectEvent)
-            .join(ProjectEvent.project)
-            .filter(ProjectEvent.project_id == project.id)
-            .order_by(ProjectEvent.time.desc())
+            db_request.db.query(Project.Event)
+            .join(Project.Event.source)
+            .filter(Project.Event.source_id == project.id)
+            .order_by(Project.Event.time.desc())
         )
 
         events_page = SQLAlchemyORMPage(
@@ -4541,13 +4537,13 @@ class TestManageProjectHistory:
         total_items = items_per_page + 2
         for _ in range(total_items):
             ProjectEventFactory.create(
-                project=project, tag="fake:event", ip_address="0.0.0.0"
+                source=project, tag="fake:event", ip_address="0.0.0.0"
             )
         events_query = (
-            db_request.db.query(ProjectEvent)
-            .join(ProjectEvent.project)
-            .filter(ProjectEvent.project_id == project.id)
-            .order_by(ProjectEvent.time.desc())
+            db_request.db.query(Project.Event)
+            .join(Project.Event.source)
+            .filter(Project.Event.source_id == project.id)
+            .order_by(Project.Event.time.desc())
         )
 
         events_page = SQLAlchemyORMPage(
@@ -4572,7 +4568,7 @@ class TestManageProjectHistory:
         total_items = items_per_page + 2
         for _ in range(total_items):
             ProjectEventFactory.create(
-                project=project, tag="fake:event", ip_address="0.0.0.0"
+                source=project, tag="fake:event", ip_address="0.0.0.0"
             )
 
         with pytest.raises(HTTPNotFound):

--- a/warehouse/accounts/models.py
+++ b/warehouse/accounts/models.py
@@ -30,11 +30,12 @@ from sqlalchemy import (
     select,
     sql,
 )
-from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm.exc import NoResultFound
 
 from warehouse import db
+from warehouse.events.models import HasEvents
 from warehouse.sitemap.models import SitemapMixin
 from warehouse.utils.attrs import make_repr
 from warehouse.utils.db.types import TZDateTime
@@ -57,7 +58,7 @@ class DisableReason(enum.Enum):
     AccountFrozen = "account frozen"
 
 
-class User(SitemapMixin, db.Model):
+class User(SitemapMixin, HasEvents, db.Model):
 
     __tablename__ = "users"
     __table_args__ = (
@@ -107,20 +108,6 @@ class User(SitemapMixin, db.Model):
         "Macaroon", backref="user", cascade="all, delete-orphan", lazy=True
     )
 
-    events = orm.relationship(
-        "UserEvent", backref="user", cascade="all, delete-orphan", lazy=True
-    )
-
-    def record_event(self, *, tag, ip_address, additional):
-        session = orm.object_session(self)
-        event = UserEvent(
-            user=self, tag=tag, ip_address=ip_address, additional=additional
-        )
-        session.add(event)
-        session.flush()
-
-        return event
-
     @property
     def primary_email(self):
         primaries = [x for x in self.emails if x.primary]
@@ -167,9 +154,11 @@ class User(SitemapMixin, db.Model):
         session = orm.object_session(self)
         last_ninety = datetime.datetime.now() - datetime.timedelta(days=90)
         return (
-            session.query(UserEvent)
-            .filter((UserEvent.user_id == self.id) & (UserEvent.time >= last_ninety))
-            .order_by(UserEvent.time.desc())
+            session.query(User.Event)
+            .filter(
+                (User.Event.source_id == self.id) & (User.Event.time >= last_ninety)
+            )
+            .order_by(User.Event.time.desc())
             .all()
         )
 
@@ -215,21 +204,6 @@ class RecoveryCode(db.Model):
     code = Column(String(length=128), nullable=False)
     generated = Column(DateTime, nullable=False, server_default=sql.func.now())
     burned = Column(DateTime, nullable=True)
-
-
-class UserEvent(db.Model):
-    __tablename__ = "user_events"
-
-    user_id = Column(
-        UUID(as_uuid=True),
-        ForeignKey("users.id", deferrable=True, initially="DEFERRED"),
-        nullable=False,
-        index=True,
-    )
-    tag = Column(String, nullable=False)
-    time = Column(DateTime, nullable=False, server_default=sql.func.now())
-    ip_address = Column(String, nullable=False)
-    additional = Column(JSONB, nullable=True)
 
 
 class UnverifyReasons(enum.Enum):

--- a/warehouse/events/models.py
+++ b/warehouse/events/models.py
@@ -1,0 +1,57 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from sqlalchemy import Column, DateTime, ForeignKey, String, orm, sql
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.ext.declarative import declared_attr
+
+from warehouse import db
+
+
+class Event:
+    tag = Column(String, nullable=False)
+    time = Column(DateTime, nullable=False, server_default=sql.func.now())
+    ip_address = Column(String, nullable=False)
+    additional = Column(JSONB, nullable=True)
+
+
+class HasEvents:
+    @declared_attr
+    def events(cls):  # noqa: N805
+        cls.Event = type(
+            "%sEvent" % cls.__name__,
+            (Event, db.Model),
+            dict(
+                __tablename__="%s_events" % cls.__tablename__,
+                source_id=Column(
+                    UUID(as_uuid=True),
+                    ForeignKey(
+                        "%s.id" % cls.__tablename__,
+                        deferrable=True,
+                        initially="DEFERRED",
+                    ),
+                    nullable=False,
+                ),
+                source=orm.relationship(cls),
+            ),
+        )
+        return orm.relationship(cls.Event, cascade="all, delete-orphan", lazy=True)
+
+    def record_event(self, *, tag, ip_address, additional=None):
+        session = orm.object_session(self)
+        event = self.Event(
+            source=self, tag=tag, ip_address=ip_address, additional=additional
+        )
+        session.add(event)
+        session.flush()
+
+        return event

--- a/warehouse/events/models.py
+++ b/warehouse/events/models.py
@@ -52,7 +52,6 @@ class Event(AbstractConcreteBase):
         return orm.relationship(cls._parent_class)
 
     def __init_subclass__(cls, /, parent_class, **kwargs):
-        # super().__init_subclass__(cls, **kwargs)
         cls._parent_class = parent_class
         return cls
 

--- a/warehouse/events/models.py
+++ b/warehouse/events/models.py
@@ -24,11 +24,11 @@ class Event(AbstractConcreteBase):
     additional = Column(JSONB, nullable=True)
 
     @declared_attr
-    def __tablename__(cls):
+    def __tablename__(cls):  # noqa: N805
         return "_".join([cls.__name__.removesuffix("Event").lower(), "events"])
 
     @declared_attr
-    def __mapper_args__(cls):
+    def __mapper_args__(cls):  # noqa: N805
         return (
             {"polymorphic_identity": cls.__name__, "concrete": True}
             if cls.__name__ != "Event"
@@ -36,7 +36,7 @@ class Event(AbstractConcreteBase):
         )
 
     @declared_attr
-    def source_id(cls):
+    def source_id(cls):  # noqa: N805
         return Column(
             UUID(as_uuid=True),
             ForeignKey(
@@ -48,7 +48,7 @@ class Event(AbstractConcreteBase):
         )
 
     @declared_attr
-    def source(cls):
+    def source(cls):  # noqa: N805
         return orm.relationship(cls._parent_class)
 
     def __init_subclass__(cls, /, parent_class, **kwargs):
@@ -65,7 +65,7 @@ class HasEvents:
         return cls
 
     @declared_attr
-    def events(cls):
+    def events(cls):  # noqa: N805
         return orm.relationship(cls.Event, cascade="all, delete-orphan", lazy=True)
 
     def record_event(self, *, tag, ip_address, additional=None):

--- a/warehouse/events/models.py
+++ b/warehouse/events/models.py
@@ -12,12 +12,12 @@
 
 from sqlalchemy import Column, DateTime, ForeignKey, String, orm, sql
 from sqlalchemy.dialects.postgresql import JSONB, UUID
-from sqlalchemy.ext.declarative import declared_attr
+from sqlalchemy.ext.declarative import AbstractConcreteBase, declared_attr
 
 from warehouse import db
 
 
-class Event:
+class Event(AbstractConcreteBase):
     tag = Column(String, nullable=False)
     time = Column(DateTime, nullable=False, server_default=sql.func.now())
     ip_address = Column(String, nullable=False)
@@ -32,6 +32,10 @@ class HasEvents:
             (Event, db.Model),
             dict(
                 __tablename__="%s_events" % cls.__tablename__,
+                __mapper_args__={
+                    "polymorphic_identity": cls.__tablename__,
+                    "concrete": True,
+                },
                 source_id=Column(
                     UUID(as_uuid=True),
                     ForeignKey(

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -116,7 +116,7 @@ msgstr ""
 msgid "Successful WebAuthn assertion"
 msgstr ""
 
-#: warehouse/accounts/views.py:441 warehouse/manage/views.py:814
+#: warehouse/accounts/views.py:441 warehouse/manage/views.py:813
 msgid "Recovery code accepted. The supplied code cannot be used again."
 msgstr ""
 
@@ -225,51 +225,51 @@ msgstr ""
 msgid "Banner Preview"
 msgstr ""
 
-#: warehouse/manage/views.py:245
+#: warehouse/manage/views.py:244
 msgid "Email ${email_address} added - check your email for a verification link"
 msgstr ""
 
-#: warehouse/manage/views.py:762
+#: warehouse/manage/views.py:761
 msgid "Recovery codes already generated"
 msgstr ""
 
-#: warehouse/manage/views.py:763
+#: warehouse/manage/views.py:762
 msgid "Generating new recovery codes will invalidate your existing codes."
 msgstr ""
 
-#: warehouse/manage/views.py:1191
+#: warehouse/manage/views.py:1190
 msgid ""
 "There have been too many attempted OpenID Connect registrations. Try "
 "again later."
 msgstr ""
 
-#: warehouse/manage/views.py:1872
+#: warehouse/manage/views.py:1871
 msgid "User '${username}' already has ${role_name} role for project"
 msgstr ""
 
-#: warehouse/manage/views.py:1883
+#: warehouse/manage/views.py:1882
 msgid ""
 "User '${username}' does not have a verified primary email address and "
 "cannot be added as a ${role_name} for project"
 msgstr ""
 
-#: warehouse/manage/views.py:1896
+#: warehouse/manage/views.py:1895
 msgid "User '${username}' already has an active invite. Please try again later."
 msgstr ""
 
-#: warehouse/manage/views.py:1954
+#: warehouse/manage/views.py:1953
 msgid "Invitation sent to '${username}'"
 msgstr ""
 
-#: warehouse/manage/views.py:2001
+#: warehouse/manage/views.py:2000
 msgid "Could not find role invitation."
 msgstr ""
 
-#: warehouse/manage/views.py:2012
+#: warehouse/manage/views.py:2011
 msgid "Invitation already expired."
 msgstr ""
 
-#: warehouse/manage/views.py:2036
+#: warehouse/manage/views.py:2035
 msgid "Invitation revoked from '${username}'."
 msgstr ""
 

--- a/warehouse/malware/checks/package_turnover/check.py
+++ b/warehouse/malware/checks/package_turnover/check.py
@@ -13,14 +13,14 @@
 from datetime import datetime, timedelta
 from textwrap import dedent
 
-from warehouse.accounts.models import UserEvent
+from warehouse.accounts.models import User
 from warehouse.malware.checks.base import MalwareCheckBase
 from warehouse.malware.models import (
     MalwareVerdict,
     VerdictClassification,
     VerdictConfidence,
 )
-from warehouse.packaging.models import ProjectEvent, Release
+from warehouse.packaging.models import Project, Release
 
 
 class PackageTurnoverCheck(MalwareCheckBase):
@@ -43,10 +43,10 @@ class PackageTurnoverCheck(MalwareCheckBase):
     def user_posture_verdicts(self, project):
         for user in project.users:
             has_removed_2fa_method = self.db.query(
-                self.db.query(UserEvent)
-                .filter(UserEvent.user_id == user.id)
-                .filter(UserEvent.time >= self._scan_interval)
-                .filter(UserEvent.tag == "account:two_factor:method_removed")
+                self.db.query(User.Event)
+                .filter(User.Event.source_id == user.id)
+                .filter(User.Event.time >= self._scan_interval)
+                .filter(User.Event.tag == "account:two_factor:method_removed")
                 .exists()
             ).scalar()
 
@@ -64,10 +64,10 @@ class PackageTurnoverCheck(MalwareCheckBase):
         # release, then reverts the ownership to the original maintainers and removes
         # themself again.
         recent_role_adds = (
-            self.db.query(ProjectEvent.additional)
-            .filter(ProjectEvent.project_id == project.id)
-            .filter(ProjectEvent.time >= self._scan_interval)
-            .filter(ProjectEvent.tag == "project:role:add")
+            self.db.query(Project.Event.additional)
+            .filter(Project.Event.source_id == project.id)
+            .filter(Project.Event.time >= self._scan_interval)
+            .filter(Project.Event.tag == "project:role:add")
             .all()
         )
 

--- a/warehouse/manage/views.py
+++ b/warehouse/manage/views.py
@@ -87,7 +87,6 @@ from warehouse.packaging.models import (
     File,
     JournalEntry,
     Project,
-    ProjectEvent,
     Release,
     Role,
     RoleInvitation,
@@ -2201,10 +2200,10 @@ def manage_project_history(project, request):
         raise HTTPBadRequest("'page' must be an integer.")
 
     events_query = (
-        request.db.query(ProjectEvent)
-        .join(ProjectEvent.project)
-        .filter(ProjectEvent.project_id == project.id)
-        .order_by(ProjectEvent.time.desc())
+        request.db.query(Project.Event)
+        .join(Project.Event.source)
+        .filter(Project.Event.source_id == project.id)
+        .order_by(Project.Event.time.desc())
     )
 
     events = SQLAlchemyORMPage(

--- a/warehouse/migrations/versions/5e02c4f9f95c_generic_events.py
+++ b/warehouse/migrations/versions/5e02c4f9f95c_generic_events.py
@@ -1,0 +1,178 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Generic Events
+
+Revision ID: 5e02c4f9f95c
+Revises: 87509f4ae027
+Create Date: 2020-07-26 06:12:58.519387
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "5e02c4f9f95c"
+down_revision = "84262e097c26"
+
+
+def upgrade():
+    # Create new tables
+    op.create_table(
+        "projects_events",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            server_default=sa.text("gen_random_uuid()"),
+            nullable=False,
+        ),
+        sa.Column("tag", sa.String(), nullable=False),
+        sa.Column(
+            "time", sa.DateTime(), server_default=sa.text("now()"), nullable=False
+        ),
+        sa.Column("ip_address", sa.String(), nullable=False),
+        sa.Column("additional", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("source_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["source_id"], ["projects.id"], initially="DEFERRED", deferrable=True
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_table(
+        "users_events",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            server_default=sa.text("gen_random_uuid()"),
+            nullable=False,
+        ),
+        sa.Column("tag", sa.String(), nullable=False),
+        sa.Column(
+            "time", sa.DateTime(), server_default=sa.text("now()"), nullable=False
+        ),
+        sa.Column("ip_address", sa.String(), nullable=False),
+        sa.Column("additional", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("source_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["source_id"], ["users.id"], initially="DEFERRED", deferrable=True
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    # Data migration
+    op.execute(
+        "INSERT INTO projects_events "
+        "(id, source_id, tag, time, ip_address, additional) "
+        "SELECT id, project_id, tag, time, ip_address, additional "
+        "FROM project_events"
+    )
+    op.execute(
+        "INSERT INTO users_events "
+        "(id, source_id, tag, time, ip_address, additional) "
+        "SELECT id, user_id, tag, time, ip_address, additional "
+        "FROM user_events"
+    )
+
+    # Drop old tables
+    op.drop_table("user_events")
+    op.drop_table("project_events")
+
+
+def downgrade():
+    # Create new tables
+    op.create_table(
+        "project_events",
+        sa.Column(
+            "id",
+            postgresql.UUID(),
+            server_default=sa.text("gen_random_uuid()"),
+            autoincrement=False,
+            nullable=False,
+        ),
+        sa.Column("project_id", postgresql.UUID(), autoincrement=False, nullable=False),
+        sa.Column("tag", sa.VARCHAR(), autoincrement=False, nullable=False),
+        sa.Column(
+            "time",
+            postgresql.TIMESTAMP(),
+            server_default=sa.text("now()"),
+            autoincrement=False,
+            nullable=False,
+        ),
+        sa.Column("ip_address", sa.VARCHAR(), autoincrement=False, nullable=False),
+        sa.Column(
+            "additional",
+            postgresql.JSONB(astext_type=sa.Text()),
+            autoincrement=False,
+            nullable=True,
+        ),
+        sa.ForeignKeyConstraint(
+            ["project_id"],
+            ["projects.id"],
+            name="project_events_project_id_fkey",
+            initially="DEFERRED",
+            deferrable=True,
+        ),
+        sa.PrimaryKeyConstraint("id", name="project_events_pkey"),
+    )
+    op.create_table(
+        "user_events",
+        sa.Column(
+            "id",
+            postgresql.UUID(),
+            server_default=sa.text("gen_random_uuid()"),
+            autoincrement=False,
+            nullable=False,
+        ),
+        sa.Column("user_id", postgresql.UUID(), autoincrement=False, nullable=False),
+        sa.Column("tag", sa.VARCHAR(), autoincrement=False, nullable=False),
+        sa.Column(
+            "time",
+            postgresql.TIMESTAMP(),
+            server_default=sa.text("now()"),
+            autoincrement=False,
+            nullable=False,
+        ),
+        sa.Column("ip_address", sa.VARCHAR(), autoincrement=False, nullable=False),
+        sa.Column(
+            "additional",
+            postgresql.JSONB(astext_type=sa.Text()),
+            autoincrement=False,
+            nullable=True,
+        ),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["users.id"],
+            name="user_events_user_id_fkey",
+            initially="DEFERRED",
+            deferrable=True,
+        ),
+        sa.PrimaryKeyConstraint("id", name="user_events_pkey"),
+    )
+
+    # Data migration
+    op.execute(
+        "INSERT INTO project_events "
+        "(id, project_id, tag, time, ip_address, additional) "
+        "SELECT id, source_id, tag, time, ip_address, additional "
+        "FROM projects_events"
+    )
+    op.execute(
+        "INSERT INTO user_events "
+        "(id, user_id, tag, time, ip_address, additional) "
+        "SELECT id, source_id, tag, time, ip_address, additional "
+        "FROM users_events"
+    )
+
+    # Drop old tables
+    op.drop_table("users_events")
+    op.drop_table("projects_events")

--- a/warehouse/migrations/versions/5e02c4f9f95c_generic_events.py
+++ b/warehouse/migrations/versions/5e02c4f9f95c_generic_events.py
@@ -25,28 +25,20 @@ down_revision = "84262e097c26"
 
 
 def upgrade():
-    op.rename_table("project_events", "projects_events")
-    op.alter_column("projects_events", "project_id", new_column_name="source_id")
-    op.execute("ALTER INDEX project_events_pkey RENAME TO projects_events_pkey")
+    op.alter_column("project_events", "project_id", new_column_name="source_id")
     op.execute(
-        "ALTER INDEX ix_project_events_project_id RENAME TO ix_projects_events_source_id"  # noqa
+        "ALTER INDEX ix_project_events_project_id RENAME TO ix_project_events_source_id"  # noqa
     )
 
-    op.rename_table("user_events", "users_events")
-    op.alter_column("users_events", "user_id", new_column_name="source_id")
-    op.execute("ALTER INDEX user_events_pkey RENAME TO users_events_pkey")
-    op.execute("ALTER INDEX ix_user_events_user_id RENAME TO ix_users_events_source_id")
+    op.alter_column("user_events", "user_id", new_column_name="source_id")
+    op.execute("ALTER INDEX ix_user_events_user_id RENAME TO ix_user_events_source_id")
 
 
 def downgrade():
-    op.rename_table("projects_events", "project_events")
     op.alter_column("project_events", "source_id", new_column_name="project_id")
-    op.execute("ALTER INDEX projects_events_pkey RENAME TO project_events_pkey")
     op.execute(
-        "ALTER INDEX ix_projects_events_source_id RENAME TO ix_project_events_project_id"  # noqa
+        "ALTER INDEX ix_project_events_source_id RENAME TO ix_project_events_project_id"  # noqa
     )
 
-    op.rename_table("users_events", "user_events")
     op.alter_column("user_events", "source_id", new_column_name="user_id")
-    op.execute("ALTER INDEX users_events_pkey RENAME TO user_events_pkey")
-    op.execute("ALTER INDEX ix_users_events_source_id RENAME TO ix_user_events_user_id")
+    op.execute("ALTER INDEX ix_user_events_source_id RENAME TO ix_user_events_user_id")


### PR DESCRIPTION
This PR introduces a generic `HasEvents` subclass for models that have related events, and migrates the existing `UserEvents` and `ProjectEvents` models to it. It uses generic associations but maintains essentially the same underlying "table per related" structure.

This ensures that events are created and associated with their sources in a consistent and generic way, and allows us to add event support to any new or existing model simply by adding the `HasEvents` mixin to the models class definition.