### PR TITLE
Remove release version from email subjects

### DIFF
--- a/warehouse/templates/email/removed-project-release/subject.txt
+++ b/warehouse/templates/email/removed-project-release/subject.txt
@@ -14,4 +14,4 @@
 
 {% extends "email/_base/subject.txt" %}
 
-{% block subject %}The {{ project_name }} release {{ release_version }} has been deleted.{% endblock %}
+{% block subject %}A release for {{ project_name }} has been deleted.{% endblock %}

--- a/warehouse/templates/email/yanked-project-release/subject.txt
+++ b/warehouse/templates/email/yanked-project-release/subject.txt
@@ -14,4 +14,4 @@
 
 {% extends "email/_base/subject.txt" %}
 
-{% block subject %}{% trans project=project, release=release %}The {{ project }} release {{ release }} has been yanked.{% endtrans  %}{% endblock %}
+{% block subject %}{% trans project=project, release=release %}A release for {{ project }} has been yanked.{% endtrans  %}{% endblock %}


### PR DESCRIPTION
Removing the version makes it possible for email clients to thread multiple consecutive notification emails into a single thread.