### PR TITLE
Move basic auth + 2FA check

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -135,6 +135,7 @@ def pyramid_request(pyramid_services, jinja, remote_addr):
     dummy_request = pyramid.testing.DummyRequest()
     dummy_request.find_service = pyramid_services.find_service
     dummy_request.remote_addr = remote_addr
+    dummy_request.authentication_method = pretend.stub()
 
     dummy_request.registry.registerUtility(jinja, IJinja2Environment, name=".jinja2")
 

--- a/tests/unit/accounts/test_core.py
+++ b/tests/unit/accounts/test_core.py
@@ -17,6 +17,7 @@ import pretend
 import pytest
 
 from warehouse import accounts
+from warehouse.accounts import AuthenticationMethod
 from warehouse.accounts.interfaces import (
     IPasswordBreachedService,
     ITokenService,
@@ -227,6 +228,7 @@ class TestLogin:
         ]
         assert service.update_user.calls == [pretend.call(2, last_login=now)]
         assert authenticate.calls == [pretend.call(2, pyramid_request)]
+        assert pyramid_request.authentication_method == AuthenticationMethod.BASIC_AUTH
 
     def test_via_basic_auth_compromised(
         self, monkeypatch, pyramid_request, pyramid_services
@@ -419,6 +421,7 @@ class TestSessionAuthenticate:
         )
         assert accounts._session_authenticate(1, request) is None
         assert authenticate_obj.calls == []
+        assert request.authentication_method == AuthenticationMethod.SESSION
 
     def test_route_matched_name_ok(self, monkeypatch):
         authenticate_obj = pretend.call_recorder(lambda *a, **kw: True)
@@ -428,6 +431,7 @@ class TestSessionAuthenticate:
         )
         assert accounts._session_authenticate(1, request) is True
         assert authenticate_obj.calls == [pretend.call(1, request)]
+        assert request.authentication_method == AuthenticationMethod.SESSION
 
 
 class TestMacaroonAuthenticate:
@@ -439,6 +443,7 @@ class TestMacaroonAuthenticate:
         )
         assert accounts._macaroon_authenticate(1, request) is True
         assert authenticate_obj.calls == [pretend.call(1, request)]
+        assert request.authentication_method == AuthenticationMethod.MACAROON
 
 
 class TestUser:

--- a/tests/unit/accounts/test_core.py
+++ b/tests/unit/accounts/test_core.py
@@ -282,64 +282,6 @@ class TestLogin:
         ]
         assert send_email.calls == [pretend.call(pyramid_request, user)]
 
