### PR TITLE
Fix projects_requiring_2fa query

### DIFF
--- a/tests/unit/manage/test_views.py
+++ b/tests/unit/manage/test_views.py
@@ -2299,6 +2299,12 @@ class TestManageProjects:
         project_where_pypi_mandates_2fa = ProjectFactory(
             releases=[], created=datetime.datetime(2022, 1, 2), pypi_mandates_2fa=True
         )
+        another_project_where_owners_require_2fa = ProjectFactory(
+            releases=[], created=datetime.datetime(2022, 3, 1), owners_require_2fa=True
+        )
+        another_project_where_pypi_mandates_2fa = ProjectFactory(
+            releases=[], created=datetime.datetime(2022, 3, 2), pypi_mandates_2fa=True
+        )
         db_request.user = UserFactory()
         RoleFactory.create(
             user=db_request.user,
@@ -2344,9 +2350,21 @@ class TestManageProjects:
             project=project_where_pypi_mandates_2fa,
             role_name="Owner",
         )
+        RoleFactory.create(
+            user=db_request.user,
+            project=another_project_where_owners_require_2fa,
+            role_name="Maintainer",
+        )
+        RoleFactory.create(
+            user=db_request.user,
+            project=another_project_where_pypi_mandates_2fa,
+            role_name="Maintainer",
+        )
 
         assert views.manage_projects(db_request) == {
             "projects": [
+                another_project_where_pypi_mandates_2fa,
+                another_project_where_owners_require_2fa,
                 project_where_pypi_mandates_2fa,
                 project_where_owners_require_2fa,
                 newer_project_with_no_releases,
@@ -2368,6 +2386,8 @@ class TestManageProjects:
             "projects_requiring_2fa": {
                 project_where_owners_require_2fa.name,
                 project_where_pypi_mandates_2fa.name,
+                another_project_where_owners_require_2fa.name,
+                another_project_where_pypi_mandates_2fa.name,
             },
             "project_invites": [],
         }

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -116,7 +116,7 @@ msgstr ""
 msgid "Successful WebAuthn assertion"
 msgstr ""
 
-#: warehouse/accounts/views.py:439 warehouse/manage/views.py:779
+#: warehouse/accounts/views.py:439 warehouse/manage/views.py:786
 msgid "Recovery code accepted. The supplied code cannot be used again."
 msgstr ""
 
@@ -225,45 +225,45 @@ msgstr ""
 msgid "Banner Preview"
 msgstr ""
 
-#: warehouse/manage/views.py:215
+#: warehouse/manage/views.py:222
 msgid "Email ${email_address} added - check your email for a verification link"
 msgstr ""
 
-#: warehouse/manage/views.py:727
+#: warehouse/manage/views.py:734
 msgid "Recovery codes already generated"
 msgstr ""
 
-#: warehouse/manage/views.py:728
+#: warehouse/manage/views.py:735
 msgid "Generating new recovery codes will invalidate your existing codes."
 msgstr ""
 
-#: warehouse/manage/views.py:1591
+#: warehouse/manage/views.py:1598
 msgid "User '${username}' already has ${role_name} role for project"
 msgstr ""
 
-#: warehouse/manage/views.py:1602
+#: warehouse/manage/views.py:1609
 msgid ""
 "User '${username}' does not have a verified primary email address and "
 "cannot be added as a ${role_name} for project"
 msgstr ""
 
-#: warehouse/manage/views.py:1615
+#: warehouse/manage/views.py:1622
 msgid "User '${username}' already has an active invite. Please try again later."
 msgstr ""
 
-#: warehouse/manage/views.py:1673
+#: warehouse/manage/views.py:1680
 msgid "Invitation sent to '${username}'"
 msgstr ""
 
-#: warehouse/manage/views.py:1720
+#: warehouse/manage/views.py:1727
 msgid "Could not find role invitation."
 msgstr ""
 
-#: warehouse/manage/views.py:1731
+#: warehouse/manage/views.py:1738
 msgid "Invitation already expired."
 msgstr ""
 
-#: warehouse/manage/views.py:1755
+#: warehouse/manage/views.py:1762
 msgid "Invitation revoked from '${username}'."
 msgstr ""
 

--- a/warehouse/manage/views.py
+++ b/warehouse/manage/views.py
@@ -96,6 +96,13 @@ def user_projects(request):
         .subquery()
     )
 
+    projects_collaborator = (
+        request.db.query(Project.id)
+        .join(Role.project)
+        .filter(Role.user == request.user)
+        .subquery()
+    )
+
     with_sole_owner = (
         request.db.query(Role.project_id)
         .join(projects_owned)
@@ -117,7 +124,7 @@ def user_projects(request):
         ),
         "projects_requiring_2fa": (
             request.db.query(Project)
-            .join(projects_owned, Project.id == projects_owned.c.id)
+            .join(projects_collaborator, Project.id == projects_collaborator.c.id)
             .filter(Project.two_factor_required)
             .order_by(Project.name)
             .all()


### PR DESCRIPTION
This PR updates the `projects_requiring_2fa` query to take into account both Maintainer and Owner roles for a user.