### PR TITLE
chore: move database expansion to run in container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ initdb: .state/docker-build-web
 	docker-compose run --rm web psql -h db -d postgres -U postgres -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname ='warehouse';"
 	docker-compose run --rm web psql -h db -d postgres -U postgres -c "DROP DATABASE IF EXISTS warehouse"
 	docker-compose run --rm web psql -h db -d postgres -U postgres -c "CREATE DATABASE warehouse ENCODING 'UTF8'"
-	xz -d -f -k dev/$(DB).sql.xz --stdout | docker-compose run --rm web psql -h db -d warehouse -U postgres -v ON_ERROR_STOP=1 -1 -f -
+	docker-compose run --rm web bash -c "xz -d -f -k dev/$(DB).sql.xz --stdout | psql -h db -d warehouse -U postgres -v ON_ERROR_STOP=1 -1 -f -"
 	docker-compose run --rm web python -m warehouse db upgrade head
 	docker-compose run --rm web python -m warehouse sponsors populate-db
 	$(MAKE) reindex

--- a/docs/development/getting-started.rst
+++ b/docs/development/getting-started.rst
@@ -241,11 +241,6 @@ This command will:
 * load some example data from `Test PyPI`_, and
 * index all the data for the search database.
 
-.. note::
-
-    If you get an error about xz, you may need to install the ``xz`` utility.
-    This is highly likely on macOS and Windows.
-
 Once the ``make initdb`` command has finished, you are ready to continue.
 
 


### PR DESCRIPTION
When moving all development actions to containers in #10803, this step
remained outside on the host OS.

As `xz-utils` are installed in the `web` image already, use those
instead of relying on the host to install them.

Refs: #5872
Closes: #5980

Signed-off-by: Mike Fiedler <miketheman@gmail.com>