### PR TITLE
Add make test-shell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,8 +84,16 @@ debug: .state/docker-build
 	docker-compose run --rm --service-ports web
 
 tests: .state/docker-build
+	docker-compose up -d db
 	docker-compose run --rm web env -i ENCODING="C.UTF-8" \
 								  PATH="/opt/warehouse/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
+								  bin/tests --postgresql-host db $(T) $(TESTARGS)
+
+test-shell: .state/docker-build
+	docker-compose up -d db
+	docker-compose run --rm web env -i ENCODING="C.UTF-8" \
+								  PATH="/opt/warehouse/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
+								  OPEN_SHELL=1 \
 								  bin/tests --postgresql-host db $(T) $(TESTARGS)
 
 static_tests: .state/docker-build

--- a/bin/tests
+++ b/bin/tests
@@ -29,6 +29,12 @@ if [ $ATTEMPTS -eq 5 ]; then
   exit 1
 fi
 
+if [ -n "${OPEN_SHELL:-}" ]; then
+    export PYTHONPATH=/opt/warehouse/src/
+    echo "Welcome to the test shell. Use 'pytest' to run the tests."
+    exec bash
+fi
+
 # Print all the followng commands
 set -x
 

--- a/docs/development/getting-started.rst
+++ b/docs/development/getting-started.rst
@@ -552,6 +552,21 @@ If you want to run a specific test, you can use the ``T`` variable:
 
     T=tests/unit/i18n/test_filters.py make tests
 
+If you find yourself launching some tests multiple times in a row, you may
+find out that the startup time of docker can get in the way of a quick
+feedback loop. In this case, you may want to run:
+
+.. code-block:: console
+
+    make test-shell
+
+This will open a bash console in a configured docker-container, where you can
+run ``pytest`` directly. `Some pytest options`__ such as ``--last-failed`` or
+``--stepwise`` which keep a cache between test runs and allow a faster
+feedback loop, are much easier to use in a test-shell.
+
+.. __: https://docs.pytest.org/en/6.2.x/cache.html
+
 You can run linters, programs that check the code, with:
 
 .. code-block:: console


### PR DESCRIPTION
Maybe the makefile could be improved and simplified a bit (after #10021 is merged) but meanwhile, this might help.

This PR adds a makefile target that lets you dramatically speed up the feedback loop of tests when you write some code and run tests and iterate.