### PR TITLE
call flush when uploading sponsor logos smaller than buffer size

### DIFF
--- a/warehouse/admin/services.py
+++ b/warehouse/admin/services.py
@@ -50,6 +50,7 @@ class LocalSponsorLogoStorage:
         with open(destination, "wb") as dest_fp:
             with open(file_path, "rb") as src_fp:
                 dest_fp.write(src_fp.read())
+                dest_fp.flush()
         return f"http://files:9001/sponsorlogos/{path}"
 
 

--- a/warehouse/admin/views/sponsors.py
+++ b/warehouse/admin/views/sponsors.py
@@ -108,6 +108,7 @@ def _upload_image(image_name, request, form):
     if request.POST.get(image_name) not in [None, b""]:
         with tempfile.NamedTemporaryFile() as fp:
             fp.write(request.POST[image_name].file.read())
+            fp.flush()
             content_type = request.POST[image_name].type
             storage = request.find_service(ISponsorLogoStorage)
             extension = os.path.splitext(request.POST[image_name].filename)[-1]


### PR DESCRIPTION
Sponsor logos in footer are missing as a result of attempting to migrate them all to our new storage 🤦🏼 