### PR TITLE
Add cursor to updates RSS feed.

### DIFF
--- a/docs/api-reference/feeds.rst
+++ b/docs/api-reference/feeds.rst
@@ -21,6 +21,10 @@ Available at https://pypi.org/rss/updates.xml, this feed provides the latest
 newly created releases for individual projects on PyPI, including the project
 name and description, release version, and a link to the release page.
 
+Accepts an optional `before` cursor, which limits results to the latest
+releases before the given UTC integer seconds since the epoch (e.g., the
+``timestamp`` method to a ``datetime.datetime`` object).
+
 
 Project Releases Feed
 ---------------------

--- a/docs/api-reference/feeds.rst
+++ b/docs/api-reference/feeds.rst
@@ -21,7 +21,7 @@ Available at https://pypi.org/rss/updates.xml, this feed provides the latest
 newly created releases for individual projects on PyPI, including the project
 name and description, release version, and a link to the release page.
 
-Accepts an optional `before` cursor, which limits results to the latest
+Accepts an optional ``before`` cursor, which limits results to the latest
 releases before the given UTC integer seconds since the epoch (e.g., the
 ``timestamp`` method to a ``datetime.datetime`` object).
 

--- a/docs/api-reference/feeds.rst
+++ b/docs/api-reference/feeds.rst
@@ -21,9 +21,10 @@ Available at https://pypi.org/rss/updates.xml, this feed provides the latest
 newly created releases for individual projects on PyPI, including the project
 name and description, release version, and a link to the release page.
 
-Accepts an optional ``before`` cursor, which limits results to the latest
-releases before the given UTC integer seconds since the epoch (e.g., the
-``timestamp`` method to a ``datetime.datetime`` object).
+Accepts an optional ``after`` integer cursor, which limits results to the
+releases after the given seconds since the UTC epoch (e.g., the
+``timestamp`` method to a ``datetime.datetime`` object). Note that this changes
+the ordering of the results from newest->oldest to oldest->newest.
 
 
 Project Releases Feed

--- a/tests/unit/rss/test_views.py
+++ b/tests/unit/rss/test_views.py
@@ -46,7 +46,8 @@ def test_rss_updates(db_request):
     }
     assert db_request.response.content_type == "text/xml"
 
-    db_request.params["before"] = release3.created.timestamp()
+    before_cursor = datetime.datetime(release3.created.year, release3.created.month, release3.created.day)
+    db_request.params["before"] = before_cursor.timestamp()
     assert rss.rss_updates(db_request) == {
         "latest_releases": tuple(
             zip((release2, release1), ("noreply@pypi.org", None))

--- a/tests/unit/rss/test_views.py
+++ b/tests/unit/rss/test_views.py
@@ -46,6 +46,13 @@ def test_rss_updates(db_request):
     }
     assert db_request.response.content_type == "text/xml"
 
+    db_request.params["before"] = release3.created.timestamp()
+    assert rss.rss_updates(db_request) == {
+        "latest_releases": tuple(
+            zip((release2, release1), ("noreply@pypi.org", None))
+        )
+    }
+    assert db_request.response.content_type == "text/xml"
 
 def test_rss_packages(db_request):
     db_request.find_service = pretend.call_recorder(

--- a/tests/unit/rss/test_views.py
+++ b/tests/unit/rss/test_views.py
@@ -46,14 +46,15 @@ def test_rss_updates(db_request):
     }
     assert db_request.response.content_type == "text/xml"
 
-    before_cursor = datetime.datetime(release3.created.year, release3.created.month, release3.created.day)
+    before_cursor = datetime.datetime(
+        release3.created.year, release3.created.month, release3.created.day
+    )
     db_request.params["before"] = before_cursor.timestamp()
     assert rss.rss_updates(db_request) == {
-        "latest_releases": tuple(
-            zip((release2, release1), ("noreply@pypi.org", None))
-        )
+        "latest_releases": tuple(zip((release2, release1), ("noreply@pypi.org", None)))
     }
     assert db_request.response.content_type == "text/xml"
+
 
 def test_rss_packages(db_request):
     db_request.find_service = pretend.call_recorder(

--- a/tests/unit/rss/test_views.py
+++ b/tests/unit/rss/test_views.py
@@ -46,12 +46,12 @@ def test_rss_updates(db_request):
     }
     assert db_request.response.content_type == "text/xml"
 
-    before_cursor = datetime.datetime(
-        release3.created.year, release3.created.month, release3.created.day
+    after_cursor = datetime.datetime(
+        release1.created.year, release1.created.month, release1.created.day
     )
-    db_request.params["before"] = before_cursor.timestamp()
+    db_request.params["after"] = after_cursor.timestamp()
     assert rss.rss_updates(db_request) == {
-        "latest_releases": tuple(zip((release2, release1), ("noreply@pypi.org", None)))
+        "latest_releases": tuple(zip((release2, release3), ("noreply@pypi.org", None)))
     }
     assert db_request.response.content_type == "text/xml"
 

--- a/warehouse/rss/views.py
+++ b/warehouse/rss/views.py
@@ -69,10 +69,8 @@ def rss_updates(request):
             after_timestamp = datetime.utcfromtimestamp(int(after_timestamp))
         except ValueError:
             raise HTTPBadRequest("'after' must be an integer") from None
-        query = (
-            query
-                .filter(Release.created > after_timestamp)
-                .order_by(Release.created.asc())
+        query = query.filter(Release.created > after_timestamp).order_by(
+            Release.created.asc()
         )
     else:
         query = query.order_by(Release.created.desc())

--- a/warehouse/rss/views.py
+++ b/warehouse/rss/views.py
@@ -76,7 +76,7 @@ def rss_updates(request):
         .options(joinedload(Release.project))
         .filter(Release.created < before_cursor)
         .order_by(Release.created.desc())
-        .limit(40)
+        .limit(100)
         .all()
     )
     release_authors = [_format_author(release) for release in latest_releases]

--- a/warehouse/rss/views.py
+++ b/warehouse/rss/views.py
@@ -11,9 +11,9 @@
 # limitations under the License.
 
 from datetime import datetime
-
 from email.utils import getaddresses
 
+from pyramid.httpexceptions import HTTPBadRequest
 from pyramid.view import view_config
 from sqlalchemy.orm import joinedload
 
@@ -62,9 +62,10 @@ def _format_author(release):
 )
 def rss_updates(request):
     try:
-        before_cursor_timestamp = int(request.params.get("before", datetime.now().timestamp()))
+        now = datetime.now().timestamp()
+        before_cursor_timestamp = int(request.params.get("before", now))
     except ValueError:
-        raise HTTPBadRequest("'before' must be a UTC timestamp integer in milliseconds.") from None
+        raise HTTPBadRequest("'before' must be an integer") from None
     before_cursor = datetime.utcfromtimestamp(before_cursor_timestamp)
 
     request.response.content_type = "text/xml"


### PR DESCRIPTION
Greetings! I have two changes to propose for the `rss/updates.xml` endpoint:

* adds an `after` cursor parameter: e.g. `https://pypi.org/rss/updates.xml?after=1542745017`. This would only return releases after the timestamp, in oldest->newest order, which should be safe since there's an index on `Release#created`.
* increases the page size from 40 to 100 releases per page. (I couldn't figure out why 40 was the original choice when this endpoint was introduced in https://github.com/pypa/warehouse/pull/990)

This should make the feed more useful to regular followers of it, allow them to hit the endpoint less frequently, and allow a way to catch up using the cursor. The legacy `changelog` XMLRPC call also has a `since` parameter for pagination, so it seemed useful to allow similar pagination in the RSS feed. 