### PR TITLE
Move reauth_view view deriver

### DIFF
--- a/tests/unit/manage/test_init.py
+++ b/tests/unit/manage/test_init.py
@@ -13,8 +13,6 @@
 import pretend
 import pytest
 
-from pyramid import viewderivers
-
 from warehouse import manage
 
 
@@ -91,7 +89,5 @@ def test_includeme():
     manage.includeme(config)
 
     assert config.add_view_deriver.calls == [
-        pretend.call(
-            manage.reauth_view, over="rendered_view", under=viewderivers.INGRESS
-        )
+        pretend.call(manage.reauth_view, over="rendered_view", under="decorated_view")
     ]

--- a/warehouse/manage/__init__.py
+++ b/warehouse/manage/__init__.py
@@ -13,7 +13,6 @@
 import functools
 import json
 
-from pyramid import viewderivers
 from pyramid.renderers import render_to_response
 
 from warehouse.accounts.forms import ReAuthenticateForm
@@ -54,6 +53,4 @@ reauth_view.options = {"require_reauth"}
 
 
 def includeme(config):
-    config.add_view_deriver(
-        reauth_view, over="rendered_view", under=viewderivers.INGRESS
-    )
+    config.add_view_deriver(reauth_view, over="rendered_view", under="decorated_view")


### PR DESCRIPTION
This needs to be lower in the view deriver stack as it assumes we already have an authenticated user.