### PR TITLE
Switch to using the "system font stack"

### DIFF
--- a/warehouse/static/sass/settings/_fonts.scss
+++ b/warehouse/static/sass/settings/_fonts.scss
@@ -14,7 +14,7 @@
 
 // SETTINGS - FONTS
 
-$base-font-family: "Source Sans Pro", "Helvetica", Arial, sans-serif;
+$base-font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji;
 $code-font: "Source Code Pro", monospace;
 
 


### PR DESCRIPTION
This is a first attempt to close #8634 by switching to a system font stack.

Should I put a line break for the list of fonts? I ran `make reformat` hoping it would sort out my formatting issues but no luck :D

<img width="624" alt="Screenshot 2021-01-12 at 13 44 28" src="https://user-images.githubusercontent.com/1448859/104316146-56290800-54dc-11eb-9b35-7f6dbde6150a.png">

I copied меншого to before the `<em>` tag to make it easier to compare (that is why it appears twice). I think it now uses the same font.

What should I do next? Are there things that can be cleaned up now that Source Sans Pro isn't in use any more?

Are there any conventions around adding `[WIP]` to the PR title or marking it as draft for stuff which needs a bit of hand-holding from an experienced person?