### PR TITLE
Quiet logs from datadog

### DIFF
--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -101,6 +101,7 @@ def test_includeme(monkeypatch, settings, expected_level):
                         "formatter": "structlog",
                     },
                 },
+                "loggers": {"datadog.dogstatsd": {"level": "ERROR"}},
                 "root": {"level": expected_level, "handlers": ["primary"]},
             }
         )

--- a/warehouse/logging.py
+++ b/warehouse/logging.py
@@ -66,6 +66,7 @@ def includeme(config):
                     "formatter": "structlog",
                 },
             },
+            "loggers": {"datadog.dogstatsd": {"level": "ERROR"}},
             "root": {
                 "level": config.registry.settings.get("logging.level", "INFO"),
                 "handlers": ["primary"],


### PR DESCRIPTION
Since https://github.com/DataDog/datadogpy/pull/692, datadog emits the following logs for every request:

```
pypi-warehouse-web-84cff6b7c7-w7brv web {"logger": "datadog.dogstatsd", "level": "INFO", "event": "Statsd buffering is disabled", "thread": 140486667159360}
pypi-warehouse-web-84cff6b7c7-w7brv web {"logger": "datadog.dogstatsd", "level": "INFO", "event": "Statsd periodic buffer flush is disabled", "thread": 140486667159360}
```

This sets the log level to silence these and clean up production logs.