### PR TITLE
[feature] transition the package_roles method onto the restful API

### DIFF
--- a/tests/unit/admin/views/test_projects.py
+++ b/tests/unit/admin/views/test_projects.py
@@ -99,6 +99,7 @@ class TestProjectDetail:
             "project": project,
             "releases": [],
             "maintainers": roles,
+            "package_roles": [],
             "journal": journals[:30],
             "ONE_MB": views.ONE_MB,
             "MAX_FILESIZE": views.MAX_FILESIZE,

--- a/warehouse/admin/views/projects.py
+++ b/warehouse/admin/views/projects.py
@@ -111,6 +111,16 @@ def project_detail(project, request):
         )
     ]
     maintainers = sorted(maintainers, key=lambda x: (x.role_name, x.user.username))
+    package_roles = [
+        role
+        for role in (
+            request.db.query(Role)
+            .join(User, Project)
+            .filter(Project.normalized_name == project)
+            .order_by(Role.role_name.desc(), User.username)
+            .all()
+        )
+    ]
     journal = [
         entry
         for entry in (
@@ -126,6 +136,7 @@ def project_detail(project, request):
         "project": project,
         "releases": releases,
         "maintainers": maintainers,
+        "package_roles": package_roles,
         "journal": journal,
         "ONE_MB": ONE_MB,
         "MAX_FILESIZE": MAX_FILESIZE,


### PR DESCRIPTION
These changes adds the `package_roles` as results of the return of the
`admin.views.project` restful API.

The `package_roles` method was available into the xmlrpc, unfortunately
these informations are missing into the restful API [1].

These changes adds the creation of an equivalent into the restful API.

[1] https://github.com/pypa/warehouse/issues/9700