### PR TITLE
dependabot: check monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
 - package-ecosystem: pip
   directory: "/"
   schedule:
-    interval: daily
+    interval: monthly
   open-pull-requests-limit: 99
   allow:
   - dependency-type: direct


### PR DESCRIPTION
Checking monthly rather than daily will reduce the number of PRs opened (and also reduce the number of newly outdated PRs closed, because a new update for a given package closes an older PR for that package).

Options are daily, weekly, monthly. It looks like monthly is fine.
 
https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#scheduleinterval

_Security updates_ can still be made outside the interval:

> Note: `schedule` defines when Dependabot attempts a new update. However, it's not the only time you may receive pull requests. Updates can be triggered based on changes to your `dependabot.yml` file, changes to your manifest file(s) after a failed update, or Dependabot security updates.
