### PR TITLE
Revamp downloads table

### DIFF
--- a/tests/unit/packaging/test_views.py
+++ b/tests/unit/packaging/test_views.py
@@ -196,6 +196,7 @@ class TestReleaseDetail:
                 release=r,
                 filename="{}-{}.tar.gz".format(project.name, r.version),
                 python_version="source",
+                packagetype="sdist",
             )
             for r in releases
         ]
@@ -210,6 +211,8 @@ class TestReleaseDetail:
             "project": project,
             "release": releases[1],
             "files": [files[1]],
+            "sdists": [files[1]],
+            "bdists": [],
             "description": "rendered description",
             "latest_version": project.latest_version,
             "all_versions": [
@@ -238,6 +241,7 @@ class TestReleaseDetail:
                 release=r,
                 filename="{}-{}.tar.gz".format(project.name, r.version),
                 python_version="source",
+                packagetype="sdist",
             )
             for r in releases
         ]
@@ -258,6 +262,8 @@ class TestReleaseDetail:
             "project": project,
             "release": releases[1],
             "files": [files[1]],
+            "sdists": [files[1]],
+            "bdists": [],
             "description": "rendered description",
             "latest_version": project.latest_version,
             "all_versions": [
@@ -280,10 +286,9 @@ class TestReleaseDetail:
         files = [
             FileFactory.create(
                 release=release,
-                filename="{}-{}-{}.tar.gz".format(
-                    project.name, release.version, py_ver
-                ),
-                python_version="source",
+                filename="{}-{}-{}.whl".format(project.name, release.version, py_ver),
+                python_version="py2.py3",
+                packagetype="bdist_wheel",
             )
             for py_ver in ["cp27", "cp310", "cp39"]  # intentionally out of order
         ]

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -325,7 +325,7 @@ msgstr ""
 #: warehouse/templates/manage/release.html:175
 #: warehouse/templates/manage/releases.html:140
 #: warehouse/templates/manage/releases.html:173
-#: warehouse/templates/packaging/detail.html:317
+#: warehouse/templates/packaging/detail.html:344
 #: warehouse/templates/pages/classifiers.html:25
 #: warehouse/templates/pages/help.html:20
 #: warehouse/templates/pages/help.html:207
@@ -1488,7 +1488,7 @@ msgstr ""
 #: warehouse/templates/manage/account.html:206
 #: warehouse/templates/manage/account/recovery_codes-provision.html:61
 #: warehouse/templates/manage/account/totp-provision.html:57
-#: warehouse/templates/packaging/detail.html:117
+#: warehouse/templates/packaging/detail.html:144
 #: warehouse/templates/pages/classifiers.html:37
 msgid "Copy to clipboard"
 msgstr ""
@@ -1975,7 +1975,6 @@ msgstr ""
 
 #: warehouse/templates/manage/account.html:473
 #: warehouse/templates/manage/release.html:58
-#: warehouse/templates/packaging/detail.html:349
 msgid "None"
 msgstr ""
 
@@ -2656,7 +2655,6 @@ msgstr ""
 
 #: warehouse/templates/manage/projects.html:119
 #: warehouse/templates/manage/releases.html:94
-#: warehouse/templates/packaging/detail.html:359
 msgid "View"
 msgstr ""
 
@@ -2699,8 +2697,6 @@ msgstr ""
 
 #: warehouse/templates/manage/release.html:37
 #: warehouse/templates/manage/release.html:48
-#: warehouse/templates/packaging/detail.html:323
-#: warehouse/templates/packaging/detail.html:334
 msgid "Filename, size"
 msgstr ""
 
@@ -2711,15 +2707,11 @@ msgstr ""
 
 #: warehouse/templates/manage/release.html:39
 #: warehouse/templates/manage/release.html:57
-#: warehouse/templates/packaging/detail.html:325
-#: warehouse/templates/packaging/detail.html:345
 msgid "Python version"
 msgstr ""
 
 #: warehouse/templates/manage/release.html:40
 #: warehouse/templates/manage/release.html:61
-#: warehouse/templates/packaging/detail.html:326
-#: warehouse/templates/packaging/detail.html:353
 msgid "Upload date"
 msgstr ""
 
@@ -3512,119 +3504,123 @@ msgid ""
 " not work with PyPI."
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:99
+#: warehouse/templates/packaging/detail.html:106
+msgid "view hashes"
+msgstr ""
+
+#: warehouse/templates/packaging/detail.html:126
 #, python-format
 msgid "RSS: latest releases for %(project_name)s"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:119
+#: warehouse/templates/packaging/detail.html:146
 msgid "Copy PIP instructions"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:129
+#: warehouse/templates/packaging/detail.html:156
 msgid "This release has been yanked"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:135
+#: warehouse/templates/packaging/detail.html:162
 #, python-format
 msgid "Stable version available (%(version)s)"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:139
+#: warehouse/templates/packaging/detail.html:166
 #, python-format
 msgid "Newer version available (%(version)s)"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:143
+#: warehouse/templates/packaging/detail.html:170
 msgid "Latest version"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:148
+#: warehouse/templates/packaging/detail.html:175
 #, python-format
 msgid "Released: %(release_date)s"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:160
+#: warehouse/templates/packaging/detail.html:187
 msgid "No project description provided"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:173
+#: warehouse/templates/packaging/detail.html:200
 msgid "Navigation"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:174
-#: warehouse/templates/packaging/detail.html:205
+#: warehouse/templates/packaging/detail.html:201
+#: warehouse/templates/packaging/detail.html:232
 #, python-format
 msgid "Navigation for %(project)s"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:177
-#: warehouse/templates/packaging/detail.html:208
+#: warehouse/templates/packaging/detail.html:204
+#: warehouse/templates/packaging/detail.html:235
 msgid "Project description. Focus will be moved to the description."
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:179
-#: warehouse/templates/packaging/detail.html:210
-#: warehouse/templates/packaging/detail.html:238
+#: warehouse/templates/packaging/detail.html:206
+#: warehouse/templates/packaging/detail.html:237
+#: warehouse/templates/packaging/detail.html:265
 msgid "Project description"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:183
-#: warehouse/templates/packaging/detail.html:220
+#: warehouse/templates/packaging/detail.html:210
+#: warehouse/templates/packaging/detail.html:247
 msgid "Release history. Focus will be moved to the history panel."
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:185
-#: warehouse/templates/packaging/detail.html:222
-#: warehouse/templates/packaging/detail.html:260
+#: warehouse/templates/packaging/detail.html:212
+#: warehouse/templates/packaging/detail.html:249
+#: warehouse/templates/packaging/detail.html:287
 msgid "Release history"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:190
-#: warehouse/templates/packaging/detail.html:227
+#: warehouse/templates/packaging/detail.html:217
+#: warehouse/templates/packaging/detail.html:254
 msgid "Download files. Focus will be moved to the project files."
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:192
-#: warehouse/templates/packaging/detail.html:229
-#: warehouse/templates/packaging/detail.html:316
+#: warehouse/templates/packaging/detail.html:219
+#: warehouse/templates/packaging/detail.html:256
+#: warehouse/templates/packaging/detail.html:343
 msgid "Download files"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:214
+#: warehouse/templates/packaging/detail.html:241
 msgid "Project details. Focus will be moved to the project details."
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:216
-#: warehouse/templates/packaging/detail.html:252
+#: warehouse/templates/packaging/detail.html:243
+#: warehouse/templates/packaging/detail.html:279
 msgid "Project details"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:245
+#: warehouse/templates/packaging/detail.html:272
 msgid "The author of this package has not provided a project description"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:262
+#: warehouse/templates/packaging/detail.html:289
 msgid "Release notifications"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:263
+#: warehouse/templates/packaging/detail.html:290
 msgid "RSS feed"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:275
+#: warehouse/templates/packaging/detail.html:302
 msgid "This version"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:295
+#: warehouse/templates/packaging/detail.html:322
 msgid "pre-release"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:300
+#: warehouse/templates/packaging/detail.html:327
 msgid "yanked"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:317
+#: warehouse/templates/packaging/detail.html:344
 #, python-format
 msgid ""
 "Download the file for your platform. If you're not sure which to choose, "
@@ -3632,20 +3628,29 @@ msgid ""
 "target=\"_blank\" rel=\"noopener\">installing packages</a>."
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:320
-#, python-format
-msgid "Files for %(project_name)s, version %(version)s"
-msgstr ""
+#: warehouse/templates/packaging/detail.html:348
+msgid ""
+"\n"
+"                Source Distribution\n"
+"              "
+msgid_plural ""
+"\n"
+"                Source Distributions\n"
+"              "
+msgstr[0] ""
+msgstr[1] ""
 
-#: warehouse/templates/packaging/detail.html:324
-#: warehouse/templates/packaging/detail.html:341
-msgid "File type"
-msgstr ""
-
-#: warehouse/templates/packaging/detail.html:327
-#: warehouse/templates/packaging/detail.html:357
-msgid "Hashes"
-msgstr ""
+#: warehouse/templates/packaging/detail.html:360
+msgid ""
+"\n"
+"                Built Distribution\n"
+"              "
+msgid_plural ""
+"\n"
+"                Built Distributions\n"
+"              "
+msgstr[0] ""
+msgstr[1] ""
 
 #: warehouse/templates/pages/classifiers.html:22
 msgid ""

--- a/warehouse/static/sass/blocks/_files.scss
+++ b/warehouse/static/sass/blocks/_files.scss
@@ -1,0 +1,62 @@
+/*!
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+  Individual file information represented as a card with meta data
+
+  <div class="file">
+    <div class="file__meta">
+      // Badge here
+    </div>
+    <div class="file__graphic"> // Node graphic with connecting line
+      <div class="file__line"></div>
+      <img class="file__node">
+    </div>
+    <a class="file__card" href="/link/to/version">
+      <p class="file__version"></p>
+      <p class="file__version-date"></p>
+    </a>
+  </div>
+*/
+
+.file {
+  @include clearfix;
+  display: table;
+  table-layout: fixed;
+  width: 100%;
+
+  &__meta {
+    font-size: 0.8rem;
+    padding-top: ($spacing-unit / 4);
+  }
+
+  &__graphic {
+    width: 26px;
+    display: table-cell;
+    text-align: center;
+    vertical-align: middle;
+    position: relative;
+    padding-right: $spacing-unit / 4;
+
+    @media screen and (max-width: $tablet) {
+      display: none;
+    }
+  }
+
+  &__card {
+    display: block;
+    margin: ($spacing-unit / 4) 0;
+  }
+
+}

--- a/warehouse/static/sass/warehouse.scss
+++ b/warehouse/static/sass/warehouse.scss
@@ -108,6 +108,7 @@
 /*rtl:begin:ignore*/
 @import "blocks/project-description";
 /*rtl:end:ignore*/
+@import "blocks/files";
 @import "blocks/release";
 @import "blocks/release-timeline";
 @import "blocks/search-form";

--- a/warehouse/templates/packaging/detail.html
+++ b/warehouse/templates/packaging/detail.html
@@ -91,6 +91,33 @@
   {%- endif -%}
 {%- endmacro -%}
 
+{%- macro file_table(files) -%}
+  {% for file in files %}
+    <div class="file">
+      <div class="file__graphic">
+        <i class="far fa-file" aria-hidden="true"></i>
+      </div>
+
+      <div class="card file__card">
+        <a href="{{ request.route_url('packaging.file', path=file.path) }}">
+          {{ file.filename }}
+        </a>
+        ({{ file.size|filesizeformat() if file.size else 0|filesizeformat() }}
+        <a href="#copy-hash-modal-{{ file.id }}">{%- trans -%}view hashes{%- endtrans -%}</a>)
+        <p class="file__meta">
+          Uploaded {{ humanize(file.upload_time) }}
+          {% if file.python_version %}
+          {% for tag in file.python_version.split('.') %}
+          <code>{{ tag }}</code>
+          {% endfor %}
+          {% endif %}
+        </p>
+      </div>
+    </div>
+  {% endfor %}
+
+{%- endmacro -%}
+
 {% block title %}{{ release.project.name }}{% endblock %}
 
 {% block description %}{{ release.summary }}{% endblock %}
@@ -316,53 +343,29 @@
             <h2 class="page-title">{% trans %}Download files{% endtrans %}</h2>
             <p>{% trans href='https://packaging.python.org/installing/', title=gettext('External link') %}Download the file for your platform. If you're not sure which to choose, learn more about <a href="{{ href }}" title="{{ title }}" target="_blank" rel="noopener">installing packages</a>.{% endtrans %}</p>
 
-            <table class="table table--downloads">
-              <caption class="sr-only">{% trans project_name=release.project.name, version=release.version %}Files for {{ project_name }}, version {{ version }}{% endtrans %}</caption>
-              <thead>
-                <tr>
-                  <th scope="col">{% trans %}Filename, size{% endtrans %}</th>
-                  <th scope="col">{% trans %}File type{% endtrans %}</th>
-                  <th scope="col">{% trans %}Python version{% endtrans %}</th>
-                  <th scope="col">{% trans %}Upload date{% endtrans %}</th>
-                  <th scope="col" class="table__align-right">{% trans %}Hashes{% endtrans %}</th>
-                </tr>
-              </thead>
-              <tbody>
-                {% for file in files %}
-                <tr>
-                  <th scope="row">
-                    <span class="table__mobile-label">{% trans %}Filename, size{% endtrans %}</span>
-                    <a href="{{ request.route_url('packaging.file', path=file.path) }}">
-                      {{ file.filename }}
-                    </a>
-                    {% if file.size %} ({{ file.size|filesizeformat() }}){% endif %}
-                  </th>
-                  <td>
-                    <span class="table__mobile-label">{% trans %}File type{% endtrans %}</span>
-                    {{ file.packagetype|format_package_type }}
-                  </td>
-                  <td>
-                    <span class="table__mobile-label">{% trans %}Python version{% endtrans %}</span>
-                    {% if file.python_version != "source" %}
-                      {{ file.python_version }}
-                    {% else %}
-                      {% trans %}None{% endtrans %}
-                    {% endif %}
-                  </td>
-                  <td>
-                    <span class="table__mobile-label">{% trans %}Upload date{% endtrans %}</span>
-                    {{ humanize(file.upload_time) }}
-                  </td>
-                  <td class="table__align-right">
-                    <span class="table__mobile-label table__mobile-label--hashes">{% trans %}Hashes{% endtrans %}</span>
-                    <a href="#copy-hash-modal-{{ file.id }}" class="button button--small button--primary">
-                      {% trans %}View{% endtrans %}
-                    </a>
-                  </td>
-                </tr>
-                {% endfor %}
-              </tbody>
-            </table>
+            {% if sdists %}
+            <h3>
+              {% trans count=sdists|length %}
+                Source Distribution
+              {% pluralize %}
+                Source Distributions
+              {% endtrans %}
+            </h3>
+
+            {{ file_table(sdists) }}
+            {% endif %}
+
+            {% if bdists %}
+            <h3>
+              {% trans count=bdists|length %}
+                Built Distribution
+              {% pluralize %}
+                Built Distributions
+              {% endtrans %}
+            </h3>
+
+            {{ file_table(bdists) }}
+            {% endif %}
           </div>
 
           {% for file in files %}


### PR DESCRIPTION
This separates source distributions and built distributions, and brings the sdist(s) to the top. It also handles long filenames better per https://github.com/pypa/warehouse/issues/10448#issuecomment-1021443408, while retaining all the same information we already provide.

Example for a project w/ just 1 sdist and 1 bdist:
![image](https://user-images.githubusercontent.com/294415/151110059-7c11a30e-c9c8-48ba-825b-21e5e63ce251.png)

Project with multiple bdists:
![image](https://user-images.githubusercontent.com/294415/151110043-384890eb-9ed6-4a97-9804-ee5f37436b07.png)
