### PR TITLE
Constrain google-cloud-bigquery<3.0.0

### DIFF
--- a/requirements/main.in
+++ b/requirements/main.in
@@ -14,7 +14,7 @@ disposable-email-domains
 elasticsearch>=7.0.0,<7.11.0
 elasticsearch_dsl>=7.0.0,<8.0.0
 first
-google-cloud-bigquery
+google-cloud-bigquery<3.0.0  # https://github.com/googleapis/python-bigquery/issues/1196
 google-cloud-storage
 hiredis
 html5lib


### PR DESCRIPTION
Closes #11056. Due to https://github.com/googleapis/python-bigquery/issues/1196.