### PR TITLE
docs: update capitalization of sponsor

### DIFF
--- a/warehouse/templates/includes/sponsors.html
+++ b/warehouse/templates/includes/sponsors.html
@@ -226,12 +226,12 @@
     sidebar=false,
   ),
   dict(
-    name="DataDog",
+    name="Datadog",
     service="Monitoring",
     url="https://www.datadoghq.com/",
     image="datadog.png",
     activity=[
-      "PyPI uses DataDog to collect metrics from the applications, services, and infrastructure behind the scenes allowing for the team to measure the impact of new changes, monitor for problems, and alert when systems fail."
+      "PyPI uses Datadog to collect metrics from the applications, services, and infrastructure behind the scenes allowing for the team to measure the impact of new changes, monitor for problems, and alert when systems fail."
     ],
     footer=false,
     psf_sponsor=false,


### PR DESCRIPTION
Noticed today, and figured I'd submit a fix, based on the
Datadog Press Kit, specifically:

> Our company name is “Datadog”: one word with only the first letter capitalized (i.e., “Data Dog” and “DataDog” are incorrect).

Refs: https://www.datadoghq.com/about/resources/