### PR TITLE
Create utility to render and store transactional snapshot of simple detail page for a project

### DIFF
--- a/dev/environment
+++ b/dev/environment
@@ -19,6 +19,7 @@ CAMO_KEY=insecurecamokey
 DOCS_URL="https://pythonhosted.org/{project}/"
 
 FILES_BACKEND=warehouse.packaging.services.LocalFileStorage path=/var/opt/warehouse/packages/ url=http://localhost:9001/packages/{path}
+SIMPLE_BACKEND=warehouse.packaging.services.LocalSimpleStorage path=/var/opt/warehouse/simple/ url=http://localhost:9001/simple/{path}
 DOCS_BACKEND=warehouse.packaging.services.LocalDocsStorage path=/var/opt/warehouse/docs/
 SPONSORLOGOS_BACKEND=warehouse.admin.services.LocalSponsorLogoStorage path=/var/opt/warehouse/sponsorlogos/
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 version: '3'
 
 volumes:
+  simple:
   packages:
   sponsorlogos:
   vault:
@@ -86,6 +87,7 @@ services:
       - .coveragerc:/opt/warehouse/src/.coveragerc:z
       - packages:/var/opt/warehouse/packages
       - sponsorlogos:/var/opt/warehouse/sponsorlogos
+      - simple:/var/opt/warehouse/simple
       - ./bin:/opt/warehouse/src/bin:z
     ports:
       - "80:8000"
@@ -98,6 +100,7 @@ services:
     volumes:
       - packages:/var/opt/warehouse/packages
       - sponsorlogos:/var/opt/warehouse/sponsorlogos
+      - simple:/var/opt/warehouse/simple
     ports:
       - "9001:9001"
 
@@ -113,6 +116,7 @@ services:
     environment:
       C_FORCE_ROOT: "1"
       FILES_BACKEND: "warehouse.packaging.services.LocalFileStorage path=/var/opt/warehouse/packages/ url=http://files:9001/packages/{path}"
+      SIMPLE_BACKEND: "warehouse.packaging.services.LocalSimpleStorage path=/var/opt/warehouse/simple/ url=http://files:9001/simple/{path}"
 
   static:
     build:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -184,7 +184,8 @@ def app_config(database):
         "ratelimit.url": "memory://",
         "elasticsearch.url": "https://localhost/warehouse",
         "files.backend": "warehouse.packaging.services.LocalFileStorage",
-        "docs.backend": "warehouse.packaging.services.LocalFileStorage",
+        "simple.backend": "warehouse.packaging.services.LocalSimpleStorage",
+        "docs.backend": "warehouse.packaging.services.LocalDocsStorage",
         "sponsorlogos.backend": "warehouse.admin.services.LocalSponsorLogoStorage",
         "mail.backend": "warehouse.email.services.SMTPEmailSender",
         "malware_check.backend": (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,12 +25,16 @@ import pyramid.testing
 import pytest
 import webtest as _webtest
 
+from jinja2 import Environment, FileSystemLoader
 from psycopg2.errors import InvalidCatalogName
 from pyramid.i18n import TranslationString
 from pyramid.static import ManifestCacheBuster
+from pyramid_jinja2 import IJinja2Environment
 from pytest_postgresql.config import get_config
 from pytest_postgresql.janitor import DatabaseJanitor
 from sqlalchemy import event
+
+import warehouse
 
 from warehouse import admin, config, static
 from warehouse.accounts import services as account_services
@@ -76,6 +80,22 @@ def metrics():
     )
 
 
+@pytest.fixture
+def jinja():
+    dir_name = os.path.join(os.path.dirname(warehouse.__file__))
+
+    env = Environment(
+        loader=FileSystemLoader(dir_name),
+        extensions=[
+            "jinja2.ext.i18n",
+            "warehouse.utils.html.ClientSideIncludeExtension",
+        ],
+        cache_size=0,
+    )
+
+    return env
+
+
 class _Services:
     def __init__(self):
         self._services = defaultdict(lambda: defaultdict(dict))
@@ -98,10 +118,12 @@ def pyramid_services(metrics):
 
 
 @pytest.fixture
-def pyramid_request(pyramid_services):
+def pyramid_request(pyramid_services, jinja):
     dummy_request = pyramid.testing.DummyRequest()
     dummy_request.find_service = pyramid_services.find_service
     dummy_request.remote_addr = "1.2.3.4"
+
+    dummy_request.registry.registerUtility(jinja, IJinja2Environment, name=".jinja2")
 
     def localize(message, **kwargs):
         ts = TranslationString(message, **kwargs)

--- a/tests/unit/packaging/test_init.py
+++ b/tests/unit/packaging/test_init.py
@@ -18,7 +18,7 @@ from celery.schedules import crontab
 from warehouse import packaging
 from warehouse.accounts.models import Email, User
 from warehouse.manage.tasks import update_role_invitation_status
-from warehouse.packaging.interfaces import IDocsStorage, IFileStorage
+from warehouse.packaging.interfaces import IDocsStorage, IFileStorage, ISimpleStorage
 from warehouse.packaging.models import File, Project, Release, Role
 from warehouse.packaging.tasks import (  # sync_bigquery_release_files,
     compute_trending,
@@ -51,7 +51,11 @@ def test_includeme(monkeypatch, with_trending, with_bq_sync):
             lambda factory, iface, name=None: None
         ),
         registry=pretend.stub(
-            settings={"files.backend": "foo.bar", "docs.backend": "wu.tang"}
+            settings={
+                "files.backend": "foo.bar",
+                "simple.backend": "bread.butter",
+                "docs.backend": "wu.tang",
+            }
         ),
         register_origin_cache_keys=pretend.call_recorder(lambda c, **kw: None),
         get_settings=lambda: settings,
