### PR TITLE
Store/display WebAuthn device label in UserEvent

### DIFF
--- a/tests/unit/accounts/test_views.py
+++ b/tests/unit/accounts/test_views.py
@@ -243,7 +243,7 @@ class TestLogin:
                 user_id,
                 tag="account:login:success",
                 ip_address=pyramid_request.remote_addr,
-                additional={"two_factor_method": None},
+                additional={"two_factor_method": None, "two_factor_label": None},
             )
         ]
 
@@ -302,7 +302,7 @@ class TestLogin:
                 1,
                 tag="account:login:success",
                 ip_address=pyramid_request.remote_addr,
-                additional={"two_factor_method": None},
+                additional={"two_factor_method": None, "two_factor_label": None},
             )
         ]
         assert pyramid_request.session.record_auth_timestamp.calls == [pretend.call()]
@@ -608,7 +608,7 @@ class TestTwoFactor:
                 "1",
                 tag="account:login:success",
                 ip_address=pyramid_request.remote_addr,
-                additional={"two_factor_method": "totp"},
+                additional={"two_factor_method": "totp", "two_factor_label": "totp"},
             )
         ]
         assert pyramid_request.session.record_auth_timestamp.calls == [pretend.call()]
@@ -835,7 +835,7 @@ class TestWebAuthn:
         user_service = pretend.stub(
             get_user=pretend.call_recorder(lambda uid: user),
             get_webauthn_by_credential_id=pretend.call_recorder(
-                lambda *a: pretend.stub()
+                lambda *a: pretend.stub(label="webauthn_label")
             ),
         )
         pyramid_request.session = pretend.stub(
@@ -856,7 +856,12 @@ class TestWebAuthn:
 
         assert _get_two_factor_data.calls == [pretend.call(pyramid_request)]
         assert _login_user.calls == [
-            pretend.call(pyramid_request, 1, two_factor_method="webauthn")
+            pretend.call(
+                pyramid_request,
+                1,
+                two_factor_method="webauthn",
+                two_factor_label="webauthn_label",
+            )
         ]
         assert pyramid_request.session.get_webauthn_challenge.calls == [pretend.call()]
         assert pyramid_request.session.clear_webauthn_challenge.calls == [
@@ -1021,7 +1026,10 @@ class TestRecoveryCode:
                 "1",
                 tag="account:login:success",
                 ip_address=pyramid_request.remote_addr,
-                additional={"two_factor_method": "recovery-code"},
+                additional={
+                    "two_factor_method": "recovery-code",
+                    "two_factor_label": None,
+                },
             ),
             pretend.call(
                 "1",
@@ -1266,7 +1274,7 @@ class TestRegister:
                 user.id,
                 tag="account:login:success",
                 ip_address=db_request.remote_addr,
-                additional={"two_factor_method": None},
+                additional={"two_factor_method": None, "two_factor_label": None},
             ),
         ]
 

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -85,122 +85,122 @@ msgid ""
 "Check your inbox and follow the verification links. (IP: ${ip})"
 msgstr ""
 
-#: warehouse/accounts/views.py:232 warehouse/accounts/views.py:289
-#: warehouse/accounts/views.py:291 warehouse/accounts/views.py:318
-#: warehouse/accounts/views.py:320 warehouse/accounts/views.py:375
+#: warehouse/accounts/views.py:232 warehouse/accounts/views.py:291
+#: warehouse/accounts/views.py:293 warehouse/accounts/views.py:320
+#: warehouse/accounts/views.py:322 warehouse/accounts/views.py:382
 msgid "Invalid or expired two factor login."
 msgstr ""
 
-#: warehouse/accounts/views.py:283
+#: warehouse/accounts/views.py:285
 msgid "Already authenticated"
 msgstr ""
 
-#: warehouse/accounts/views.py:351
+#: warehouse/accounts/views.py:358
 msgid "Successful WebAuthn assertion"
 msgstr ""
 
-#: warehouse/accounts/views.py:404
+#: warehouse/accounts/views.py:411
 msgid "Recovery code accepted. The supplied code cannot be used again."
 msgstr ""
 
-#: warehouse/accounts/views.py:490
+#: warehouse/accounts/views.py:497
 msgid ""
 "New user registration temporarily disabled. See https://pypi.org/help"
 "#admin-intervention for details."
 msgstr ""
 
-#: warehouse/accounts/views.py:607
+#: warehouse/accounts/views.py:614
 msgid "Expired token: request a new password reset link"
 msgstr ""
 
-#: warehouse/accounts/views.py:609
+#: warehouse/accounts/views.py:616
 msgid "Invalid token: request a new password reset link"
 msgstr ""
 
-#: warehouse/accounts/views.py:611 warehouse/accounts/views.py:694
-#: warehouse/accounts/views.py:790
+#: warehouse/accounts/views.py:618 warehouse/accounts/views.py:701
+#: warehouse/accounts/views.py:797
 msgid "Invalid token: no token supplied"
 msgstr ""
 
-#: warehouse/accounts/views.py:615
+#: warehouse/accounts/views.py:622
 msgid "Invalid token: not a password reset token"
 msgstr ""
 
-#: warehouse/accounts/views.py:620
+#: warehouse/accounts/views.py:627
 msgid "Invalid token: user not found"
 msgstr ""
 
