### PR TITLE
Replace factory.fuzzy class in favor of factory.Faker

### DIFF
--- a/tests/common/db/accounts.py
+++ b/tests/common/db/accounts.py
@@ -13,28 +13,33 @@
 import datetime
 
 import factory
-import factory.fuzzy
+import factory.faker
 
 from warehouse.accounts.models import Email, User, UserEvent
 
-from .base import FuzzyEmail, WarehouseFactory
+from .base import WarehouseFactory
 
 
 class UserFactory(WarehouseFactory):
     class Meta:
         model = User
 
-    username = factory.fuzzy.FuzzyText(length=12)
-    name = factory.fuzzy.FuzzyText(length=12)
+    username = factory.faker.Faker("password", special_chars=False)
+    name = factory.faker.Faker("name")
     password = "!"
     is_active = True
     is_superuser = False
     is_moderator = False
     is_psf_staff = False
-    date_joined = factory.fuzzy.FuzzyNaiveDateTime(
-        datetime.datetime(2005, 1, 1), datetime.datetime(2010, 1, 1)
+    date_joined = factory.faker.Faker(
+        "date_time_between_dates",
+        datetime_start=datetime.datetime(2005, 1, 1),
+        datetime_end=datetime.datetime(2010, 1, 1),
     )
-    last_login = factory.fuzzy.FuzzyNaiveDateTime(datetime.datetime(2011, 1, 1))
+    last_login = factory.faker.Faker(
+        "date_time_between_dates",
+        datetime_start=datetime.datetime(2011, 1, 1),
+    )
 
 
 class UserEventFactory(WarehouseFactory):
@@ -49,7 +54,7 @@ class EmailFactory(WarehouseFactory):
         model = Email
 
     user = factory.SubFactory(UserFactory)
-    email = FuzzyEmail()
+    email = factory.faker.Faker("email")
     verified = True
     primary = True
     public = False

--- a/tests/common/db/admin.py
+++ b/tests/common/db/admin.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import factory.fuzzy
+import factory.faker
 
 from warehouse.admin.flags import AdminFlag
 
@@ -21,6 +21,6 @@ class AdminFlagFactory(WarehouseFactory):
     class Meta:
         model = AdminFlag
 
-    id = factory.fuzzy.FuzzyText(length=12)
-    description = factory.fuzzy.FuzzyText(length=24)
+    id = factory.faker.Faker("password", special_chars=False, length=12)
+    description = factory.faker.Faker("text", max_nb_chars=24)
     enabled = True

--- a/tests/common/db/banners.py
+++ b/tests/common/db/banners.py
@@ -12,21 +12,21 @@
 
 from datetime import date, timedelta
 
-from factory import fuzzy
+import factory
 
 from warehouse.banners.models import Banner
 
-from .base import FuzzyUrl, WarehouseFactory
+from .base import WarehouseFactory
 
 
 class BannerFactory(WarehouseFactory):
     class Meta:
         model = Banner
 
-    name = fuzzy.FuzzyText(length=12)
-    text = fuzzy.FuzzyText(length=30)
-    link_url = FuzzyUrl()
-    link_label = fuzzy.FuzzyText(length=10)
+    name = factory.faker.Faker("word")
+    text = factory.faker.Faker("text", max_nb_chars=30)
+    link_url = factory.faker.Faker("url")
+    link_label = factory.faker.Faker("text", max_nb_chars=10)
 
     active = True
     end = date.today() + timedelta(days=2)

--- a/tests/common/db/malware.py
+++ b/tests/common/db/malware.py
@@ -11,9 +11,9 @@
 # limitations under the License.
 
 import datetime
+import random
 
 import factory
-import factory.fuzzy
 
 from warehouse.malware.models import (
     MalwareCheck,
@@ -33,16 +33,19 @@ class MalwareCheckFactory(WarehouseFactory):
     class Meta:
         model = MalwareCheck
 
-    name = factory.fuzzy.FuzzyText(length=12)
+    name = factory.faker.Faker("password", special_chars=False, length=12)
     version = 1
-    short_description = factory.fuzzy.FuzzyText(length=80)
-    long_description = factory.fuzzy.FuzzyText(length=300)
-    check_type = factory.fuzzy.FuzzyChoice(list(MalwareCheckType))
-    hooked_object = factory.fuzzy.FuzzyChoice(list(MalwareCheckObjectType))
+    short_description = factory.faker.Faker("text", max_nb_chars=80)
+    long_description = factory.faker.Faker("text", max_nb_chars=300)
+    check_type = factory.LazyFunction(lambda: random.choice(list(MalwareCheckType)))
+    hooked_object = factory.LazyFunction(
+        lambda: random.choice(list(MalwareCheckObjectType))
+    )
     schedule = {"minute": "*/10"}
-    state = factory.fuzzy.FuzzyChoice(list(MalwareCheckState))
-    created = factory.fuzzy.FuzzyNaiveDateTime(
-        datetime.datetime.utcnow() - datetime.timedelta(days=7)
+    state = factory.LazyFunction(lambda: random.choice(list(MalwareCheckState)))
+    created = factory.faker.Faker(
+        "date_time_between_dates",
+        datetime_start=(datetime.datetime.utcnow() - datetime.timedelta(days=7)),
     )
 
 
@@ -55,10 +58,16 @@ class MalwareVerdictFactory(WarehouseFactory):
     release = None
     project = None
     manually_reviewed = True
-    reviewer_verdict = factory.fuzzy.FuzzyChoice(list(VerdictClassification))
-    classification = factory.fuzzy.FuzzyChoice(list(VerdictClassification))
-    confidence = factory.fuzzy.FuzzyChoice(list(VerdictConfidence))
-    message = factory.fuzzy.FuzzyText(length=80)
-    run_date = factory.fuzzy.FuzzyNaiveDateTime(datetime.datetime.utcnow())
+    reviewer_verdict = factory.LazyFunction(
+        lambda: random.choice(list(VerdictClassification))
+    )
+    classification = factory.LazyFunction(
+        lambda: random.choice(list(VerdictClassification))
+    )
+    confidence = factory.LazyFunction(lambda: random.choice(list(VerdictConfidence)))
+    message = factory.faker.Faker("text", max_nb_chars=80)
+    run_date = factory.faker.Faker(
+        "date_time_between_dates", datetime_start=datetime.datetime.utcnow()
+    )
     full_report_link = None
     details = None

--- a/tests/common/db/packaging.py
+++ b/tests/common/db/packaging.py
@@ -13,9 +13,9 @@
 import datetime
 import hashlib
 import uuid
+import random
 
 import factory
-import factory.fuzzy
 import packaging.utils
 
 from warehouse.packaging.models import (
@@ -42,7 +42,7 @@ class ProjectFactory(WarehouseFactory):
         model = Project
 
     id = factory.LazyFunction(uuid.uuid4)
-    name = factory.fuzzy.FuzzyText(length=12)
+    name = factory.faker.Faker("password", special_chars=False, length=12)
 
 
 class ProjectEventFactory(WarehouseFactory):
@@ -57,7 +57,7 @@ class DescriptionFactory(WarehouseFactory):
         model = Description
 
     id = factory.LazyFunction(uuid.uuid4)
-    raw = factory.fuzzy.FuzzyText(length=100)
+    raw = factory.faker.Faker("text", max_nb_chars=100)
     html = factory.LazyAttribute(lambda o: readme.render(o.raw))
     rendered_by = factory.LazyAttribute(lambda o: readme.renderer_version())
 
@@ -84,7 +84,7 @@ class FileFactory(WarehouseFactory):
 
     release = factory.SubFactory(ReleaseFactory)
     python_version = "source"
-    filename = factory.fuzzy.FuzzyText(length=12)
+    filename = factory.faker.Faker("file_name")
     md5_digest = factory.LazyAttribute(
         lambda o: hashlib.md5(o.filename.encode("utf8")).hexdigest()
     )
@@ -94,7 +94,10 @@ class FileFactory(WarehouseFactory):
     blake2_256_digest = factory.LazyAttribute(
         lambda o: hashlib.blake2b(o.filename.encode("utf8"), digest_size=32).hexdigest()
     )
-    upload_time = factory.fuzzy.FuzzyNaiveDateTime(datetime.datetime(2008, 1, 1))
+    upload_time = factory.faker.Faker(
+        "date_time_between_dates",
+        datetime_start=datetime.datetime(2008, 1, 1)
+    )
     path = factory.LazyAttribute(
         lambda o: "/".join(
             [
@@ -131,8 +134,10 @@ class DependencyFactory(WarehouseFactory):
         model = Dependency
 
     release = factory.SubFactory(ReleaseFactory)
-    kind = factory.fuzzy.FuzzyChoice(int(kind) for kind in DependencyKind)
-    specifier = factory.fuzzy.FuzzyText(length=12)
+    kind = factory.LazyFunction(
+        lambda: random.choice([int(kind) for kind in DependencyKind])
+    )
+    specifier = factory.faker.Faker("word")
 
 
 class JournalEntryFactory(WarehouseFactory):
@@ -140,9 +145,12 @@ class JournalEntryFactory(WarehouseFactory):
         model = JournalEntry
 
     id = factory.Sequence(lambda n: n)
-    name = factory.fuzzy.FuzzyText(length=12)
+    name = factory.faker.Faker("password", special_chars=False, length=12)
     version = factory.Sequence(lambda n: str(n) + ".0")
-    submitted_date = factory.fuzzy.FuzzyNaiveDateTime(datetime.datetime(2008, 1, 1))
+    submitted_date = factory.faker.Faker(
+        "date_time_between_dates",
+        datetime_start=datetime.datetime(2008, 1, 1)
+    )
     submitted_by = factory.SubFactory(UserFactory)
 
 
@@ -150,6 +158,9 @@ class ProhibitedProjectFactory(WarehouseFactory):
     class Meta:
         model = ProhibitedProjectName
 
-    created = factory.fuzzy.FuzzyNaiveDateTime(datetime.datetime(2008, 1, 1))
-    name = factory.fuzzy.FuzzyText(length=12)
+    created = factory.faker.Faker(
+        "date_time_between_dates",
+        datetime_start=datetime.datetime(2008, 1, 1)
+    )
+    name = factory.faker.Faker("password", special_chars=False, length=12)
     prohibited_by = factory.SubFactory(UserFactory)

--- a/tests/common/db/ses.py
+++ b/tests/common/db/ses.py
@@ -11,35 +11,39 @@
 # limitations under the License.
 
 import datetime
+import random
 
 import factory
-import factory.fuzzy
 
 from warehouse.email.ses.models import EmailMessage, Event, EventTypes
 
-from .base import FuzzyEmail, WarehouseFactory
+from .base import WarehouseFactory
 
 
 class EmailMessageFactory(WarehouseFactory):
     class Meta:
         model = EmailMessage
 
-    created = factory.fuzzy.FuzzyNaiveDateTime(
-        datetime.datetime.utcnow() - datetime.timedelta(days=14)
+    created = factory.faker.Faker(
+        "date_time_between_dates",
+        datetime_start=datetime.datetime.utcnow() - datetime.timedelta(days=14)
     )
-    message_id = factory.fuzzy.FuzzyText(length=12)
-    from_ = FuzzyEmail()
-    to = FuzzyEmail()
-    subject = factory.fuzzy.FuzzyText(length=100)
+    from_ = factory.faker.Faker("email")
+    to = factory.faker.Faker("email")
+    message_id = factory.faker.Faker("password", special_chars=False, length=12)
+    subject = factory.faker.Faker("text", max_nb_chars=100)
 
 
 class EventFactory(WarehouseFactory):
     class Meta:
         model = Event
 
-    created = factory.fuzzy.FuzzyNaiveDateTime(
-        datetime.datetime.utcnow() - datetime.timedelta(days=14)
+    created = factory.faker.Faker(
+        "date_time_between_dates",
+        datetime_start=datetime.datetime.utcnow() - datetime.timedelta(days=14)
     )
     email = factory.SubFactory(EmailMessageFactory)
-    event_id = factory.fuzzy.FuzzyText(length=12)
-    event_type = factory.fuzzy.FuzzyChoice([e.value for e in EventTypes])
+    event_id = factory.faker.Faker("password", special_chars=False, length=12)
+    event_type = factory.LazyFunction(
+        lambda: random.choice([e.value for e in EventTypes])
+    )

--- a/tests/common/db/sponsors.py
+++ b/tests/common/db/sponsors.py
@@ -10,24 +10,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from factory import fuzzy
+import factory
 
 from warehouse.sponsors.models import Sponsor
 
-from .base import FuzzyUrl, WarehouseFactory
+from .base import WarehouseFactory
 
 
 class SponsorFactory(WarehouseFactory):
     class Meta:
         model = Sponsor
 
-    name = fuzzy.FuzzyText(length=12)
-    service = fuzzy.FuzzyText(length=12)
-    activity_markdown = fuzzy.FuzzyText(length=12)
+    name = factory.faker.Faker("word")
+    service = factory.faker.Faker("word")
+    activity_markdown = factory.faker.Faker("text")
 
-    link_url = FuzzyUrl()
-    color_logo_url = FuzzyUrl()
-    white_logo_url = FuzzyUrl()
+    link_url = factory.faker.Faker("url")
+    color_logo_url = factory.faker.Faker("url")
+    white_logo_url = factory.faker.Faker("url")
 
     is_active = True
     footer = True

--- a/tests/unit/integration/vulnerabilities/test_utils.py
+++ b/tests/unit/integration/vulnerabilities/test_utils.py
@@ -12,7 +12,6 @@
 
 import collections
 
-import factory.fuzzy
 import pretend
 import pytest
 
@@ -258,7 +257,7 @@ def test_analyze_vulnerability_project_not_found(db_request, metrics):
         utils.analyze_vulnerability(
             request=db_request,
             vulnerability_report={
-                "project": factory.fuzzy.FuzzyText(length=8).fuzz(),
+                "project": "test_project",
                 "versions": ["1", "2"],
                 "id": "vuln_id",
                 "link": "vulns.com/vuln_id",

--- a/tests/unit/legacy/api/xmlrpc/test_xmlrpc.py
+++ b/tests/unit/legacy/api/xmlrpc/test_xmlrpc.py
@@ -852,7 +852,7 @@ def test_changelog(db_request, with_ids):
             e.id,
         )
         for e in entries
-        if (e.submitted_date.replace(tzinfo=datetime.timezone.utc).timestamp() > since)
+        if (e.submitted_date.replace(tzinfo=datetime.timezone.utc).timestamp() > since - 1)
     ]
 
     if not with_ids:


### PR DESCRIPTION
This PR addresses an issue described in #9707

Basically it is a refactoring to stop using a deprecated factory.fuzzy library.

There are a few problems here, though.

* There is no direct analogue to `FuzzyText` factory
    * Sometimes we can use `word` provider. But the set of words there is very limited, which sometimes leads to collisions in database (primary key violation)
    * We can use `password` provider where `word` provider gives us collision. I don't like it though, as it leads to some confusion, as the thing we generate is not really a "password"
    * In some cases we can use `text` provider. It generates you a human readable text in English. Not always we can use spaces and punctuation though
* `test_changelog` test is broken. I have no idea why, though. According to the code `expected` variable [here](https://github.com/pypa/warehouse/blob/main/tests/unit/legacy/api/xmlrpc/test_xmlrpc.py#L855) contains all the journal entries with created time strictly greater than `since` variable. And then we [select from database](https://github.com/pypa/warehouse/blob/main/tests/unit/legacy/api/xmlrpc/test_xmlrpc.py#L865) all the entries which are greater than `since - 1`, which returns us one more entry and breaks the test case. I have no idea why did it work before and how to make it work again. So any help/advice here is appreciated
