### PR TITLE
Remove space before colon in project settings

### DIFF
--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -3071,7 +3071,7 @@ msgid "Project settings"
 msgstr ""
 
 #: warehouse/templates/manage/settings.html:23
-msgid "Project size :"
+msgid "Project size:"
 msgstr ""
 
 #: warehouse/templates/manage/settings.html:31

--- a/warehouse/templates/manage/settings.html
+++ b/warehouse/templates/manage/settings.html
@@ -20,9 +20,9 @@
 {% block main %}
   <h2>{% trans %}Project settings{% endtrans %}</h2>
   <ul>
-    <li>{% trans  %}Project size :{% endtrans %}
+    <li>{% trans  %}Project size:{% endtrans %}
     {{ project.total_size|filesizeformat(binary=True) }}</li>
-    <li>Project upload limit :
+    <li>Project upload limit:
     {% if project.upload_limit %}
       {{ project.upload_limit|filesizeformat(binary=True) }}
     {% else %}
@@ -30,7 +30,7 @@
     {% endif %}
     {% trans help_url=request.help_url(_anchor='file-size-limit') %}
     <a href="{{ help_url }}"> (request an increase) </a>{% endtrans %}</li>
-    <li>Project total size limit :
+    <li>Project total size limit:
     {% if project.total_size_limit %}
       {{ project.total_size_limit|filesizeformat(binary=True) }}
     {% else %}


### PR DESCRIPTION

Remove the space before colon in:

> * Project size : 201.7 KiB
> * Project upload limit : Default (100.0 MiB) (request an increase)
> * Project total size limit : Default (10.0 GiB) (request an increase)

![image](https://user-images.githubusercontent.com/1324225/134190846-31ac9a0d-76d1-4e5c-b741-c0b0bc2e01d9.png)

https://pypi.org/manage/project/foo/settings/

And run `make compile-pot`.


