### PR TITLE
Manage releases: Move brackets tighter (like this) to avoid inner spaces ( like this )

### DIFF
--- a/warehouse/templates/manage/releases.html
+++ b/warehouse/templates/manage/releases.html
@@ -47,11 +47,11 @@
           {{ count }} files
         {% endtrans %}
         (<span dir="ltr">
-        {% for packagetype, packagetype_count in version_to_file_counts[release.version].items() %}
+        {%- for packagetype, packagetype_count in version_to_file_counts[release.version].items() -%}
           {%- if packagetype != 'total' -%}
           {{ packagetype_count }} {{ packagetype|format_package_type }}{{ ", " if not loop.last }}
           {%- endif -%}
-        {% endfor %}
+        {%- endfor -%}
         </span>)
         {% else %}
         {% trans %}No files{% endtrans %}


### PR DESCRIPTION
On release management pages (e.g. https://test.pypi.org/manage/project/prettytable/releases/) there's extra space inside the brackets:

![image](https://user-images.githubusercontent.com/1324225/94731658-d2547100-036d-11eb-93d8-d532f65123d3.png)

Add minuses to `{%- ... -%}` to strip the extra space.

---

# Before

Tested with this minimal repro:

```python
from jinja2 import Template

things = [
    ("Wheel", 1),
    ("Source", 1),
]

template = Template(
    """
        (<span dir="ltr">
        {% for packagetype, packagetype_count in things %}
          {%- if True -%}
          {{ packagetype_count }} {{ packagetype }}{{ ", " if not loop.last }}
          {%- endif -%}
        {% endfor %}
        </span>)
    """
)

print(template.render(things=things))
```
Outputs:
```html
        (<span dir="ltr">
        1 Wheel, 1 Source
        </span>)
```

# After


```python
from jinja2 import Template

things = [
    ("Wheel", 1),
    ("Source", 1),
]

template = Template(
    """
        (<span dir="ltr">
        {%- for packagetype, packagetype_count in things -%}
          {%- if True -%}
          {{ packagetype_count }} {{ packagetype }}{{ ", " if not loop.last }}
          {%- endif -%}
        {%- endfor -%}
        </span>)
    """
)

print(template.render(things=things))
```
Outputs:
```html
        (<span dir="ltr">1 Wheel, 1 Source</span>)
```