### PR TITLE
Add check_if_macaroon_exists

### DIFF
--- a/tests/unit/macaroons/test_services.py
+++ b/tests/unit/macaroons/test_services.py
@@ -72,13 +72,16 @@ class TestDatabaseMacaroonService:
     def test_find_userid_no_macaroon(self, macaroon_service):
         assert macaroon_service.find_userid(None) is None
 
-    def test_find_userid_invalid_macaroon(self, macaroon_service):
-        raw_macaroon = pymacaroons.Macaroon(
+    @pytest.fixture
+    def raw_macaroon(self):
+        return pymacaroons.Macaroon(
             location="fake location",
             identifier=str(uuid4()),
             key=b"fake key",
             version=pymacaroons.MACAROON_V2,
         ).serialize()
+
+    def test_find_userid_invalid_macaroon(self, macaroon_service, raw_macaroon):
         raw_macaroon = f"pypi-{raw_macaroon}"
 
         assert macaroon_service.find_userid(raw_macaroon) is None
@@ -102,26 +105,13 @@ class TestDatabaseMacaroonService:
 
         assert user.id == user_id
 
-    def test_verify_unprefixed_macaroon(self, macaroon_service):
-        raw_macaroon = pymacaroons.Macaroon(
-            location="fake location",
-            identifier=str(uuid4()),
-            key=b"fake key",
-            version=pymacaroons.MACAROON_V2,
-        ).serialize()
-
+    def test_verify_unprefixed_macaroon(self, macaroon_service, raw_macaroon):
         with pytest.raises(services.InvalidMacaroon):
             macaroon_service.verify(
                 raw_macaroon, pretend.stub(), pretend.stub(), pretend.stub()
             )
 
-    def test_verify_no_macaroon(self, macaroon_service):
-        raw_macaroon = pymacaroons.Macaroon(
-            location="fake location",
-            identifier=str(uuid4()),
-            key=b"fake key",
-            version=pymacaroons.MACAROON_V2,
-        ).serialize()
+    def test_verify_no_macaroon(self, macaroon_service, raw_macaroon):
         raw_macaroon = f"pypi-{raw_macaroon}"
 
         with pytest.raises(services.InvalidMacaroon):
@@ -135,7 +125,7 @@ class TestDatabaseMacaroonService:
             "fake location", user.id, "fake description", {"fake": "caveats"}
         )
 
-        verifier_obj = pretend.stub(verify=pretend.call_recorder(lambda k: False))
+        verifier_obj = pretend.stub(verify=pretend.raiser(services.InvalidMacaroon))
         verifier_cls = pretend.call_recorder(lambda *a: verifier_obj)
         monkeypatch.setattr(services, "Verifier", verifier_cls)
 
@@ -203,7 +193,7 @@ class TestDatabaseMacaroonService:
         principals = pretend.stub()
         permissions = pretend.stub()
 
-        assert macaroon_service.verify(raw_macaroon, context, principals, permissions)
+        macaroon_service.verify(raw_macaroon, context, principals, permissions)
         assert verifier_cls.calls == [
             pretend.call(mock.ANY, context, principals, permissions)
         ]
@@ -238,3 +228,50 @@ class TestDatabaseMacaroonService:
             macaroon_service.get_macaroon_by_description(user.id, macaroon.description)
             == dm
         )
+
+    def test_check_if_macaroon_exists_unprefixed_macaroon(
+        self, macaroon_service, raw_macaroon
+    ):
+        with pytest.raises(services.InvalidMacaroon):
+            macaroon_service.check_if_macaroon_exists(raw_macaroon)
+
+    def test_check_if_macaroon_exists_no_macaroon(self, macaroon_service, raw_macaroon):
+        raw_macaroon = f"pypi-{raw_macaroon}"
+
+        with pytest.raises(services.InvalidMacaroon):
+            macaroon_service.check_if_macaroon_exists(raw_macaroon)
+
+    def test_check_if_macaroon_exists_invalid_macaroon(
+        self, monkeypatch, user_service, macaroon_service
+    ):
+        user = UserFactory.create()
+        raw_macaroon, _ = macaroon_service.create_macaroon(
+            "fake location", user.id, "fake description", {"fake": "caveats"}
+        )
+
+        verifier_obj = pretend.stub(
+            verify_signature=pretend.raiser(services.InvalidMacaroon)
+        )
+        verifier_cls = pretend.call_recorder(lambda *a, **k: verifier_obj)
+        monkeypatch.setattr(services, "Verifier", verifier_cls)
+
+        with pytest.raises(services.InvalidMacaroon):
+            macaroon_service.check_if_macaroon_exists(raw_macaroon)
+
+    def test_check_if_macaroon_exists_malformed_macaroon(self, macaroon_service):
+        with pytest.raises(services.InvalidMacaroon):
+            macaroon_service.check_if_macaroon_exists("pypi-thiswillnotdeserialize")
+
+    def test_check_if_macaroon_exists_valid_macaroon(
+        self, monkeypatch, macaroon_service
+    ):
+        user = UserFactory.create()
+        raw_macaroon, data_macaroon = macaroon_service.create_macaroon(
+            "fake location", user.id, "fake description", {"fake": "caveats"}
+        )
+
+        verifier_obj = pretend.stub(verify_signature=lambda k: None)
+        verifier_cls = pretend.call_recorder(lambda *a, **k: verifier_obj)
+        monkeypatch.setattr(services, "Verifier", verifier_cls)
+
+        assert macaroon_service.check_if_macaroon_exists(raw_macaroon) is data_macaroon

--- a/warehouse/macaroons/interfaces.py
+++ b/warehouse/macaroons/interfaces.py
@@ -43,6 +43,14 @@ class IMacaroonService(Interface):
         Raises InvalidMacaroon if the macaroon is not valid.
         """
 
+    def check_if_macaroon_exists(raw_macaroon):
+        """
+        Returns the database macaroon if the given raw (serialized) macaroon is
+        an existing valid macaroon, whatever its permissions.
+
+        Raises InvalidMacaroon otherwise.
+        """
+
     def create_macaroon(location, user_id, description, caveats):
         """
         Returns a new raw (serialized) macaroon. The description provided


### PR DESCRIPTION
Addresses the revert of #7124

Root causes:
- There was a test for the error branch of Verifier.verify but no test for the success case
- It was not very clear whether the method was supposed to
  - return True or False
  - return True or raise (:point_left:  what it does)
  - pass or raise
- The unit test mocks a lot, and there's no functional check that checks the whole chain.

This PR:
- Extracts all the code that touches macaroon from #7124 
- Fixes the problem: the function `Verifier.verify` needs to return True if it's ok, not raising is not enough.
- Fixes the test.

This PR doesn't:
- Address that https://github.com/pypa/warehouse/blob/faa49c6dbdf45f64648d96ae367b0a9014fbc2ac/warehouse/macaroons/services.py#L118 is dead code: `verify()` either returns `True` or raise, there's no `False`.  This is confusing and should be address too. I can adress it here or in a separate PR.