### PR TITLE
Display 2FA status on package co-owners/maintainers

### DIFF
--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -2932,12 +2932,18 @@ msgstr ""
 msgid "Manage '%(project_name)s' collaborators"
 msgstr ""
 
-#: warehouse/templates/manage/roles.html:24
+#: warehouse/templates/manage/roles.html:22
 msgid "2FA enabled"
 msgstr ""
 
-#: warehouse/templates/manage/roles.html:29
-msgid "No 2FA"
+#: warehouse/templates/manage/roles.html:23
+#: warehouse/templates/manage/roles.html:28
+#: warehouse/templates/manage/roles.html:53
+msgid "2FA"
+msgstr ""
+
+#: warehouse/templates/manage/roles.html:27
+msgid "2FA disabled"
 msgstr ""
 
 #: warehouse/templates/manage/roles.html:36
@@ -2985,10 +2991,6 @@ msgstr ""
 #: warehouse/templates/manage/roles.html:86
 #: warehouse/templates/manage/roles.html:180
 msgid "Role"
-msgstr ""
-
-#: warehouse/templates/manage/roles.html:53
-msgid "2FA"
 msgstr ""
 
 #: warehouse/templates/manage/roles.html:94

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -822,8 +822,8 @@ msgstr ""
 #: warehouse/templates/manage/account.html:426
 #: warehouse/templates/manage/account/totp-provision.html:69
 #: warehouse/templates/manage/account/webauthn-provision.html:44
-#: warehouse/templates/manage/roles.html:153
-#: warehouse/templates/manage/roles.html:165
+#: warehouse/templates/manage/roles.html:170
+#: warehouse/templates/manage/roles.html:182
 #: warehouse/templates/manage/token.html:136
 #: warehouse/templates/manage/token.html:153
 #: warehouse/templates/re-auth.html:51
@@ -912,7 +912,7 @@ msgstr ""
 #: warehouse/templates/accounts/register.html:89
 #: warehouse/templates/manage/account.html:272
 #: warehouse/templates/manage/account/recovery_codes-provision.html:81
-#: warehouse/templates/manage/roles.html:156
+#: warehouse/templates/manage/roles.html:173
 msgid "Username"
 msgstr ""
 
@@ -938,8 +938,8 @@ msgstr ""
 
 #: warehouse/templates/accounts/profile.html:23
 #: warehouse/templates/manage/account.html:247
-#: warehouse/templates/manage/roles.html:47
-#: warehouse/templates/manage/roles.html:109
+#: warehouse/templates/manage/roles.html:62
+#: warehouse/templates/manage/roles.html:125
 msgid "Avatar for {user} from gravatar.com"
 msgstr ""
 
@@ -1428,7 +1428,7 @@ msgstr ""
 #: warehouse/templates/manage/manage_base.html:96
 #: warehouse/templates/manage/release.html:118
 #: warehouse/templates/manage/releases.html:172
-#: warehouse/templates/manage/roles.html:24
+#: warehouse/templates/manage/roles.html:38
 #: warehouse/templates/manage/settings.html:70
 #: warehouse/templates/search/results.html:199
 msgid "Close"
@@ -1571,7 +1571,7 @@ msgid "Releases"
 msgstr ""
 
 #: warehouse/templates/includes/manage/manage-project-menu.html:25
-#: warehouse/templates/manage/roles.html:21
+#: warehouse/templates/manage/roles.html:35
 msgid "Collaborators"
 msgstr ""
 
@@ -2467,8 +2467,8 @@ msgstr ""
 
 #: warehouse/templates/manage/journal.html:37
 #: warehouse/templates/manage/journal.html:52
-#: warehouse/templates/manage/roles.html:37
-#: warehouse/templates/manage/roles.html:151
+#: warehouse/templates/manage/roles.html:51
+#: warehouse/templates/manage/roles.html:168
 msgid "User"
 msgstr ""
 
@@ -2678,7 +2678,7 @@ msgstr ""
 
 #: warehouse/templates/manage/release.html:118
 #: warehouse/templates/manage/releases.html:172
-#: warehouse/templates/manage/roles.html:24
+#: warehouse/templates/manage/roles.html:38
 #: warehouse/templates/manage/settings.html:70
 msgid "Dismiss"
 msgstr ""
