### PR TITLE
Fix admin project detail prohibit rollup 

### DIFF
--- a/warehouse/admin/templates/admin/projects/detail.html
+++ b/warehouse/admin/templates/admin/projects/detail.html
@@ -296,7 +296,7 @@
             <textarea name="comment" class="form-control" id="prohibitedComment" rows="3" placeholder="Enter comment ..." {{ "disabled" if not request.has_permission('admin') }}></textarea>
           </div>
         </div>
-      
+
         <div class="box-footer">
           <div class="pull-right">
             <button type="submit" class="btn btn-primary" title="{{ "Submitting requires superuser privileges" if not request.has_permission('admin') }}"  {{ "disabled" if not request.has_permission('admin') }}>Submit</button>

--- a/warehouse/admin/templates/admin/projects/detail.html
+++ b/warehouse/admin/templates/admin/projects/detail.html
@@ -287,21 +287,23 @@
       </div>
     </div>
 
-    <form method="GET" action="{{ request.route_path('admin.prohibited_project_names.add') }}">
-      <input name="project" type="hidden" value="{{ project.normalized_name }}">
-      <div class="box-body">
-        <div class="form-group col-sm-12">
-          <label for="prohibitedComment">Comment</label>
-          <textarea name="comment" class="form-control" id="prohibitedComment" rows="3" placeholder="Enter comment ..." {{ "disabled" if not request.has_permission('admin') }}></textarea>
-        </div>
-      </div>
+    <div class="box-body">
+        <form method="GET" action="{{ request.route_path('admin.prohibited_project_names.add') }}">
+          <input name="project" type="hidden" value="{{ project.normalized_name }}">
+          <div class="box-body">
+            <div class="form-group col-sm-12">
+              <label for="prohibitedComment">Comment</label>
+              <textarea name="comment" class="form-control" id="prohibitedComment" rows="3" placeholder="Enter comment ..." {{ "disabled" if not request.has_permission('admin') }}></textarea>
+            </div>
+          </div>
 
-      <div class="box-footer">
-        <div class="pull-right">
-          <button type="submit" class="btn btn-primary" title="{{ "Submitting requires superuser privileges" if not request.has_permission('admin') }}"  {{ "disabled" if not request.has_permission('admin') }}>Submit</button>
-        </div>
-      </div>
-    </form>
+          <div class="box-footer">
+            <div class="pull-right">
+              <button type="submit" class="btn btn-primary" title="{{ "Submitting requires superuser privileges" if not request.has_permission('admin') }}"  {{ "disabled" if not request.has_permission('admin') }}>Submit</button>
+            </div>
+          </div>
+        </form>
+    </div>
   </div>
 
 {% endblock %}

--- a/warehouse/admin/templates/admin/projects/detail.html
+++ b/warehouse/admin/templates/admin/projects/detail.html
@@ -288,21 +288,21 @@
     </div>
 
     <div class="box-body">
-        <form method="GET" action="{{ request.route_path('admin.prohibited_project_names.add') }}">
-          <input name="project" type="hidden" value="{{ project.normalized_name }}">
-          <div class="box-body">
-            <div class="form-group col-sm-12">
-              <label for="prohibitedComment">Comment</label>
-              <textarea name="comment" class="form-control" id="prohibitedComment" rows="3" placeholder="Enter comment ..." {{ "disabled" if not request.has_permission('admin') }}></textarea>
-            </div>
+      <form method="GET" action="{{ request.route_path('admin.prohibited_project_names.add') }}">
+        <input name="project" type="hidden" value="{{ project.normalized_name }}">
+        <div class="box-body">
+          <div class="form-group col-sm-12">
+            <label for="prohibitedComment">Comment</label>
+            <textarea name="comment" class="form-control" id="prohibitedComment" rows="3" placeholder="Enter comment ..." {{ "disabled" if not request.has_permission('admin') }}></textarea>
           </div>
-
-          <div class="box-footer">
-            <div class="pull-right">
-              <button type="submit" class="btn btn-primary" title="{{ "Submitting requires superuser privileges" if not request.has_permission('admin') }}"  {{ "disabled" if not request.has_permission('admin') }}>Submit</button>
-            </div>
+        </div>
+      
+        <div class="box-footer">
+          <div class="pull-right">
+            <button type="submit" class="btn btn-primary" title="{{ "Submitting requires superuser privileges" if not request.has_permission('admin') }}"  {{ "disabled" if not request.has_permission('admin') }}>Submit</button>
           </div>
-        </form>
+        </div>
+      </form>
     </div>
   </div>
 


### PR DESCRIPTION
Noticed the admin project details "Prohibit Project Name" collapse button wasn't working. This just adds the container `<div class="box-body">` to fix it.

Review with whitespace off.

![Screen Shot 2020-11-12 at 2 25 39 AM](https://user-images.githubusercontent.com/512288/98908764-e8863e80-248e-11eb-80b0-b9b3b625c38a.png)
