### PR TITLE
Document how I setup remote access to development warehouse instances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ node_modules/
 dev/example.sql
 dev/prod.sql
 dev/prod.sql.xz
+dev/environment.local
 ./data/
 
 warehouse/.commit

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,7 +70,9 @@ services:
         DEVEL: "yes"
         IPYTHON: "no"
     command: gunicorn --reload -b 0.0.0.0:8000 warehouse.wsgi:application
-    env_file: dev/environment
+    env_file:
+      - dev/environment
+      - dev/environment.local
     volumes:
       # We specify all of these directories instead of just . because we want to
       # avoid having ./node_modules from the host OS being shared with the docker
@@ -121,7 +123,9 @@ services:
     command: hupper -m celery -A warehouse worker -B -S redbeat.RedBeatScheduler -l info
     volumes:
       - ./warehouse:/opt/warehouse/src/warehouse:z
-    env_file: dev/environment
+    env_file:
+      - dev/environment
+      - dev/environment.local
     environment:
       C_FORCE_ROOT: "1"
       FILES_BACKEND: "warehouse.packaging.services.LocalFileStorage path=/var/opt/warehouse/packages/ url=http://files:9001/packages/{path}"

--- a/docs/development/index.rst
+++ b/docs/development/index.rst
@@ -39,6 +39,7 @@ Get involved or find help using:
     email
     malware-checks
     token-scanning
+    remote-access
 
 .. _`GitHub`: https://github.com/pypa/warehouse
 .. _`"What to put in your bug report"`: http://www.contribution-guide.org/#what-to-put-in-your-bug-report

--- a/docs/development/remote-access.rst
+++ b/docs/development/remote-access.rst
@@ -1,0 +1,73 @@
+Providing Remote Access For User Testing
+========================================
+
+.. contents::
+    :local:
+
+Motivation
+----------
+
+From time to time you may want to provide access to a development instance
+of warehouse running locally with someone else. A common usecase is testing
+or reviewing a new feature without merging changes or deploying software.
+
+Tools
+-----
+
+Historically `ngrok <https://ngrok.com>`_ has been used and is what warehouse
+maintainers are familiar with, but
+`alternatives <https://github.com/anderspitman/awesome-tunneling>`_
+exist, if there's a tool that you use that suits, please open a pull request
+to add docs here!
+
+ngrok (simple)
+--------------
+
+Follow `ngrok's quickstart guide <https://ngrok.com/docs/guides/quickstart>`_
+to get ngrok installed, authenticated, and familiarize yourself.
+
+After installation, you can start the warehouse services locally with
+``make serve``, then in a separate terminal window run ``ngrok http 80``.
+
+Share the URL from ``ngrok``'s output with anyone you want.
+
+.. warning::
+    The most notable thing that does not work with the simple ``ngrok http 80``
+    command above is external images such as gravatar profile pictures, sponsor
+    logos, and images included in project descriptions
+
+    Follow the advanced guide if you need these features to work when sharing
+    local environment
+
+ngrok (advanced)
+----------------
+
+.. warning::
+    This requires a paid ngrok.com account
+
+Create an ngrok configuration file such as
+
+.. code-block::
+
+    authtoken: deadbeefdeadbeefdeadbeefdeadbeefdeadbeef
+    tunnels:
+      warehouse-local:
+        addr: 80
+        proto: http
+        subdomain: pypi-preview
+      camo-local:
+        addr: 9000
+        proto: http
+        subdomain: camo-preview
+
+Update ``dev/enviroment.local`` with the camo URL
+
+.. code-block::
+
+    $ cat dev/environment.local
+    CAMO_URL=https://camo-preview.ngrok.io/
+
+Start and stop your local instances via docker-compose to pick up the
+configuration change.
+
+Camo will now work!


### PR DESCRIPTION
For user testing or preview work, I've used `ngrok` in the past, this documents my setup as well as a less complete solution.

~Note: This also introduces `dev/environment.local` which is configured to be completely ignored by git, but exist as an empty file in the repository allowing for local overrides of environment variable provided to the docker containers.~ [Edit: Hmmm... seems skip-worktree doesn't propagate up]