### PR TITLE
Make malware checks unordered

### DIFF
--- a/tests/unit/malware/test_utils.py
+++ b/tests/unit/malware/test_utils.py
@@ -29,7 +29,7 @@ class TestGetEnabledChecks:
             state=MalwareCheckState.Enabled, check_type=MalwareCheckType.EventHook
         )
         assert get_enabled_hooked_checks(db_session) == {
-            check.hooked_object.value: [check.name]
+            check.hooked_object.value: {check.name}
         }
 
     def test_many(self, db_session):
@@ -44,7 +44,7 @@ class TestGetEnabledChecks:
             hooked_object=MalwareCheckObjectType.Project,
         )
         assert get_enabled_hooked_checks(db_session) == {
-            check.hooked_object.value: [check.name, other_check.name]
+            check.hooked_object.value: {check.name, other_check.name}
         }
 
     def test_none(self, db_session):

--- a/warehouse/malware/utils.py
+++ b/warehouse/malware/utils.py
@@ -38,9 +38,9 @@ def get_enabled_hooked_checks(session):
         .filter(MalwareCheck.state == MalwareCheckState.Enabled)
         .all()
     )
-    results = defaultdict(list)
+    results = defaultdict(set)
 
     for check_name, object_type in checks:
-        results[object_type.value].append(check_name)
+        results[object_type.value].add(check_name)
 
     return results


### PR DESCRIPTION
This test was flaky and there's no inherent ordering to the checks, so no reason to make this an ordered list.