### PR TITLE
Skip invalid releases on the vulnerability report

### DIFF
--- a/tests/unit/integration/vulnerabilities/test_utils.py
+++ b/tests/unit/integration/vulnerabilities/test_utils.py
@@ -269,8 +269,8 @@ def test_analyze_vulnerability_project_not_found(db_request, metrics):
         )
 
     assert metrics_counter == {
-        ("warehouse.vulnerabilities.received", ("origin:test_report_source",)): 2,
-        ("warehouse.vulnerabilities.valid", ("origin:test_report_source",)): 2,
+        ("warehouse.vulnerabilities.received", ("origin:test_report_source",)): 1,
+        ("warehouse.vulnerabilities.valid", ("origin:test_report_source",)): 1,
         (
             "warehouse.vulnerabilities.error.project_not_found",
             ("origin:test_report_source",),

--- a/tests/unit/integration/vulnerabilities/test_utils.py
+++ b/tests/unit/integration/vulnerabilities/test_utils.py
@@ -274,7 +274,7 @@ def test_analyze_vulnerability_project_not_found(db_request, metrics):
         (
             "warehouse.vulnerabilities.error.project_not_found",
             ("origin:test_report_source",),
-        ): 2,
+        ): 1,
     }
 
 

--- a/tests/unit/integration/vulnerabilities/test_utils.py
+++ b/tests/unit/integration/vulnerabilities/test_utils.py
@@ -274,7 +274,7 @@ def test_analyze_vulnerability_project_not_found(db_request, metrics):
         (
             "warehouse.vulnerabilities.error.project_not_found",
             ("origin:test_report_source",),
-        ): 1,
+        ): 2,
     }
 
 

--- a/tests/unit/integration/vulnerabilities/test_utils.py
+++ b/tests/unit/integration/vulnerabilities/test_utils.py
@@ -289,7 +289,7 @@ def test_analyze_vulnerability_release_not_found(db_request, metrics):
 
     metrics = pretend.stub(increment=metrics_increment, timed=metrics.timed)
 
-    with pytest.raises(NoResultFound):
+    with pytest.raises(HTTPBadRequest):
         utils.analyze_vulnerability(
             request=db_request,
             vulnerability_report={

--- a/tests/unit/integration/vulnerabilities/test_utils.py
+++ b/tests/unit/integration/vulnerabilities/test_utils.py
@@ -304,8 +304,8 @@ def test_analyze_vulnerability_release_not_found(db_request, metrics):
         )
 
     assert metrics_counter == {
-        ("warehouse.vulnerabilities.received", ("origin:test_report_source",)): 2,
-        ("warehouse.vulnerabilities.valid", ("origin:test_report_source",)): 2,
+        ("warehouse.vulnerabilities.received", ("origin:test_report_source",)): 1,
+        ("warehouse.vulnerabilities.valid", ("origin:test_report_source",)): 1,
         (
             "warehouse.vulnerabilities.error.release_not_found",
             ("origin:test_report_source",),

--- a/tests/unit/integration/vulnerabilities/test_utils.py
+++ b/tests/unit/integration/vulnerabilities/test_utils.py
@@ -269,8 +269,8 @@ def test_analyze_vulnerability_project_not_found(db_request, metrics):
         )
 
     assert metrics_counter == {
-        ("warehouse.vulnerabilities.received", ("origin:test_report_source",)): 1,
-        ("warehouse.vulnerabilities.valid", ("origin:test_report_source",)): 1,
+        ("warehouse.vulnerabilities.received", ("origin:test_report_source",)): 2,
+        ("warehouse.vulnerabilities.valid", ("origin:test_report_source",)): 2,
         (
             "warehouse.vulnerabilities.error.project_not_found",
             ("origin:test_report_source",),
@@ -304,8 +304,8 @@ def test_analyze_vulnerability_release_not_found(db_request, metrics):
         )
 
     assert metrics_counter == {
-        ("warehouse.vulnerabilities.received", ("origin:test_report_source",)): 1,
-        ("warehouse.vulnerabilities.valid", ("origin:test_report_source",)): 1,
+        ("warehouse.vulnerabilities.received", ("origin:test_report_source",)): 2,
+        ("warehouse.vulnerabilities.valid", ("origin:test_report_source",)): 2,
         (
             "warehouse.vulnerabilities.error.release_not_found",
             ("origin:test_report_source",),

--- a/tests/unit/integration/vulnerabilities/test_utils.py
+++ b/tests/unit/integration/vulnerabilities/test_utils.py
@@ -311,6 +311,10 @@ def test_analyze_vulnerability_release_not_found(db_request, metrics):
             "warehouse.vulnerabilities.error.release_not_found",
             ("origin:test_report_source",),
         ): 2,
+        (
+            'warehouse.vulnerabilities.error.unknown',
+            ('origin:test_report_source',),
+        ): 1
     }
 
 

--- a/tests/unit/integration/vulnerabilities/test_utils.py
+++ b/tests/unit/integration/vulnerabilities/test_utils.py
@@ -16,6 +16,7 @@ import factory.fuzzy
 import pretend
 import pytest
 
+from pyramid.httpexceptions import HTTPBadRequest
 from sqlalchemy.orm.exc import NoResultFound
 
 from tests.common.db.packaging import ProjectFactory, ReleaseFactory

--- a/tests/unit/integration/vulnerabilities/test_utils.py
+++ b/tests/unit/integration/vulnerabilities/test_utils.py
@@ -312,8 +312,8 @@ def test_analyze_vulnerability_release_not_found(db_request, metrics):
             ("origin:test_report_source",),
         ): 2,
         (
-            'warehouse.vulnerabilities.error.unknown',
-            ('origin:test_report_source',),
+            "warehouse.vulnerabilities.error.unknown",
+            ("origin:test_report_source",),
         ): 1
     }
 

--- a/tests/unit/integration/vulnerabilities/test_utils.py
+++ b/tests/unit/integration/vulnerabilities/test_utils.py
@@ -309,7 +309,7 @@ def test_analyze_vulnerability_release_not_found(db_request, metrics):
         (
             "warehouse.vulnerabilities.error.release_not_found",
             ("origin:test_report_source",),
-        ): 1,
+        ): 2,
     }
 
 

