### PR TITLE
Camo: add `PORT` env var

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,6 +57,7 @@ services:
       - "9000:9000"
     environment:
       CAMO_KEY: "insecurecamokey"
+      PORT: 9000
 
   web:
     build:


### PR DESCRIPTION
Different node versions pick different default ports, we always want 9000 here.

refs https://github.com/pypa/warehouse-camo/pull/5 and indirectly https://github.com/pypa/warehouse/issues/10171.