### PR TITLE
Logic reversed in translation check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -196,7 +196,7 @@ build-mos: compile-pot
 		done
 
 translations: compile-pot
-ifneq ($(filter false,$(GITHUB_ACTIONS)),)
+ifneq ($(GITHUB_ACTIONS), false)
 	git diff --quiet ./warehouse/locale/messages.pot || (echo "There are outstanding translations, run 'make translations' and commit the changes."; exit 1)
 else
 endif


### PR DESCRIPTION
`make translation` supposedly fails with exit 1 if a change is found after computing the pot file, but only in the CI.

As it is today, it does the opposite: it passes on the CI and fails if not on the CI. This PR fixes that.
Note that the `ifneq` form was what we had when we just had Travis. I believe it broke when we removed Travis, but kept the `filter`.

After the change (I've replaced the contents of `compile-pot` for my test)
```console
$ GITHUB_ACTIONS=true make translations
echo "yay" >> ./warehouse/locale/messages.pot
# PYTHONPATH=/Users/joachim/code/warehouse /Users/joachim/code/warehouse/.state/env/bin/pybabel extract \
	# 	-F babel.cfg \
	# 	--omit-header \
	# 	--output="warehouse/locale/messages.pot" \
	# 	warehouse
git diff --quiet ./warehouse/locale/messages.pot || (echo "There are outstanding translations, run 'make translations' and commit the changes."; exit 1)
There are outstanding translations, run 'make translations' and commit the changes.
make: *** [translations] Error 1

$ make translations
echo "yay" >> ./warehouse/locale/messages.pot
# PYTHONPATH=/Users/joachim/code/warehouse /Users/joachim/code/warehouse/.state/env/bin/pybabel extract \
	# 	-F babel.cfg \
	# 	--omit-header \
	# 	--output="warehouse/locale/messages.pot" \
	# 	warehouse
```

Before my change, it was the opposite.

We'll need to merge it before #9690 I think, otherwise it silences an important check.