### PR TITLE
Send added-as-collaborator email in same thread

### DIFF
--- a/tests/unit/email/test_init.py
+++ b/tests/unit/email/test_init.py
@@ -1482,16 +1482,16 @@ class TestAddedAsCollaboratorEmail:
         )
 
         assert result == {
-            "project": "test_project",
+            "project_name": "test_project",
             "role": "Owner",
-            "submitter": stub_submitter_user.username,
+            "initiator_username": stub_submitter_user.username,
         }
         subject_renderer.assert_()
-        body_renderer.assert_(submitter=stub_submitter_user.username)
-        body_renderer.assert_(project="test_project")
+        body_renderer.assert_(initiator_username=stub_submitter_user.username)
+        body_renderer.assert_(project_name="test_project")
         body_renderer.assert_(role="Owner")
-        html_renderer.assert_(submitter=stub_submitter_user.username)
-        html_renderer.assert_(project="test_project")
+        html_renderer.assert_(initiator_username=stub_submitter_user.username)
+        html_renderer.assert_(project_name="test_project")
         html_renderer.assert_(role="Owner")
 
         assert pyramid_request.task.calls == [pretend.call(send_email)]
@@ -1572,16 +1572,16 @@ class TestAddedAsCollaboratorEmail:
         )
 
         assert result == {
-            "project": "test_project",
+            "project_name": "test_project",
             "role": "Owner",
-            "submitter": stub_submitter_user.username,
+            "initiator_username": stub_submitter_user.username,
         }
         subject_renderer.assert_()
-        body_renderer.assert_(submitter=stub_submitter_user.username)
-        body_renderer.assert_(project="test_project")
+        body_renderer.assert_(initiator_username=stub_submitter_user.username)
+        body_renderer.assert_(project_name="test_project")
         body_renderer.assert_(role="Owner")
-        html_renderer.assert_(submitter=stub_submitter_user.username)
-        html_renderer.assert_(project="test_project")
+        html_renderer.assert_(initiator_username=stub_submitter_user.username)
+        html_renderer.assert_(project_name="test_project")
         html_renderer.assert_(role="Owner")
 
         assert pyramid_request.task.calls == []

--- a/warehouse/email/__init__.py
+++ b/warehouse/email/__init__.py
@@ -256,7 +256,11 @@ def send_project_role_verification_email(
 
 @_email("added-as-collaborator")
 def send_added_as_collaborator_email(request, user, *, submitter, project_name, role):
-    return {"project": project_name, "submitter": submitter.username, "role": role}
+    return {
+        "project_name": project_name,
+        "initiator_username": submitter.username,
+        "role": role,
+    }
 
 
 @_email("collaborator-removed")

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -1230,14 +1230,14 @@ msgstr ""
 #, python-format
 msgid ""
 "You have been added as <strong>%(role)s</strong> to the %(site)s project "
-"%(project)s by %(submitter)s."
+"%(project_name)s by %(initiator_username)s."
 msgstr ""
 
 #: warehouse/templates/email/added-as-collaborator/body.html:24
 #, python-format
 msgid ""
-"You are receiving this because you have been added by %(submitter)s to a "
-"project on %(site)s."
+"You are receiving this because you have been added by "
+"%(initiator_username)s to a project on %(site)s."
 msgstr ""
 
 #: warehouse/templates/email/password-change/body.html:18

--- a/warehouse/templates/email/added-as-collaborator/body.html
+++ b/warehouse/templates/email/added-as-collaborator/body.html
@@ -16,10 +16,10 @@
 {% set site = request.registry.settings["site.name"] %}
 
 {% block content %}
-<p>{% trans role=role, site=site, project=project, submitter=submitter %}You have been added as <strong>{{ role }}</strong> to the {{ site }} project {{ project }} by {{ submitter }}.{% endtrans %}</p>
+<p>{% trans role=role, site=site, project_name=project_name, initiator_username=initiator_username %}You have been added as <strong>{{ role }}</strong> to the {{ site }} project {{ project_name }} by {{ initiator_username }}.{% endtrans %}</p>
 {% endblock %}
 
 
 {% block reason %}
-{% trans submitter=submitter, site=site %}You are receiving this because you have been added by {{ submitter }} to a project on {{ site }}.{% endtrans %}
+{% trans initiator_username=initiator_username, site=site %}You are receiving this because you have been added by {{ initiator_username }} to a project on {{ site }}.{% endtrans %}
 {% endblock %}

--- a/warehouse/templates/email/added-as-collaborator/body.txt
+++ b/warehouse/templates/email/added-as-collaborator/body.txt
@@ -16,7 +16,7 @@
 {% set site = request.registry.settings["site.name"] %}
 
 {% block content %}
-{% trans role=role, site=site, project=project, submitter=submitter %}You have been added as {{ role }} to the {{ site }} project {{ project }} by {{ submitter }}.{% endtrans %}
+{% trans role=role, site=site, project_name=project_name, initiator_username=initiator_username %}You have been added as {{ role }} to the {{ site }} project {{ project_name }} by {{ initiator_username }}.{% endtrans %}
 {% endblock %}
 
-{% block reason %}{% trans submitter=submitter, site=site %}You are receiving this because you have been added by {{ submitter }} to a project on {{ site }}.{% endtrans %}{% endblock %}
+{% block reason %}{% trans initiator_username=initiator_username, site=site %}You are receiving this because you have been added by {{ initiator_username }} to a project on {{ site }}.{% endtrans %}{% endblock %}

--- a/warehouse/templates/email/added-as-collaborator/subject.txt
+++ b/warehouse/templates/email/added-as-collaborator/subject.txt
@@ -14,4 +14,4 @@
 
 {% extends "email/_base/subject.txt" %}
 
-{% block subject %}{% trans %}Collaborator added notification{% endtrans %}{% endblock %}
+{% block subject %}{{ initiator_username }} has invited you to join the {{ project_name }} project{% endblock %}

--- a/warehouse/templates/manage/projects.html
+++ b/warehouse/templates/manage/projects.html
@@ -19,7 +19,7 @@
 
 {% block main %}
   {% if project_invites %}
-  <h1>{% trans project_count=project_invites|length %}Pending invitations ({{ project_count }}){% endtrans %}</h1>
+  <h1 class="page-title">{% trans project_count=project_invites|length %}Pending invitations ({{ project_count }}){% endtrans %}</h1>
   <div class="package-list">
     {% for project, token in project_invites %}
     {% set release = project.releases[0] if project.releases else None %}


### PR DESCRIPTION
This changes the notification when accepting an collaborator invitation to be in the same thread as the original invitation.