### PR TITLE
Verbose security log message for yanked release

### DIFF
--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -2230,21 +2230,21 @@ msgid "Recent account activity"
 msgstr ""
 
 #: warehouse/templates/manage/account.html:694
-#: warehouse/templates/manage/history.html:88
+#: warehouse/templates/manage/history.html:93
 msgid "Event"
 msgstr ""
 
 #: warehouse/templates/manage/account.html:695
 #: warehouse/templates/manage/account.html:703
-#: warehouse/templates/manage/history.html:89
-#: warehouse/templates/manage/history.html:98
+#: warehouse/templates/manage/history.html:94
+#: warehouse/templates/manage/history.html:103
 msgid "Date / time"
 msgstr ""
 
 #: warehouse/templates/manage/account.html:696
 #: warehouse/templates/manage/account.html:707
-#: warehouse/templates/manage/history.html:90
-#: warehouse/templates/manage/history.html:102
+#: warehouse/templates/manage/history.html:95
+#: warehouse/templates/manage/history.html:107
 msgid "IP address"
 msgstr ""
 
@@ -2423,7 +2423,16 @@ msgstr ""
 msgid "Controlled by:"
 msgstr ""
 
-#: warehouse/templates/manage/history.html:85
+#: warehouse/templates/manage/history.html:79
+#, python-format
+msgid "Release version %(version)s yanked"
+msgstr ""
+
+#: warehouse/templates/manage/history.html:81
+msgid "Yanked by:"
+msgstr ""
+
+#: warehouse/templates/manage/history.html:90
 #, python-format
 msgid "Security history for %(project_name)s"
 msgstr ""

--- a/warehouse/templates/manage/history.html
+++ b/warehouse/templates/manage/history.html
@@ -75,6 +75,11 @@
       {% trans %}Controlled by:{% endtrans %} <a href="{{ request.route_path('accounts.profile', username=event.additional.user) }}">{{ event.additional.user }}</a><br>
       {% trans %}Token name:{% endtrans %} {{ event.additional.description }}
     </small>
+    {% elif event.tag == "project:release:yank" %}
+    <strong>{% trans version=event.additional.canonical_version %}Release version {{ version }} yanked{% endtrans %}</strong><br>
+    <small>
+      {% trans %}Yanked by:{% endtrans %} <a href="{{ request.route_path('accounts.profile', username=event.additional.submitted_by) }}">{{ event.additional.submitted_by }}</a>
+    </small>
     {% else %}
     <strong>{{ event.tag }}</strong>
     {% endif %}


### PR DESCRIPTION
Fixes #8564

This PR is a very straightforward one and with no tests since it's just HTML. So, as a minimal proof that it's working, here's a print screen from my local env:

![Screenshot from 2021-05-04 12-12-13](https://user-images.githubusercontent.com/238223/117026373-1d52b000-acd2-11eb-8e05-bc3d7c31ecb7.png)
