### PR TITLE
Adding the ability to translate tip text

### DIFF
--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -781,7 +781,16 @@ msgid "Forgot password?"
 msgstr ""
 
 #: warehouse/templates/re-auth.html:80
-msgid "sensitive action"
+#, python-format
+msgid ""
+"\n"
+"              <b>Tip:</b> you are about to perform a <a "
+"href=\"%(href)s\">sensitive action</a>.\n"
+"              If you are not on a personal computer, make sure to log out"
+" once you're done with your session.\n"
+"              We won't ask you to confirm your password again for the "
+"next hour.\n"
+"              "
 msgstr ""
 
 #: warehouse/templates/upload.html:25

--- a/warehouse/templates/re-auth.html
+++ b/warehouse/templates/re-auth.html
@@ -77,8 +77,11 @@
               </span>
             </div>
             <span>
-              {% trans href=request.help_url(_anchor="sensitiveactions") %}<b>Tip:</b> you are about to perform a <a href="{{ href }}">sensitive action</a>. If you are not on a personal computer, make sure to log out once you're done with your session.
-              We won't ask you to confirm your password again for the next hour.{% endtrans %}
+              {% trans href=request.help_url(_anchor="sensitiveactions") %}
+              <b>Tip:</b> you are about to perform a <a href="{{ href }}">sensitive action</a>.
+              If you are not on a personal computer, make sure to log out once you're done with your session.
+              We won't ask you to confirm your password again for the next hour.
+              {% endtrans %}
             </span>
           </div>
         </form>

--- a/warehouse/templates/re-auth.html
+++ b/warehouse/templates/re-auth.html
@@ -77,8 +77,8 @@
               </span>
             </div>
             <span>
-              <b>Tip:</b> you are about to perform a <a href="{{ request.help_url(_anchor="sensitiveactions") }}">{% trans %}sensitive action{% endtrans %}</a>. If you are not on a personal computer, make sure to log out once you're done with your session.
-              We won't ask you to confirm your password again for the next hour.
+              {% trans href=request.help_url(_anchor="sensitiveactions") %}<b>Tip:</b> you are about to perform a <a href="{{ href }}">sensitive action</a>. If you are not on a personal computer, make sure to log out once you're done with your session.
+              We won't ask you to confirm your password again for the next hour.{% endtrans %}
             </span>
           </div>
         </form>


### PR DESCRIPTION
Now the surrounding text in the template is not enclosed in the ``trans`` tag and therefore cannot be translated. This pull request fixing that.