### PR TITLE
add win_arm64 to allowed platforms

### DIFF
--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -107,6 +107,7 @@ STDLIB_PROHIBITED = {
 _allowed_platforms = {
     "any",
     "win32",
+    "win_arm64",
     "win_amd64",
     "win_ia64",
     "manylinux1_x86_64",


### PR DESCRIPTION
This patch enables uploading win_arm64 binary wheels to the PyPI repository.

CPython and key packages have been already ported to win/arm64 platforms. Python upstream CI is running for win/arm64 and Python official support is expected from Python 3.11. There are many package maintainers keen to start pushing win_arm64 binary wheels and would be helpful if win_arm64 is added to the permitted platform list.
