### PR TITLE
directly import normalize from the node_modules path

### DIFF
--- a/Gulpfile.babel.js
+++ b/Gulpfile.babel.js
@@ -134,12 +134,11 @@ gulp.task("dist:js", () => {
 
 gulp.task("dist:noscript", () => {
   let sassPath = path.join(staticPrefix, "sass");
-  let nodeModules = "node_modules";
 
   return gulp.src(path.join(sassPath, "noscript.scss"))
     .pipe(sourcemaps.init())
     .pipe(
-      sass({ includePaths: [sassPath, nodeModules] })
+      sass({ includePaths: [sassPath] })
         .on("error", sass.logError))
     .pipe(postcss(postCSSPlugins))
     .pipe(sourcemaps.write("."))

--- a/warehouse/static/sass/warehouse.scss
+++ b/warehouse/static/sass/warehouse.scss
@@ -43,7 +43,7 @@
 
 // RESETS LAYER: applies CSS resets and sensible defaults
 @import "resets/boxsizing";
-@import "normalize.css/normalize.css";
+@import "node_modules/normalize.css/normalize";
 @import "resets/reset";
 
 // BASE LAYER: adds styles to anything without a class


### PR DESCRIPTION
resolves broken import from #10061, in my local environment it appears to be behaving correctly, specifically resolving issues with font sizes for the logged in user bits.

it also resolves #10199 when configuring a banner locally.

prod:
<img width="250" alt="Screen Shot 2021-10-18 at 12 40 02 PM" src="https://user-images.githubusercontent.com/1200832/137773099-c18cc8e0-78f5-4620-bd3a-55036faebf06.png">

dev:
<img width="262" alt="Screen Shot 2021-10-18 at 12 40 40 PM" src="https://user-images.githubusercontent.com/1200832/137773115-0945b34b-4bcd-40c6-b889-41866230a447.png">


