### PR TITLE
Fix typo in recovery_codes-burn.html

### DIFF
--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -3596,7 +3596,7 @@ msgstr ""
 msgid ""
 "\n"
 "      <strong>Forgot to safely store your recovery codes?</strong> You'll"
-" need to generate a them again.\n"
+" need to generate them again.\n"
 "      "
 msgstr ""
 

--- a/warehouse/templates/manage/account/recovery_codes-burn.html
+++ b/warehouse/templates/manage/account/recovery_codes-burn.html
@@ -42,7 +42,7 @@
       </p>
       <p>
       {% trans %}
-      <strong>Forgot to safely store your recovery codes?</strong> You'll need to generate a them again.
+      <strong>Forgot to safely store your recovery codes?</strong> You'll need to generate them again.
       {% endtrans %}
       </p>
       <a href="{{ request.route_path('manage.account.recovery-codes.regenerate') }}" class="button button--secondary">


### PR DESCRIPTION
Remove the extra "a".

The various i18n's in the `warehouse/locale/{locale}/LC_MESSAGES/messages.po` files (e.g., [here](https://github.com/pypa/warehouse/blob/86509281dbb5fb63ec242aa049960ffc5586ec3d/warehouse/locale/uz_Latn/LC_MESSAGES/messages.po#L3677)) may also need to be updated, if they are not autogenerated.