### PR TITLE
fix command line syntax error from #10463

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -99,8 +99,8 @@ RUN set -x \
 # that code changes don't require triggering an entire install of all of
 # Warehouse's dependencies.
 RUN set -x \
-    && pip --no-deps --no-cache-dir --disable-pip-version-check \
-            install --no-binary hiredis \
+    && pip --no-cache-dir --disable-pip-version-check \
+            install --no-deps --no-binary hiredis \
                     -r /tmp/requirements/deploy.txt \
                     -r /tmp/requirements/main.txt \
                     $(if [ "$DEVEL" = "yes" ]; then echo '-r /tmp/requirements/tests.txt -r /tmp/requirements/lint.txt'; fi) \


### PR DESCRIPTION
containers were failing to build with:

```
 > [build 8/8] RUN set -x     && pip --no-deps --no-cache-dir --disable-pip-version-check             install --no-binary hiredis                     -r /tmp/requirements/deploy.txt                     -r /tmp/requirements/main.txt                     $(if [ "yes" = "yes" ]; then echo '-r /tmp/requirements/tests.txt -r /tmp/requirements/lint.txt'; fi)     && find /opt/warehouse -name '*.pyc' -delete:
#28 0.969 + [ yes = yes ]
#28 0.969 + echo -r /tmp/requirements/tests.txt -r /tmp/requirements/lint.txt
#28 0.970 + pip --no-deps --no-cache-dir --disable-pip-version-check install --no-binary hiredis -r /tmp/requirements/deploy.txt -r /tmp/requirements/main.txt -r /tmp/requirements/tests.txt -r /tmp/requirements/lint.txt
#28 1.518 
#28 1.518 Usage:   
#28 1.518   pip <command> [options]
#28 1.518 
#28 1.518 no such option: --no-deps
------
executor failed running [/bin/sh -c set -x     && pip --no-deps --no-cache-dir --disable-pip-version-check             install --no-binary hiredis                     -r /tmp/requirements/deploy.txt                     -r /tmp/requirements/main.txt                     $(if [ "$DEVEL" = "yes" ]; then echo '-r /tmp/requirements/tests.txt -r /tmp/requirements/lint.txt'; fi)     && find /opt/warehouse -name '*.pyc' -delete]: exit code: 2
ERROR: Service 'web' failed to build : Build failed
```