### PR TITLE
pyramid_multiauth 1.0 removes support for pyramid 1.x

### DIFF
--- a/requirements/main.in
+++ b/requirements/main.in
@@ -36,7 +36,7 @@ pyramid>=1.9,<1.11.0
 pymacaroons
 pyramid_jinja2>=2.5
 pyramid_mailer>=0.14.1
-pyramid_multiauth
+pyramid_multiauth<1
 pyramid_retry>=0.3
 pyramid_rpc>=0.7
 pyramid_services>=2.1


### PR DESCRIPTION
See https://github.com/mozilla-services/pyramid_multiauth/releases/tag/1.0.0

This currently breaks the build: https://github.com/pypa/warehouse/runs/3968820790?check_suite_focus=true