### PR TITLE
Fix docs: static tests don't run with `make tests`

### DIFF
--- a/docs/development/frontend.rst
+++ b/docs/development/frontend.rst
@@ -26,10 +26,9 @@ Tests
 -----
 
 The JavaScript codebase includes tests that can be ran via
-``make static_tests`` which is also ran with the ``make tests`` target.
-Both targets will run the tests in the Docker environment but they
-may also be ran locally using ``npm run test`` once NodeJS and the
-dependencies are installed as described above.
+``make static_tests``. This target will run the static tests in the Docker
+environment but they may also be ran locally using ``npm run test`` once NodeJS
+and the dependencies are installed as described above.
 
 JavaScript tests use the `Jest testing framework <https://jestjs.io/>`_
 along with `jest-dom <https://github.com/testing-library/jest-dom>`_

--- a/docs/development/getting-started.rst
+++ b/docs/development/getting-started.rst
@@ -554,6 +554,7 @@ To run all tests, in the root of the repository:
 .. code-block:: console
 
     make tests
+    make static_tests
 
 This will run the tests with the supported interpreter as well as all of the
 additional testing that we require.


### PR DESCRIPTION
As far as I can tell, `make tests` executes bin/tests and only runs pytest for our Python code. `make static_tests` is required to execute bin/static_tests and run jest for our JavaScript code.

https://github.com/pypa/warehouse/blob/6b63c17a798f24ae6c98650a3edeeb3986a7c7e1/Makefile#L55-L59

https://github.com/pypa/warehouse/blob/6b63c17a798f24ae6c98650a3edeeb3986a7c7e1/bin/tests#L35-L38

https://github.com/pypa/warehouse/blob/6b63c17a798f24ae6c98650a3edeeb3986a7c7e1/bin/static_tests#L11-L12