### PR TITLE
Temporarily disable hourly sync_bigquery_release_files

### DIFF
--- a/tests/unit/packaging/test_init.py
+++ b/tests/unit/packaging/test_init.py
@@ -20,9 +20,8 @@ from warehouse.accounts.models import Email, User
 from warehouse.manage.tasks import update_role_invitation_status
 from warehouse.packaging.interfaces import IDocsStorage, IFileStorage
 from warehouse.packaging.models import File, Project, Release, Role
-from warehouse.packaging.tasks import (
+from warehouse.packaging.tasks import (  # sync_bigquery_release_files,
     compute_trending,
-    sync_bigquery_release_files,
     update_description_html,
 )
 
@@ -120,13 +119,13 @@ def test_includeme(monkeypatch, with_trending, with_bq_sync):
             pretend.call(crontab(minute="*/5"), update_description_html),
             pretend.call(crontab(minute="*/5"), update_role_invitation_status),
             pretend.call(crontab(minute=0, hour=3), compute_trending),
-            pretend.call(crontab(minute=0), sync_bigquery_release_files),
+            # pretend.call(crontab(minute=0), sync_bigquery_release_files),
         ]
     elif with_bq_sync:
         assert config.add_periodic_task.calls == [
             pretend.call(crontab(minute="*/5"), update_description_html),
             pretend.call(crontab(minute="*/5"), update_role_invitation_status),
-            pretend.call(crontab(minute=0), sync_bigquery_release_files),
+            # pretend.call(crontab(minute=0), sync_bigquery_release_files),
         ]
     elif with_trending:
         assert config.add_periodic_task.calls == [

--- a/warehouse/packaging/__init__.py
+++ b/warehouse/packaging/__init__.py
@@ -19,9 +19,8 @@ from warehouse.cache.origin import key_factory, receive_set
 from warehouse.manage.tasks import update_role_invitation_status
 from warehouse.packaging.interfaces import IDocsStorage, IFileStorage
 from warehouse.packaging.models import File, Project, Release, Role
-from warehouse.packaging.tasks import (
+from warehouse.packaging.tasks import (  # sync_bigquery_release_files,
     compute_trending,
-    sync_bigquery_release_files,
     update_description_html,
 )
 
@@ -102,5 +101,6 @@ def includeme(config):
     if config.get_settings().get("warehouse.trending_table"):
         config.add_periodic_task(crontab(minute=0, hour=3), compute_trending)
 
-    if config.get_settings().get("warehouse.release_files_table"):
-        config.add_periodic_task(crontab(minute=0), sync_bigquery_release_files)
+    # TODO: restore this
+    # if config.get_settings().get("warehouse.release_files_table"):
+    #     config.add_periodic_task(crontab(minute=0), sync_bigquery_release_files)


### PR DESCRIPTION
I'm trying to track down a steady churn in our database and quota hits on BigQuery usage.

This PR temporarily disables the hourly sync_bigquery_release_files task which is the most likely culprit.

Graph of runs of the task (note that they're stacking up way over 1 per hour) correlates to the spike in DB load.

<img width="841" alt="Screen Shot 2021-10-26 at 5 09 54 PM" src="https://user-images.githubusercontent.com/1200832/138961474-647862d1-8f0f-4baf-b22e-2981ccbc14c1.png">

I'm fairly certain these tasks are stacking up and getting lost in the 15 minute visibility timeout in our queueing, making the problem worse.

This PR temporarily disables the task to see if we settle out to a reduction in DB load and BigQuery usage overnight.