### PR TITLE
Implement PEP 629: specifying the API support of /simple pages

### DIFF
--- a/warehouse/templates/legacy/api/simple/detail.html
+++ b/warehouse/templates/legacy/api/simple/detail.html
@@ -14,6 +14,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <meta name="pypi:repository-version" content="1.0">
     <title>Links for {{ project.name }}</title>
   </head>
   <body>

--- a/warehouse/templates/legacy/api/simple/index.html
+++ b/warehouse/templates/legacy/api/simple/index.html
@@ -14,6 +14,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <meta name="pypi:repository-version" content="1.0">
     <title>Simple index</title>
   </head>
   <body>


### PR DESCRIPTION
The PEP specifically says what PyPI currently does is v1.0.

Closes #9027 