### PR TITLE
Fix JSON endpoint 404 when only yanked releases are available

### DIFF
--- a/tests/unit/legacy/api/test_json.py
+++ b/tests/unit/legacy/api/test_json.py
@@ -118,6 +118,23 @@ class TestJSONProject:
         assert resp is response
         assert json_release.calls == [pretend.call(release, db_request)]
 
+    def test_latest_release_yanked(self, monkeypatch, db_request):
+        project = ProjectFactory.create()
+
+        ReleaseFactory.create(project=project, version="1.0")
+        ReleaseFactory.create(project=project, version="3.0", yanked=True)
+
+        release = ReleaseFactory.create(project=project, version="2.0")
+
+        response = pretend.stub()
+        json_release = pretend.call_recorder(lambda ctx, request: response)
+        monkeypatch.setattr(json, "json_release", json_release)
+
+        resp = json.json_project(project, db_request)
+
+        assert resp is response
+        assert json_release.calls == [pretend.call(release, db_request)]
+
     def test_all_releases_yanked(self, monkeypatch, db_request):
         project = ProjectFactory.create()
 
@@ -151,6 +168,7 @@ class TestJSONProject:
 
         assert resp is response
         assert json_release.calls == [pretend.call(release, db_request)]
+
 
 class TestJSONProjectSlash:
     def test_normalizing_redirects(self, db_request):

--- a/tests/unit/legacy/api/test_json.py
+++ b/tests/unit/legacy/api/test_json.py
@@ -118,11 +118,40 @@ class TestJSONProject:
         assert resp is response
         assert json_release.calls == [pretend.call(release, db_request)]
 
+    def test_all_releases_yanked(self, monkeypatch, db_request):
+        """
+        If all releases are yanked, the endpoint should return the same release as
+        if none of the releases are yanked.
+        """
+
+        project = ProjectFactory.create()
+
+        ReleaseFactory.create(project=project, version="1.0", yanked=True)
+        ReleaseFactory.create(project=project, version="2.0", yanked=True)
+        ReleaseFactory.create(project=project, version="4.0.dev0", yanked=True)
+
+        release = ReleaseFactory.create(project=project, version="3.0", yanked=True)
+
+        response = pretend.stub()
+        json_release = pretend.call_recorder(lambda ctx, request: response)
+        monkeypatch.setattr(json, "json_release", json_release)
+
+        resp = json.json_project(project, db_request)
+
+        assert resp is response
+        assert json_release.calls == [pretend.call(release, db_request)]
+
     def test_latest_release_yanked(self, monkeypatch, db_request):
+        """
+        If the latest version is yanked, the endpoint should fall back on the
+        latest non-prerelease version that is not yanked, if one is available.
+        """
+
         project = ProjectFactory.create()
 
         ReleaseFactory.create(project=project, version="1.0")
         ReleaseFactory.create(project=project, version="3.0", yanked=True)
+        ReleaseFactory.create(project=project, version="3.0.dev0")
 
         release = ReleaseFactory.create(project=project, version="2.0")
 
@@ -135,30 +164,20 @@ class TestJSONProject:
         assert resp is response
         assert json_release.calls == [pretend.call(release, db_request)]
 
-    def test_all_releases_yanked(self, monkeypatch, db_request):
-        project = ProjectFactory.create()
-
-        ReleaseFactory.create(project=project, version="1.0", yanked=True)
-        ReleaseFactory.create(project=project, version="2.0", yanked=True)
-        release = ReleaseFactory.create(project=project, version="3.0", yanked=True)
-
-        response = pretend.stub()
-        json_release = pretend.call_recorder(lambda ctx, request: response)
-        monkeypatch.setattr(json, "json_release", json_release)
-
-        resp = json.json_project(project, db_request)
-
-        assert resp is response
-        assert json_release.calls == [pretend.call(release, db_request)]
-
     def test_all_non_prereleases_yanked(self, monkeypatch, db_request):
+        """
+        If all non-prerelease versions are yanked, the endpoint should return the
+        latest prerelease version that is not yanked.
+        """
+
         project = ProjectFactory.create()
 
         ReleaseFactory.create(project=project, version="1.0", yanked=True)
         ReleaseFactory.create(project=project, version="2.0", yanked=True)
