### PR TITLE
limit length of response status line for _exc_with_message in forklift/legacy

### DIFF
--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -943,7 +943,11 @@ class TestFileUpload:
                     "md5_digest": "a fake md5 digest",
                     "summary": "A" * 513,
                 },
-                "'" + "A" * 60 + "...' is an invalid value for Summary. "
+                "'"
+                + "A" * 30
+                + "..."
+                + "A" * 30
+                + "' is an invalid value for Summary. "
                 "Error: Field cannot be longer than 512 characters. "
                 "See "
                 "https://packaging.python.org/specifications/core-metadata"

--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -943,7 +943,7 @@ class TestFileUpload:
                     "md5_digest": "a fake md5 digest",
                     "summary": "A" * 513,
                 },
-                "'" + "A" * 513 + "' is an invalid value for Summary. "
+                "'" + "A" * 60 + "...' is an invalid value for Summary. "
                 "Error: Field cannot be longer than 512 characters. "
                 "See "
                 "https://packaging.python.org/specifications/core-metadata"

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -870,7 +870,7 @@ def file_upload(request):
                 error_message = (
                     "{value!r} is an invalid value for {field}. ".format(
                         value=(
-                            field.data[:60] + "..."
+                            field.data[:30] + "..." + field.data[-30:]
                             if len(field.data) > 60
                             else field.data
                         ),

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -869,7 +869,12 @@ def file_upload(request):
             if field.description and isinstance(field, wtforms.StringField):
                 error_message = (
                     "{value!r} is an invalid value for {field}. ".format(
-                        value=field.data, field=field.description
+                        value=(
+                            field.data[:60] + "..."
+                            if len(field.data) > 60
+                            else field.data
+                        ),
+                        field=field.description,
                     )
                     + "Error: {} ".format(form.errors[field_name][0])
                     + "See "


### PR DESCRIPTION
addresses cases like #10501 where the Response Status line will be much larger than is reasonable.

in theory this is crashing the request at some part of our HTTP stack, I believe between our gunicorn servers and the TLS terminator right above it.

Fixes #10501.