### PR TITLE
pin ES client version to < 7.11

### DIFF
--- a/requirements/main.in
+++ b/requirements/main.in
@@ -11,7 +11,7 @@ click
 cryptography
 datadog>=0.19.0
 disposable-email-domains
-elasticsearch>=7.0.0,<8.0.0
+elasticsearch>=7.0.0,<7.11.0
 elasticsearch_dsl>=7.0.0,<8.0.0
 first
 google-cloud-bigquery

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -268,9 +268,9 @@ docutils==0.17.1 \
     --hash=sha256:686577d2e4c32380bb50cbb22f575ed742d58168cee37e99117a854bcd88f125 \
     --hash=sha256:cf316c8370a737a022b72b56874f6602acf974a37a9fba42ec2876387549fc61
     # via readme-renderer
-elasticsearch==7.15.1 \
-    --hash=sha256:1e9a6302945d98046899a7c9b3d345c881ac7b05ba176d3a49c9d2702b1e8bc8 \
-    --hash=sha256:b728a3cdde3a4d3a93b9e92f0e7f0fe636226d236219913db32311ccaf8a9d16
+elasticsearch==7.10.1 \
+    --hash=sha256:4ebd34fd223b31c99d9f3b6b6236d3ac18b3046191a37231e8235b06ae7db955 \
+    --hash=sha256:a725dd923d349ca0652cf95d6ce23d952e2153740cf4ab6daf4a2d804feeed48
     # via
     #   -r requirements/main.in
     #   elasticsearch-dsl


### PR DESCRIPTION
matches server version, and doesn't block AWS OpenSearch hosted Elasticsearch 7.10.1