-#: warehouse/accounts/views.py:627
+#: warehouse/accounts/views.py:634
 msgid "Invalid token: user has logged in since this token was requested"
 msgstr ""
 
-#: warehouse/accounts/views.py:636
+#: warehouse/accounts/views.py:643
 msgid ""
 "Invalid token: password has already been changed since this token was "
 "requested"
 msgstr ""
 
-#: warehouse/accounts/views.py:663
+#: warehouse/accounts/views.py:670
 msgid "You have reset your password"
 msgstr ""
 
-#: warehouse/accounts/views.py:690
+#: warehouse/accounts/views.py:697
 msgid "Expired token: request a new email verification link"
 msgstr ""
 
-#: warehouse/accounts/views.py:692
+#: warehouse/accounts/views.py:699
 msgid "Invalid token: request a new email verification link"
 msgstr ""
 
-#: warehouse/accounts/views.py:698
+#: warehouse/accounts/views.py:705
 msgid "Invalid token: not an email verification token"
 msgstr ""
 
-#: warehouse/accounts/views.py:707
+#: warehouse/accounts/views.py:714
 msgid "Email not found"
 msgstr ""
 
-#: warehouse/accounts/views.py:710
+#: warehouse/accounts/views.py:717
 msgid "Email already verified"
 msgstr ""
 
-#: warehouse/accounts/views.py:725
+#: warehouse/accounts/views.py:732
 msgid "You can now set this email as your primary address"
 msgstr ""
 
-#: warehouse/accounts/views.py:729
+#: warehouse/accounts/views.py:736
 msgid "This is your primary address"
 msgstr ""
 
-#: warehouse/accounts/views.py:734
+#: warehouse/accounts/views.py:741
 msgid "Email address ${email_address} verified. ${confirm_message}."
 msgstr ""
 
-#: warehouse/accounts/views.py:786
+#: warehouse/accounts/views.py:793
 msgid "Expired token: request a new project role invite"
 msgstr ""
 
-#: warehouse/accounts/views.py:788
+#: warehouse/accounts/views.py:795
 msgid "Invalid token: request a new project role invite"
 msgstr ""
 
-#: warehouse/accounts/views.py:794
+#: warehouse/accounts/views.py:801
 msgid "Invalid token: not a collaboration invitation token"
 msgstr ""
 
-#: warehouse/accounts/views.py:798
+#: warehouse/accounts/views.py:805
 msgid "Role invitation is not valid."
 msgstr ""
 
-#: warehouse/accounts/views.py:813
+#: warehouse/accounts/views.py:820
 msgid "Role invitation no longer exists."
 msgstr ""
 
-#: warehouse/accounts/views.py:825
+#: warehouse/accounts/views.py:832
 msgid "Invitation for '${project_name}' is declined."
 msgstr ""
 
-#: warehouse/accounts/views.py:892
+#: warehouse/accounts/views.py:899
 msgid "You are now ${role} of the '${project_name}' project."
 msgstr ""
 

--- a/warehouse/templates/manage/account.html
+++ b/warehouse/templates/manage/account.html
@@ -567,7 +567,7 @@
         {% if event.additional.two_factor_method == None %}
           {% trans %}None{% endtrans %}
         {% elif event.additional.two_factor_method  == "webauthn" %}
-          {% trans %}Security device (<abbr title="web authentication">WebAuthn</abbr>){% endtrans %}{% if event.additional.two_factor_label %} - "{{ event.additional.two_factor_label }}"{% endif %}
+          {% if event.additional.two_factor_label %}<strong>"{{ event.additional.two_factor_label }}"</strong> - {% endif %}{% trans %}Security device (<abbr title="web authentication">WebAuthn</abbr>){% endtrans %}
         {% elif event.additional.two_factor_method  == "totp" %}
           {% trans %}Authentication application (<abbr title="time-based one-time password">TOTP</abbr>){% endtrans %}
         {% elif event.additional.two_factor_method  == "recovery-code" %}

--- a/warehouse/templates/manage/account.html
+++ b/warehouse/templates/manage/account.html
@@ -567,7 +567,7 @@
         {% if event.additional.two_factor_method == None %}
           {% trans %}None{% endtrans %}
         {% elif event.additional.two_factor_method  == "webauthn" %}
-          {% trans %}Security device (<abbr title="web authentication">WebAuthn</abbr>){% endtrans %}
+          {% trans %}Security device (<abbr title="web authentication">WebAuthn</abbr>){% endtrans %}{% if event.additional.two_factor_label %} - "{{ event.additional.two_factor_label }}"{% endif %}
         {% elif event.additional.two_factor_method  == "totp" %}
           {% trans %}Authentication application (<abbr title="time-based one-time password">TOTP</abbr>){% endtrans %}
         {% elif event.additional.two_factor_method  == "recovery-code" %}


### PR DESCRIPTION
Allow for identifying what WebAuthn device was used for login.

<img width="808" alt="Screen Shot 2021-09-30 at 12 54 53 PM" src="https://user-images.githubusercontent.com/1200832/135500270-ea546231-fffb-476a-b73c-8d05195ea964.png">

While testing #10116, I realized we have the opportunity to store/share this information with Users... worth logging.