### PR TITLE
Sort release filenames naturally on details page

### DIFF
--- a/requirements/main.in
+++ b/requirements/main.in
@@ -24,6 +24,7 @@ limits
 lxml
 mistune
 msgpack
+natsort
 packaging>=15.2
 paginate>=0.5.2
 paginate_sqlalchemy

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -711,6 +711,10 @@ msgpack==1.0.2 \
     --hash=sha256:fae04496f5bc150eefad4e9571d1a76c55d021325dcd484ce45065ebbdd00984 \
     --hash=sha256:fe07bc6735d08e492a327f496b7850e98cb4d112c56df69b0c844dbebcbb47f6
     # via -r requirements/main.in
+natsort==8.0.0 \
+    --hash=sha256:5f5f4ea471d655b1b1611eef1cf0c6d3397095d2d3a1aab7098d6a50e4c3901a \
+    --hash=sha256:a0a4fd71aee20a6d648da61e01180a63f7268e69983d0440bd3ad80ef1ba6981
+    # via -r requirements/main.in
 packaging==21.3 \
     --hash=sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb \
     --hash=sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522

--- a/warehouse/packaging/views.py
+++ b/warehouse/packaging/views.py
@@ -10,6 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from natsort import natsorted
 from pyramid.httpexceptions import HTTPMovedPermanently, HTTPNotFound
 from pyramid.view import view_config
 from sqlalchemy.orm.exc import NoResultFound
@@ -125,7 +126,8 @@ def release_detail(release, request):
         "project": project,
         "release": release,
         "description": description,
-        "files": release.files.all(),
+        # We cannot easily sort naturally in SQL, sort here and pass to template
+        "files": natsorted(release.files.all(), reverse=True, key=lambda f: f.filename),
         "latest_version": project.latest_version,
         "all_versions": project.all_versions,
         "maintainers": maintainers,


### PR DESCRIPTION
Resolves #10262

I spent some time trying to understand if there was a "simple" way to pass `natsorted` (or something) to [SQLAlchemy Custom Comparators](https://docs.sqlalchemy.org/en/14/core/operators.html#operator-customization), but that bore little fruit. My understanding is that whatever custom comparisons added to the `order_by` of the relationship would be performed SQL-side, so we'd not be able use the Python library, and might have to implement a migration to add a stored function to accomplish this.

I also considered adding [`__gt__`-style operators](https://docs.python.org/3.8/reference/datamodel.html#object.__gt__) to `File` class, and then using Python's default `.sort()` or `sorted()`, but that also seemed wrong, since it would apply filename-based sorting to the entire class. I also pursued this in hopes of using [Jinja2 `sort()`](https://jinja.palletsprojects.com/en/3.0.x/templates/#jinja-filters.sort) directly in the template - but it has the same problem of not using natural sorting.

Finally, I landed on performing the sort in the view, which felt like the right balance.

Note: in trove-classifiers, the sort order is 2.7 => 3.9 => 3.10 - and I reverse the order here - happy to change that, but I felt like the most recent files are going to be more readily useful to a user.