### PR TITLE
Limit password gauge latency

### DIFF
--- a/warehouse/static/js/warehouse/controllers/password_strength_gauge_controller.js
+++ b/warehouse/static/js/warehouse/controllers/password_strength_gauge_controller.js
@@ -28,7 +28,7 @@ export default class extends Controller {
       // following recommendations on the zxcvbn JS docs
       // the zxcvbn function is available by loading `vendor/zxcvbn.js`
       // in the register, account and reset password templates
-      let zxcvbnResult = zxcvbn(password);
+      let zxcvbnResult = zxcvbn(password.substring(0, 100));
       this.strengthGaugeTarget.setAttribute("class", `password-strength__gauge password-strength__gauge--${zxcvbnResult.score}`);
       this.strengthGaugeTarget.setAttribute("data-zxcvbn-score", zxcvbnResult.score);
       this.setScreenReaderMessage(zxcvbnResult.feedback.suggestions.join(" ") || "Password is strong");


### PR DESCRIPTION
Currently the complete password is given to zxcvbn to estimate it’s strength and display that in the gauge.
If the password is sufficiently long, this takes an exponential amount of time.
For that reason it is recommended to truncate the password to a sensible length when gauging the strength.
Cf. https://github.com/dropbox/zxcvbn#runtime-latency