### PR TITLE
correct logic in github-actions-deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-GITHUB_BASE_REF := $(shell echo "$${GITHUB_BASE_REF:-false}")
 DB := example
 IPYTHON := no
 

--- a/bin/github-actions-deps
+++ b/bin/github-actions-deps
@@ -10,7 +10,7 @@ export LANG="${ENCODING:-en_US.UTF-8}"
 # Print all the followng commands
 set -x
 
-if [[ -z "${GITHUB_BASE_REF}" ]]; then
+if [[ ! -z "${GITHUB_BASE_REF}" ]]; then
     git fetch origin ${GITHUB_BASE_REF}:refs/remotes/origin/${GITHUB_BASE_REF}
     # Check that the following diff will exit with 0 or 1
     git diff --name-only FETCH_HEAD || test $? -le 1 || exit 1


### PR DESCRIPTION
Resolves regression in #10803

Previously we had

```
GITHUB_BASE_REF := $(shell echo "$${GITHUB_BASE_REF:-false}")

ifneq ($(GITHUB_BASE_REF), false)
...
```

in the Makefile, this set the value of the Make var to `false` if no GITHUB_BASE_REF existed in environment

Now we soley rely on [GitHub Actions env vars](https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables) since the Make variable doesn't propogate to the script.

"The name of the base ref or target branch of the pull request in a workflow run. This is only set when the event that triggers a workflow run is either pull_request or pull_request_target. For example, main."

So, on pushes to main this is empty.

Thus our current condtion:

```
if [[ -z "${GITHUB_BASE_REF}" ]]; then
...
```

Is actually the opposite effect of what we had previously.