### PR TITLE
Remove 'on' from join date string

### DIFF
--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -975,7 +975,7 @@ msgstr ""
 
 #: warehouse/templates/accounts/profile.html:44
 #, python-format
-msgid "Joined on %(start_date)s"
+msgid "Joined %(start_date)s"
 msgstr ""
 
 #: warehouse/templates/accounts/profile.html:58

--- a/warehouse/templates/accounts/profile.html
+++ b/warehouse/templates/accounts/profile.html
@@ -41,7 +41,7 @@
             <div class="author-profile__metadiv">
               <i class="fa fa-calendar-alt" aria-hidden="true"></i>
               <span class="sr-only">{% trans %}Date joined{% endtrans %}</span>
-              &nbsp;&nbsp;{% trans start_date=humanize(user.date_joined) %}Joined on {{ start_date }}{% endtrans %}
+              &nbsp;&nbsp;{% trans start_date=humanize(user.date_joined) %}Joined {{ start_date }}{% endtrans %}
             </div>
             {% endif %}
           </div>


### PR DESCRIPTION
Because this date is humanized, this can currently end up becoming something like:

> Joined on 38 minutes ago

Removing the 'on' works for all humanized dates, not just the most common ones.