@@ -62,6 +66,7 @@ def test_includeme(monkeypatch, with_trending, with_bq_sync):
 
     assert config.register_service_factory.calls == [
         pretend.call(storage_class.create_service, IFileStorage),
+        pretend.call(storage_class.create_service, ISimpleStorage),
         pretend.call(storage_class.create_service, IDocsStorage),
     ]
     assert config.register_origin_cache_keys.calls == [

--- a/tests/unit/packaging/test_services.py
+++ b/tests/unit/packaging/test_services.py
@@ -26,6 +26,7 @@ from warehouse.packaging.interfaces import IDocsStorage, IFileStorage, ISimpleSt
 from warehouse.packaging.services import (
     GCSFileStorage,
     GCSSimpleStorage,
+    GenericLocalBlobStorage,
     LocalDocsStorage,
     LocalFileStorage,
     LocalSimpleStorage,
@@ -631,3 +632,9 @@ class TestGCSSimpleStorage:
         storage.store("foo/bar.txt", filename, meta=meta)
 
         assert blob.metadata == meta
+
+
+class TestGenericLocalBlobStorage:
+    def test_notimplementederror(self):
+        with pytest.raises(NotImplementedError):
+            GenericLocalBlobStorage.create_service(pretend.stub(), pretend.stub())

--- a/tests/unit/packaging/test_services.py
+++ b/tests/unit/packaging/test_services.py
@@ -578,7 +578,8 @@ class TestGCSSimpleStorage:
             fp.write(b"Test File!")
 
         blob = pretend.stub(
-            upload_from_filename=pretend.call_recorder(lambda file_path: None)
+            upload_from_filename=pretend.call_recorder(lambda file_path: None),
+            exists=lambda: False,
         )
         bucket = pretend.stub(blob=pretend.call_recorder(lambda path: blob))
         storage = GCSSimpleStorage(bucket)
@@ -597,7 +598,8 @@ class TestGCSSimpleStorage:
             fp.write(b"Second Test File!")
 
         blob = pretend.stub(
-            upload_from_filename=pretend.call_recorder(lambda file_path: None)
+            upload_from_filename=pretend.call_recorder(lambda file_path: None),
+            exists=lambda: False,
         )
         bucket = pretend.stub(blob=pretend.call_recorder(lambda path: blob))
         storage = GCSSimpleStorage(bucket)
@@ -621,6 +623,7 @@ class TestGCSSimpleStorage:
         blob = pretend.stub(
             upload_from_filename=pretend.call_recorder(lambda file_path: None),
             patch=pretend.call_recorder(lambda: None),
+            exists=lambda: False,
         )
         bucket = pretend.stub(blob=pretend.call_recorder(lambda path: blob))
         storage = GCSSimpleStorage(bucket)

--- a/tests/unit/packaging/test_services.py
+++ b/tests/unit/packaging/test_services.py
@@ -22,11 +22,13 @@ from zope.interface.verify import verifyClass
 
 import warehouse.packaging.services
 
-from warehouse.packaging.interfaces import IDocsStorage, IFileStorage
+from warehouse.packaging.interfaces import IDocsStorage, IFileStorage, ISimpleStorage
 from warehouse.packaging.services import (
     GCSFileStorage,
+    GCSSimpleStorage,
     LocalDocsStorage,
     LocalFileStorage,
+    LocalSimpleStorage,
     S3DocsStorage,
     S3FileStorage,
 )
@@ -135,6 +137,67 @@ class TestLocalDocsStorage:
 
         response = storage.remove_by_prefix("foo")
         assert response is None
+
+
+class TestLocalSimpleStorage:
+    def test_verify_service(self):
+        assert verifyClass(ISimpleStorage, LocalSimpleStorage)
+
+    def test_basic_init(self):
+        storage = LocalSimpleStorage("/foo/bar/")
+        assert storage.base == "/foo/bar/"
+
+    def test_create_service(self):
+        request = pretend.stub(
+            registry=pretend.stub(settings={"simple.path": "/simple/one/two/"})
+        )
+        storage = LocalSimpleStorage.create_service(None, request)
+        assert storage.base == "/simple/one/two/"
+
+    def test_gets_file(self, tmpdir):
+        with open(str(tmpdir.join("file.txt")), "wb") as fp:
+            fp.write(b"my test file contents")
+
+        storage = LocalSimpleStorage(str(tmpdir))
+        file_object = storage.get("file.txt")
+        assert file_object.read() == b"my test file contents"
+
+    def test_raises_when_file_non_existent(self, tmpdir):
+        storage = LocalSimpleStorage(str(tmpdir))
+        with pytest.raises(FileNotFoundError):
+            storage.get("file.txt")
+
+    def test_stores_file(self, tmpdir):
+        filename = str(tmpdir.join("testfile.txt"))
+        with open(filename, "wb") as fp:
+            fp.write(b"Test File!")
+
+        storage_dir = str(tmpdir.join("storage"))
+        storage = LocalSimpleStorage(storage_dir)
+        storage.store("foo/bar.txt", filename)
+
+        with open(os.path.join(storage_dir, "foo/bar.txt"), "rb") as fp:
+            assert fp.read() == b"Test File!"
+
+    def test_stores_two_files(self, tmpdir):
+        filename1 = str(tmpdir.join("testfile1.txt"))
+        with open(filename1, "wb") as fp:
+            fp.write(b"First Test File!")
+
+        filename2 = str(tmpdir.join("testfile2.txt"))
+        with open(filename2, "wb") as fp:
+            fp.write(b"Second Test File!")
+
+        storage_dir = str(tmpdir.join("storage"))
+        storage = LocalSimpleStorage(storage_dir)
+        storage.store("foo/first.txt", filename1)
+        storage.store("foo/second.txt", filename2)
+
+        with open(os.path.join(storage_dir, "foo/first.txt"), "rb") as fp:
+            assert fp.read() == b"First Test File!"
+
+        with open(os.path.join(storage_dir, "foo/second.txt"), "rb") as fp:
+            assert fp.read() == b"Second Test File!"
 
 
 class TestS3FileStorage:
@@ -479,3 +542,89 @@ class TestS3DocsStorage:
                 },
             ),
         ]
