### PR TITLE
Add Sphinx configuration

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,3 +9,9 @@ version: 2
 python:
   install:
     - requirements: requirements/docs.txt
+
+# Sphinx configuration
+sphinx:
+  builder: dirhtml
+  configuration: conf.py
+  fail_on_warning: true


### PR DESCRIPTION
The changes in #8625 made it so that Sphinx is configured via this file rather than via the web UI. This should ensure that we're using the `dirhtml` builder rather than the default `html` builder.