### PR TITLE
remove redirect to simple added in #9908

### DIFF
--- a/tests/unit/test_routes.py
+++ b/tests/unit/test_routes.py
@@ -420,7 +420,6 @@ def test_routes(warehouse):
         pretend.call("/sponsor/", "/sponsors/", domain=warehouse),
         pretend.call("/u/{username}/", "/user/{username}/", domain=warehouse),
         pretend.call("/p/{name}/", "/project/{name}/", domain=warehouse),
-        pretend.call("/s/{name}/", "/simple/{name}/", domain=warehouse),
         pretend.call("/pypi/{name}/", "/project/{name}/", domain=warehouse),
         pretend.call(
             "/pypi/{name}/{version}/", "/project/{name}/{version}/", domain=warehouse

--- a/warehouse/routes.py
+++ b/warehouse/routes.py
@@ -347,7 +347,6 @@ def includeme(config):
 
     # Legacy URLs
     config.add_route("legacy.api.simple.index", "/simple/", domain=warehouse)
-    config.add_redirect("/s/{name}/", "/simple/{name}/", domain=warehouse)
     config.add_route(
         "legacy.api.simple.detail",
         "/simple/{name}/",


### PR DESCRIPTION
Simple is an API endpoint, and redirects can be costly to our backends. It _also_ could lead to people relying on this undocumented URL.