### PR TITLE
Fix config test: ignore all env vars in test environment

### DIFF
--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -225,7 +225,7 @@ def test_configure(monkeypatch, settings, environment):
     )
     monkeypatch.setattr(config, "transaction", transaction)
 
-    result = config.configure(settings=settings)
+    result = config.configure(settings=settings.copy() if settings else None)
 
     expected_settings = {
         "warehouse.env": environment,

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -157,17 +157,17 @@ def test_maybe_set_compound(monkeypatch, environ, base, name, envvar, expected):
 
 
 @pytest.mark.parametrize(
-    ("settings", "environment", "other_settings"),
+    ("settings", "environment"),
     [
-        (None, config.Environment.production, {}),
-        ({}, config.Environment.production, {}),
-        ({"my settings": "the settings value"}, config.Environment.production, {}),
-        (None, config.Environment.development, {}),
-        ({}, config.Environment.development, {}),
-        ({"my settings": "the settings value"}, config.Environment.development, {}),
+        (None, config.Environment.production),
+        ({}, config.Environment.production),
+        ({"my settings": "the settings value"}, config.Environment.production),
+        (None, config.Environment.development),
+        ({}, config.Environment.development),
+        ({"my settings": "the settings value"}, config.Environment.development),
     ],
 )
-def test_configure(monkeypatch, settings, environment, other_settings):
+def test_configure(monkeypatch, settings, environment):
     json_renderer_obj = pretend.stub()
     json_renderer_cls = pretend.call_recorder(lambda **kw: json_renderer_obj)
     monkeypatch.setattr(renderers, "JSON", json_renderer_cls)
@@ -190,7 +190,7 @@ def test_configure(monkeypatch, settings, environment, other_settings):
                 "warehouse.xmlrpc.client.ratelimit_string": "3600 per hour",
             }
 
-    configurator_settings = other_settings.copy()
+    configurator_settings = dict()
     configurator_obj = pretend.stub(
         registry=FakeRegistry(),
         set_root_factory=pretend.call_recorder(lambda rf: None),

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -10,6 +10,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
 from unittest import mock
 
 import pretend
@@ -176,8 +178,17 @@ def test_configure(monkeypatch, settings, environment):
     xmlrpc_renderer_cls = pretend.call_recorder(lambda **kw: xmlrpc_renderer_obj)
     monkeypatch.setattr(config, "XMLRPCRenderer", xmlrpc_renderer_cls)
 
-    if environment == config.Environment.development:
-        monkeypatch.setenv("WAREHOUSE_ENV", "development")
+    # Ignore all environment variables in the test environment, except for WAREHOUSE_ENV
+    monkeypatch.setattr(
+        os,
+        "environ",
+        {
+            "WAREHOUSE_ENV": {
+                config.Environment.development: "development",
+                config.Environment.production: "production",
+            }[environment],
+        },
+    )
 
     class FakeRegistry(dict):
         def __init__(self):


### PR DESCRIPTION
The change in #10803 to remove the `env -i` flag to `docker-compose run` in favor of moving these variables into the `dev/environment` file instead had the effect of inserting all environment variables in `dev/environment` into the test environment when run via `make tests`

This didn't affect any tests except for `test_config`, which was making assumptions about what environment variables were present in the test environment. To remedy this, we make the test explicitly ignore all environment variables in the test environment to restore it's intended behavior.

Also cleans up the test a bit.