### PR TITLE
test: couple of nits

### DIFF
--- a/tests/unit/utils/test_paginate.py
+++ b/tests/unit/utils/test_paginate.py
@@ -79,10 +79,6 @@ class FakeQuery:
         self.range = range
         return self
 
-    @property
-    def results(self):
-        return pretend.stub(hits=pretend.stub(total=len(self.fake)))
-
     def execute(self):
         return FakeResult(self.fake[self.range], len(self.fake))
 
@@ -95,10 +91,6 @@ class FakeQuery6:
     def __getitem__(self, range):
         self.range = range
         return self
-
-    @property
-    def results(self):
-        return pretend.stub(hits=pretend.stub(total=len(self.fake)))
 
     def execute(self):
         return FakeResult6(self.fake[self.range], len(self.fake))

--- a/tests/unit/utils/test_project.py
+++ b/tests/unit/utils/test_project.py
@@ -65,7 +65,7 @@ def test_confirm_no_input():
 
     with pytest.raises(HTTPSeeOther) as err:
         confirm_project(project, request, fail_route="fail_route")
-        assert err.value == "/the-redirect"
+    assert err.value.location == "/the-redirect"
 
     assert request.route_path.calls == [call("fail_route", project_name="foobar")]
     assert request.session.flash.calls == [call("Confirm the request", queue="error")]
@@ -81,7 +81,7 @@ def test_confirm_incorrect_input():
 
     with pytest.raises(HTTPSeeOther) as err:
         confirm_project(project, request, fail_route="fail_route")
-        assert err.value == "/the-redirect"
+    assert err.value.location == "/the-redirect"
 
     assert request.route_path.calls == [call("fail_route", project_name="foobar")]
     assert request.session.flash.calls == [


### PR DESCRIPTION
test: remove unused methods

Two of the `FakeQuery` instances implemented a `.results` method
that was never needed/exercised via tests, and can safely be removed.

Unless they are needed for some reason?

---

test: assert value on the exception location

The inner assertion was getting "swallowed" during pytest's assertion
rewriting, so the target location wasn't being validated.

Moving the assert outside of the context manager provides us access to
assert against the value.

Outdenting this assertion provided the visibility that the assertion was
incorrect, as the err.value is a Pyramid exception, which has a
`location` property we are validating against.

Refs: [docs.pytest.org/en/6.2.x/assert.html#assertions-about-expected-exceptions](https://docs.pytest.org/en/6.2.x/assert.html#assertions-about-expected-exceptions)
Refs: [docs.pylonsproject.org/projects/pyramid/en/latest/api/httpexceptions.html#pyramid.httpexceptions.HTTPSeeOther](https://docs.pylonsproject.org/projects/pyramid/en/latest/api/httpexceptions.html#pyramid.httpexceptions.HTTPSeeOther)
