### PR TITLE
allow macosx_11 wheel upload

### DIFF
--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -2566,6 +2566,7 @@ class TestFileUpload:
             "manylinux_3_0_s390x",
             "macosx_10_6_intel",
             "macosx_10_13_x86_64",
+            "macosx_11_0_x86_64",
             # A real tag used by e.g. some numpy wheels
             (
                 "macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64."
@@ -2790,7 +2791,16 @@ class TestFileUpload:
             )
         ]
 
-    @pytest.mark.parametrize("plat", ["linux_x86_64", "linux_x86_64.win32"])
+    @pytest.mark.parametrize(
+        "plat",
+        [
+            "linux_x86_64",
+            "linux_x86_64.win32",
+            "macosx_9_2_x86_64",
+            "macosx_12_2_x86_64",
+            "macosx_10_15_amd64",
+        ],
+    )
     def test_upload_fails_with_unsupported_wheel_plat(
         self, monkeypatch, pyramid_config, db_request, plat
     ):

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -124,7 +124,7 @@ _allowed_platforms = {
     "linux_armv7l",
 }
 # macosx is a little more complicated:
-_macosx_platform_re = re.compile(r"macosx_10_(\d+)_(?P<arch>.*)")
+_macosx_platform_re = re.compile(r"macosx_(10|11)_(\d+)_(?P<arch>.*)")
 _macosx_arches = {
     "ppc",
     "ppc64",


### PR DESCRIPTION
only allow macos 10 and 11, not new amd64 arch tags or not-yet-released macos major versions

stricter short-term alternative to #8881 in case that wants to wait for some further discussion

closes #8870

#8881 or similar is still needed for amd64 wheels, but this expands upload versions to allow for wheels built with current stable Python on current stable macOS.