### PR TITLE
fix call to user service record_event in github token disclosure integration

### DIFF
--- a/tests/unit/integration/github/test_utils.py
+++ b/tests/unit/integration/github/test_utils.py
@@ -559,7 +559,7 @@ def test_analyze_disclosure(monkeypatch):
 
     find = pretend.call_recorder(lambda *a, **kw: database_macaroon)
     delete = pretend.call_recorder(lambda *a, **kw: None)
-    record_event = pretend.call_recorder(lambda *a, **kw: None)
+    record_event = pretend.call_recorder(lambda user_id, *, tag, additional=None: None)
     svc = {
         utils.IMetricsService: pretend.stub(increment=metrics_increment),
         utils.IMacaroonService: pretend.stub(
@@ -596,7 +596,6 @@ def test_analyze_disclosure(monkeypatch):
         pretend.call(
             user_id,
             tag="account:api_token:removed_leak",
-            ip_address="127.0.0.1",
             additional={
                 "macaroon_id": "12",
                 "public_url": "http://example.com",

--- a/warehouse/integrations/github/utils.py
+++ b/warehouse/integrations/github/utils.py
@@ -248,7 +248,6 @@ def _analyze_disclosure(request, disclosure_record, origin):
     user_service.record_event(
         database_macaroon.user.id,
         tag="account:api_token:removed_leak",
-        ip_address="127.0.0.1",
         additional={
             "macaroon_id": str(database_macaroon.id),
             "public_url": disclosure.public_url,


### PR DESCRIPTION
introduced in #10707

resolves https://sentry.io/share/issue/bd36f5a3cca74563af91fb53b586dae7/