### PR TITLE
Ensure that headers returned from upload endpoint are valid ISO-8895-1

### DIFF
--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -82,11 +82,20 @@ _TAR_BZ2_PKG_STORAGE_HASH = hashlib.blake2b(
 ).hexdigest()
 
 
-def test_exc_with_message():
-    exc = legacy._exc_with_message(HTTPBadRequest, "My Test Message.")
-    assert isinstance(exc, HTTPBadRequest)
-    assert exc.status_code == 400
-    assert exc.status == "400 My Test Message."
+class TestExcWithMessage:
+    def test_exc_with_message(self):
+        exc = legacy._exc_with_message(HTTPBadRequest, "My Test Message.")
+        assert isinstance(exc, HTTPBadRequest)
+        assert exc.status_code == 400
+        assert exc.status == "400 My Test Message."
+
+    def test_exc_with_exotic_message(self):
+        exc = legacy._exc_with_message(
+            HTTPBadRequest, "look at these wild chars: аÃ¤â€—"
+        )
+        assert isinstance(exc, HTTPBadRequest)
+        assert exc.status_code == 400
+        assert exc.status == "400 look at these wild chars: ?Ã¤â??"
 
 
 class TestValidation:

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -213,7 +213,11 @@ def _exc_with_message(exc, message, **kwargs):
     # The crappy old API that PyPI offered uses the status to pass down
     # messages to the client. So this function will make that easier to do.
     resp = exc(detail=message, **kwargs)
-    resp.status = "{} {}".format(resp.status_code, message)
+    # We need to guard against characters outside of iso-8859-1 per RFC.
+    # Specifically here, where user-supplied text may appear in the message,
+    # which our WSGI server may not appropriately handle (indeed gunicorn does not).
+    status_message = message.encode("iso-8859-1", "replace").decode("iso-8859-1")
+    resp.status = "{} {}".format(resp.status_code, status_message)
     return resp
 
 


### PR DESCRIPTION
Because the legacy upload endpoint returns user supplied text, we need to guard against characters in the Status header that the web server (gunicorn in our case) cannot handle.

This roundtrips the message that may contain user supplied text through ISO-8895-1 encoding/decoding before sending it off as a header.