### PR TITLE
Rephrase search error not to say temporarily

### DIFF
--- a/tests/unit/legacy/api/xmlrpc/test_xmlrpc.py
+++ b/tests/unit/legacy/api/xmlrpc/test_xmlrpc.py
@@ -124,7 +124,7 @@ class TestSearch:
             xmlrpc.search(pyramid_request, {"name": "foo", "summary": ["one", "two"]})
 
         assert exc.value.faultString == (
-            "RuntimeError: PyPI's XMLRPC API has been temporarily disabled due to "
+            "RuntimeError: PyPI's XMLRPC API is currently disabled due to "
             "unmanageable load and will be deprecated in the near future. See "
             "https://status.python.org/ for more information."
         )

--- a/warehouse/legacy/api/xmlrpc/views.py
+++ b/warehouse/legacy/api/xmlrpc/views.py
@@ -238,7 +238,7 @@ def search(request, spec: Mapping[str, Union[str, List[str]]], operator: str = "
         raise XMLRPCWrappedError(
             RuntimeError(
                 (
-                    "PyPI's XMLRPC API has been temporarily disabled due to "
+                    "PyPI's XMLRPC API is currently disabled due to "
                     "unmanageable load and will be deprecated in the near "
                     "future. See https://status.python.org/ for more "
                     "information."


### PR DESCRIPTION
It is entirely unnecessary to communicate why xmlrpc is unavailable