@@ -2932,93 +2932,105 @@ msgstr ""
 msgid "Manage '%(project_name)s' collaborators"
 msgstr ""
 
-#: warehouse/templates/manage/roles.html:22
+#: warehouse/templates/manage/roles.html:24
+msgid "2FA enabled"
+msgstr ""
+
+#: warehouse/templates/manage/roles.html:29
+msgid "No 2FA"
+msgstr ""
+
+#: warehouse/templates/manage/roles.html:36
 #, python-format
 msgid ""
 "Use this page to control which PyPI users can help you to manage "
 "%(project_name)s"
 msgstr ""
 
-#: warehouse/templates/manage/roles.html:25
+#: warehouse/templates/manage/roles.html:39
 #: warehouse/templates/pages/help.html:556
 msgid "There are two possible roles for collaborators:"
 msgstr ""
 
-#: warehouse/templates/manage/roles.html:27
-#: warehouse/templates/manage/roles.html:64
-#: warehouse/templates/manage/roles.html:73
+#: warehouse/templates/manage/roles.html:41
+#: warehouse/templates/manage/roles.html:79
+#: warehouse/templates/manage/roles.html:88
 msgid "Maintainer"
 msgstr ""
 
-#: warehouse/templates/manage/roles.html:28
+#: warehouse/templates/manage/roles.html:42
 msgid ""
 "Can upload releases for a package. Cannot invite collaborators. Cannot "
 "delete files, releases, or the project."
 msgstr ""
 
-#: warehouse/templates/manage/roles.html:29
-#: warehouse/templates/manage/roles.html:62
-#: warehouse/templates/manage/roles.html:73
+#: warehouse/templates/manage/roles.html:43
+#: warehouse/templates/manage/roles.html:77
+#: warehouse/templates/manage/roles.html:88
 msgid "Owner"
 msgstr ""
 
-#: warehouse/templates/manage/roles.html:30
+#: warehouse/templates/manage/roles.html:44
 msgid ""
 "Can upload releases. Can invite other collaborators. Can delete files, "
 "releases, or the entire project."
 msgstr ""
 
-#: warehouse/templates/manage/roles.html:34
+#: warehouse/templates/manage/roles.html:48
 #, python-format
 msgid "Users who can manage %(project_name)s"
 msgstr ""
 
-#: warehouse/templates/manage/roles.html:38
-#: warehouse/templates/manage/roles.html:71
-#: warehouse/templates/manage/roles.html:163
+#: warehouse/templates/manage/roles.html:52
+#: warehouse/templates/manage/roles.html:86
+#: warehouse/templates/manage/roles.html:180
 msgid "Role"
 msgstr ""
 
-#: warehouse/templates/manage/roles.html:79
+#: warehouse/templates/manage/roles.html:53
+msgid "2FA"
+msgstr ""
+
+#: warehouse/templates/manage/roles.html:94
 msgid "Save role"
 msgstr ""
 
 #: warehouse/templates/manage/account/recovery_codes-provision.html:65
-#: warehouse/templates/manage/roles.html:80
+#: warehouse/templates/manage/roles.html:95
 msgid "Save"
 msgstr ""
 
-#: warehouse/templates/manage/roles.html:93
+#: warehouse/templates/manage/roles.html:109
 msgid "Cannot remove yourself as owner"
 msgstr ""
 
-#: warehouse/templates/manage/roles.html:96
+#: warehouse/templates/manage/roles.html:112
 #, python-format
 msgid "Remove %(user)s from this project"
 msgstr ""
 
-#: warehouse/templates/manage/roles.html:123
+#: warehouse/templates/manage/roles.html:139
 msgid "Invite pending"
 msgstr ""
 
-#: warehouse/templates/manage/roles.html:125
+#: warehouse/templates/manage/roles.html:141
 msgid "Invite expired"
 msgstr ""
 
-#: warehouse/templates/manage/roles.html:135
+#: warehouse/templates/manage/roles.html:152
 #, python-format
 msgid "Revoke invitation for %(user)s"
 msgstr ""
 
-#: warehouse/templates/manage/roles.html:137
+#: warehouse/templates/manage/roles.html:154
 msgid "Revoke invite"
 msgstr ""
 
-#: warehouse/templates/manage/roles.html:146
+#: warehouse/templates/manage/roles.html:163
 msgid "Invite collaborator"
 msgstr ""
 
