### PR TITLE
Replace factory.fuzzy by factory.Faker

### DIFF
--- a/tests/common/db/accounts.py
+++ b/tests/common/db/accounts.py
@@ -13,28 +13,31 @@
 import datetime
 
 import factory
-import factory.fuzzy
 
 from warehouse.accounts.models import Email, User, UserEvent
 
-from .base import FuzzyEmail, WarehouseFactory
+from .base import WarehouseFactory
 
 
 class UserFactory(WarehouseFactory):
     class Meta:
         model = User
 
-    username = factory.fuzzy.FuzzyText(length=12)
-    name = factory.fuzzy.FuzzyText(length=12)
+    username = factory.Faker("pystr", max_chars=12)
+    name = factory.Faker("word")
     password = "!"
     is_active = True
     is_superuser = False
     is_moderator = False
     is_psf_staff = False
-    date_joined = factory.fuzzy.FuzzyNaiveDateTime(
-        datetime.datetime(2005, 1, 1), datetime.datetime(2010, 1, 1)
+    date_joined = factory.Faker(
+        "date_time_between_dates",
+        datetime_start=datetime.datetime(2005, 1, 1),
+        datetime_end=datetime.datetime(2010, 1, 1),
     )
-    last_login = factory.fuzzy.FuzzyNaiveDateTime(datetime.datetime(2011, 1, 1))
+    last_login = factory.Faker(
+        "date_time_between_dates", datetime_start=datetime.datetime(2011, 1, 1)
+    )
 
 
 class UserEventFactory(WarehouseFactory):
@@ -49,7 +52,7 @@ class EmailFactory(WarehouseFactory):
         model = Email
 
     user = factory.SubFactory(UserFactory)
-    email = FuzzyEmail()
+    email = factory.Faker("safe_email")
     verified = True
     primary = True
     public = False

--- a/tests/common/db/admin.py
+++ b/tests/common/db/admin.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import factory.fuzzy
+import factory
 
 from warehouse.admin.flags import AdminFlag
 
@@ -21,6 +21,6 @@ class AdminFlagFactory(WarehouseFactory):
     class Meta:
         model = AdminFlag
 
-    id = factory.fuzzy.FuzzyText(length=12)
-    description = factory.fuzzy.FuzzyText(length=24)
+    id = factory.Faker("text", max_nb_chars=12)
+    description = factory.Faker("sentence")
     enabled = True

--- a/tests/common/db/banners.py
+++ b/tests/common/db/banners.py
@@ -10,23 +10,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from datetime import date, timedelta
-
-from factory import fuzzy
+import factory
 
 from warehouse.banners.models import Banner
 
-from .base import FuzzyUrl, WarehouseFactory
+from .base import WarehouseFactory
 
 
 class BannerFactory(WarehouseFactory):
     class Meta:
         model = Banner
 
-    name = fuzzy.FuzzyText(length=12)
-    text = fuzzy.FuzzyText(length=30)
-    link_url = FuzzyUrl()
-    link_label = fuzzy.FuzzyText(length=10)
+    name = factory.Faker("word")
+    text = factory.Faker("sentence")
+    link_url = factory.Faker("uri")
+    link_label = factory.Faker("word")
 
     active = True
-    end = date.today() + timedelta(days=2)
+    end = factory.Faker("future_date")

--- a/tests/common/db/base.py
+++ b/tests/common/db/base.py
@@ -10,10 +10,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import random
-import string
-
-from factory import fuzzy
 from factory.alchemy import SQLAlchemyModelFactory
 
 from . import Session
@@ -35,37 +31,3 @@ class WarehouseFactory(SQLAlchemyModelFactory):
         session.flush()
         session.expire_all()
         return r
-
-
-class FuzzyEmail(fuzzy.BaseFuzzyAttribute):
-    def __init__(self, domain="example.com", *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.domain = domain
-
-    def fuzz(self):
-        chars = string.ascii_letters + string.digits
-        username = "".join(random.choice(chars) for i in range(12))
-        return "@".join([username, self.domain])
-
-
-class FuzzyList(fuzzy.BaseFuzzyAttribute):
-    def __init__(self, item_factory, item_kwargs=None, size=1, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.item_factory = item_factory
-        self.item_kwargs = item_kwargs or {}
-        self.size = size
-
-    def fuzz(self):
-        return [self.item_factory(**self.item_kwargs).fuzz() for i in range(self.size)]
-
-
-class FuzzyUrl(fuzzy.BaseFuzzyAttribute):
-    def __init__(self, domain="example.com", is_secure=False, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.domain = domain
-        self.protocol = "https" if is_secure else "http"
-
-    def fuzz(self):
-        chars = string.ascii_letters
-        path = "".join(random.choice(chars) for i in range(12))
-        return f"{self.protocol}://{self.domain}/{path}"

--- a/tests/common/db/malware.py
+++ b/tests/common/db/malware.py
@@ -32,7 +32,7 @@ class MalwareCheckFactory(WarehouseFactory):
     class Meta:
         model = MalwareCheck
 
-    name = factory.Faker("word")
+    name = factory.Faker("pystr", max_chars=12)
     version = 1
     short_description = factory.Faker("sentence", nb_words=6)
     long_description = factory.Faker("sentence", nb_words=12)

--- a/tests/common/db/malware.py
+++ b/tests/common/db/malware.py
@@ -13,7 +13,6 @@
 import datetime
 
 import factory
-import factory.fuzzy
 
 from warehouse.malware.models import (
     MalwareCheck,
@@ -33,16 +32,19 @@ class MalwareCheckFactory(WarehouseFactory):
     class Meta:
         model = MalwareCheck
 
-    name = factory.fuzzy.FuzzyText(length=12)
+    name = factory.Faker("word")
     version = 1
-    short_description = factory.fuzzy.FuzzyText(length=80)
-    long_description = factory.fuzzy.FuzzyText(length=300)
-    check_type = factory.fuzzy.FuzzyChoice(list(MalwareCheckType))
-    hooked_object = factory.fuzzy.FuzzyChoice(list(MalwareCheckObjectType))
+    short_description = factory.Faker("sentence", nb_words=6)
+    long_description = factory.Faker("sentence", nb_words=12)
+    check_type = factory.Faker("random_element", elements=list(MalwareCheckType))
+    hooked_object = factory.Faker(
+        "random_element", elements=list(MalwareCheckObjectType)
+    )
     schedule = {"minute": "*/10"}
-    state = factory.fuzzy.FuzzyChoice(list(MalwareCheckState))
-    created = factory.fuzzy.FuzzyNaiveDateTime(
-        datetime.datetime.utcnow() - datetime.timedelta(days=7)
+    state = factory.Faker("random_element", elements=list(MalwareCheckState))
+    created = factory.Faker(
+        "date_time_between_dates",
+        datetime_start=datetime.datetime.utcnow() - datetime.timedelta(days=7),
     )
 
 
@@ -55,10 +57,14 @@ class MalwareVerdictFactory(WarehouseFactory):
     release = None
     project = None
     manually_reviewed = True
-    reviewer_verdict = factory.fuzzy.FuzzyChoice(list(VerdictClassification))
-    classification = factory.fuzzy.FuzzyChoice(list(VerdictClassification))
-    confidence = factory.fuzzy.FuzzyChoice(list(VerdictConfidence))
-    message = factory.fuzzy.FuzzyText(length=80)
-    run_date = factory.fuzzy.FuzzyNaiveDateTime(datetime.datetime.utcnow())
+    reviewer_verdict = factory.Faker(
+        "random_element", elements=list(VerdictClassification)
+    )
+    classification = factory.Faker(
+        "random_element", elements=list(VerdictClassification)
+    )
+    confidence = factory.Faker("random_element", elements=list(VerdictConfidence))
+    message = factory.Faker("paragraph")
+    run_date = factory.Faker("date_time_between_dates")
     full_report_link = None
     details = None

--- a/tests/common/db/packaging.py
+++ b/tests/common/db/packaging.py
@@ -12,10 +12,8 @@
 
 import datetime
 import hashlib
-import uuid
 
 import factory
-import factory.fuzzy
 import packaging.utils
 
 from warehouse.packaging.models import (
@@ -41,8 +39,8 @@ class ProjectFactory(WarehouseFactory):
     class Meta:
         model = Project
 
-    id = factory.LazyFunction(uuid.uuid4)
-    name = factory.fuzzy.FuzzyText(length=12)
+    id = factory.Faker("uuid4", cast_to=None)
+    name = factory.Faker("pystr", max_chars=12)
 
 
 class ProjectEventFactory(WarehouseFactory):
@@ -56,8 +54,8 @@ class DescriptionFactory(WarehouseFactory):
     class Meta:
         model = Description
 
-    id = factory.LazyFunction(uuid.uuid4)
-    raw = factory.fuzzy.FuzzyText(length=100)
+    id = factory.Faker("uuid4", cast_to=None)
+    raw = factory.Faker("paragraph")
     html = factory.LazyAttribute(lambda o: readme.render(o.raw))
     rendered_by = factory.LazyAttribute(lambda o: readme.renderer_version())
 
@@ -66,7 +64,7 @@ class ReleaseFactory(WarehouseFactory):
     class Meta:
         model = Release
 
-    id = factory.LazyFunction(uuid.uuid4)
+    id = factory.Faker("uuid4", cast_to=None)
     project = factory.SubFactory(ProjectFactory)
     version = factory.Sequence(lambda n: str(n) + ".0")
     canonical_version = factory.LazyAttribute(
@@ -84,7 +82,7 @@ class FileFactory(WarehouseFactory):
 
     release = factory.SubFactory(ReleaseFactory)
     python_version = "source"
-    filename = factory.fuzzy.FuzzyText(length=12)
+    filename = factory.Faker("file_name")
     md5_digest = factory.LazyAttribute(
         lambda o: hashlib.md5(o.filename.encode("utf8")).hexdigest()
     )
@@ -94,7 +92,9 @@ class FileFactory(WarehouseFactory):
     blake2_256_digest = factory.LazyAttribute(
         lambda o: hashlib.blake2b(o.filename.encode("utf8"), digest_size=32).hexdigest()
     )
-    upload_time = factory.fuzzy.FuzzyNaiveDateTime(datetime.datetime(2008, 1, 1))
+    upload_time = factory.Faker(
+        "date_time_between_dates", datetime_start=datetime.datetime(2008, 1, 1)
+    )
     path = factory.LazyAttribute(
         lambda o: "/".join(
             [
@@ -131,8 +131,10 @@ class DependencyFactory(WarehouseFactory):
         model = Dependency
 
     release = factory.SubFactory(ReleaseFactory)
-    kind = factory.fuzzy.FuzzyChoice(int(kind) for kind in DependencyKind)
-    specifier = factory.fuzzy.FuzzyText(length=12)
+    kind = factory.Faker(
+        "random_element", elements=[int(kind) for kind in DependencyKind]
+    )
+    specifier = factory.Faker("word")
 
 
 class JournalEntryFactory(WarehouseFactory):
@@ -140,9 +142,11 @@ class JournalEntryFactory(WarehouseFactory):
         model = JournalEntry
 
     id = factory.Sequence(lambda n: n)
-    name = factory.fuzzy.FuzzyText(length=12)
+    name = factory.Faker("word")
     version = factory.Sequence(lambda n: str(n) + ".0")
-    submitted_date = factory.fuzzy.FuzzyNaiveDateTime(datetime.datetime(2008, 1, 1))
+    submitted_date = factory.Faker(
+        "date_time_between_dates", datetime_start=datetime.datetime(2008, 1, 1)
+    )
     submitted_by = factory.SubFactory(UserFactory)
 
 
@@ -150,6 +154,8 @@ class ProhibitedProjectFactory(WarehouseFactory):
     class Meta:
         model = ProhibitedProjectName
 
-    created = factory.fuzzy.FuzzyNaiveDateTime(datetime.datetime(2008, 1, 1))
-    name = factory.fuzzy.FuzzyText(length=12)
+    created = factory.Faker(
+        "date_time_between_dates", datetime_start=datetime.datetime(2008, 1, 1)
+    )
+    name = factory.Faker("pystr", max_chars=12)
     prohibited_by = factory.SubFactory(UserFactory)

--- a/tests/common/db/ses.py
+++ b/tests/common/db/ses.py
@@ -13,33 +13,34 @@
 import datetime
 
 import factory
-import factory.fuzzy
 
 from warehouse.email.ses.models import EmailMessage, Event, EventTypes
 
-from .base import FuzzyEmail, WarehouseFactory
+from .base import WarehouseFactory
 
 
 class EmailMessageFactory(WarehouseFactory):
     class Meta:
         model = EmailMessage
 
-    created = factory.fuzzy.FuzzyNaiveDateTime(
-        datetime.datetime.utcnow() - datetime.timedelta(days=14)
+    created = factory.Faker(
+        "date_time_between_dates",
+        datetime_start=datetime.datetime.utcnow() - datetime.timedelta(days=14),
     )
-    message_id = factory.fuzzy.FuzzyText(length=12)
-    from_ = FuzzyEmail()
-    to = FuzzyEmail()
-    subject = factory.fuzzy.FuzzyText(length=100)
+    message_id = factory.Faker("pystr", max_chars=12)
+    from_ = factory.Faker("safe_email")
+    to = factory.Faker("safe_email")
+    subject = factory.Faker("sentence")
 
 
 class EventFactory(WarehouseFactory):
     class Meta:
         model = Event
 
-    created = factory.fuzzy.FuzzyNaiveDateTime(
-        datetime.datetime.utcnow() - datetime.timedelta(days=14)
+    created = factory.Faker(
+        "date_time_between_dates",
+        datetime_start=datetime.datetime.utcnow() - datetime.timedelta(days=14),
     )
     email = factory.SubFactory(EmailMessageFactory)
-    event_id = factory.fuzzy.FuzzyText(length=12)
-    event_type = factory.fuzzy.FuzzyChoice([e.value for e in EventTypes])
+    event_id = factory.Faker("pystr", max_chars=12)
+    event_type = factory.Faker("random_element", elements=[e.value for e in EventTypes])

--- a/tests/common/db/sponsors.py
+++ b/tests/common/db/sponsors.py
@@ -10,24 +10,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from factory import fuzzy
+import factory
 
 from warehouse.sponsors.models import Sponsor
 
-from .base import FuzzyUrl, WarehouseFactory
+from .base import WarehouseFactory
 
 
 class SponsorFactory(WarehouseFactory):
     class Meta:
         model = Sponsor
 
-    name = fuzzy.FuzzyText(length=12)
-    service = fuzzy.FuzzyText(length=12)
-    activity_markdown = fuzzy.FuzzyText(length=12)
+    name = factory.Faker("word")
+    service = factory.Faker("sentence")
+    activity_markdown = factory.Faker("sentence")
 
-    link_url = FuzzyUrl()
-    color_logo_url = FuzzyUrl()
-    white_logo_url = FuzzyUrl()
+    link_url = factory.Faker("uri")
+    color_logo_url = factory.Faker("image_url")
+    white_logo_url = factory.Faker("image_url")
 
     is_active = True
     footer = True


### PR DESCRIPTION
Fixes #9707 

This PR replaces deprecated `factory.fuzzy` calls by `factory.Faker` ones. A few comments about this PR:

-  At several places I used `Faker("pystr")` instead of more meaningful providers such as `user_name`. This is because a few tests broke due to unique constraints violations;
- For some reason a few legacy tests are failing with no apparent reason to me. I spent some time investigating them, but couldn't figure out why. I decided to open this PR to get some help with them.