### PR TITLE
Update unavailable project help text

### DIFF
--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -4842,7 +4842,7 @@ msgstr ""
 msgid ""
 "Your publishing tool may return an error that your new project can't be "
 "created with your desired name, despite no evidence of a project or "
-"release of the same name on PyPI. Currently, there are three primary "
+"release of the same name on PyPI. Currently, there are four primary "
 "reasons this may occur:"
 msgstr ""
 
@@ -4873,6 +4873,11 @@ msgstr ""
 msgid ""
 "The project name has been registered by another user, but no releases "
 "have been created."
+msgstr ""
+
+#: warehouse/templates/pages/help.html:554
+#, python-format
+msgid "See <a href=\"%(href)s\">%(anchor_text)s</a>"
 msgstr ""
 
 #: warehouse/templates/pages/help.html:558

--- a/warehouse/templates/pages/help.html
+++ b/warehouse/templates/pages/help.html
@@ -546,7 +546,7 @@
         <p>{% trans href='https://pypi.org/project/devpi/' %}PyPI does not support publishing private packages. If you need to publish your private package to a package index, the recommended solution is to run your own deployment of the <a href="{{ href }}">devpi project</a>.{% endtrans %}</p>
 
         <h3 id="project-name">{{ project_name() }}</h3>
-        <p>{% trans %}Your publishing tool may return an error that your new project can't be created with your desired name, despite no evidence of a project or release of the same name on PyPI. Currently, there are three primary reasons this may occur:{% endtrans %}</p>
+        <p>{% trans %}Your publishing tool may return an error that your new project can't be created with your desired name, despite no evidence of a project or release of the same name on PyPI. Currently, there are four primary reasons this may occur:{% endtrans %}</p>
         <ul>
           <li>{% trans href='https://docs.python.org/3/library/index.html', title=gettext('External link') %}The project name conflicts with a <a href="{{ href }}" title="{{ title }}" target="_blank" rel="noopener">Python Standard Library</a> module from any major version from 2.5 to present.{% endtrans %}</li>
           <li>{% trans %}The project name is too similar to an existing project and may be confusable.{% endtrans %}</li>

--- a/warehouse/templates/pages/help.html
+++ b/warehouse/templates/pages/help.html
@@ -551,7 +551,7 @@
           <li>{% trans href='https://docs.python.org/3/library/index.html', title=gettext('External link') %}The project name conflicts with a <a href="{{ href }}" title="{{ title }}" target="_blank" rel="noopener">Python Standard Library</a> module from any major version from 2.5 to present.{% endtrans %}</li>
           <li>{% trans %}The project name is too similar to an existing project and may be confusable.{% endtrans %}</li>
           <li>{% trans incorrect_code='pip install requirements.txt', correct_code='pip install -r requirements.txt' %}The project name has been explicitly prohibited by the PyPI administrators. For example, <code>{{ incorrect_code }}</code> is a common typo for <code>{{ correct_code }}</code>, and should not surprise the user with a malicious package.{% endtrans %}</li>
-          <li>{% trans %}The project name has been registered by another user, but no releases have been created.{% endtrans %}</li>
+          <li>{% trans %}The project name has been registered by another user, but no releases have been created.{% endtrans %}{% trans href='#project-name-claim', anchor_text=project_name_claim() %}See <a href="{{ href }}">{{ anchor_text }}</a>{% endtrans %}</li>
         </ul>
 
         <h3 id="project-name-claim">{{ project_name_claim() }}</h3>


### PR DESCRIPTION
Adds a clarifying link and updates an incorrect count in the help text.