--- a/tests/unit/integration/vulnerabilities/test_utils.py
+++ b/tests/unit/integration/vulnerabilities/test_utils.py
@@ -311,10 +311,6 @@ def test_analyze_vulnerability_release_not_found(db_request, metrics):
             "warehouse.vulnerabilities.error.release_not_found",
             ("origin:test_report_source",),
         ): 2,
-        (
-            "warehouse.vulnerabilities.error.unknown",
-            ("origin:test_report_source",),
-        ): 1,
     }
 
 

--- a/tests/unit/integration/vulnerabilities/test_utils.py
+++ b/tests/unit/integration/vulnerabilities/test_utils.py
@@ -314,7 +314,7 @@ def test_analyze_vulnerability_release_not_found(db_request, metrics):
         (
             "warehouse.vulnerabilities.error.unknown",
             ("origin:test_report_source",),
-        ): 1
+        ): 1,
     }
 
 

--- a/warehouse/integrations/vulnerabilities/utils.py
+++ b/warehouse/integrations/vulnerabilities/utils.py
@@ -11,7 +11,6 @@
 # limitations under the License.
 
 from pyramid.httpexceptions import HTTPBadRequest
-
 from sqlalchemy import func, orm
 from sqlalchemy.orm.exc import NoResultFound
 

--- a/warehouse/integrations/vulnerabilities/utils.py
+++ b/warehouse/integrations/vulnerabilities/utils.py
@@ -146,7 +146,7 @@ def analyze_vulnerability(request, vulnerability_report, origin, metrics):
     except (
         vulnerabilities.InvalidVulnerabilityReportRequest,
         NoResultFound,
-        HTTPBadRequest
+        HTTPBadRequest,
     ):
         raise
     except Exception:

--- a/warehouse/integrations/vulnerabilities/utils.py
+++ b/warehouse/integrations/vulnerabilities/utils.py
@@ -101,12 +101,13 @@ def _analyze_vulnerability(request, vulnerability_report, origin, metrics):
         )
         raise
 
-    report_found_releases = []  # store the found releases
+    found_releases = False  # by now, we don't have any release found
 
     for version in report.versions:
         try:
             release = _get_release(request, project, version)
             report_found_releases.append(release)
+            found_releases = True  # at least one release found
         except NoResultFound:
             metrics.increment(
                 "warehouse.vulnerabilities.error.release_not_found",
@@ -116,7 +117,7 @@ def _analyze_vulnerability(request, vulnerability_report, origin, metrics):
         if release not in vulnerability_record.releases:
             vulnerability_record.releases.append(release)
 
-    if len(report_found_releases) < 1:
+    if not found_releases:
         # no releases found, then raise an exception
         raise NoResultFound("None of the releases were found")
 

--- a/warehouse/integrations/vulnerabilities/utils.py
+++ b/warehouse/integrations/vulnerabilities/utils.py
@@ -10,6 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from pyramid.httpexceptions import HTTPBadRequest
 
 from sqlalchemy import func, orm
 from sqlalchemy.orm.exc import NoResultFound
@@ -119,7 +120,7 @@ def _analyze_vulnerability(request, vulnerability_report, origin, metrics):
 
     if not found_releases:
         # no releases found, then raise an exception
-        raise NoResultFound("None of the releases were found")
+        raise HTTPBadRequest("None of the releases were found")
 
     # Unassociate any releases that no longer apply.
     for release in list(vulnerability_record.releases):

--- a/warehouse/integrations/vulnerabilities/utils.py
+++ b/warehouse/integrations/vulnerabilities/utils.py
@@ -143,7 +143,11 @@ def analyze_vulnerability(request, vulnerability_report, origin, metrics):
         metrics.increment(
             "warehouse.vulnerabilities.processed", tags=[f"origin:{origin}"]
         )
-    except (vulnerabilities.InvalidVulnerabilityReportRequest, NoResultFound):
+    except (
+        vulnerabilities.InvalidVulnerabilityReportRequest,
+        NoResultFound,
+        HTTPBadRequest
+    ):
         raise
     except Exception:
         metrics.increment(

--- a/warehouse/integrations/vulnerabilities/utils.py
+++ b/warehouse/integrations/vulnerabilities/utils.py
@@ -106,7 +106,6 @@ def _analyze_vulnerability(request, vulnerability_report, origin, metrics):
     for version in report.versions:
         try:
             release = _get_release(request, project, version)
-            report_found_releases.append(release)
             found_releases = True  # at least one release found
         except NoResultFound:
             metrics.increment(

--- a/warehouse/integrations/vulnerabilities/utils.py
+++ b/warehouse/integrations/vulnerabilities/utils.py
@@ -112,6 +112,7 @@ def _analyze_vulnerability(request, vulnerability_report, origin, metrics):
                 "warehouse.vulnerabilities.error.release_not_found",
                 tags=[f"origin:{origin}"],
             )
+            continue  # skip that release
 
         if release not in vulnerability_record.releases:
             vulnerability_record.releases.append(release)


### PR DESCRIPTION
Closes #9913. Store the releases found on the vulnerability report, and skip those versions that are not found. If no releases were saved, then we can raise an exception.

CC @di