### PR TITLE
Add minimum _resets_in to XML-RPC ratelimit error

### DIFF
--- a/warehouse/legacy/api/xmlrpc/views.py
+++ b/warehouse/legacy/api/xmlrpc/views.py
@@ -126,7 +126,7 @@ def ratelimit():
                 )
                 _resets_in = ratelimiter.resets_in(request.remote_addr)
                 if _resets_in is not None:
-                    _resets_in = int(_resets_in.total_seconds())
+                    _resets_in = max(1, int(_resets_in.total_seconds()))
                     message += f" Limit may reset in {_resets_in} seconds."
                 raise XMLRPCWrappedError(HTTPTooManyRequests(message))
             metrics.increment("warehouse.xmlrpc.ratelimiter.hit", tags=[])


### PR DESCRIPTION
Without this the message may include a zero-value due to a fractional timedelta, e.g.:

```
xmlrpc.client.Fault: <Fault -32500: 'HTTPTooManyRequests: The action could
not be performed because there were too many requests by the client. Limit
may reset in 0 seconds.'>
```