### PR TITLE
tests: omit covered files

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -24,3 +24,6 @@ omit =
 exclude_lines =
     pragma: no cover
     class \w+\(Interface\):
+
+# Don't show us anything that's already 100% covered.
+skip_covered = True


### PR DESCRIPTION
When the tests complete, we get a lovely list of files that are 100%
covered by tests - woohoo!

As the file count grows, seeing anything that isn't 100% covered is
harder, so we can omit any file that coverage.py reports is fully
covered.

Signed-off-by: Mike Fiedler <miketheman@gmail.com>