-#: warehouse/templates/manage/roles.html:174
+#: warehouse/templates/manage/roles.html:191
 msgid "Invite"
 msgstr ""
 

--- a/warehouse/templates/manage/roles.html
+++ b/warehouse/templates/manage/roles.html
@@ -19,14 +19,14 @@
 
 {% macro two_factor_badge(user) -%}
   {% if user.has_two_factor %}
-    <span class="badge badge--success">
-      <i class="fa fa-check" aria-hidden="true"></i>
-      {% trans %}2FA enabled{% endtrans %}
-    </span>
+  <span class="badge badge--success" title="{% trans %}2FA enabled{% endtrans %}">
+    {% trans %}2FA{% endtrans %}
+    <i class="fa fa-check" aria-hidden="true"></i>
+  </span>
   {% else %}
-  <span class="badge badge--danger">
+  <span class="badge badge--danger" title="{% trans %}2FA disabled{% endtrans %}">
+    {% trans %}2FA{% endtrans %}
     <i class="fa fa-times" aria-hidden="true"></i>
-    {% trans %}No 2FA{% endtrans %}
   </span>
   {% endif %}
 {% endmacro %}

--- a/warehouse/templates/manage/roles.html
+++ b/warehouse/templates/manage/roles.html
@@ -17,6 +17,20 @@
 
 {% block title %}{% trans project_name=project.name %}Manage '{{ project_name }}' collaborators{% endtrans %}{% endblock %}
 
+{% macro two_factor_badge(user) -%}
+  {% if user.has_two_factor %}
+    <span class="badge badge--success">
+      <i class="fa fa-check" aria-hidden="true"></i>
+      {% trans %}2FA enabled{% endtrans %}
+    </span>
+  {% else %}
+  <span class="badge badge--danger">
+    <i class="fa fa-times" aria-hidden="true"></i>
+    {% trans %}No 2FA{% endtrans %}
+  </span>
+  {% endif %}
+{% endmacro %}
+
 {% block main %}
   <h2>{% trans %}Collaborators{% endtrans %}</h2>
   <p>{% trans project_name=project.name %}Use this page to control which PyPI users can help you to manage {{ project_name }}{% endtrans %}</p>
@@ -36,6 +50,7 @@
       <tr>
         <th scope="col">{% trans %}User{% endtrans %}</th>
         <th scope="col">{% trans %}Role{% endtrans %}</th>
+        <th scope="col">{% trans %}2FA{% endtrans %}</th>
         <th></th>
       </tr>
     </thead>
@@ -82,6 +97,7 @@
           </form>
         {% endif %}
         </td>
+        <td>{{ two_factor_badge(role.user) }}</td>
         <td class="table__align-right">
           <form method="POST" action="{{ request.route_path('manage.project.delete_role', project_name=project.name) }}">
             <input name="csrf_token" type="hidden" value="{{ request.session.get_csrf_token() }}">
@@ -125,6 +141,7 @@
             {% trans %}Invite expired{% endtrans %}
           {% endif %}
         </td>
+        <td></td>
         <td class="table__align-right">
           <form method="POST" action="{{ request.route_path('manage.project.revoke_invite', project_name=project.name) }}">
             <input name="csrf_token" type="hidden" value="{{ request.session.get_csrf_token() }}">


### PR DESCRIPTION
Closes #5791

I believe that given this is 100% a template fix, we should still have 100% coverage, and I believe we don't write automated tests for this, so, yolo :)

I choose not to display a badge if no 2FA rather than displaying a red badge, but this can be discussed.

EDIT: I originally added this to invites too, but re-reading the ticket highlighted that this might not be desirable. I'm not sure if it's really problematic that an attacker can know if you have 2FA or not but I can imagine it's not something to handle lightly.

<img width="822" alt="Capture d’écran 2021-04-17 à 14 37 28" src="https://user-images.githubusercontent.com/1457576/115113553-3c8bd680-9f8b-11eb-8ba0-a988de070fc1.png">

The screenshot below shows than even if user ewdurbin has 2FA, the interface doesn't show it because the invite is pending.
<img width="830" alt="Capture d’écran 2021-04-17 à 14 56 34" src="https://user-images.githubusercontent.com/1457576/115113976-326ad780-9f8d-11eb-94fb-bc22e88cce52.png">