+
+
+class TestGCSSimpleStorage:
+    def test_verify_service(self):
+        assert verifyClass(ISimpleStorage, GCSSimpleStorage)
+
+    def test_basic_init(self):
+        bucket = pretend.stub()
+        storage = GCSSimpleStorage(bucket)
+        assert storage.bucket is bucket
+
+    def test_create_service(self):
+        service = pretend.stub(
+            get_bucket=pretend.call_recorder(lambda bucket_name: pretend.stub())
+        )
+        request = pretend.stub(
+            find_service=pretend.call_recorder(lambda name: service),
+            registry=pretend.stub(settings={"simple.bucket": "froblob"}),
+        )
+        GCSSimpleStorage.create_service(None, request)
+
+        assert request.find_service.calls == [pretend.call(name="gcloud.gcs")]
+        assert service.get_bucket.calls == [pretend.call("froblob")]
+
+    def test_gets_file_raises(self):
+        storage = GCSSimpleStorage(pretend.stub())
+
+        with pytest.raises(NotImplementedError):
+            storage.get("file.txt")
+
+    def test_stores_file(self, tmpdir):
+        filename = str(tmpdir.join("testfile.txt"))
+        with open(filename, "wb") as fp:
+            fp.write(b"Test File!")
+
+        blob = pretend.stub(
+            upload_from_filename=pretend.call_recorder(lambda file_path: None)
+        )
+        bucket = pretend.stub(blob=pretend.call_recorder(lambda path: blob))
+        storage = GCSSimpleStorage(bucket)
+        storage.store("foo/bar.txt", filename)
+
+        assert bucket.blob.calls == [pretend.call("foo/bar.txt")]
+        assert blob.upload_from_filename.calls == [pretend.call(filename)]
+
+    def test_stores_two_files(self, tmpdir):
+        filename1 = str(tmpdir.join("testfile1.txt"))
+        with open(filename1, "wb") as fp:
+            fp.write(b"First Test File!")
+
+        filename2 = str(tmpdir.join("testfile2.txt"))
+        with open(filename2, "wb") as fp:
+            fp.write(b"Second Test File!")
+
+        blob = pretend.stub(
+            upload_from_filename=pretend.call_recorder(lambda file_path: None)
+        )
+        bucket = pretend.stub(blob=pretend.call_recorder(lambda path: blob))
+        storage = GCSSimpleStorage(bucket)
+        storage.store("foo/first.txt", filename1)
+        storage.store("foo/second.txt", filename2)
+
+        assert bucket.blob.calls == [
+            pretend.call("foo/first.txt"),
+            pretend.call("foo/second.txt"),
+        ]
+        assert blob.upload_from_filename.calls == [
+            pretend.call(filename1),
+            pretend.call(filename2),
+        ]
+
+    def test_stores_metadata(self, tmpdir):
+        filename = str(tmpdir.join("testfile.txt"))
+        with open(filename, "wb") as fp:
+            fp.write(b"Test File!")
+
+        blob = pretend.stub(
+            upload_from_filename=pretend.call_recorder(lambda file_path: None),
+            patch=pretend.call_recorder(lambda: None),
+        )
+        bucket = pretend.stub(blob=pretend.call_recorder(lambda path: blob))
+        storage = GCSSimpleStorage(bucket)
+        meta = {"foo": "bar"}
+        storage.store("foo/bar.txt", filename, meta=meta)
+
+        assert blob.metadata == meta

--- a/tests/unit/packaging/test_utils.py
+++ b/tests/unit/packaging/test_utils.py
@@ -43,7 +43,10 @@ def test_render_simple_detail(db_request, monkeypatch, jinja):
     assert fake_hasher.hexdigest.calls == [pretend.call()]
 
     assert content_hash == "deadbeefdeadbeefdeadbeefdeadbeef"
-    assert path == f"{project.normalized_name}/deadbeefdeadbeefdeadbeefdeadbeef.{project.normalized_name}.html"
+    assert path == (
+        f"{project.normalized_name}/deadbeefdeadbeefdeadbeefdeadbeef"
+        + f".{project.normalized_name}.html"
+    )
 
 
 def test_render_simple_detail_with_store(db_request, monkeypatch, jinja):
