### PR TITLE
Fix typo with API token instructions

### DIFF
--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -3173,7 +3173,7 @@ msgstr ""
 #, python-format
 msgid ""
 "Set your password to the token value, including the "
-"<code>%(site)s%(prefix)s</code> prefix"
+"<code>%(prefix)s</code> prefix"
 msgstr ""
 
 #: warehouse/templates/manage/token.html:82

--- a/warehouse/templates/manage/token.html
+++ b/warehouse/templates/manage/token.html
@@ -73,7 +73,7 @@
 
     <ul>
       <li>{% trans token='__token__' %}Set your username to <code>{{ token }}</code>{% endtrans %}</li>
-      <li>{% trans prefix='-' %}Set your password to the token value, including the <code>{{ site }}{{ prefix }}</code> prefix{% endtrans %}</li>
+      <li>{% trans prefix='pypi-' %}Set your password to the token value, including the <code>{{ prefix }}</code> prefix{% endtrans %}</li>
     </ul>
 
     {% if macaroon.caveats.permissions == "user" %}


### PR DESCRIPTION
From #8554.