### PR TITLE
Clarify browser support

### DIFF
--- a/docs/development/frontend.rst
+++ b/docs/development/frontend.rst
@@ -89,6 +89,10 @@ Browser Support
  IE       11+
 ========= ====================
 
+See the ``browserslist`` key in ``package.json`` for the configuration of
+supported browsers.
+You can see the full list of supported browsers by running ``npx browerslist``
+in the root of the project.
 
 HTML Code Style
 ---------------

--- a/docs/development/frontend.rst
+++ b/docs/development/frontend.rst
@@ -78,20 +78,10 @@ of some pages, but the "new" version of others.
 Browser Support
 ---------------
 
-========= ====================
- Browser  Supported Versions
-========= ====================
- Chrome   Current, Current - 1
- Firefox  Current, Current - 1
- Edge     Current, Current - 1
- Opera    Current, Current - 1
- Safari   9.0+
- IE       11+
-========= ====================
+We aim to support all major browsers, including IE11. We also support one-back,
+and follow the ``defaults`` recommendation from ``browserslist``.
 
-See the ``browserslist`` key in ``package.json`` for the configuration of
-supported browsers.
-You can see the full list of supported browsers by running ``npx browerslist``
+You can see the full list of supported browsers by running ``npx browserslist``
 in the root of the project.
 
 HTML Code Style

--- a/package.json
+++ b/package.json
@@ -62,6 +62,12 @@
     "node-webcrypto-ossl": "1.0.48",
     "sass-lint": "1.13.1"
   },
+  "browserslist": [
+    "last 2 versions",
+    "Safari >= 9",
+    "IE >= 11",
+    "not dead"
+  ],
   "eslintConfig": {
     "env": {
       "browser": true,

--- a/package.json
+++ b/package.json
@@ -62,12 +62,6 @@
     "node-webcrypto-ossl": "1.0.48",
     "sass-lint": "1.13.1"
   },
-  "browserslist": [
-    "last 2 versions",
-    "Safari >= 9",
-    "IE >= 11",
-    "not dead"
-  ],
   "eslintConfig": {
     "env": {
       "browser": true,


### PR DESCRIPTION
Edit: Scope changed.

Simplify the static table and inform user on how to see which browsers are supported.

---

As noted in the frontend development docs, the development target
supports current version and one back, plus some other versions.

As frontend tooling will generate code based on capabilities, create a
configuration item that confirms to the documentation.
This key will inform packages that use `browserslist`, which in turn use
`caniuse-lite` to generate output code, so having the setting in place
helps confirm to the documentation.

Refs: https://github.com/browserslist/browserslist#packagejson
Refs: https://warehouse.pypa.io/development/frontend.html#browser-support

Note: The defaults that are currently in place without this
configuration are:

    '> 0.5%',
    'last 2 versions',
    'Firefox ESR',
    'not dead'

The difference from defaults and this one is:

    $ diff defaults.txt warehouse.txt
    9,11d8
    < chrome 94
    < chrome 93
    < chrome 92
    16,18d12
    < firefox 92
    < firefox 91
    < firefox 78
    22,23d15
    < ios_saf 14.0-14.4
    < ios_saf 12.2-12.5
    29d20
    < opera 79
    32a24
    > safari 14
    33a26,34
    > safari 13
    > safari 12.1
    > safari 12
    > safari 11.1
    > safari 11
    > safari 10.1
    > safari 10
    > safari 9.1
    > safari 9

Once merged, this should be followed with a change based on running:

    npx browserslist@latest --update-db

which will update `package-lock.json` with the updated browser versions
based on the configuration - something that should be run periodically.

Signed-off-by: Mike Fiedler <miketheman@gmail.com>