### PR TITLE
Autofocus on the TOTP input

### DIFF
--- a/warehouse/templates/accounts/two-factor.html
+++ b/warehouse/templates/accounts/two-factor.html
@@ -89,7 +89,7 @@
               <span class="form-group__required">{% trans %}(required){% endtrans %}</span>
               {% endif %}
             </label>
-            {{ totp_form.totp_value(autocapitalize="off", autocomplete="off", inputmode="numeric", pattern="[0-9]*", required="required", spellcheck="false", class_="form-group__field", **{"aria-describedby":"totp-errors"}) }}
+            {{ totp_form.totp_value(autocapitalize="off", autocomplete="off", inputmode="numeric", pattern="[0-9]*", required="required", autofocus="autofocus", spellcheck="false", class_="form-group__field", **{"aria-describedby":"totp-errors"}) }}
             {% if totp_form.totp_value.errors %}
             <ul id="totp-errors" class="form-errors" role="alert">
               {% for error in totp_form.totp_value.errors %}


### PR DESCRIPTION
By autofocusing on this element, we remove the need for the user to
navigate to it, to perform the primary action on this page.