### PR TITLE
Limit sponsors logo size via CSS

### DIFF
--- a/warehouse/static/sass/blocks/_sponsor-grid.scss
+++ b/warehouse/static/sass/blocks/_sponsor-grid.scss
@@ -90,7 +90,7 @@
     }
 
     &__sponsor-img {
-      height: 150px;
+      height: 200px;
       width: 250px;
       max-width: 100%;
       margin: 0 auto;
@@ -100,6 +100,10 @@
 
       @media screen and (max-width: $mobile) {
         height: 130px;
+      }
+
+      img {
+        padding: 2em;
       }
     }
 

--- a/warehouse/static/sass/blocks/_sponsors.scss
+++ b/warehouse/static/sass/blocks/_sponsors.scss
@@ -72,7 +72,7 @@
   }
 
   &__image {
-    max-height: 45px;
+    max-width: 100px;
     opacity: 0.8;
 
     @media only screen and (max-width: $tablet) {

--- a/warehouse/templates/pages/sponsors.html
+++ b/warehouse/templates/pages/sponsors.html
@@ -117,9 +117,11 @@
           <div class="sponsor-grid__sponsor-img">
             {{ sponsor.color_logo_img|camoify|safe }}
           </div>
-          <h2 class="sponsor-grid__sponsor-name">{{ sponsor.name }}</h2>
-          <div class="sponsor-grid__sponsor-activity">
-          {{ sponsor.activity|safe }}
+          <div class="sponsor-grid__sponsor-description">
+            <h2 class="sponsor-grid__sponsor-name">{{ sponsor.name }}</h2>
+            <div class="sponsor-grid__sponsor-activity">
+            {{ sponsor.activity|safe }}
+            </div>
           </div>
           <a href="{{ sponsor.link_url }}" target="_blank" rel="noopener" class="sponsor-grid__sponsor-link button">Visit {{ sponsor.name }}</a>
         </div>


### PR DESCRIPTION
Fixes #9676

This PR updates the CSS for the footer and sponsors grid logos to limit their sizes. I didn't have to change anything to properly display the logo in the sidebar.

Anyway, the current CSS solution can be a kind of house of cards for future bigger logos. After we implement the logo upload in the admin form, definitely some type of thumbnail alternative generated with Pillow or opencv is something good to go with.

Here are screenshots from the final result from my local environment:

**Footer**

![Screenshot from 2021-06-22 17-41-51](https://user-images.githubusercontent.com/238223/122996873-be302400-d381-11eb-8ecc-8d841361ba07.png)

**Sponsors grid**

![Screenshot from 2021-06-22 17-42-31](https://user-images.githubusercontent.com/238223/122996928-d43de480-d381-11eb-8070-1bf7f250c729.png)

**Sidebar**

![Screenshot from 2021-06-22 17-41-41](https://user-images.githubusercontent.com/238223/122996939-d86a0200-d381-11eb-97b8-060aab3efb6f.png)
