### PR TITLE
Add uploader next to author/maintainer in info json

### DIFF
--- a/warehouse/legacy/api/json.py
+++ b/warehouse/legacy/api/json.py
@@ -190,6 +190,7 @@ def json_release(release, request):
             "author_email": release.author_email,
             "maintainer": release.maintainer,
             "maintainer_email": release.maintainer_email,
+            "uploader": release.uploader,
             "requires_python": release.requires_python,
             "platform": release.platform,
             "downloads": {"last_day": -1, "last_week": -1, "last_month": -1},


### PR DESCRIPTION
I've noticed that on https://pypi.org/project/identifier/ I can see the user "Collie" as maintainer, but on https://pypi.org/pypi/identifier/json the user cannot be seen at all.

It would be nice to be able to get the same information in a structured way as via the GUI.