### PR TITLE
Noindex new projects

### DIFF
--- a/tests/unit/test_filters.py
+++ b/tests/unit/test_filters.py
@@ -208,3 +208,18 @@ def test_parse_version(inp, expected):
 def test_localize_datetime(inp, expected):
     datetime_format = "%Y-%m-%d %H:%M:%S.%f %Z"
     assert filters.localize_datetime(inp).strftime(datetime_format) == expected
+
+
+@pytest.mark.parametrize(
+    "delta, expected",
+    [
+        (datetime.timedelta(days=31), False),
+        (datetime.timedelta(days=30), False),
+        (datetime.timedelta(days=29), True),
+        (datetime.timedelta(), True),
+        (datetime.timedelta(days=-1), True),
+    ],
+)
+def test_is_recent(delta, expected):
+    timestamp = datetime.datetime.now() - delta
+    assert filters.is_recent(timestamp) == expected

--- a/warehouse/config.py
+++ b/warehouse/config.py
@@ -389,6 +389,7 @@ def configure(settings=None):
     filters.setdefault("format_package_type", "warehouse.filters:format_package_type")
     filters.setdefault("parse_version", "warehouse.filters:parse_version")
     filters.setdefault("localize_datetime", "warehouse.filters:localize_datetime")
+    filters.setdefault("is_recent", "warehouse.filters:is_recent")
 
     # We also want to register some global functions for Jinja
     jglobals = config.get_settings().setdefault("jinja2.globals", {})

--- a/warehouse/filters.py
+++ b/warehouse/filters.py
@@ -12,6 +12,7 @@
 
 import binascii
 import collections
+import datetime
 import enum
 import hmac
 import json
@@ -154,6 +155,10 @@ def parse_version(version_str):
 
 def localize_datetime(timestamp):
     return pytz.utc.localize(timestamp)
+
+
+def is_recent(timestamp):
+    return timestamp + datetime.timedelta(days=30) > datetime.datetime.now()
 
 
 def includeme(config):

--- a/warehouse/templates/base.html
+++ b/warehouse/templates/base.html
@@ -107,6 +107,7 @@
     <meta property="og:image" content="{{ request.static_url('warehouse:static/dist/images/twitter.jpg') }}">
     <meta property="og:title" content="{{ self.title()|default('Python Package Index') }}">
     <meta property="og:description" content="{{ self.description() }}">
+    {% block extra_meta %}{% endblock %}
 
     <link rel="search" type="application/opensearchdescription+xml" title="PyPI" href="{{ request.route_path('opensearch.xml') }}">
 

--- a/warehouse/templates/packaging/detail.html
+++ b/warehouse/templates/packaging/detail.html
@@ -128,6 +128,12 @@
 
 {% block canonical_url %}{{ request.route_url('packaging.project', name=release.project.name) }}{% endblock %}
 
+{% block extra_meta %}
+{% if release.project.created|is_recent %}
+<meta name="googlebot" content="noindex">
+{% endif %}
+{% endblock %}
+
 {% block content %}
 {% csi request.route_path("includes.administer-project-include", project_name=project.normalized_name) %}
 {% endcsi %}


### PR DESCRIPTION
This PR adds a Jinja filter `is_recent` that can be used to determine if a given timestamp is within the last 30 days. This is then used on the project page to add a `noindex` meta tag for projects created recently, which should give us sufficient time to remove spam before googlebot indexes the project.