### PR TITLE
Add a make target to run pip-compile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,6 +130,10 @@ deps: .state/env/pyvenv.cfg
 	rm -r $(TMPDIR)
 	$(BINDIR)/pip check
 
+requirements/%.txt: requirements/%.in
+	$(BINDIR)/pip-compile --allow-unsafe --generate-hashes --output-file=$@ $< > /dev/null
+
+
 github-actions-deps:
 ifneq ($(GITHUB_BASE_REF), false)
 	git fetch origin $(GITHUB_BASE_REF):refs/remotes/origin/$(GITHUB_BASE_REF)

--- a/docs/development/patterns.rst
+++ b/docs/development/patterns.rst
@@ -68,7 +68,7 @@ To add a new dependency:
 1. Add the project name to the appropriate ``.in`` file
 2. From the repositories root directory, recompile the dependencies for each modified ``.in`` file::
 
-   $ make requirements/{file}.in
+   $ make requirements/{file}.txt
 
 3. Commit the changes
 

--- a/docs/development/patterns.rst
+++ b/docs/development/patterns.rst
@@ -68,7 +68,7 @@ To add a new dependency:
 1. Add the project name to the appropriate ``.in`` file
 2. From the repositories root directory, recompile the dependencies for each modified ``.in`` file::
 
-   $ pip-compile --allow-unsafe --generate-hashes --output-file=requirements/{file}.txt requirements/{file}.in
+   $ make requirements/{file}.in
 
 3. Commit the changes
 


### PR DESCRIPTION
This has been annoying me one or twice. The command for updating .txt files when adding new dependencies is documented but not integrated to the Makefile.

Not anymore.