### PR TITLE
Pin webauthn<1.0.0

### DIFF
--- a/requirements/main.in
+++ b/requirements/main.in
@@ -57,7 +57,7 @@ structlog
 transaction
 trove-classifiers
 typeguard
-webauthn
+webauthn<1.0.0  # https://github.com/pypa/warehouse/pull/10202
 whitenoise
 WTForms[email]>=2.0.0
 yara-python


### PR DESCRIPTION
This library has breaking changes and also adds/removes subdependencies, which is breaking our dependency checker. Pinning this back until we make the necessary changes to merge https://github.com/pypa/warehouse/pull/10202.