### PR TITLE
Update pytest-postgresql to version supporting pytest 7

### DIFF
--- a/requirements/tests.in
+++ b/requirements/tests.in
@@ -5,6 +5,6 @@ fakeredis
 freezegun
 pretend
 pytest>=3.0.0
-pytest-postgresql<4.0.0
+pytest-postgresql>=3.1.3,<4.0.0
 responses>=0.5.1
 webtest

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -159,9 +159,9 @@ pytest==7.0.1 \
     # via
     #   -r requirements/tests.in
     #   pytest-postgresql
-pytest-postgresql==3.1.2 \
-    --hash=sha256:32a15caa8cbebb7e8cbccb1c03bda55a00e7de9a2409add8b04dfbfa60f6432b \
-    --hash=sha256:f3582a51506b0aa2dd292bfd12bac5f27982ef9235b516140437d7af8e4b7287
+pytest-postgresql==3.1.3 \
+    --hash=sha256:05b87a192741511f5171e0300689a531a2a48b4483c69ae2b5f565d3e429b1d5 \
+    --hash=sha256:3649bcac5a0cd0d2cc1470a1087739990d402e2e910d53265ac486321a833898
     # via -r requirements/tests.in
 python-dateutil==2.8.2 \
     --hash=sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86 \


### PR DESCRIPTION
@di Here's a pytest-postgresql version supporting pytest 7, but still working psycopg2.