### PR TITLE
fix(dev): correct healtcheck command

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       # 5432 may already in use by another PostgreSQL on host
       - "5433:5432"
     healthcheck:
-      test: ["CMD", "pg_isready", "-d", "postgres"]
+      test: ["CMD", "pg_isready", "-U", "postgres", "-d", "postgres"]
 
   redis:
     image: redis:4.0


### PR DESCRIPTION
While the previous command works, and reports that the db is indeed
ready and live for traffic, it emits warnings in the logs that the
role named "root" does not exist, since it's executing under the user
context it was started with.
The healthcheck runs at 30 second intervals, so gets noisy.

Pass the explicit user role to prevent these warnings.

Introduced in #11175

Signed-off-by: Mike Fiedler <miketheman@gmail.com>