### PR TITLE
Update maildev ports {80 => 1080} and {25 => 1025}

### DIFF
--- a/dev/environment
+++ b/dev/environment
@@ -26,7 +26,7 @@ SIMPLE_BACKEND=warehouse.packaging.services.LocalSimpleStorage path=/var/opt/war
 DOCS_BACKEND=warehouse.packaging.services.LocalDocsStorage path=/var/opt/warehouse/docs/
 SPONSORLOGOS_BACKEND=warehouse.admin.services.LocalSponsorLogoStorage path=/var/opt/warehouse/sponsorlogos/
 
-MAIL_BACKEND=warehouse.email.services.ConsoleAndSMTPEmailSender host=maildev port=25 ssl=false sender=noreply@pypi.org
+MAIL_BACKEND=warehouse.email.services.ConsoleAndSMTPEmailSender host=maildev port=1025 ssl=false sender=noreply@pypi.org
 
 BREACHED_PASSWORDS=warehouse.accounts.NullPasswordBreachedService
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -134,9 +134,10 @@ services:
       - ./bin:/opt/warehouse/src/bin:z
 
   maildev:
-    image: maildev/maildev
+    image: maildev/maildev:2.0.2
     ports:
-      - "1080:80"
+      - "1080:1080"
+      - "1025:1025"
 
   notdatadog:
     build:


### PR DESCRIPTION
maildev, the mock email service used for development, wasn't working:

1. The `warehouse.email.send_email` task hit `ConnectionRefusedError`.
2. The maildev interface http://localhost:1080/ wouldn't load.

Turns out that maildev ports were updated with v1.1.1. Updating ports according to maildev/maildev#281 resolved both issues, and pinning the version to v2.0.2 will prevent unexpected changes in the future.