### PR TITLE
Replace a plain CSS import with a normal Scss import

### DIFF
--- a/warehouse/static/sass/warehouse.scss
+++ b/warehouse/static/sass/warehouse.scss
@@ -43,7 +43,7 @@
 
 // RESETS LAYER: applies CSS resets and sensible defaults
 @import "resets/boxsizing";
-@import "normalize.css/normalize.css";
+@import "normalize.css/normalize";
 @import "resets/reset";
 
 // BASE LAYER: adds styles to anything without a class


### PR DESCRIPTION
Fixes the issue introduced by #10061

Because of the extension, sass treats the import as a plain css import instead of leaving it as-is.
https://sass-lang.com/documentation/at-rules/import#importing-css

Currently, the website doesn't have normalize.css, which means it must be much less compatible with older browsers.

I haven't tried the PR locally yet.