### PR TITLE
docs: prepare the user that they need python 3.8

### DIFF
--- a/docs/development/getting-started.rst
+++ b/docs/development/getting-started.rst
@@ -324,6 +324,11 @@ Errors when executing ``make build``
 
     snap install docker
 
+* If you receive the error: ``python3.8: command not found`` , ensure you have
+  Python 3.8 installed on your system.
+  This is the "base" Python version that Warehouse uses to create the rest of
+  the development environment.
+
 Errors when executing ``make serve``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
Until all `make` targets are built in containers, a new contributor will
stumble on this error and there's nothing in the docs that tell you what
you need.

Refs: https://github.com/pypa/warehouse/issues/4948

Signed-off-by: Mike Fiedler <miketheman@gmail.com>