### PR TITLE
Show tooltip on buttons even if disabled

### DIFF
--- a/warehouse/static/sass/blocks/_package-snippet.scss
+++ b/warehouse/static/sass/blocks/_package-snippet.scss
@@ -99,6 +99,7 @@
     .button {
       display: inline-block;
       float: left;
+      pointer-events: auto;
     }
 
     .button--primary {


### PR DESCRIPTION
Fixes #6217.

![image](https://user-images.githubusercontent.com/294415/148289682-6a38fa96-7799-4cea-8c89-275017dadd1d.png)

![image](https://user-images.githubusercontent.com/294415/148289746-dfa63714-2baa-4b18-aff5-d480f4f7d1e4.png)
