### PR TITLE
Admin UI project detail reindex button

### DIFF
--- a/tests/unit/admin/test_routes.py
+++ b/tests/unit/admin/test_routes.py
@@ -107,6 +107,13 @@ def test_includeme():
             traverse="/{project_name}",
             domain=warehouse,
         ),
+        pretend.call(
+            "admin.project.reindex",
+            "/admin/projects/{project_name}/reindex/",
+            factory="warehouse.packaging.models:ProjectFactory",
+            traverse="/{project_name}",
+            domain=warehouse,
+        ),
         pretend.call("admin.journals.list", "/admin/journals/", domain=warehouse),
         pretend.call(
             "admin.prohibited_project_names.list",

--- a/warehouse/admin/routes.py
+++ b/warehouse/admin/routes.py
@@ -102,6 +102,13 @@ def includeme(config):
         traverse="/{project_name}",
         domain=warehouse,
     )
+    config.add_route(
+        "admin.project.reindex",
+        "/admin/projects/{project_name}/reindex/",
+        factory="warehouse.packaging.models:ProjectFactory",
+        traverse="/{project_name}",
+        domain=warehouse,
+    )
 
     # Journal related Admin pages
     config.add_route("admin.journals.list", "/admin/journals/", domain=warehouse)

--- a/warehouse/admin/templates/admin/projects/detail.html
+++ b/warehouse/admin/templates/admin/projects/detail.html
@@ -320,7 +320,7 @@
       <form method="GET" action="{{ request.route_path('admin.project.reindex', project_name=project.normalized_name) }}">
         <div class="box-footer">
           <div class="pull-right">
-            <button type="submit" class="btn btn-primary" title="{{ "Submitting requires superuser privileges" if not request.has_permission('admin') }}"  {{ "disabled" if not request.has_permission('admin') }}>Reindex</button>
+            <button type="submit" class="btn btn-primary">Reindex</button>
           </div>
         </div>
       </form>

--- a/warehouse/admin/templates/admin/projects/detail.html
+++ b/warehouse/admin/templates/admin/projects/detail.html
@@ -306,4 +306,25 @@
     </div>
   </div>
 
+  <!-- ReindexProject form -->
+  <div class="box box-secondary collapsed-box">
+    <div class="box-header with-border">
+      <h3 class="box-title">Reindex Project</h3>
+      <div class="box-tools">
+        <button class="btn btn-box-tool" data-widget="collapse" data-toggle="tooltip" title="Expand"><i class="fa fa-plus"></i></button>
+      </div>
+    </div>
+
+    <div class="box-body">
+      <p>Trigger reindex for this project</p>
+      <form method="GET" action="{{ request.route_path('admin.project.reindex', project_name=project.normalized_name) }}">
+        <div class="box-footer">
+          <div class="pull-right">
+            <button type="submit" class="btn btn-primary" title="{{ "Submitting requires superuser privileges" if not request.has_permission('admin') }}"  {{ "disabled" if not request.has_permission('admin') }}>Reindex</button>
+          </div>
+        </div>
+      </form>
+    </div>
+  </div>
+
 {% endblock %}

--- a/warehouse/admin/views/projects.py
+++ b/warehouse/admin/views/projects.py
@@ -22,6 +22,7 @@ from sqlalchemy.orm.exc import NoResultFound
 from warehouse.accounts.models import User
 from warehouse.forklift.legacy import MAX_FILESIZE, MAX_PROJECT_SIZE
 from warehouse.packaging.models import JournalEntry, Project, Release, Role
+from warehouse.search.tasks import reindex_project as _reindex_project
 from warehouse.utils.paginate import paginate_url_factory
 from warehouse.utils.project import confirm_project, remove_project
 
@@ -465,3 +466,20 @@ def delete_project(project, request):
     remove_project(project, request)
 
     return HTTPSeeOther(request.route_path("admin.project.list"))
+
+
+@view_config(
+    route_name="admin.project.reindex",
+    permission="admin",
+    request_method="GET",
+    uses_session=True,
+    require_methods=False,
+)
+def reindex_project(project, request):
+    request.task(_reindex_project).delay(project.normalized_name)
+    request.session.flash(
+        f"Task sent to reindex the project {project.name!r}", queue="success"
+    )
+    return HTTPSeeOther(
+        request.route_path("admin.project.detail", project_name=project.normalized_name)
+    )

--- a/warehouse/admin/views/projects.py
+++ b/warehouse/admin/views/projects.py
@@ -470,7 +470,7 @@ def delete_project(project, request):
 
 @view_config(
     route_name="admin.project.reindex",
-    permission="admin",
+    permission="moderator",
     request_method="GET",
     uses_session=True,
     require_methods=False,


### PR DESCRIPTION
Refs #8321

Was mentioned in issue that an admin UI reindex button would be helpful. This adds a simple reindex button to the admin UI project detail page to fire off the reindex_project task. 

Unit test mocks the task function and just checks that the task was called and that the UI alert happens. I didn't see any frontend tests for admin views, correct me if i'm wrong, so I didn't add any.

![YwYZ79gfuj](https://user-images.githubusercontent.com/512288/98984922-d3da9280-24f0-11eb-85f5-7bceb9128ba1.gif)
