### PR TITLE
Switch to NodeJS 14.15 LTS (fixes #10158)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
       - uses: actions/setup-node@v2
         if: ${{ matrix.needs-node }}
         with:
-          node-version: 14.4.0
+          node-version: 14.15
       - name: Cache Node dependencies
         if: ${{ matrix.needs-node }}
         uses: actions/cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
       - uses: actions/setup-node@v2
         if: ${{ matrix.needs-node }}
         with:
-          node-version: 14.15
+          node-version: 14.15.5
       - name: Cache Node dependencies
         if: ${{ matrix.needs-node }}
         uses: actions/cache@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # our static assets with. It is important that the steps in this remain the
 # same as the steps in Dockerfile.static, EXCEPT this may include additional
 # steps appended onto the end.
-FROM node:14.15 as static
+FROM node:14.15.5 as static
 
 WORKDIR /opt/warehouse/src/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # our static assets with. It is important that the steps in this remain the
 # same as the steps in Dockerfile.static, EXCEPT this may include additional
 # steps appended onto the end.
-FROM node:14.4.0 as static
+FROM node:14.15 as static
 
 WORKDIR /opt/warehouse/src/
 
@@ -23,7 +23,6 @@ COPY package.json package-lock.json .babelrc /opt/warehouse/src/
 # over our static files so that, you guessed it, we don't invalidate the cache
 # of installed dependencies just because files have been modified.
 RUN set -x \
-    && npm install -g npm@latest \
     && npm install -g gulp-cli \
     && npm ci
 

--- a/Dockerfile.static
+++ b/Dockerfile.static
@@ -19,6 +19,5 @@ COPY package.json package-lock.json .babelrc /opt/warehouse/src/
 # over our static files so that, you guessed it, we don't invalidate the cache
 # of installed dependencies just because files have been modified.
 RUN set -x \
-    && npm install -g npm@latest \
     && npm install -g gulp-cli \
     && npm ci

--- a/Dockerfile.static
+++ b/Dockerfile.static
@@ -1,4 +1,4 @@
-FROM node:14.15 as static
+FROM node:14.15.5 as static
 
 WORKDIR /opt/warehouse/src/
 

--- a/Dockerfile.static
+++ b/Dockerfile.static
@@ -1,4 +1,4 @@
-FROM node:14.4.0 as static
+FROM node:14.15 as static
 
 WORKDIR /opt/warehouse/src/
 

--- a/docs/development/frontend.rst
+++ b/docs/development/frontend.rst
@@ -14,7 +14,7 @@ Building
 
 Static files should be automatically built when ``make serve`` is running;
 however, you can trigger a manual build of them by installing
-`NodeJS 10.x <https://nodejs.org/en/download/releases/>`_, installing
+`NodeJS 14.x <https://nodejs.org/en/download/releases/>`_, installing
 the dependencies using ``npm install`` and then running ``gulp dist``.
 
 If you're in a POSIX environment you may find


### PR DESCRIPTION
Fixes build failure in docker build that started two days ago after `npm 8` released.

Uses `npm` versions that is provided by the image, and switches the image to 14.15 which is a minimum required by `npm` 8 in case it will be needed.