### PR TITLE
Add a configuration option to disable XMLRPC search

### DIFF
--- a/tests/unit/legacy/api/xmlrpc/test_xmlrpc.py
+++ b/tests/unit/legacy/api/xmlrpc/test_xmlrpc.py
@@ -124,8 +124,9 @@ class TestSearch:
             xmlrpc.search(pyramid_request, {"name": "foo", "summary": ["one", "two"]})
 
         assert exc.value.faultString == (
-            "RuntimeError: This API has been deprecated due to unmanageable load. "
-            "Please use the Simple or JSON API instead."
+            "RuntimeError: This API has been temporarily disabled due to unmanageable "
+            "load and will be deprecated in near future. Please use the Simple or "
+            "JSON API instead."
         )
         assert metrics.increment.calls == [
             pretend.call("warehouse.xmlrpc.search.deprecated")

--- a/tests/unit/legacy/api/xmlrpc/test_xmlrpc.py
+++ b/tests/unit/legacy/api/xmlrpc/test_xmlrpc.py
@@ -125,7 +125,7 @@ class TestSearch:
 
         assert exc.value.faultString == (
             "RuntimeError: This API has been deprecated due to unmanageable load. "
-            "Please Use the Simple or JSON API instead."
+            "Please use the Simple or JSON API instead."
         )
         assert metrics.increment.calls == [
             pretend.call("warehouse.xmlrpc.search.deprecated")

--- a/tests/unit/legacy/api/xmlrpc/test_xmlrpc.py
+++ b/tests/unit/legacy/api/xmlrpc/test_xmlrpc.py
@@ -125,7 +125,7 @@ class TestSearch:
 
         assert exc.value.faultString == (
             "RuntimeError: This API has been temporarily disabled due to unmanageable "
-            "load and will be deprecated in near future. Please use the Simple or "
+            "load and will be deprecated in the near future. Please use the Simple or "
             "JSON API instead."
         )
         assert metrics.increment.calls == [

--- a/tests/unit/legacy/api/xmlrpc/test_xmlrpc.py
+++ b/tests/unit/legacy/api/xmlrpc/test_xmlrpc.py
@@ -114,6 +114,23 @@ class TestRateLimiting:
 
 
 class TestSearch:
+    def test_error_when_disabled(self, pyramid_request, metrics, monkeypatch):
+        monkeypatch.setattr(
+            pyramid_request.registry,
+            "settings",
+            {"warehouse.xmlrpc.search.enabled": False},
+        )
+        with pytest.raises(xmlrpc.XMLRPCWrappedError) as exc:
+            xmlrpc.search(pyramid_request, {"name": "foo", "summary": ["one", "two"]})
+
+        assert exc.value.faultString == (
+            "RuntimeError: This API has been deprecated due to unmanageable load. "
+            "Please Use the Simple or JSON API instead."
+        )
+        assert metrics.increment.calls == [
+            pretend.call("warehouse.xmlrpc.search.deprecated")
+        ]
+
     def test_fails_with_invalid_operator(self, pyramid_request, metrics):
         with pytest.raises(xmlrpc.XMLRPCWrappedError) as exc:
             xmlrpc.search(pyramid_request, {}, "lol nope")

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -230,6 +230,7 @@ def test_configure(monkeypatch, settings, environment, other_settings):
         "token.two_factor.max_age": 300,
         "token.default.max_age": 21600,
         "warehouse.xmlrpc.client.ratelimit_string": "3600 per hour",
+        "warehouse.xmlrpc.search.enabled": True,
     }
 
     if environment == config.Environment.development:

--- a/warehouse/config.py
+++ b/warehouse/config.py
@@ -10,6 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import distutils.util
 import enum
 import os
 import shlex
@@ -183,6 +184,13 @@ def configure(settings=None):
     maybe_set(settings, "token.password.secret", "TOKEN_PASSWORD_SECRET")
     maybe_set(settings, "token.email.secret", "TOKEN_EMAIL_SECRET")
     maybe_set(settings, "token.two_factor.secret", "TOKEN_TWO_FACTOR_SECRET")
+    maybe_set(
+        settings,
+        "warehouse.xmlrpc.search.enabled",
+        "WAREHOUSE_XMLRPC_SEARCH",
+        coercer=distutils.util.strtobool,
+        default=True,
+    )
     maybe_set(settings, "warehouse.xmlrpc.cache.url", "REDIS_URL")
     maybe_set(
         settings,

--- a/warehouse/legacy/api/xmlrpc/views.py
+++ b/warehouse/legacy/api/xmlrpc/views.py
@@ -227,12 +227,27 @@ def exception_view(exc, request):
 
 @xmlrpc_method(method="search")
 def search(request, spec: Mapping[str, Union[str, List[str]]], operator: str = "and"):
+    metrics = request.find_service(IMetricsService, context=None)
+
+    # This uses a setting instead of an admin flag to avoid hitting the DB/Elasticsearch
+    # at all since the broad purpose of this flag is to enable us to control the load to
+    # our backend servers. This does mean that turning search on or off requires a
+    # deploy, but it should be infrequent enough to not matter.
+    if not request.registry.settings.get("warehouse.xmlrpc.search.enabled", True):
+        metrics.increment("warehouse.xmlrpc.search.deprecated")
+        raise XMLRPCWrappedError(
+            RuntimeError(
+                (
+                    "This API has been deprecated due to unmanageable load. Please Use "
+                    "the Simple or JSON API instead."
+                )
+            )
+        )
+
     if operator not in {"and", "or"}:
         raise XMLRPCWrappedError(
             ValueError("Invalid operator, must be one of 'and' or 'or'.")
         )
-
-    metrics = request.find_service(IMetricsService, context=None)
 
     # Remove any invalid spec fields
     spec = {

--- a/warehouse/legacy/api/xmlrpc/views.py
+++ b/warehouse/legacy/api/xmlrpc/views.py
@@ -238,8 +238,9 @@ def search(request, spec: Mapping[str, Union[str, List[str]]], operator: str = "
         raise XMLRPCWrappedError(
             RuntimeError(
                 (
-                    "This API has been deprecated due to unmanageable load. Please use "
-                    "the Simple or JSON API instead."
+                    "This API has been temporarily disabled due to unmanageable load "
+                    "and will be deprecated in near future. Please use the Simple or "
+                    "JSON API instead."
                 )
             )
         )

--- a/warehouse/legacy/api/xmlrpc/views.py
+++ b/warehouse/legacy/api/xmlrpc/views.py
@@ -239,8 +239,8 @@ def search(request, spec: Mapping[str, Union[str, List[str]]], operator: str = "
             RuntimeError(
                 (
                     "This API has been temporarily disabled due to unmanageable load "
-                    "and will be deprecated in near future. Please use the Simple or "
-                    "JSON API instead."
+                    "and will be deprecated in the near future. Please use the Simple "
+                    "or JSON API instead."
                 )
             )
         )

--- a/warehouse/legacy/api/xmlrpc/views.py
+++ b/warehouse/legacy/api/xmlrpc/views.py
@@ -238,7 +238,7 @@ def search(request, spec: Mapping[str, Union[str, List[str]]], operator: str = "
         raise XMLRPCWrappedError(
             RuntimeError(
                 (
-                    "This API has been deprecated due to unmanageable load. Please Use "
+                    "This API has been deprecated due to unmanageable load. Please use "
                     "the Simple or JSON API instead."
                 )
             )


### PR DESCRIPTION
This enables us to enable/disable the XMLRPC search API.

* Config: ``WAREHOUSE_XMLRPC_SEARCH=(y|n|yes|no|t|true|f|false|1|0``
  * Defaults to ``yes``, which will have the search API in a functional, non deprecated, state.
* Metrics: ``warehouse.xmlrpc.search.deprecated``
  * Incremented for every request that gets the deprecation message.

I left the wording purposely vague, which will allow us to either turn it on/off as a load shedding mechanism, or as part of a deprecation path.