### PR TITLE
chore: remove host rewrite middleware

### DIFF
--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -24,7 +24,7 @@ from pyramid.tweens import EXCVIEW
 
 from warehouse import config
 from warehouse.errors import BasicAuthBreachedPassword, BasicAuthFailedPassword
-from warehouse.utils.wsgi import HostRewrite, ProxyFixer, VhmRootRemover
+from warehouse.utils.wsgi import ProxyFixer, VhmRootRemover
 
 
 class TestRequireHTTPSTween:
@@ -301,7 +301,6 @@ def test_configure(monkeypatch, settings, environment):
     assert configurator_obj.add_wsgi_middleware.calls == [
         pretend.call(ProxyFixer, token="insecure token", num_proxies=1),
         pretend.call(VhmRootRemover),
-        pretend.call(HostRewrite),
     ]
     assert configurator_obj.include.calls == (
         [

--- a/tests/unit/utils/test_wsgi.py
+++ b/tests/unit/utils/test_wsgi.py
@@ -162,29 +162,3 @@ class TestVhmRootRemover:
 
         assert resp is response
         assert app.calls == [pretend.call({"HTTP_X_FOOBAR": "wat"}, start_response)]
-
-
-class TestHostRewrite:
-    def test_rewrites_host(self):
-        response = pretend.stub()
-        app = pretend.call_recorder(lambda e, s: response)
-        environ = {"HTTP_HOST": "upload.pypi.io"}
-        start_response = pretend.stub()
-
-        resp = wsgi.HostRewrite(app)(environ, start_response)
-
-        assert resp is response
-        assert app.calls == [
-            pretend.call({"HTTP_HOST": "upload.pypi.org"}, start_response)
-        ]
-
-    def test_ignores_other_hosts(self):
-        response = pretend.stub()
-        app = pretend.call_recorder(lambda e, s: response)
-        environ = {"HTTP_HOST": "example.com"}
-        start_response = pretend.stub()
-
-        resp = wsgi.HostRewrite(app)(environ, start_response)
-
-        assert resp is response
-        assert app.calls == [pretend.call({"HTTP_HOST": "example.com"}, start_response)]

--- a/warehouse/config.py
+++ b/warehouse/config.py
@@ -26,7 +26,7 @@ from pyramid_rpc.xmlrpc import XMLRPCRenderer
 
 from warehouse.errors import BasicAuthBreachedPassword, BasicAuthFailedPassword
 from warehouse.utils.static import ManifestCacheBuster
-from warehouse.utils.wsgi import HostRewrite, ProxyFixer, VhmRootRemover
+from warehouse.utils.wsgi import ProxyFixer, VhmRootRemover
 
 
 class Environment(enum.Enum):
@@ -567,10 +567,6 @@ def configure(settings=None):
 
     # Protect against cache poisoning via the X-Vhm-Root headers.
     config.add_wsgi_middleware(VhmRootRemover)
-
-    # Fix our host header when getting sent upload.pypi.io as a HOST.
-    # TODO: Remove this, this is at the wrong layer.
-    config.add_wsgi_middleware(HostRewrite)
 
     # We want Sentry to be the last things we add here so that it's the outer
     # most WSGI middleware.

--- a/warehouse/utils/wsgi.py
+++ b/warehouse/utils/wsgi.py
@@ -81,19 +81,3 @@ class VhmRootRemover:
             del environ["HTTP_X_VHM_ROOT"]
 
         return self.app(environ, start_response)
-
-
-class HostRewrite:
-
-    # TODO: This entire class should not be required.
-
-    def __init__(self, app):
-        self.app = app
-
-    def __call__(self, environ, start_response):
-        # If the host header matches upload.pypi.io, then we want to rewrite it
-        # so that it is instead upload.pypi.org.
-        if environ.get("HTTP_HOST", "").lower() == "upload.pypi.io":
-            environ["HTTP_HOST"] = "upload.pypi.org"
-
-        return self.app(environ, start_response)


### PR DESCRIPTION
Introduced in #1414 in 2016
Replaced in twine in pypa/twine#201

The DNS entry no longer resolves either.

    $ host upload.pypi.io
    Host upload.pypi.io not found: 3(NXDOMAIN)

Signed-off-by: Mike Fiedler <miketheman@gmail.com>