-        ReleaseFactory.create(project=project, version="4.0.dev0")
+        ReleaseFactory.create(project=project, version="3.0", yanked=True)
+        ReleaseFactory.create(project=project, version="3.0.dev0", yanked=True)
 
-        release = ReleaseFactory.create(project=project, version="3.0", yanked=True)
+        release = ReleaseFactory.create(project=project, version="2.0.dev0")
 
         response = pretend.stub()
         json_release = pretend.call_recorder(lambda ctx, request: response)

--- a/tests/unit/legacy/api/test_json.py
+++ b/tests/unit/legacy/api/test_json.py
@@ -118,6 +118,39 @@ class TestJSONProject:
         assert resp is response
         assert json_release.calls == [pretend.call(release, db_request)]
 
+    def test_all_releases_yanked(self, monkeypatch, db_request):
+        project = ProjectFactory.create()
+
+        ReleaseFactory.create(project=project, version="1.0", yanked=True)
+        ReleaseFactory.create(project=project, version="2.0", yanked=True)
+        release = ReleaseFactory.create(project=project, version="3.0", yanked=True)
+
+        response = pretend.stub()
+        json_release = pretend.call_recorder(lambda ctx, request: response)
+        monkeypatch.setattr(json, "json_release", json_release)
+
+        resp = json.json_project(project, db_request)
+
+        assert resp is response
+        assert json_release.calls == [pretend.call(release, db_request)]
+
+    def test_all_non_prereleases_yanked(self, monkeypatch, db_request):
+        project = ProjectFactory.create()
+
+        ReleaseFactory.create(project=project, version="1.0", yanked=True)
+        ReleaseFactory.create(project=project, version="2.0", yanked=True)
+        ReleaseFactory.create(project=project, version="4.0.dev0")
+
+        release = ReleaseFactory.create(project=project, version="3.0", yanked=True)
+
+        response = pretend.stub()
+        json_release = pretend.call_recorder(lambda ctx, request: response)
+        monkeypatch.setattr(json, "json_release", json_release)
+
+        resp = json.json_project(project, db_request)
+
+        assert resp is response
+        assert json_release.calls == [pretend.call(release, db_request)]
 
 class TestJSONProjectSlash:
     def test_normalizing_redirects(self, db_request):

--- a/warehouse/legacy/api/json.py
+++ b/warehouse/legacy/api/json.py
@@ -67,8 +67,8 @@ def json_project(project, request):
             request.db.query(Release)
             .filter(Release.project == project)
             .order_by(
-                Release.is_prerelease.nullslast(),
                 Release.yanked.asc(),
+                Release.is_prerelease.nullslast(),
                 Release._pypi_ordering.desc(),
             )
             .limit(1)

--- a/warehouse/legacy/api/json.py
+++ b/warehouse/legacy/api/json.py
@@ -65,8 +65,8 @@ def json_project(project, request):
     try:
         release = (
             request.db.query(Release)
-            .filter(Release.project == project, Release.yanked.is_(False))
-            .order_by(Release.is_prerelease.nullslast(), Release._pypi_ordering.desc())
+            .filter(Release.project == project)
+            .order_by(Release.is_prerelease.nullslast(), Release.yanked.asc(), Release._pypi_ordering.desc())
             .limit(1)
             .one()
         )

--- a/warehouse/legacy/api/json.py
+++ b/warehouse/legacy/api/json.py
@@ -66,7 +66,11 @@ def json_project(project, request):
         release = (
             request.db.query(Release)
             .filter(Release.project == project)
-            .order_by(Release.is_prerelease.nullslast(), Release.yanked.asc(), Release._pypi_ordering.desc())
+            .order_by(
+                Release.is_prerelease.nullslast(),
+                Release.yanked.asc(),
+                Release._pypi_ordering.desc(),
+            )
             .limit(1)
             .one()
         )


### PR DESCRIPTION
Fixes #8966 

This PR removes the check on "yanked" from the filter clause and adds it to the order by clause in the JSON endpoint's releases query. This ensures that yanked releases are returned from the DB query, but are prioritized lower than all other release variants.

This PR also adds unit tests for this behavior.