### PR TITLE
Fix typo in error reporting and erroneous test for macaroon auth policy

### DIFF
--- a/tests/unit/macaroons/test_auth_policy.py
+++ b/tests/unit/macaroons/test_auth_policy.py
@@ -171,7 +171,8 @@ class TestMacaroonAuthorizationPolicy:
         policy = auth_policy.MacaroonAuthorizationPolicy(policy=backing_policy)
         result = policy.permits(pretend.stub(), pretend.stub(), pretend.stub())
 
-        assert result == Denied("There was no active request.")
+        assert result == Denied("")
+        assert result.s == "There was no active request."
 
     def test_permits_no_macaroon(self, monkeypatch):
         request = pretend.stub()
@@ -212,7 +213,8 @@ class TestMacaroonAuthorizationPolicy:
         policy = auth_policy.MacaroonAuthorizationPolicy(policy=backing_policy)
         result = policy.permits(pretend.stub(), pretend.stub(), pretend.stub())
 
-        assert result == Denied("The supplied token was invalid: foo")
+        assert result == Denied("")
+        assert result.s == "Invalid API Token: InvalidMacaroon('foo')"
 
     def test_permits_valid_macaroon(self, monkeypatch):
         macaroon_service = pretend.stub(
@@ -266,7 +268,8 @@ class TestMacaroonAuthorizationPolicy:
         policy = auth_policy.MacaroonAuthorizationPolicy(policy=backing_policy)
         result = policy.permits(pretend.stub(), pretend.stub(), invalid_permission)
 
-        assert result == Denied(
+        assert result == Denied("")
+        assert result.s == (
             f"API tokens are not valid for permission: {invalid_permission}!"
         )
 

--- a/warehouse/macaroons/auth_policy.py
+++ b/warehouse/macaroons/auth_policy.py
@@ -139,7 +139,7 @@ class MacaroonAuthorizationPolicy:
                 macaroon_service.verify(macaroon, context, principals, permission)
             except InvalidMacaroon as exc:
                 return WarehouseDenied(
-                    f"Invalid API Token: {exc}!r", reason="invalid_api_token"
+                    f"Invalid API Token: {exc!r}", reason="invalid_api_token"
                 )
 
             # If our Macaroon is verified, and for a valid permission then we'll pass


### PR DESCRIPTION
Just to be extra-clear: this is not the root cause of the revert of https://github.com/pypa/warehouse/pull/7124 . It's just the reason why the error message read `Invalid API Token: invalid macaroon!r` with the `!r` at the end. So here's to smaller PRs with less risks involved :)

Note: `Denied` inherits `int` and `__eq__` is not overloaded, so comparing 2 `Denied` objects will return `True` if their integer values are equal. I'm making the string comparison in a separate step.