### PR TITLE
Tune search reindex task

### DIFF
--- a/warehouse/search/tasks.py
+++ b/warehouse/search/tasks.py
@@ -101,7 +101,7 @@ def _project_docs(db, project_name=None):
         .outerjoin(Release.project)
     )
 
-    for release in windowed_query(release_data, Release.project_id, 50000):
+    for release in windowed_query(release_data, Project.id, 25000):
         p = ProjectDocument.from_db(release)
         p._index = None
         p.full_clean()


### PR DESCRIPTION
The previous windowed_query call broke us up into an interation over ~3 million project_ids from the releases table, which led to a sort of fragmentation where these expensive queries were only retrieving ~30% of the the requested count.

This updates the windowed_query call to partition over the entire Project.id space, which should lead to more efficient queries.

In testing, this _did_ lead to more results and higher memory consumption, so i reduced the count per fetch.

In all this took the reindex task down in time from ~40 minutes to just over 6.