### PR TITLE
Clarify the ``python_version`` field of conveyor service URL doc

### DIFF
--- a/docs/api-reference/integration-guide.rst
+++ b/docs/api-reference/integration-guide.rst
@@ -125,3 +125,6 @@ where ``project_l`` is the first letter of the project name.
 ``python_version`` can be one of many things, akin to the old file
 structure PyPI used to hold on disk. In general this is only a good idea
 for ``source`` as a ``python_version`` to fetch tar and zip files.
+Otherwise, you will want to match the format of the ``python_version``
+field of the releases in the `JSON
+API <https://warehouse.readthedocs.io/api-reference/json/>`__.


### PR DESCRIPTION
Refs #4304

Add a sentence in the documentation that may have streamlined the issue.