### PR TITLE
Fixed #10218. Added Vulnerabilities documentation for Sampleproject and Django.

### DIFF
--- a/docs/api-reference/json.rst
+++ b/docs/api-reference/json.rst
@@ -121,14 +121,6 @@ Project
                     }
                 ]
             },
-            vulnerabilities : {
-            "id": 123,
-            "source": "vulnerability_record source",
-            "link": "https://pypi.org/project/sampleproject/1.2.0/",
-            "aliases": "Aliases",
-            "details": "vulnerability_record Details",
-            "fixed_in": 1.0,
-            },
             "urls": [
                 {
                     "comment_text": "",
@@ -166,7 +158,26 @@ Project
                     "yanked": false,
                     "yanked_reason": null
                 }
-            ]
+            ],
+            "vulnerabilities" :{
+                "sampleproject" : [],
+                "Django" : {
+                    0 : {
+                        "aliases" : [
+                            0 : "CVE-2021-3281"
+                        ],
+                        "details" : "In Django 2.2 before 2.2.18, 3.0 before 3.0.12, and 3.1 before 3.1.6, the django.utils.archive.extract method (used by \"startapp --template\" and \"startproject --template\") allows directory traversal via an archive with absolute paths or relative paths with dot segments.",
+                        "fixed_in" : [
+                            0 : "2.2.18",
+                            1 : "3.0.12",
+                            2 : "3.1.6"
+                        ],
+                        "id" : "PYSEC-2021-9",
+                        "link" : "https://osv.dev/vulnerability/PYSEC-2021-9",
+                        "source" : "osv"
+                    }
+                }
+            }
         }
 
     :statuscode 200: no error


### PR DESCRIPTION
Fixed #10218 after suggestion from @di regarding pull #10253 Showing that ``Sampleproject`` has [no vulnerabilities](https://pypi.org/pypi/sampleproject/json) and then adding a subsection showing the vulnerabilities from ``Django`` using it's [json link](https://pypi.org/pypi/Django/3.0.2/json)