-    def test_via_basic_auth_2fa_enabled(
-        self, monkeypatch, pyramid_request, pyramid_services
-    ):
-        principals = pretend.stub()
-        authenticate = pretend.call_recorder(lambda userid, request: principals)
-        monkeypatch.setattr(accounts, "_authenticate", authenticate)
-        send_email = pretend.call_recorder(lambda *a, **kw: None)
-        monkeypatch.setattr(
-            accounts, "send_basic_auth_with_two_factor_email", send_email
-        )
-
-        user = pretend.stub(id=2, has_two_factor=True)
-        service = pretend.stub(
-            get_user=pretend.call_recorder(lambda user_id: user),
-            find_userid=pretend.call_recorder(lambda username: 2),
-            check_password=pretend.call_recorder(
-                lambda userid, password, tags=None: True
-            ),
-            is_disabled=pretend.call_recorder(lambda user_id: (False, None)),
-            disable_password=pretend.call_recorder(lambda user_id, reason=None: None),
-            update_user=pretend.call_recorder(lambda userid, last_login: None),
-        )
-        breach_service = pretend.stub(
-            check_password=pretend.call_recorder(lambda pw, tags=None: False)
-        )
-
-        pyramid_services.register_service(service, IUserService, None)
-        pyramid_services.register_service(
-            breach_service, IPasswordBreachedService, None
-        )
-
-        pyramid_request.matched_route = pretend.stub(name="forklift.legacy.file_upload")
-
-        now = datetime.datetime.utcnow()
-
-        with freezegun.freeze_time(now):
-            assert (
-                accounts._basic_auth_check("myuser", "mypass", pyramid_request)
-                is principals
-            )
-
-        assert service.find_userid.calls == [pretend.call("myuser")]
-        assert service.get_user.calls == [pretend.call(2)]
-        assert service.is_disabled.calls == [pretend.call(2)]
-        assert service.check_password.calls == [
-            pretend.call(
-                2,
-                "mypass",
-                tags=["mechanism:basic_auth", "method:auth", "auth_method:basic"],
-            )
-        ]
-        assert breach_service.check_password.calls == [
-            pretend.call("mypass", tags=["method:auth", "auth_method:basic"])
-        ]
-        assert send_email.calls == [pretend.call(pyramid_request, user)]
-        assert service.update_user.calls == [pretend.call(2, last_login=now)]
-        assert authenticate.calls == [pretend.call(2, pyramid_request)]
-
 
 class TestAuthenticate:
     @pytest.mark.parametrize(

--- a/warehouse/accounts/__init__.py
+++ b/warehouse/accounts/__init__.py
@@ -11,6 +11,7 @@
 # limitations under the License.
 
 import datetime
+import enum
 
 from pyramid.authorization import ACLAuthorizationPolicy
 from pyramid_multiauth import MultiAuthenticationPolicy
@@ -49,6 +50,12 @@ __all__ = ["NullPasswordBreachedService", "HaveIBeenPwnedPasswordBreachedService
 REDIRECT_FIELD_NAME = "next"
 
 
+class AuthenticationMethod(enum.Enum):
+    BASIC_AUTH = "basic-auth"
+    SESSION = "session"
+    MACAROON = "macaroon"
+
+
 def _format_exc_status(exc, message):
     exc.status = f"{exc.status_code} {message}"
     return exc
@@ -79,6 +86,8 @@ def _authenticate(userid, request):
 
 
 def _basic_auth_check(username, password, request):
+    request.authentication_method = AuthenticationMethod.BASIC_AUTH
+
     # Basic authentication can only be used for uploading
     if request.matched_route.name not in ["forklift.legacy.file_upload"]:
         return
@@ -140,6 +149,8 @@ def _basic_auth_check(username, password, request):
 
 
 def _session_authenticate(userid, request):
+    request.authentication_method = AuthenticationMethod.SESSION
+
     # Session authentication cannot be used for uploading
     if request.matched_route.name in ["forklift.legacy.file_upload"]:
         return
@@ -148,6 +159,7 @@ def _session_authenticate(userid, request):
 
 
 def _macaroon_authenticate(userid, request):
+    request.authentication_method = AuthenticationMethod.MACAROON
     return _authenticate(userid, request)
 
 

--- a/warehouse/accounts/__init__.py
+++ b/warehouse/accounts/__init__.py
@@ -33,10 +33,7 @@ from warehouse.accounts.services import (
     TokenServiceFactory,
     database_login_factory,
 )
-from warehouse.email import (
-    send_basic_auth_with_two_factor_email,
-    send_password_compromised_email_hibp,
-)
+from warehouse.email import send_password_compromised_email_hibp
 from warehouse.errors import BasicAuthBreachedPassword, BasicAuthFailedPassword
 from warehouse.macaroons.auth_policy import (
     MacaroonAuthenticationPolicy,
@@ -126,10 +123,6 @@ def _basic_auth_check(username, password, request):
                 raise _format_exc_status(
                     BasicAuthBreachedPassword(), breach_service.failure_message_plain
                 )
-
-            if user.has_two_factor:
-                send_basic_auth_with_two_factor_email(request, user)
-                # Eventually, raise here to disable basic auth with 2FA enabled
 
             login_service.update_user(user.id, last_login=datetime.datetime.utcnow())
             return _authenticate(user.id, request)


### PR DESCRIPTION
This PR adds a marker on the request object, `request.authentication_method`, that allows us to distinguish requests later in the response cycle. It also moves the basic auth + 2FA check into the upload view, to cut down on duplicate messages.