### PR TITLE
Pin sqlalchemy<1.4.0

### DIFF
--- a/requirements/main.in
+++ b/requirements/main.in
@@ -48,7 +48,7 @@ redis>=2.8.0
 rfc3986
 sentry-sdk
 setuptools
-sqlalchemy>=0.9
+sqlalchemy>=0.9,<1.4.0  # https://github.com/pypa/warehouse/pull/9228
 sqlalchemy-citext
 stdlib-list
 structlog


### PR DESCRIPTION
This introduces a new dependency, `greenlet`, that will cause our depchecker job to fail until we upgrade in  https://github.com/pypa/warehouse/pull/9228.