@@ -97,7 +100,10 @@ def test_render_simple_detail_with_store(db_request, monkeypatch, jinja):
 
     assert storage_service.store.calls == [
         pretend.call(
-            f"{project.normalized_name}/deadbeefdeadbeefdeadbeefdeadbeef.{project.normalized_name}.html",
+            (
+                f"{project.normalized_name}/deadbeefdeadbeefdeadbeefdeadbeef"
+                + f".{project.normalized_name}.html"
+            ),
             "/tmp/wutang",
             meta={
                 "project": project.normalized_name,
@@ -117,4 +123,7 @@ def test_render_simple_detail_with_store(db_request, monkeypatch, jinja):
     ]
 
     assert content_hash == "deadbeefdeadbeefdeadbeefdeadbeef"
-    assert path == f"{project.normalized_name}/deadbeefdeadbeefdeadbeefdeadbeef.{project.normalized_name}.html"
+    assert path == (
+        f"{project.normalized_name}/deadbeefdeadbeefdeadbeefdeadbeef"
+        + f".{project.normalized_name}.html"
+    )

--- a/tests/unit/packaging/test_utils.py
+++ b/tests/unit/packaging/test_utils.py
@@ -43,7 +43,7 @@ def test_render_simple_detail(db_request, monkeypatch, jinja):
     assert fake_hasher.hexdigest.calls == [pretend.call()]
 
     assert content_hash == "deadbeefdeadbeefdeadbeefdeadbeef"
-    assert path == f"deadbeefdeadbeefdeadbeefdeadbeef.{project.normalized_name}"
+    assert path == f"{project.normalized_name}/deadbeefdeadbeefdeadbeefdeadbeef.{project.normalized_name}.html"
 
 
 def test_render_simple_detail_with_store(db_request, monkeypatch, jinja):
@@ -97,22 +97,24 @@ def test_render_simple_detail_with_store(db_request, monkeypatch, jinja):
 
     assert storage_service.store.calls == [
         pretend.call(
-            f"deadbeefdeadbeefdeadbeefdeadbeef.{project.normalized_name}",
+            f"{project.normalized_name}/deadbeefdeadbeefdeadbeefdeadbeef.{project.normalized_name}.html",
             "/tmp/wutang",
             meta={
                 "project": project.normalized_name,
+                "pypi-last-serial": project.last_serial,
                 "hash": "deadbeefdeadbeefdeadbeefdeadbeef",
             },
         ),
         pretend.call(
-            f"{project.normalized_name}",
+            f"{project.normalized_name}/index.html",
             "/tmp/wutang",
             meta={
                 "project": project.normalized_name,
+                "pypi-last-serial": project.last_serial,
                 "hash": "deadbeefdeadbeefdeadbeefdeadbeef",
             },
         ),
     ]
 
     assert content_hash == "deadbeefdeadbeefdeadbeefdeadbeef"
-    assert path == f"deadbeefdeadbeefdeadbeefdeadbeef.{project.normalized_name}"
+    assert path == f"{project.normalized_name}/deadbeefdeadbeefdeadbeefdeadbeef.{project.normalized_name}.html"

--- a/tests/unit/packaging/test_utils.py
+++ b/tests/unit/packaging/test_utils.py
@@ -1,0 +1,118 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import hashlib
+import tempfile
+
+import pretend
+
+from warehouse.packaging.interfaces import ISimpleStorage
+from warehouse.packaging.utils import _simple_detail, render_simple_detail
+
+from ...common.db.packaging import ProjectFactory
+
+
+def test_render_simple_detail(db_request, monkeypatch, jinja):
+    project = ProjectFactory.create()
+
+    fake_hasher = pretend.stub(
+        update=pretend.call_recorder(lambda x: None),
+        hexdigest=pretend.call_recorder(lambda: "deadbeefdeadbeefdeadbeefdeadbeef"),
+    )
+    fakeblake2b = pretend.call_recorder(lambda *a, **kw: fake_hasher)
+    monkeypatch.setattr(hashlib, "blake2b", fakeblake2b)
+
+    template = jinja.get_template("templates/legacy/api/simple/detail.html")
+    expected_content = template.render(
+        **_simple_detail(project, db_request), request=db_request
+    ).encode("utf-8")
+
+    content_hash, path = render_simple_detail(project, db_request)
+
+    assert fakeblake2b.calls == [pretend.call(digest_size=32)]
+    assert fake_hasher.update.calls == [pretend.call(expected_content)]
+    assert fake_hasher.hexdigest.calls == [pretend.call()]
+
+    assert content_hash == "deadbeefdeadbeefdeadbeefdeadbeef"
+    assert path == f"deadbeefdeadbeefdeadbeefdeadbeef.{project.normalized_name}"
+
+
+def test_render_simple_detail_with_store(db_request, monkeypatch, jinja):
+    project = ProjectFactory.create()
+
+    storage_service = pretend.stub(
+        store=pretend.call_recorder(
+            lambda path, file_path, *, meta=None: f"http://files/sponsorlogos/{path}"
+        )
+    )
+    db_request.find_service = pretend.call_recorder(
+        lambda svc, name=None, context=None: {
+            ISimpleStorage: storage_service,
+        }.get(svc)
+    )
+
+    fake_hasher = pretend.stub(
+        update=pretend.call_recorder(lambda x: None),
+        hexdigest=pretend.call_recorder(lambda: "deadbeefdeadbeefdeadbeefdeadbeef"),
+    )
+    fakeblake2b = pretend.call_recorder(lambda *a, **kw: fake_hasher)
+    monkeypatch.setattr(hashlib, "blake2b", fakeblake2b)
+
+    fake_named_temporary_file = pretend.stub(
+        name="/tmp/wutang",
+        write=pretend.call_recorder(lambda data: None),
+    )
+
+    class FakeNamedTemporaryFile:
+        def __init__(self):
+            return None
+
+        def __enter__(self):
+            return fake_named_temporary_file
+
+        def __exit__(self, type, value, traceback):
+            pass
+
+    monkeypatch.setattr(tempfile, "NamedTemporaryFile", FakeNamedTemporaryFile)
+
+    template = jinja.get_template("templates/legacy/api/simple/detail.html")
+    expected_content = template.render(
+        **_simple_detail(project, db_request), request=db_request
+    ).encode("utf-8")
+
+    content_hash, path = render_simple_detail(project, db_request, store=True)
+
+    assert fakeblake2b.calls == [pretend.call(digest_size=32)]
+    assert fake_hasher.update.calls == [pretend.call(expected_content)]
+    assert fake_hasher.hexdigest.calls == [pretend.call()]
+
+    assert storage_service.store.calls == [
+        pretend.call(
+            f"deadbeefdeadbeefdeadbeefdeadbeef.{project.normalized_name}",
+            "/tmp/wutang",
+            meta={
+                "project": project.normalized_name,
+                "hash": "deadbeefdeadbeefdeadbeefdeadbeef",
+            },
+        ),
+        pretend.call(
+            f"{project.normalized_name}",
+            "/tmp/wutang",
+            meta={
+                "project": project.normalized_name,
+                "hash": "deadbeefdeadbeefdeadbeefdeadbeef",
+            },
+        ),
+    ]
+
+    assert content_hash == "deadbeefdeadbeefdeadbeefdeadbeef"
+    assert path == f"deadbeefdeadbeefdeadbeefdeadbeef.{project.normalized_name}"

--- a/tests/unit/packaging/test_utils.py
+++ b/tests/unit/packaging/test_utils.py
@@ -73,6 +73,7 @@ def test_render_simple_detail_with_store(db_request, monkeypatch, jinja):
     fake_named_temporary_file = pretend.stub(
         name="/tmp/wutang",
         write=pretend.call_recorder(lambda data: None),
+        flush=pretend.call_recorder(lambda: None),
     )
 
     class FakeNamedTemporaryFile:
@@ -93,6 +94,9 @@ def test_render_simple_detail_with_store(db_request, monkeypatch, jinja):
     ).encode("utf-8")
 
     content_hash, path = render_simple_detail(project, db_request, store=True)
+
+    assert fake_named_temporary_file.write.calls == [pretend.call(expected_content)]
+    assert fake_named_temporary_file.flush.calls == [pretend.call()]
 
     assert fakeblake2b.calls == [pretend.call(digest_size=32)]
     assert fake_hasher.update.calls == [pretend.call(expected_content)]

--- a/warehouse/config.py
+++ b/warehouse/config.py
@@ -225,6 +225,7 @@ def configure(settings=None):
         default=21600,  # 6 hours
     )
     maybe_set_compound(settings, "files", "backend", "FILES_BACKEND")
