### PR TITLE
Split lint job for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ matrix:
   include:
     - env:
       - SUITE=Tests
-    - script: make lint BINDIR="$(dirname $(which python))"
+    - script: bin/lint
       env:
         - SUITE=Lint
     - script: make docs BINDIR="$(dirname $(which python))"
@@ -61,6 +61,9 @@ matrix:
     - script: bin/static_tests
       env:
         - SUITE="Static Tests"
+    - script: bin/static_lint
+      env:
+        - SUITE="Static Lint"
     - script: bin/static_pipeline
       env:
         - SUITE="Static Pipeline"


### PR DESCRIPTION
#9083 moved the lint job into the container but I forgot to update the Travis config to match. This should make our overall Travis runtime a bit faster while we still have it around.