### PR TITLE
resolve error when invalid password supplied during reauthentication

### DIFF
--- a/tests/unit/accounts/test_forms.py
+++ b/tests/unit/accounts/test_forms.py
@@ -753,8 +753,9 @@ class TestWebAuthnAuthenticationForm:
 class TestReAuthenticateForm:
     def test_creation(self):
         user_service = pretend.stub()
+        request = pretend.stub()
 
-        form = forms.ReAuthenticateForm(user_service=user_service)
+        form = forms.ReAuthenticateForm(request=request, user_service=user_service)
 
         assert form.user_service is user_service
         assert form.__params__ == [

--- a/tests/unit/accounts/test_views.py
+++ b/tests/unit/accounts/test_views.py
@@ -2326,6 +2326,7 @@ class TestReAuthentication:
                 username=pyramid_request.user.username,
                 next_route=pyramid_request.matched_route.name,
                 next_route_matchdict=json.dumps(pyramid_request.matchdict),
+                action="reauthenticate",
                 user_service=user_service,
                 check_password_metrics_tags=[
                     "method:reauth",

--- a/tests/unit/manage/test_forms.py
+++ b/tests/unit/manage/test_forms.py
@@ -122,11 +122,12 @@ class TestAddEmailForm:
 
 class TestChangePasswordForm:
     def test_creation(self):
+        request = pretend.stub()
         user_service = pretend.stub()
         breach_service = pretend.stub()
 
         form = forms.ChangePasswordForm(
-            user_service=user_service, breach_service=breach_service
+            request=request, user_service=user_service, breach_service=breach_service
         )
 
         assert form.user_service is user_service
@@ -162,12 +163,14 @@ class TestProvisionTOTPForm:
 
 class TestDeleteTOTPForm:
     def test_creation(self):
+        request = pretend.stub()
         user_service = pretend.stub()
-        form = forms.DeleteTOTPForm(user_service=user_service)
+        form = forms.DeleteTOTPForm(request=request, user_service=user_service)
 
         assert form.user_service is user_service
 
     def test_validate_confirm_password(self):
+        request = pretend.stub()
         user_service = pretend.stub(
             find_userid=pretend.call_recorder(lambda userid: 1),
             check_password=pretend.call_recorder(
@@ -175,7 +178,10 @@ class TestDeleteTOTPForm:
             ),
         )
         form = forms.DeleteTOTPForm(
-            username="username", user_service=user_service, password="password"
+            username="username",
+            request=request,
+            user_service=user_service,
+            password="password",
         )
 
         assert form.validate()
@@ -446,9 +452,12 @@ class TestCreateMacaroonForm:
 class TestDeleteMacaroonForm:
     def test_creation(self):
         macaroon_service = pretend.stub()
+        request = pretend.stub()
         user_service = pretend.stub()
         form = forms.DeleteMacaroonForm(
-            macaroon_service=macaroon_service, user_service=user_service
+            request=request,
+            macaroon_service=macaroon_service,
+            user_service=user_service,
         )
 
         assert form.macaroon_service is macaroon_service
@@ -461,8 +470,10 @@ class TestDeleteMacaroonForm:
         user_service = pretend.stub(
             find_userid=lambda *a, **kw: 1, check_password=lambda *a, **kw: True
         )
+        request = pretend.stub()
         form = forms.DeleteMacaroonForm(
             data={"macaroon_id": pretend.stub(), "password": "password"},
+            request=request,
             macaroon_service=macaroon_service,
             user_service=user_service,
             username="username",
@@ -478,8 +489,10 @@ class TestDeleteMacaroonForm:
         user_service = pretend.stub(
             find_userid=lambda *a, **kw: 1, check_password=lambda *a, **kw: True
         )
+        request = pretend.stub()
         form = forms.DeleteMacaroonForm(
             data={"macaroon_id": pretend.stub(), "password": "password"},
+            request=request,
             macaroon_service=macaroon_service,
             username="username",
             user_service=user_service,

--- a/tests/unit/manage/test_views.py
+++ b/tests/unit/manage/test_views.py
@@ -114,7 +114,11 @@ class TestManageAccount:
             pretend.call(user_id=user_id, user_service=user_service)
         ]
         assert change_pass_cls.calls == [
-            pretend.call(user_service=user_service, breach_service=breach_service)
+            pretend.call(
+                request=request,
+                user_service=user_service,
+                breach_service=breach_service,
+            )
         ]
 
     def test_active_projects(self, db_request):

--- a/warehouse/accounts/forms.py
+++ b/warehouse/accounts/forms.py
@@ -109,7 +109,11 @@ class PasswordMixin:
 
     password = wtforms.PasswordField(validators=[wtforms.validators.DataRequired()])
 
-    def __init__(self, *args, check_password_metrics_tags=None, **kwargs):
+    def __init__(
+        self, *args, request, action="login", check_password_metrics_tags=None, **kwargs
+    ):
+        self.request = request
+        self.action = action
         self._check_password_metrics_tags = check_password_metrics_tags
         super().__init__(*args, **kwargs)
 
@@ -122,7 +126,7 @@ class PasswordMixin:
                 ):
                     self.user_service.record_event(
                         userid,
-                        tag="account:login:failure",
+                        tag=f"account:{self.action}:failure",
                         ip_address=self.request.remote_addr,
                         additional={"reason": "invalid_password"},
                     )
@@ -258,9 +262,8 @@ class RegistrationForm(
 
 
 class LoginForm(PasswordMixin, UsernameMixin, forms.Form):
-    def __init__(self, *args, request, user_service, breach_service, **kwargs):
+    def __init__(self, *args, user_service, breach_service, **kwargs):
         super().__init__(*args, **kwargs)
-        self.request = request
         self.user_service = user_service
         self.breach_service = breach_service
 

--- a/warehouse/accounts/views.py
+++ b/warehouse/accounts/views.py
@@ -1020,6 +1020,7 @@ def reauthenticate(request, _form_class=ReAuthenticateForm):
         next_route=request.matched_route.name,
         next_route_matchdict=json.dumps(request.matchdict),
         user_service=user_service,
+        action="reauthenticate",
         check_password_metrics_tags=[
             "method:reauth",
             "auth_method:reauthenticate_form",

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -27,55 +27,55 @@ msgid ""
 "different username."
 msgstr ""
 
-#: warehouse/accounts/forms.py:130
+#: warehouse/accounts/forms.py:134
 msgid "The password is invalid. Try again."
 msgstr ""
 
-#: warehouse/accounts/forms.py:134 warehouse/accounts/views.py:76
+#: warehouse/accounts/forms.py:138 warehouse/accounts/views.py:76
 msgid "There have been too many unsuccessful login attempts. Try again later."
 msgstr ""
 
-#: warehouse/accounts/forms.py:156
+#: warehouse/accounts/forms.py:160
 msgid "Your passwords don't match. Try again."
 msgstr ""
 
-#: warehouse/accounts/forms.py:187 warehouse/accounts/forms.py:198
+#: warehouse/accounts/forms.py:191 warehouse/accounts/forms.py:202
 msgid "The email address isn't valid. Try again."
 msgstr ""
 
-#: warehouse/accounts/forms.py:206
+#: warehouse/accounts/forms.py:210
 msgid "You can't use an email address from this domain. Use a different email."
 msgstr ""
 
-#: warehouse/accounts/forms.py:217
+#: warehouse/accounts/forms.py:221
 msgid ""
 "This email address is already being used by this account. Use a different"
 " email."
 msgstr ""
 
-#: warehouse/accounts/forms.py:224
+#: warehouse/accounts/forms.py:228
 msgid ""
 "This email address is already being used by another account. Use a "
 "different email."
 msgstr ""
 
-#: warehouse/accounts/forms.py:246
+#: warehouse/accounts/forms.py:250
 msgid "The name is too long. Choose a name with 100 characters or less."
 msgstr ""
 
-#: warehouse/accounts/forms.py:317
+#: warehouse/accounts/forms.py:320
 msgid "Invalid TOTP code."
 msgstr ""
 
-#: warehouse/accounts/forms.py:334
+#: warehouse/accounts/forms.py:337
 msgid "Invalid WebAuthn assertion: Bad payload"
 msgstr ""
 
-#: warehouse/accounts/forms.py:389
+#: warehouse/accounts/forms.py:392
 msgid "Invalid recovery code."
 msgstr ""
 
-#: warehouse/accounts/forms.py:407
+#: warehouse/accounts/forms.py:410
 msgid "No user found with that username or email"
 msgstr ""
 
@@ -208,55 +208,55 @@ msgstr ""
 msgid "Banner Preview"
 msgstr ""
 
-#: warehouse/manage/views.py:205
+#: warehouse/manage/views.py:207
 msgid "Email ${email_address} added - check your email for a verification link"
 msgstr ""
 
-#: warehouse/manage/views.py:692 warehouse/manage/views.py:728
+#: warehouse/manage/views.py:694 warehouse/manage/views.py:730
 msgid ""
 "You must provision a two factor method before recovery codes can be "
 "generated"
 msgstr ""
 
-#: warehouse/manage/views.py:703
+#: warehouse/manage/views.py:705
 msgid "Recovery codes already generated"
 msgstr ""
 
-#: warehouse/manage/views.py:704
+#: warehouse/manage/views.py:706
 msgid "Generating new recovery codes will invalidate your existing codes."
 msgstr ""
 
-#: warehouse/manage/views.py:755
+#: warehouse/manage/views.py:757
 msgid "Invalid credentials. Try again"
 msgstr ""
 
-#: warehouse/manage/views.py:1503
+#: warehouse/manage/views.py:1505
 msgid "User '${username}' already has ${role_name} role for project"
 msgstr ""
 
-#: warehouse/manage/views.py:1514
+#: warehouse/manage/views.py:1516
 msgid ""
 "User '${username}' does not have a verified primary email address and "
 "cannot be added as a ${role_name} for project"
 msgstr ""
 
-#: warehouse/manage/views.py:1527
+#: warehouse/manage/views.py:1529
 msgid "User '${username}' already has an active invite. Please try again later."
 msgstr ""
 
-#: warehouse/manage/views.py:1585
+#: warehouse/manage/views.py:1587
 msgid "Invitation sent to '${username}'"
 msgstr ""
 
-#: warehouse/manage/views.py:1632
+#: warehouse/manage/views.py:1634
 msgid "Could not find role invitation."
 msgstr ""
 
-#: warehouse/manage/views.py:1643
+#: warehouse/manage/views.py:1645
 msgid "Invitation already expired."
 msgstr ""
 
-#: warehouse/manage/views.py:1667
+#: warehouse/manage/views.py:1669
 msgid "Invitation revoked from '${username}'."
 msgstr ""
 
@@ -520,7 +520,7 @@ msgstr ""
 #: warehouse/templates/base.html:162 warehouse/templates/base.html:171
 #: warehouse/templates/base.html:181
 #: warehouse/templates/includes/session-notifications.html:19
-#: warehouse/templates/manage/account.html:772
+#: warehouse/templates/manage/account.html:783
 #: warehouse/templates/manage/documentation.html:27
 #: warehouse/templates/manage/manage_base.html:106
 #: warehouse/templates/manage/manage_base.html:158
@@ -2089,11 +2089,13 @@ msgid "Login failed"
 msgstr ""
 
 #: warehouse/templates/manage/account.html:581
+#: warehouse/templates/manage/account.html:598
 #: warehouse/templates/manage/history.html:84
 msgid "Reason:"
 msgstr ""
 
 #: warehouse/templates/manage/account.html:583
+#: warehouse/templates/manage/account.html:600
 msgid "Incorrect Password"
 msgstr ""
 
@@ -2110,151 +2112,155 @@ msgid "Invalid two factor (Recovery code)"
 msgstr ""
 
 #: warehouse/templates/manage/account.html:596
+msgid "Session reauthentication failed"
+msgstr ""
+
+#: warehouse/templates/manage/account.html:607
 msgid "Email added to account"
 msgstr ""
 
-#: warehouse/templates/manage/account.html:599
+#: warehouse/templates/manage/account.html:610
 msgid "Email removed from account"
 msgstr ""
 
-#: warehouse/templates/manage/account.html:602
+#: warehouse/templates/manage/account.html:613
 msgid "Email verified"
 msgstr ""
 
-#: warehouse/templates/manage/account.html:605
+#: warehouse/templates/manage/account.html:616
 msgid "Email reverified"
 msgstr ""
 
-#: warehouse/templates/manage/account.html:609
+#: warehouse/templates/manage/account.html:620
 msgid "Primary email changed"
 msgstr ""
 
-#: warehouse/templates/manage/account.html:611
+#: warehouse/templates/manage/account.html:622
 msgid "Old primary email:"
 msgstr ""
 
-#: warehouse/templates/manage/account.html:612
+#: warehouse/templates/manage/account.html:623
 msgid "New primary email:"
 msgstr ""
 
-#: warehouse/templates/manage/account.html:615
+#: warehouse/templates/manage/account.html:626
 msgid "Primary email set"
 msgstr ""
 
-#: warehouse/templates/manage/account.html:621
+#: warehouse/templates/manage/account.html:632
 msgid "Email sent"
 msgstr ""
 
-#: warehouse/templates/manage/account.html:623
+#: warehouse/templates/manage/account.html:634
 msgid "From:"
 msgstr ""
 
-#: warehouse/templates/manage/account.html:624
+#: warehouse/templates/manage/account.html:635
 msgid "To:"
 msgstr ""
 
-#: warehouse/templates/manage/account.html:625
+#: warehouse/templates/manage/account.html:636
 msgid "Subject:"
 msgstr ""
 
-#: warehouse/templates/manage/account.html:629
+#: warehouse/templates/manage/account.html:640
 msgid "Password reset requested"
 msgstr ""
 
-#: warehouse/templates/manage/account.html:631
+#: warehouse/templates/manage/account.html:642
 msgid "Password reset attempted"
 msgstr ""
 
-#: warehouse/templates/manage/account.html:633
+#: warehouse/templates/manage/account.html:644
 msgid "Password successfully reset"
 msgstr ""
 
-#: warehouse/templates/manage/account.html:635
+#: warehouse/templates/manage/account.html:646
 msgid "Password successfully changed"
 msgstr ""
 
-#: warehouse/templates/manage/account.html:638
+#: warehouse/templates/manage/account.html:649
 msgid "Two factor authentication added"
 msgstr ""
 
-#: warehouse/templates/manage/account.html:641
-#: warehouse/templates/manage/account.html:651
+#: warehouse/templates/manage/account.html:652
+#: warehouse/templates/manage/account.html:662
 msgid ""
 "Method: Security device (<abbr title=\"web "
 "authentication\">WebAuthn</abbr>)"
 msgstr ""
 
-#: warehouse/templates/manage/account.html:642
-#: warehouse/templates/manage/account.html:652
+#: warehouse/templates/manage/account.html:653
+#: warehouse/templates/manage/account.html:663
 msgid "Device name:"
 msgstr ""
 
-#: warehouse/templates/manage/account.html:644
-#: warehouse/templates/manage/account.html:654
+#: warehouse/templates/manage/account.html:655
+#: warehouse/templates/manage/account.html:665
 msgid ""
 "Method: Authentication application (<abbr title=\"time-based one-time "
 "password\">TOTP</abbr>)"
 msgstr ""
 
-#: warehouse/templates/manage/account.html:648
+#: warehouse/templates/manage/account.html:659
 msgid "Two factor authentication removed"
 msgstr ""
 
-#: warehouse/templates/manage/account.html:659
+#: warehouse/templates/manage/account.html:670
 msgid "Recovery codes generated"
 msgstr ""
 
-#: warehouse/templates/manage/account.html:663
+#: warehouse/templates/manage/account.html:674
 msgid "Recovery codes regenerated"
 msgstr ""
 
-#: warehouse/templates/manage/account.html:667
+#: warehouse/templates/manage/account.html:678
 msgid "Recovery code used for login"
 msgstr ""
 
-#: warehouse/templates/manage/account.html:673
+#: warehouse/templates/manage/account.html:684
 #: warehouse/templates/manage/history.html:65
 msgid "API token added"
 msgstr ""
 
-#: warehouse/templates/manage/account.html:675
-#: warehouse/templates/manage/account.html:690
+#: warehouse/templates/manage/account.html:686
+#: warehouse/templates/manage/account.html:701
 #: warehouse/templates/manage/history.html:69
 #: warehouse/templates/manage/history.html:76
 msgid "Token name:"
 msgstr ""
 
-#: warehouse/templates/manage/account.html:677
-#: warehouse/templates/manage/account.html:693
+#: warehouse/templates/manage/account.html:688
+#: warehouse/templates/manage/account.html:704
 msgid "Token scope: entire account"
 msgstr ""
 
-#: warehouse/templates/manage/account.html:679
-#: warehouse/templates/manage/account.html:695
+#: warehouse/templates/manage/account.html:690
+#: warehouse/templates/manage/account.html:706
 #, python-format
 msgid "Token scope: Project %(project_name)s"
 msgstr ""
 
-#: warehouse/templates/manage/account.html:684
+#: warehouse/templates/manage/account.html:695
 #: warehouse/templates/manage/history.html:72
 msgid "API token removed"
 msgstr ""
 
-#: warehouse/templates/manage/account.html:685
-#: warehouse/templates/manage/account.html:691
+#: warehouse/templates/manage/account.html:696
+#: warehouse/templates/manage/account.html:702
 msgid "Unique identifier:"
 msgstr ""
 
-#: warehouse/templates/manage/account.html:688
+#: warehouse/templates/manage/account.html:699
 msgid "API token automatically removed for security reasons"
 msgstr ""
 
-#: warehouse/templates/manage/account.html:697
+#: warehouse/templates/manage/account.html:708
 #, python-format
 msgid "Reason: Token found at <a href=\"%(public_url)s\">public url</a>"
 msgstr ""
 
-#: warehouse/templates/manage/account.html:706
+#: warehouse/templates/manage/account.html:717
 #, python-format
 msgid ""
 "Events appear here as security-related actions occur on your account. If "
@@ -2262,42 +2268,42 @@ msgid ""
 "your account</a> as soon as possible."
 msgstr ""
 
-#: warehouse/templates/manage/account.html:711
+#: warehouse/templates/manage/account.html:722
 msgid "Recent account activity"
 msgstr ""
 
-#: warehouse/templates/manage/account.html:713
+#: warehouse/templates/manage/account.html:724
 #: warehouse/templates/manage/history.html:97
 msgid "Event"
 msgstr ""
 
-#: warehouse/templates/manage/account.html:714
-#: warehouse/templates/manage/account.html:722
+#: warehouse/templates/manage/account.html:725
+#: warehouse/templates/manage/account.html:733
 #: warehouse/templates/manage/history.html:98
 #: warehouse/templates/manage/history.html:107
 msgid "Date / time"
 msgstr ""
 
-#: warehouse/templates/manage/account.html:715
 #: warehouse/templates/manage/account.html:726
+#: warehouse/templates/manage/account.html:737
 #: warehouse/templates/manage/history.html:99
 #: warehouse/templates/manage/history.html:111
 msgid "IP address"
 msgstr ""
 
-#: warehouse/templates/manage/account.html:734
+#: warehouse/templates/manage/account.html:745
 msgid "Events will appear here as security-related actions occur on your account."
 msgstr ""
 
-#: warehouse/templates/manage/account.html:741
+#: warehouse/templates/manage/account.html:752
 msgid "Delete account"
 msgstr ""
 
-#: warehouse/templates/manage/account.html:744
+#: warehouse/templates/manage/account.html:755
 msgid "Cannot delete account"
 msgstr ""
 
-#: warehouse/templates/manage/account.html:746
+#: warehouse/templates/manage/account.html:757
 #, python-format
 msgid ""
 "\n"
@@ -2312,7 +2318,7 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: warehouse/templates/manage/account.html:751
+#: warehouse/templates/manage/account.html:762
 msgid ""
 "\n"
 "          You must transfer ownership or delete this project before you "
@@ -2326,23 +2332,23 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: warehouse/templates/manage/account.html:761
+#: warehouse/templates/manage/account.html:772
 #, python-format
 msgid ""
 "<a href=\"%(transfer_href)s\">transfer ownership</a> or <a "
 "href=\"%(delete_href)s\">delete project</a>"
 msgstr ""
 
-#: warehouse/templates/manage/account.html:770
+#: warehouse/templates/manage/account.html:781
 #: warehouse/templates/manage/token.html:169
 msgid "Proceed with caution!"
 msgstr ""
 
-#: warehouse/templates/manage/account.html:773
+#: warehouse/templates/manage/account.html:784
 msgid "You will not be able to recover your account after you delete it"
 msgstr ""
 
-#: warehouse/templates/manage/account.html:775
+#: warehouse/templates/manage/account.html:786
 msgid "Delete your PyPI account"
 msgstr ""
 

--- a/warehouse/manage/views.py
+++ b/warehouse/manage/views.py
@@ -149,7 +149,9 @@ class ManageAccountViews:
                 user_service=self.user_service, user_id=self.request.user.id
             ),
             "change_password_form": ChangePasswordForm(
-                user_service=self.user_service, breach_service=self.breach_service
+                request=self.request,
+                user_service=self.user_service,
+                breach_service=self.breach_service,
             ),
             "active_projects": self.active_projects,
         }

--- a/warehouse/templates/manage/account.html
+++ b/warehouse/templates/manage/account.html
@@ -592,6 +592,17 @@
         {% endif %}
       </small>
 
+      {% elif event.tag == "account:reauthenticate:failure" %}
+      <strong>{% trans %}Session reauthentication failed{% endtrans %}</strong><br>
+      <small>
+        {% trans %}Reason:{% endtrans %}
+        {% if event.additional.reason == "invalid_password" %}
+          {% trans %}Incorrect Password{% endtrans %}
+        {% else %}
+          {{ event.additional.reason }}
+        {% endif %}
+      </small>
+
       {% elif event.tag  == "account:email:add" %}
       <strong>{% trans %}Email added to account{% endtrans %}</strong><br>
       <small>{{ event.additional.email }}</small>


### PR DESCRIPTION
#10119 introduced an error during reauthentication if an invalid password is supplied: https://sentry.io/share/issue/1409bceeb7ba46d186246fc40b210c3e/

This resolves that and stores/displays a separate event for `login:reauthentication:failure` in this case.

<img width="801" alt="Screen Shot 2021-10-04 at 1 32 13 PM" src="https://user-images.githubusercontent.com/1200832/135903826-33cdf9af-7f56-4ae8-8bc6-7f204fe47386.png">