+    maybe_set_compound(settings, "simple", "backend", "SIMPLE_BACKEND")
     maybe_set_compound(settings, "docs", "backend", "DOCS_BACKEND")
     maybe_set_compound(settings, "sponsorlogos", "backend", "SPONSORLOGOS_BACKEND")
     maybe_set_compound(settings, "origin_cache", "backend", "ORIGIN_CACHE")

--- a/warehouse/legacy/api/simple.py
+++ b/warehouse/legacy/api/simple.py
@@ -18,7 +18,7 @@ from sqlalchemy import func
 from warehouse.cache.http import cache_control
 from warehouse.cache.origin import origin_cache
 from warehouse.packaging.models import JournalEntry, Project
-from warehouse.packaging.utils import _simple_detail, render_simple_detail
+from warehouse.packaging.utils import _simple_detail
 
 
 @view_config(
@@ -72,7 +72,5 @@ def simple_detail(project, request):
 
     # Get the latest serial number for this project.
     request.response.headers["X-PyPI-Last-Serial"] = str(project.last_serial)
-
-    render_simple_detail(project, request, store=True)
 
     return _simple_detail(project, request)

--- a/warehouse/packaging/__init__.py
+++ b/warehouse/packaging/__init__.py
@@ -43,7 +43,9 @@ def includeme(config):
     files_storage_class = config.maybe_dotted(config.registry.settings["files.backend"])
     config.register_service_factory(files_storage_class.create_service, IFileStorage)
 
-    simple_storage_class = config.maybe_dotted(config.registry.settings["simple.backend"])
+    simple_storage_class = config.maybe_dotted(
+        config.registry.settings["simple.backend"]
+    )
     config.register_service_factory(simple_storage_class.create_service, ISimpleStorage)
 
     docs_storage_class = config.maybe_dotted(config.registry.settings["docs.backend"])

--- a/warehouse/packaging/__init__.py
+++ b/warehouse/packaging/__init__.py
@@ -17,7 +17,7 @@ from warehouse import db
 from warehouse.accounts.models import Email, User
 from warehouse.cache.origin import key_factory, receive_set
 from warehouse.manage.tasks import update_role_invitation_status
-from warehouse.packaging.interfaces import IDocsStorage, IFileStorage
+from warehouse.packaging.interfaces import IDocsStorage, IFileStorage, ISimpleStorage
 from warehouse.packaging.models import File, Project, Release, Role
 from warehouse.packaging.tasks import (  # sync_bigquery_release_files,
     compute_trending,
@@ -42,6 +42,9 @@ def includeme(config):
     # our package files.
     files_storage_class = config.maybe_dotted(config.registry.settings["files.backend"])
     config.register_service_factory(files_storage_class.create_service, IFileStorage)
+
+    simple_storage_class = config.maybe_dotted(config.registry.settings["simple.backend"])
+    config.register_service_factory(simple_storage_class.create_service, ISimpleStorage)
 
     docs_storage_class = config.maybe_dotted(config.registry.settings["docs.backend"])
     config.register_service_factory(docs_storage_class.create_service, IDocsStorage)

--- a/warehouse/packaging/interfaces.py
+++ b/warehouse/packaging/interfaces.py
@@ -34,6 +34,27 @@ class IFileStorage(Interface):
         """
 
 
+class ISimpleStorage(Interface):
+    def create_service(context, request):
+        """
+        Create the service, given the context and request for which it is being
+        created for, passing a name for settings.
+        """
+
+    def get(path):
+        """
+        Return a file like object that can be read to access the file located
+        at the given path.
+        """
+
+    def store(path, file_path, *, meta=None):
+        """
+        Save the file located at file_path to the file storage at the location
+        specified by path. An additional meta keyword argument may contain
+        extra information that an implementation may or may not store.
+        """
+
+
 class IDocsStorage(Interface):
     def create_service(context, request):
         """

--- a/warehouse/packaging/interfaces.py
+++ b/warehouse/packaging/interfaces.py
@@ -13,7 +13,7 @@
 from zope.interface import Interface
 
 
-class IFileStorage(Interface):
+class IGenericFileStorage(Interface):
     def create_service(context, request):
         """
         Create the service, given the context and request for which it is being
@@ -34,25 +34,12 @@ class IFileStorage(Interface):
         """
 
 
-class ISimpleStorage(Interface):
-    def create_service(context, request):
-        """
-        Create the service, given the context and request for which it is being
-        created for, passing a name for settings.
-        """
+class IFileStorage(IGenericFileStorage):
+    pass
 
-    def get(path):
-        """
-        Return a file like object that can be read to access the file located
-        at the given path.
-        """
 
-    def store(path, file_path, *, meta=None):
-        """
-        Save the file located at file_path to the file storage at the location
-        specified by path. An additional meta keyword argument may contain
-        extra information that an implementation may or may not store.
-        """
+class ISimpleStorage(IGenericFileStorage):
+    pass
 
 
 class IDocsStorage(Interface):

--- a/warehouse/packaging/services.py
+++ b/warehouse/packaging/services.py
@@ -21,7 +21,7 @@ import sentry_sdk
 
 from zope.interface import implementer
 
-from warehouse.packaging.interfaces import IDocsStorage, IFileStorage
+from warehouse.packaging.interfaces import IDocsStorage, IFileStorage, ISimpleStorage
 
 
 class InsecureStorageWarning(UserWarning):
@@ -53,6 +53,38 @@ class LocalFileStorage:
 
     def store(self, path, file_path, *, meta=None):
         destination = os.path.join(self.base, path)
+        os.makedirs(os.path.dirname(destination), exist_ok=True)
+        with open(destination, "wb") as dest_fp:
+            with open(file_path, "rb") as src_fp:
+                dest_fp.write(src_fp.read())
+
+
+@implementer(ISimpleStorage)
+class LocalSimpleStorage:
+    def __init__(self, base):
+        # This class should not be used in production, it's trivial for it to
+        # be used to read arbitrary files from the disk. It is intended ONLY
+        # for local development with trusted users. To make this clear, we'll
+        # raise a warning.
+        warnings.warn(
+            "LocalSimpleStorage is intended only for use in development, you "
+            "should not use it in production due to the lack of safe guards "
+            "for safely locating files on disk.",
+            InsecureStorageWarning,
+        )
+
+        self.base = base
+
+    @classmethod
+    def create_service(cls, context, request):
+        return cls(request.registry.settings["simple.path"])
+
+    def get(self, path):
+        return open(os.path.join(self.base, path), "rb")
+
+    def store(self, path, file_path, *, meta=None):
+        destination = os.path.join(self.base, path)
+        print(destination)
         os.makedirs(os.path.dirname(destination), exist_ok=True)
         with open(destination, "wb") as dest_fp:
             with open(file_path, "rb") as src_fp:
@@ -138,6 +170,37 @@ class S3FileStorage(GenericFileStorage):
         self.bucket.upload_file(file_path, path, ExtraArgs=extra_args)
 
 
+@implementer(ISimpleStorage)
+class S3SimpleStorage(GenericFileStorage):
+    @classmethod
+    def create_service(cls, context, request):
+        session = request.find_service(name="aws.session")
+        s3 = session.resource("s3")
+        bucket = s3.Bucket(request.registry.settings["files.bucket"])
+        prefix = request.registry.settings.get("files.prefix")
+        return cls(bucket, prefix=prefix)
+
+    def get(self, path):
+        # Note: this is not actually used in production, instead our CDN is
+        # configured to connect directly to our storage bucket. See:
+        # https://github.com/python/pypi-infra/blob/master/terraform/file-hosting/vcl/main.vcl
+        try:
+            return self.bucket.Object(self._get_path(path)).get()["Body"]
+        except botocore.exceptions.ClientError as exc:
+            if exc.response["Error"]["Code"] != "NoSuchKey":
+                raise
+            raise FileNotFoundError("No such key: {!r}".format(path)) from None
+
+    def store(self, path, file_path, *, meta=None):
+        extra_args = {}
+        if meta is not None:
+            extra_args["Metadata"] = meta
+
+        path = self._get_path(path)
+
+        self.bucket.upload_file(file_path, path, ExtraArgs=extra_args)
+
+
 @implementer(IDocsStorage)
 class S3DocsStorage:
     def __init__(self, s3_client, bucket_name, *, prefix=None):
@@ -173,6 +236,56 @@ class S3DocsStorage:
 
 @implementer(IFileStorage)
 class GCSFileStorage(GenericFileStorage):
+    @classmethod
+    @google.api_core.retry.Retry(
+        predicate=google.api_core.retry.if_exception_type(
+            google.api_core.exceptions.ServiceUnavailable
+        )
+    )
+    def create_service(cls, context, request):
+        storage_client = request.find_service(name="gcloud.gcs")
+        bucket_name = request.registry.settings["files.bucket"]
+        bucket = storage_client.get_bucket(bucket_name)
+        prefix = request.registry.settings.get("files.prefix")
+
+        return cls(bucket, prefix=prefix)
+
+    def get(self, path):
+        # Note: this is not actually used in production, instead our CDN is
+        # configured to connect directly to our storage bucket. See:
+        # https://github.com/python/pypi-infra/blob/master/terraform/file-hosting/vcl/main.vcl
+        raise NotImplementedError
+
+    @google.api_core.retry.Retry(
+        predicate=google.api_core.retry.if_exception_type(
+            google.api_core.exceptions.ServiceUnavailable
+        )
+    )
+    def store(self, path, file_path, *, meta=None):
+        path = self._get_path(path)
+        blob = self.bucket.blob(path)
+        if meta is not None:
+            blob.metadata = meta
+
+        # Our upload is not fully transactional, meaning that this upload may
+        # succeed, and the corresponding write to DB may fail. If/when that
+        # happens, the distribution will not be on PyPI, but the file will be
+        # in the object store, and future repeated upload attempts will fail
+        # due missing DB entries for this file, and due to our object store
+        # disallowing overwrites.
+        #
+        # Because the file_path always includes the file's hash (that we
+        # calculate on upload) we can be assured that any attempt to upload a
+        # blob that already exists is a result of this edge case, and we can
+        # safely skip the upload.
+        if not blob.exists():
+            blob.upload_from_filename(file_path)
+        else:
+            sentry_sdk.capture_message(f"Skipped uploading duplicate file: {file_path}")
+
+
+@implementer(ISimpleStorage)
+class GCSSimpleStorage(GenericFileStorage):
     @classmethod
     @google.api_core.retry.Retry(
         predicate=google.api_core.retry.if_exception_type(

--- a/warehouse/packaging/services.py
+++ b/warehouse/packaging/services.py
@@ -84,7 +84,6 @@ class LocalSimpleStorage:
 
     def store(self, path, file_path, *, meta=None):
         destination = os.path.join(self.base, path)
-        print(destination)
         os.makedirs(os.path.dirname(destination), exist_ok=True)
         with open(destination, "wb") as dest_fp:
             with open(file_path, "rb") as src_fp:

--- a/warehouse/packaging/utils.py
+++ b/warehouse/packaging/utils.py
@@ -1,0 +1,36 @@
+import hashlib
+import os.path
+
+from jinja2 import Environment, FileSystemLoader
+
+import warehouse
+
+from warehouse.legacy.api.simple import _simple_detail
+
+
+def render_simple_detail(project, request, store=False):
+    context = _simple_detail(project, request)
+
+    #  TODO: use pyramid_jinja2 "get_jinja2_environment" method instead:
+    #  https://docs.pylonsproject.org/projects/pyramid_jinja2/en/latest/api.html#pyramid_jinja2.get_jinja2_environment
+    dir_name = os.path.join(os.path.dirname(warehouse.__file__), "templates")
+    env = Environment(
+        loader=FileSystemLoader(dir_name),
+        extensions=[],
+        cache_size=0,
+    )
+
+    template = env.get_template("legacy/api/simple/detail.html")
+    content = template.render(**context, request=request)
+
+    content_hasher = hashlib.blake2b(digest_size=256 // 8)
+    content_hasher.update(content.encode("utf-8"))
+    content_hash = content_hasher.hexdigest().lower()
+    simple_detail_path = f"/simple/{project.normalized_name}/{content_hash}/"
+
+    if store:
+        #  TODO: Store generated file in FileStorage
+        #        We should probably configure a new FileStorage for a new simple-files bucket in GCS
+        pass
+
+    return (content_hash, simple_detail_path)

--- a/warehouse/packaging/utils.py
+++ b/warehouse/packaging/utils.py
@@ -47,7 +47,9 @@ def render_simple_detail(project, request, store=False):
     content_hasher.update(content.encode("utf-8"))
     content_hash = content_hasher.hexdigest().lower()
 
-    simple_detail_path = f"{project.normalized_name}/{content_hash}.{project.normalized_name}.html"
+    simple_detail_path = (
+        f"{project.normalized_name}/{content_hash}.{project.normalized_name}.html"
+    )
 
     if store:
         storage = request.find_service(ISimpleStorage)

--- a/warehouse/packaging/utils.py
+++ b/warehouse/packaging/utils.py
@@ -1,7 +1,7 @@
 import hashlib
 import os.path
 
-from jinja2 import Environment, FileSystemLoader
+from pyramid_jinja2 import IJinja2Environment
 
 import warehouse
 
@@ -11,15 +11,7 @@ from warehouse.legacy.api.simple import _simple_detail
 def render_simple_detail(project, request, store=False):
     context = _simple_detail(project, request)
 
-    #  TODO: use pyramid_jinja2 "get_jinja2_environment" method instead:
-    #  https://docs.pylonsproject.org/projects/pyramid_jinja2/en/latest/api.html#pyramid_jinja2.get_jinja2_environment
-    dir_name = os.path.join(os.path.dirname(warehouse.__file__), "templates")
-    env = Environment(
-        loader=FileSystemLoader(dir_name),
-        extensions=[],
-        cache_size=0,
-    )
-
+    env = request.registry.queryUtility(IJinja2Environment, name=".jinja2")
     template = env.get_template("legacy/api/simple/detail.html")
     content = template.render(**context, request=request)
 

--- a/warehouse/packaging/utils.py
+++ b/warehouse/packaging/utils.py
@@ -46,7 +46,7 @@ def render_simple_detail(project, request, store=False):
     content_hasher.update(content.encode("utf-8"))
     content_hash = content_hasher.hexdigest().lower()
 
-    simple_detail_path = f"{content_hash}.{project.normalized_name}"
+    simple_detail_path = f"{project.normalized_name}/{content_hash}.{project.normalized_name}.html"
     #  should we maybe do something similar to how packages are stored like...
     #  simple_detail_path = (
     #      "/".join(

--- a/warehouse/packaging/utils.py
+++ b/warehouse/packaging/utils.py
@@ -11,6 +11,7 @@
 # limitations under the License.
 
 import hashlib
+import os.path
 import tempfile
 
 from packaging.version import parse
@@ -47,17 +48,6 @@ def render_simple_detail(project, request, store=False):
     content_hash = content_hasher.hexdigest().lower()
 
     simple_detail_path = f"{project.normalized_name}/{content_hash}.{project.normalized_name}.html"
-    #  should we maybe do something similar to how packages are stored like...
-    #  simple_detail_path = (
-    #      "/".join(
-    #          [
-    #              content_hash[:2],
-    #              content_hash[2:4],
-    #              content_hash[4:],
-    #          ]
-    #      )
-    #      + f".{project.normalized_name}"
-    #  )
 
     if store:
         storage = request.find_service(ISimpleStorage)
@@ -68,6 +58,7 @@ def render_simple_detail(project, request, store=False):
                 f.name,
                 meta={
                     "project": project.normalized_name,
+                    "pypi-last-serial": project.last_serial,
                     "hash": content_hash,
                 },
             )
@@ -76,6 +67,7 @@ def render_simple_detail(project, request, store=False):
                 f.name,
                 meta={
                     "project": project.normalized_name,
+                    "pypi-last-serial": project.last_serial,
                     "hash": content_hash,
                 },
             )

--- a/warehouse/packaging/utils.py
+++ b/warehouse/packaging/utils.py
@@ -33,7 +33,19 @@ def render_simple_detail(project, request, store=False):
     content_hasher = hashlib.blake2b(digest_size=256 // 8)
     content_hasher.update(content.encode("utf-8"))
     content_hash = content_hasher.hexdigest().lower()
-    simple_detail_path = f"{project.normalized_name}/{content_hash}.html"
+
+    simple_detail_path = f"{content_hash}.{project.normalized_name}"
+    #  should we maybe do something similar to how packages are stored like...
+    #  simple_detail_path = (
+    #      "/".join(
+    #          [
+    #              content_hash[:2],
+    #              content_hash[2:4],
+    #              content_hash[4:],
+    #          ]
+    #      )
+    #      + f".{project.normalized_name}"
+    #  )
 
     if store:
         storage = request.find_service(ISimpleStorage)
@@ -41,6 +53,14 @@ def render_simple_detail(project, request, store=False):
             f.write(content.encode("utf-8"))
             storage.store(
                 simple_detail_path,
+                f.name,
+                meta={
+                    "project": project.normalized_name,
+                    "hash": content_hash,
+                },
+            )
+            storage.store(
+                project.normalized_name,
                 f.name,
                 meta={
                     "project": project.normalized_name,

--- a/warehouse/packaging/utils.py
+++ b/warehouse/packaging/utils.py
@@ -72,7 +72,7 @@ def render_simple_detail(project, request, store=False):
                 },
             )
             storage.store(
-                project.normalized_name,
+                os.path.join(project.normalized_name, "index.html"),
                 f.name,
                 meta={
                     "project": project.normalized_name,

--- a/warehouse/packaging/utils.py
+++ b/warehouse/packaging/utils.py
@@ -1,3 +1,15 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import hashlib
 import tempfile
 

--- a/warehouse/packaging/utils.py
+++ b/warehouse/packaging/utils.py
@@ -1,28 +1,51 @@
 import hashlib
-import os.path
+import tempfile
 
+from packaging.version import parse
 from pyramid_jinja2 import IJinja2Environment
+from sqlalchemy.orm import joinedload
 
-import warehouse
+from warehouse.packaging.interfaces import ISimpleStorage
+from warehouse.packaging.models import File, Release
 
-from warehouse.legacy.api.simple import _simple_detail
+
+def _simple_detail(project, request):
+   # Get all of the files for this project.
+    files = sorted(
+        request.db.query(File)
+        .options(joinedload(File.release))
+        .join(Release)
+        .filter(Release.project == project)
+        .all(),
+        key=lambda f: (parse(f.release.version), f.filename),
+    )
+
+    return {"project": project, "files": files}
 
 
 def render_simple_detail(project, request, store=False):
     context = _simple_detail(project, request)
 
     env = request.registry.queryUtility(IJinja2Environment, name=".jinja2")
-    template = env.get_template("legacy/api/simple/detail.html")
+    template = env.get_template("templates/legacy/api/simple/detail.html")
     content = template.render(**context, request=request)
 
     content_hasher = hashlib.blake2b(digest_size=256 // 8)
     content_hasher.update(content.encode("utf-8"))
     content_hash = content_hasher.hexdigest().lower()
-    simple_detail_path = f"/simple/{project.normalized_name}/{content_hash}/"
+    simple_detail_path = f"{project.normalized_name}/{content_hash}.html"
 
     if store:
-        #  TODO: Store generated file in FileStorage
-        #        We should probably configure a new FileStorage for a new simple-files bucket in GCS
-        pass
+        storage = request.find_service(ISimpleStorage)
+        with tempfile.NamedTemporaryFile() as f:
+            f.write(content.encode('utf-8'))
+            storage.store(
+                simple_detail_path,
+                f.name,
+                meta={
+                    "project": project.normalized_name,
+                    "hash": content_hash,
+                },
+            )
 
     return (content_hash, simple_detail_path)

--- a/warehouse/packaging/utils.py
+++ b/warehouse/packaging/utils.py
@@ -10,7 +10,7 @@ from warehouse.packaging.models import File, Release
 
 
 def _simple_detail(project, request):
-   # Get all of the files for this project.
+    # Get all of the files for this project.
     files = sorted(
         request.db.query(File)
         .options(joinedload(File.release))
@@ -38,7 +38,7 @@ def render_simple_detail(project, request, store=False):
     if store:
         storage = request.find_service(ISimpleStorage)
         with tempfile.NamedTemporaryFile() as f:
-            f.write(content.encode('utf-8'))
+            f.write(content.encode("utf-8"))
             storage.store(
                 simple_detail_path,
                 f.name,

--- a/warehouse/packaging/utils.py
+++ b/warehouse/packaging/utils.py
@@ -55,6 +55,8 @@ def render_simple_detail(project, request, store=False):
         storage = request.find_service(ISimpleStorage)
         with tempfile.NamedTemporaryFile() as f:
             f.write(content.encode("utf-8"))
+            f.flush()
+
             storage.store(
                 simple_detail_path,
                 f.name,


### PR DESCRIPTION
Needed for #8487.

Exposes `packaging.utils.render_simple_detail` for use in TUF integration.

```
def render_simple_detail(project, request, store=False):
```

Returns `(content_hash, simple_detail_path)`

The `store` flag can be used to control wether the resulting rendered/hashed simple detail page is pushed to our storage service.