### PR TITLE
Fix a s/as/has/ typo in `basic-auth-with-2fa`

### DIFF
--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -1246,7 +1246,7 @@ msgstr ""
 msgid ""
 "During your recent upload or upload attempt to %(site)s, we noticed you "
 "used basic authentication (username &amp; password). However, your "
-"account as two-factor authentication (2FA) enabled."
+"account has two-factor authentication (2FA) enabled."
 msgstr ""
 
 #: warehouse/templates/email/basic-auth-with-2fa/body.html:22

--- a/warehouse/templates/email/basic-auth-with-2fa/body.html
+++ b/warehouse/templates/email/basic-auth-with-2fa/body.html
@@ -16,7 +16,7 @@
 {% block content %}
 <h3>{% trans %}What?{% endtrans %}</h3>
 <p>
-  {% trans site=request.registry.settings["site.name"] %}During your recent upload or upload attempt to {{ site }}, we noticed you used basic authentication (username &amp; password). However, your account as two-factor authentication (2FA) enabled.{% endtrans %}
+  {% trans site=request.registry.settings["site.name"] %}During your recent upload or upload attempt to {{ site }}, we noticed you used basic authentication (username &amp; password). However, your account has two-factor authentication (2FA) enabled.{% endtrans %}
 </p>
 <p>
   {% trans site=request.registry.settings["site.name"] %}In the near future, {{ site }} will begin prohibiting uploads using basic authentication for accounts with two-factor authentication enabled. Instead, we will require API tokens to be used instead.{% endtrans %}

--- a/warehouse/templates/email/basic-auth-with-2fa/body.txt
+++ b/warehouse/templates/email/basic-auth-with-2fa/body.txt
@@ -16,7 +16,7 @@
 {% block content %}
 # {% trans %}What?{% endtrans %}
 
-{% trans site=request.registry.settings["site.name"] %}During your recent upload or upload attempt to {{ site }}, we noticed you used basic authentication (username & password). However, your account as two-factor authentication (2FA) enabled.{% endtrans %}
+{% trans site=request.registry.settings["site.name"] %}During your recent upload or upload attempt to {{ site }}, we noticed you used basic authentication (username & password). However, your account has two-factor authentication (2FA) enabled.{% endtrans %}
 
 {% trans site=request.registry.settings["site.name"] %}In the near future, {{ site }} will begin prohibiting uploads using basic authentication for accounts with two-factor authentication enabled. Instead, we will require API tokens to be used instead.{% endtrans %}
 


### PR DESCRIPTION
Ref #10836