### PR TITLE
users without a name break selection of some 2fa keys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ on: [push, pull_request]
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - name: Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,6 @@ on: [push, pull_request]
 jobs:
   test:
     strategy:
-      fail-fast: false
       matrix:
         include:
           - name: Tests

--- a/tests/unit/accounts/test_services.py
+++ b/tests/unit/accounts/test_services.py
@@ -519,6 +519,19 @@ class TestDatabaseUserService:
         assert options["rp"]["id"] == rp_id
         assert "icon" not in options["user"]
 
+    def test_get_webauthn_credential_options_for_blank_name(self, user_service):
+        user = UserFactory.create(name="")
+
+        options = user_service.get_webauthn_credential_options(
+            user.id,
+            challenge="fake_challenge",
+            rp_name="fake_rp_name",
+            rp_id="fake_rp_id",
+        )
+
+        assert options["user"]["name"] == user.username
+        assert options["user"]["displayName"] == user.username
+
     def test_get_webauthn_assertion_options(self, user_service):
         user = UserFactory.create()
         user_service.add_webauthn(

--- a/warehouse/utils/webauthn.py
+++ b/warehouse/utils/webauthn.py
@@ -42,7 +42,7 @@ def _get_webauthn_users(user, *, rp_id):
         pywebauthn.WebAuthnUser(
             str(user.id),
             user.username,
-            user.name,
+            user.name or user.username,
             None,
             credential.credential_id,
             credential.public_key,
@@ -85,7 +85,7 @@ def get_credential_options(user, *, challenge, rp_name, rp_id):
         rp_id,
         str(user.id),
         user.username,
-        user.name,
+        user.name or user.username,
         None,
         user_verification="discouraged",
     )


### PR DESCRIPTION
For some 2FA keys both the user [1] `name` and `displayName` are required. If a user's name is not set, this provides the user's username as both the `name` and the `displayName`.

This can be tested and confirmed by setting up [the flask demo app](https://github.com/duo-labs/py_webauthn#flask-demo) and applying the patch to remove the `displayName` validation:

```diff
diff --git a/flask_demo/app.py b/flask_demo/app.py
index c0083fd..d0aa284 100644
--- a/flask_demo/app.py
+++ b/flask_demo/app.py
@@ -59,12 +59,12 @@ def index():
 def webauthn_begin_activate():
     # MakeCredentialOptions
     username = request.form.get('register_username')
-    display_name = request.form.get('register_display_name')
+    display_name = request.form.get('register_display_name') or ''
 
     if not util.validate_username(username):
         return make_response(jsonify({'fail': 'Invalid username.'}), 401)
-    if not util.validate_display_name(display_name):
-        return make_response(jsonify({'fail': 'Invalid display name.'}), 401)
+#    if not util.validate_display_name(display_name):
+#        return make_response(jsonify({'fail': 'Invalid display name.'}), 401)
 
     if User.query.filter_by(username=username).first():
         return make_response(jsonify({'fail': 'User already exists.'}), 401)
```

And then using a Yubi 5 nano will not work (`ykman info`): 

```
Device type: YubiKey 5 Nano
Serial number: [redacted]
Firmware version: 5.1.2
Form factor: Nano (USB-A)
Enabled USB interfaces: FIDO

Applications
OTP     	Disabled	
FIDO U2F	Enabled 	
OpenPGP 	Disabled	
PIV     	Disabled	
OATH    	Disabled	
FIDO2   	Enabled 
```

[1]: https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredentialCreationOptions/user