### PR TITLE
Use EthicalAds to display PSF sponsor logos at sponsor page

### DIFF
--- a/warehouse/admin/templates/admin/sponsors/edit.html
+++ b/warehouse/admin/templates/admin/sponsors/edit.html
@@ -136,6 +136,25 @@
             {{ render_field("One Time", form.one_time, "sponsor-one-time") }}
             {{ render_field("Sidebar", form.sidebar, "sponsor-sidebar") }}
 
+            {% if sponsor %}
+            <div class="box-header with-border">
+              <h3 class="box-title">Info from Python.org Logo Placement API</h3>
+              <hr>
+
+              <div class="">
+                <label for="{{ input_id }}" class="col-sm-2 align-right">Origin</label>
+                <p>{{ sponsor.origin }}</p>
+                <label for="{{ input_id }}" class="col-sm-2 align-right">Level Name</label>
+                <p>{{ sponsor.level_name|default("---", true) }}</p>
+                <label for="{{ input_id }}" class="col-sm-2 align-right">Level Order</label>
+                <p>{{ sponsor.level_order|default("---", true) }}</p>
+                <label for="{{ input_id }}" class="col-sm-2 align-right">Slug</label>
+                <p>{{ sponsor.slug|default("---", true) }}</p>
+              </div>
+
+            </div>
+            {% endif %}
+
             <div class="form-group">
               <div class="col-sm-offset-10 col-sm-2">
                 <button type="submit" class="btn btn-danger" title="{{ "Submitting requires superuser privileges" if not request.has_permission('psf_staff') }}" {{ "disabled" if not request.has_permission('psf_staff') }}>Submit</button>

--- a/warehouse/templates/pages/sponsors.html
+++ b/warehouse/templates/pages/sponsors.html
@@ -112,8 +112,8 @@
         <a href="https://www.python.org/sponsors/application/" target="_blank" rel="noopener" class="sponsor-grid__sponsor-link button button--primary">See sponsorship packages</a>
       </div>
       {% for sponsor in request.sponsors %}
-        {% if sponsor.psf_sponsor %}
         <div class="sponsor-grid__sponsor">
+          {% if sponsor.psf_sponsor and not sponsor.slug %}
           <div class="sponsor-grid__sponsor-img">
             {{ sponsor.color_logo_img|camoify|safe }}
           </div>
@@ -124,8 +124,10 @@
             </div>
           </div>
           <a href="{{ sponsor.link_url }}" target="_blank" rel="noopener" class="sponsor-grid__sponsor-link button">Visit {{ sponsor.name }}</a>
+          {% elif sponsor.psf_sponsor and sponsor.slug %}
+          <div data-ea-publisher="psf" data-ea-type="psf" data-ea-force-ad="{{ sponsor.slug }}-pypi-sponsors"></div>
+          {% endif %}
         </div>
-        {% endif %}
       {% endfor %}
     </div>
 


### PR DESCRIPTION
This PR is a #10766 follow-up. Its core is the update on sponsors page to display PSF sponsors logo from EthicalAds instead of using from pypi's static images. This PR also improves sponsor detail admin by displaying the information from logo placement's API as read-only data. Here's a screen shot of how it looks like:

![Screenshot from 2022-02-23 18-11-34](https://user-images.githubusercontent.com/238223/155411286-5dec2c9f-2167-4f00-bb87-09043048e7c4.png)
