### PR TITLE
Caveats should return True or False, not raise

### DIFF
--- a/warehouse/macaroons/services.py
+++ b/warehouse/macaroons/services.py
@@ -97,10 +97,11 @@ class DatabaseMacaroonService:
 
         return dm.user.id
 
-    def verify(self, raw_macaroon, context, principals, permission):
+    def verify(self, raw_macaroon, context, principals, permission) -> None:
         """
-        Returns True if the given raw (serialized) macaroon is
+        Passes if the given raw (serialized) macaroon is
         valid for the context, principals, and requested permission.
+        Updates the last_used date for the macaroon.
 
         Raises InvalidMacaroon if the macaroon is not valid.
         """
@@ -111,11 +112,8 @@ class DatabaseMacaroonService:
             raise InvalidMacaroon("deleted or nonexistent macaroon")
 
         verifier = Verifier(m, context, principals, permission)
-        if verifier.verify(dm.key):
-            dm.last_used = datetime.datetime.now()
-            return True
-
-        raise InvalidMacaroon("invalid macaroon")
+        verifier.verify(dm.key)
+        dm.last_used = datetime.datetime.now()
 
     def create_macaroon(self, location, user_id, description, caveats):
         """


### PR DESCRIPTION
This is #8562 with one more commit to take care of #8591/#8565.
EDIT: Actually no, read below for detail, but this PR does 1 thing: make the code much more explicit regarding raising vs returning False in macaroon-related code to express the idea that there was a problem when verifying a macaroon.

In addition to the 100% coverage that has proven unsufficient twice in a row, here are the tests I did:

```console
$ git rev-parse --short HEAD
dbf49b83

$ cat ~/.pypirc|grep -v password
[distutils]
index-servers =
    pypi
    testpypi
    local-warehouse

[...]

[local-warehouse]
repository = http://localhost/legacy/
username = __token__

$ cd ../umbrella
$ twine upload -r local-warehouse dist/*
Uploading distributions to http://localhost/legacy/
Uploading raincoat_umbrella-1.0.0-py2-none-any.whl
100%|████████████████████████████████████████████████████████████████████████████████████████| 7.94k/7.94k [00:02<00:00, 2.85kB/s]
Uploading raincoat_umbrella-1.0.0-py3-none-any.whl
100%|████████████████████████████████████████████████████████████████████████████████████████| 8.70k/8.70k [00:03<00:00, 2.88kB/s]
Uploading raincoat-umbrella-1.0.0.tar.gz
100%|████████████████████████████████████████████████████████████████████████████████████████| 6.78k/6.78k [00:00<00:00, 31.2kB/s]
```

I've tested that the same twine upload on my previous PR failed, and now it works.

That being said, I want to add integration tests too, to avoid regressions. I'll add the integration tests in a different unrelated PR that we can merge before this one to make sure.