### PR TITLE
Handle some Deprecations

### DIFF
--- a/bin/tests
+++ b/bin/tests
@@ -33,6 +33,6 @@ fi
 set -x
 
 # Actually run our tests.
-python -m coverage run -m pytest --strict $COMMAND_ARGS
+python -m coverage run -m pytest --strict-markers $COMMAND_ARGS
 python -m coverage html
 python -m coverage report -m --fail-under 100

--- a/tests/unit/admin/test_flags.py
+++ b/tests/unit/admin/test_flags.py
@@ -16,6 +16,7 @@ from ...common.db.admin import AdminFlagFactory
 
 
 class TestAdminFlagValues(enum.Enum):
+    __test__ = False
     NOT_A_REAL_FLAG = "not-a-real-flag"
     THIS_FLAG_IS_ENABLED = "this-flag-is-enabled"
 

--- a/tests/unit/i18n/test_filters.py
+++ b/tests/unit/i18n/test_filters.py
@@ -70,7 +70,7 @@ def test_format_rfc822_datetime(monkeypatch):
 def test_format_number(monkeypatch):
     formatted = pretend.stub()
     format_number = pretend.call_recorder(lambda *a, **kw: formatted)
-    monkeypatch.setattr(babel.numbers, "format_number", format_number)
+    monkeypatch.setattr(babel.numbers, "format_decimal", format_number)
 
     request = pretend.stub(locale=pretend.stub())
     ctx = pretend.stub(get=pretend.call_recorder(lambda k: request))

--- a/tests/unit/packaging/test_models.py
+++ b/tests/unit/packaging/test_models.py
@@ -15,8 +15,8 @@ from collections import OrderedDict
 import pretend
 import pytest
 
+from pyramid.authorization import Allow
 from pyramid.location import lineage
-from pyramid.security import Allow
 
 from warehouse.packaging.models import Dependency, DependencyKind, File, ProjectFactory
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -16,8 +16,8 @@ import pretend
 import pytest
 
 from pyramid import renderers
+from pyramid.authorization import Allow, Authenticated
 from pyramid.httpexceptions import HTTPForbidden, HTTPUnauthorized
-from pyramid.security import Allow, Authenticated
 from pyramid.tweens import EXCVIEW
 
 from warehouse import config

--- a/warehouse/accounts/forms.py
+++ b/warehouse/accounts/forms.py
@@ -16,7 +16,7 @@ from email.errors import HeaderParseError
 from email.headerregistry import Address
 
 import disposable_email_domains
-import jinja2
+import markupsafe
 import wtforms
 import wtforms.fields
 import wtforms.fields.html5
@@ -181,7 +181,7 @@ class NewPasswordMixin:
             field.data, tags=["method:new_password"]
         ):
             raise wtforms.validators.ValidationError(
-                jinja2.Markup(self._breach_service.failure_message)
+                markupsafe.Markup(self._breach_service.failure_message)
             )
 
 
@@ -278,7 +278,7 @@ class LoginForm(PasswordMixin, UsernameMixin, forms.Form):
             is_disabled, disabled_for = self.user_service.is_disabled(userid)
             if is_disabled and disabled_for == DisableReason.CompromisedPassword:
                 raise wtforms.validators.ValidationError(
-                    jinja2.Markup(self.breach_service.failure_message)
+                    markupsafe.Markup(self.breach_service.failure_message)
                 )
 
         # Do our typical validation of the password.
@@ -297,7 +297,7 @@ class LoginForm(PasswordMixin, UsernameMixin, forms.Form):
                     user.id, reason=DisableReason.CompromisedPassword
                 )
                 raise wtforms.validators.ValidationError(
-                    jinja2.Markup(self.breach_service.failure_message)
+                    markupsafe.Markup(self.breach_service.failure_message)
                 )
 
 

--- a/warehouse/config.py
+++ b/warehouse/config.py
@@ -18,9 +18,9 @@ import shlex
 import transaction
 
 from pyramid import renderers
+from pyramid.authorization import Allow, Authenticated
 from pyramid.config import Configurator as _Configurator
 from pyramid.response import Response
-from pyramid.security import Allow, Authenticated
 from pyramid.tweens import EXCVIEW
 from pyramid_rpc.xmlrpc import XMLRPCRenderer
 

--- a/warehouse/filters.py
+++ b/warehouse/filters.py
@@ -63,7 +63,7 @@ def _camo_url(request, url):
     return urllib.parse.urljoin(camo_url, path)
 
 
-@jinja2.contextfilter
+@jinja2.pass_context
 def camoify(ctx, value):
     request = ctx.get("request") or get_current_request()
 

--- a/warehouse/i18n/filters.py
+++ b/warehouse/i18n/filters.py
@@ -19,26 +19,26 @@ import jinja2
 from pyramid.threadlocal import get_current_request
 
 
-@jinja2.contextfilter
+@jinja2.pass_context
 def format_date(ctx, *args, **kwargs):
     request = ctx.get("request") or get_current_request()
     kwargs.setdefault("locale", request.locale)
     return babel.dates.format_date(*args, **kwargs)
 
 
-@jinja2.contextfilter
+@jinja2.pass_context
 def format_datetime(ctx, *args, **kwargs):
     request = ctx.get("request") or get_current_request()
     kwargs.setdefault("locale", request.locale)
     return babel.dates.format_datetime(*args, **kwargs)
 
 
-@jinja2.contextfilter
+@jinja2.pass_context
 def format_rfc822_datetime(ctx, dt, *args, **kwargs):
     return email.utils.formatdate(dt.timestamp(), usegmt=True)
 
 
-@jinja2.contextfilter
+@jinja2.pass_context
 def format_number(ctx, number, locale=None):
     request = ctx.get("request") or get_current_request()
     if locale is None:

--- a/warehouse/i18n/filters.py
+++ b/warehouse/i18n/filters.py
@@ -43,4 +43,4 @@ def format_number(ctx, number, locale=None):
     request = ctx.get("request") or get_current_request()
     if locale is None:
         locale = request.locale
-    return babel.numbers.format_number(number, locale=locale)
+    return babel.numbers.format_decimal(number, locale=locale)

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -18,7 +18,7 @@ from urllib.parse import urlparse
 import packaging.utils
 
 from citext import CIText
-from pyramid.security import Allow
+from pyramid.authorization import Allow
 from pyramid.threadlocal import get_current_request
 from sqlalchemy import (
     BigInteger,

--- a/warehouse/policy.py
+++ b/warehouse/policy.py
@@ -13,7 +13,7 @@
 import os.path
 
 import html5lib
-import jinja2
+import markupsafe
 import mistune
 
 import warehouse
@@ -39,7 +39,7 @@ def markdown_view_factory(*, filename):
 
         title = html.find("//h1[1]").text
 
-        return {"title": title, "html": jinja2.Markup(rendered)}
+        return {"title": title, "html": markupsafe.Markup(rendered)}
 
     return markdown_view
 


### PR DESCRIPTION
When running the test suite, I saw a bunch of deprecation warnings that looked to be relatively minimal to handle, so took a shot and cleaning up some of the output.

Each commit contains some text as to the change, and any links I could dig up with references to the source.

Reduced 175 warnings emitted in CI to 156.