### PR TITLE
Fix classifier sort order for Python 3.10

### DIFF
--- a/tests/functional/test_templates.py
+++ b/tests/functional/test_templates.py
@@ -21,7 +21,6 @@ FILTERS = {
     "format_datetime": "warehouse.i18n.filters:format_datetime",
     "format_rfc822_datetime": "warehouse.i18n.filters:format_rfc822_datetime",
     "format_number": "warehouse.i18n.filters:format_number",
-    "format_classifiers": "warehouse.filters:format_classifiers",
     "classifier_id": "warehouse.filters:classifier_id",
     "format_tags": "warehouse.filters:format_tags",
     "json": "warehouse.filters:tojson",

--- a/tests/unit/test_filters.py
+++ b/tests/unit/test_filters.py
@@ -136,23 +136,6 @@ def test_format_tags(inp, expected):
 
 
 @pytest.mark.parametrize(
-    ("inp", "expected"),
-    [
-        (
-            ["Foo :: Bar :: Baz", "Foo :: Bar :: Qux", "Vleep"],
-            [("Foo", ["Bar :: Baz", "Bar :: Qux"])],
-        ),
-        (
-            ["Vleep :: Foo", "Foo :: Bar :: Qux", "Foo :: Bar :: Baz"],
-            [("Foo", ["Bar :: Baz", "Bar :: Qux"]), ("Vleep", ["Foo"])],
-        ),
-    ],
-)
-def test_format_classifiers(inp, expected):
-    assert list(filters.format_classifiers(inp).items()) == expected
-
-
-@pytest.mark.parametrize(
     ("inp", "expected"), [("Foo", "Foo"), ("Foo :: Foo", "Foo_._Foo")]
 )
 def test_classifier_id(inp, expected):

--- a/warehouse/config.py
+++ b/warehouse/config.py
@@ -315,7 +315,6 @@ def configure(settings=None):
 
     # We'll want to configure some filters for Jinja2 as well.
     filters = config.get_settings().setdefault("jinja2.filters", {})
-    filters.setdefault("format_classifiers", "warehouse.filters:format_classifiers")
     filters.setdefault("classifier_id", "warehouse.filters:classifier_id")
     filters.setdefault("format_tags", "warehouse.filters:format_tags")
     filters.setdefault("json", "warehouse.filters:tojson")

--- a/warehouse/filters.py
+++ b/warehouse/filters.py
@@ -11,7 +11,6 @@
 # limitations under the License.
 
 import binascii
-import collections
 import enum
 import hmac
 import json
@@ -121,27 +120,6 @@ def format_tags(tags):
     formatted_tags = [t for t in stripped_tags if t]
 
     return formatted_tags
-
-
-def format_classifiers(classifiers):
-    structured = collections.defaultdict(list)
-
-    # Split up our classifiers into our data structure
-    for classifier in classifiers:
-        key, *value = classifier.split(" :: ", 1)
-        if value:
-            structured[key].append(value[0])
-
-    # Go through and ensure that all of the lists in our classifiers are in
-    # sorted order.
-    structured = {k: sorted(v) for k, v in structured.items()}
-
-    # Now, we'll ensure that our keys themselves are in sorted order, using an
-    # OrderedDict to preserve this ordering when we pass this data back up to
-    # our caller.
-    structured = collections.OrderedDict(sorted(structured.items()))
-
-    return structured
 
 
 def classifier_id(classifier):

--- a/warehouse/templates/includes/packaging/project-data.html
+++ b/warehouse/templates/includes/packaging/project-data.html
@@ -125,7 +125,7 @@
 <div class="sidebar-section">
   <h3 class="sidebar-section__title">{% trans %}Classifiers{% endtrans %}</h3>
   <ul class="sidebar-section__classifiers">
-    {% for classifier_head, classifier_tail in (release.classifiers|format_classifiers()).items() %}
+    {% for classifier_head, classifier_tail in release.classifiers.items() %}
     <li>
       <strong>{{ classifier_head }}</strong>
       <ul>


### PR DESCRIPTION
Fixes https://github.com/pypa/warehouse/issues/8843.

Remove `format_classifiers` sort to retain original classifiers sort order: https://github.com/pypa/warehouse/issues/8843#issuecomment-896959818.

(Not tested locally, ran out of disk space for Docker.)
