### PR TITLE
Fixes #4703 Implement API for obtaining prohibited names

### DIFF
--- a/warehouse/legacy/api/json.py
+++ b/warehouse/legacy/api/json.py
@@ -19,7 +19,7 @@ from sqlalchemy.orm.exc import NoResultFound
 
 from warehouse.cache.http import cache_control
 from warehouse.cache.origin import origin_cache
-from warehouse.packaging.models import File, Project, Release
+from warehouse.packaging.models import File, ProhibitedProjectName, Project, Release
 
 # Generate appropriate CORS headers for the JSON endpoint.
 # We want to allow Cross-Origin requests here so that users can interact
@@ -213,3 +213,22 @@ def json_release_slash(release, request):
         ),
         headers=_CORS_HEADERS,
     )
+
+
+@view_config(
+    route_name="legacy.api.json.prohibited_project_name",
+    renderer="json",
+    decorator=_CACHE_DECORATOR,
+)
+def json_prohibited_project_name(request):
+    return {
+        "names": [
+            p.name for p in
+            request.db.query(ProhibitedProjectName)
+                .options(
+                    Load(ProhibitedProjectName).load_only("name")
+                )
+                .order_by(ProhibitedProjectName.name)
+                .all()
+        ]
+    }

--- a/warehouse/routes.py
+++ b/warehouse/routes.py
@@ -358,6 +358,11 @@ def includeme(config):
         read_only=True,
         domain=warehouse,
     )
+    config.add_route(
+        "legacy.api.json.prohibited_project_name",
+        "/pypi_prohibited_project_name/json/",
+        domain=warehouse,
+    )
 
     # Legacy Action URLs
     # TODO: We should probably add Warehouse routes for these that just error


### PR DESCRIPTION
This is very much a work in progress for implementing #4703, but I wanted to get feedback on the direction as I go.

In particular, the API route can't (trivially) go under `/api/prohibited_project_name` because that's a lookup for a package by that name. I replaced the slash with an underscore so I could test it, but open to other ideas on where to put it.

At least in my dev environment, putting it at `/admin/prohibited_project_name/json` seems to work okay. But totally open to other suggestions.