### PR TITLE
Pyramid testing: call setUp/tearDown

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -124,6 +124,7 @@ def pyramid_services(metrics):
 
 @pytest.fixture
 def pyramid_request(pyramid_services, jinja, remote_addr):
+    pyramid.testing.setUp()
     dummy_request = pyramid.testing.DummyRequest()
     dummy_request.find_service = pyramid_services.find_service
     dummy_request.remote_addr = remote_addr
@@ -136,7 +137,9 @@ def pyramid_request(pyramid_services, jinja, remote_addr):
 
     dummy_request._ = localize
 
-    return dummy_request
+    yield dummy_request
+
+    pyramid.testing.tearDown()
 
 
 @pytest.fixture

--- a/tests/unit/search/test_tasks.py
+++ b/tests/unit/search/test_tasks.py
@@ -499,6 +499,8 @@ class TestPartialReindex:
         docs = pretend.stub()
         task = pretend.stub()
 
+        db_request.registry.settings = {"celery.scheduler_url": "redis://redis:6379/0"}
+
         def project_docs(db, project_name=None):
             return docs
 
@@ -531,6 +533,8 @@ class TestPartialReindex:
     def test_unindex_fails_when_raising(self, db_request, monkeypatch):
         task = pretend.stub()
 
+        db_request.registry.settings = {"celery.scheduler_url": "redis://redis:6379/0"}
+
         class TestError(Exception):
             pass
 
@@ -549,6 +553,8 @@ class TestPartialReindex:
 
     def test_unindex_accepts_defeat(self, db_request, monkeypatch):
         task = pretend.stub()
+
+        db_request.registry.settings = {"celery.scheduler_url": "redis://redis:6379/0"}
 
         es_client = FakeESClient()
         es_client.delete = pretend.call_recorder(
@@ -607,6 +613,8 @@ class TestPartialReindex:
     def test_successfully_indexes(self, db_request, monkeypatch):
         docs = pretend.stub()
         task = pretend.stub()
+
+        db_request.registry.settings = {"celery.scheduler_url": "redis://redis:6379/0"}
 
         def project_docs(db, project_name=None):
             return docs


### PR DESCRIPTION
Before this change, `pyramid_request.registry` and `db_request.registry` were a single global object shared across all tests, which caused side effects between tests.

This PR fixes this and fixes tests that were incorrectly depending on state set by other tests.