### PR TITLE
feat(dev): express dependencies better

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.9'
 
 volumes:
   simple:
@@ -29,6 +29,8 @@ services:
     ports:
       # 5432 may already in use by another PostgreSQL on host
       - "5433:5432"
+    healthcheck:
+      test: ["CMD", "pg_isready", "-d", "postgres"]
 
   redis:
     image: redis:4.0
@@ -92,7 +94,12 @@ services:
     ports:
       - "${WEB_PORT:-80}:8000"
     depends_on:
-      - db
+      db:
+        condition: service_healthy
+      elasticsearch:
+        condition: service_started
+      redis:
+        condition: service_started
 
   files:
     build:

--- a/docs/development/getting-started.rst
+++ b/docs/development/getting-started.rst
@@ -197,6 +197,20 @@ Once ``make build`` has finished,  run the command:
 
 .. code-block:: console
 
+    make initdb
+
+This command will:
+
+* create a new Postgres database,
+* install example data to the Postgres database,
+* run migrations,
+* load some example data from `Test PyPI`_, and
+* index all the data for the search database.
+
+Once the ``make initdb`` command has finished, you are ready to continue:
+
+.. code-block:: console
+
     make serve
 
 This command starts the containers that run Warehouse on your local machine.
@@ -225,23 +239,6 @@ or that the ``static`` container has finished compiling the static assets:
     static_1 | [20:28:37] Finished 'watch' after 11 ms
 
 or maybe something else.
-
-After the docker containers are setup in the previous step, in a separate
-terminal session, run:
-
-.. code-block:: console
-
-    make initdb
-
-This command will:
-
-* create a new Postgres database,
-* install example data to the Postgres database,
-* run migrations,
-* load some example data from `Test PyPI`_, and
-* index all the data for the search database.
-
-Once the ``make initdb`` command has finished, you are ready to continue.
 
 
 Viewing Warehouse in a browser


### PR DESCRIPTION
Currently, a developer is expected to perform `make serve` prior to
running `make initdb`, as the `serve` command will start **all**
services expressed in `docker-compose.yml`.

By using a `healthcheck` on `db` that uses a built-in CLI tool to test
for health, and Docker Compose 3.9 Long Syntax for the conditions, we
can now run `make initdb` in one command, followed by `make serve`.

This enables pre-build behaviors to establish the `postgres` and
`elasticsearch` databases prior to other apps starting.

Refs: https://docs.docker.com/compose/compose-file/#healthcheck
Refs: https://www.postgresql.org/docs/10/app-pg-isready.html
Refs: https://docs.docker.com/compose/compose-file/#long-syntax-1

Signed-off-by: Mike Fiedler <miketheman@gmail.com>