### PR TITLE
chore: handle more warnings in test suite

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,4 +17,5 @@ markers = [
 filterwarnings = [
     'ignore::warehouse.admin.services.InsecureStorageWarning',
     'ignore::warehouse.packaging.services.InsecureStorageWarning',
+    'ignore:UserDefinedType CIText.*:sqlalchemy.exc.SAWarning'  # See https://github.com/mahmoudimus/sqlalchemy-citext/issues/25
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,5 +15,6 @@ markers = [
     'functional: Slower running tests which test the entire system is functioning.',
 ]
 filterwarnings = [
+    'ignore::warehouse.admin.services.InsecureStorageWarning',
     'ignore::warehouse.packaging.services.InsecureStorageWarning',
 ]

--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -104,6 +104,7 @@ class TestValidation:
         form, field = pretend.stub(), pretend.stub(data=version)
         legacy._validate_pep440_version(form, field)
 
+    @pytest.mark.filterwarnings("ignore:Creating a LegacyVersion.*:DeprecationWarning")
     @pytest.mark.parametrize("version", ["dog", "1.0.dev.a1", "1.0+local"])
     def test_validates_invalid_pep440_version(self, version):
         form, field = pretend.stub(), pretend.stub(data=version)
@@ -992,6 +993,7 @@ class TestFileUpload:
             ),
         ],
     )
+    @pytest.mark.filterwarnings("ignore:Creating a LegacyVersion.*:DeprecationWarning")
     def test_fails_invalid_post_data(
         self, pyramid_config, db_request, post_data, message
     ):

--- a/tests/unit/packaging/test_tasks.py
+++ b/tests/unit/packaging/test_tasks.py
@@ -404,6 +404,9 @@ class TestUpdateBigQueryMetadata:
 
 
 class TestSyncBigQueryMetadata:
+    @pytest.mark.filterwarnings(
+        "ignore:This collection has been invalidated.:sqlalchemy.exc.SAWarning"
+    )
     @pytest.mark.parametrize(
         ("release_files_table", "expected_get_table_calls"),
         [

--- a/warehouse/accounts/models.py
+++ b/warehouse/accounts/models.py
@@ -140,7 +140,7 @@ class User(SitemapMixin, db.Model):
         return (
             select([Email.email])
             .where((Email.user_id == self.id) & (Email.primary.is_(True)))
-            .as_scalar()
+            .scalar_subquery()
         )
 
     @property

--- a/warehouse/search/tasks.py
+++ b/warehouse/search/tasks.py
@@ -61,7 +61,7 @@ def _project_docs(db, project_name=None):
         db.query(func.array_agg(r.version))
         .filter(r.project_id == Release.project_id)
         .correlate(Release)
-        .as_scalar()
+        .scalar_subquery()
         .label("all_versions")
     )
 
@@ -71,7 +71,7 @@ def _project_docs(db, project_name=None):
         .join(Classifier, Classifier.id == release_classifiers.c.trove_id)
         .filter(Release.id == release_classifiers.c.release_id)
         .correlate(Release)
-        .as_scalar()
+        .scalar_subquery()
         .label("classifiers")
     )
 


### PR DESCRIPTION
Continued poking at the environment, and saw that the warnings crept up past 2,000.

Each commit message describes what the specifics of the change are.

Takes the test suite down from ~2,200 warnings to ~108.