### PR TITLE
OIDC: More claims for GitHub's provider

### DIFF
--- a/tests/unit/oidc/test_models.py
+++ b/tests/unit/oidc/test_models.py
@@ -28,6 +28,8 @@ class TestGitHubProvider:
             # verifiable claims
             "repository",
             "workflow",
+            "repository_owner",
+            "repository_owner_id",
             # preverified claims
             "iss",
             "iat",
@@ -36,6 +38,7 @@ class TestGitHubProvider:
             "aud",
             # unchecked claims
             "actor",
+            "actor_id",
             "jti",
             "sub",
             "ref",
@@ -47,14 +50,15 @@ class TestGitHubProvider:
             "base_ref",
             "event_name",
             "ref_type",
+            "repository_id",
             "job_workflow_ref",
         }
 
     def test_github_provider_computed_properties(self):
         provider = models.GitHubProvider(
             repository_name="fakerepo",
-            owner="fakeowner",
-            owner_id="fakeid",
+            repository_owner="fakeowner",
+            repository_owner_id="fakeid",
             workflow_filename="fakeworkflow.yml",
         )
 
@@ -66,8 +70,8 @@ class TestGitHubProvider:
     def test_github_provider_unaccounted_claims(self, monkeypatch):
         provider = models.GitHubProvider(
             repository_name="fakerepo",
-            owner="fakeowner",
-            owner_id="fakeid",
+            repository_owner="fakeowner",
+            repository_owner_id="fakeid",
             workflow_filename="fakeworkflow.yml",
         )
 
@@ -90,8 +94,8 @@ class TestGitHubProvider:
     def test_github_provider_missing_claims(self, monkeypatch):
         provider = models.GitHubProvider(
             repository_name="fakerepo",
-            owner="fakeowner",
-            owner_id="fakeid",
+            repository_owner="fakeowner",
+            repository_owner_id="fakeid",
             workflow_filename="fakeworkflow.yml",
         )
 
@@ -111,8 +115,8 @@ class TestGitHubProvider:
     def test_github_provider_verifies(self, monkeypatch):
         provider = models.GitHubProvider(
             repository_name="fakerepo",
-            owner="fakeowner",
-            owner_id="fakeid",
+            repository_owner="fakeowner",
+            repository_owner_id="fakeid",
             workflow_filename="fakeworkflow.yml",
         )
 

--- a/warehouse/manage/views.py
+++ b/warehouse/manage/views.py
@@ -1311,13 +1311,13 @@ class ManageOIDCProviderViews:
 
         if form.validate():
             # GitHub OIDC providers are unique on the tuple of
-            # (repository_name, owner, workflow_filename), so we check for
+            # (repository_name, repository_owner, workflow_filename), so we check for
             # an already registered one before creating.
             provider = (
                 self.request.db.query(GitHubProvider)
                 .filter(
                     GitHubProvider.repository_name == form.repository.data,
-                    GitHubProvider.owner == form.normalized_owner,
+                    GitHubProvider.repository_owner == form.normalized_owner,
                     GitHubProvider.workflow_filename == form.workflow_filename.data,
                 )
                 .one_or_none()
@@ -1325,8 +1325,8 @@ class ManageOIDCProviderViews:
             if provider is None:
                 provider = GitHubProvider(
                     repository_name=form.repository.data,
-                    owner=form.normalized_owner,
-                    owner_id=form.owner_id,
+                    repository_owner=form.normalized_owner,
+                    repository_owner_id=form.owner_id,
                     workflow_filename=form.workflow_filename.data,
                 )
 

--- a/warehouse/migrations/versions/bb986a64761a_rename_githubprovider_fields.py
+++ b/warehouse/migrations/versions/bb986a64761a_rename_githubprovider_fields.py
@@ -1,0 +1,67 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+rename GitHubProvider fields
+
+Revision ID: bb986a64761a
+Revises: 9f0f99509d92
+Create Date: 2022-04-22 22:00:53.832695
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "bb986a64761a"
+down_revision = "9f0f99509d92"
+
+
+def upgrade():
+    op.add_column(
+        "github_oidc_providers",
+        sa.Column("repository_owner", sa.String(), nullable=True),
+    )
+    op.add_column(
+        "github_oidc_providers",
+        sa.Column("repository_owner_id", sa.String(), nullable=True),
+    )
+    op.drop_constraint(
+        "_github_oidc_provider_uc", "github_oidc_providers", type_="unique"
+    )
+    op.create_unique_constraint(
+        "_github_oidc_provider_uc",
+        "github_oidc_providers",
+        ["repository_name", "repository_owner", "workflow_filename"],
+    )
+    op.drop_column("github_oidc_providers", "owner_id")
+    op.drop_column("github_oidc_providers", "owner")
+
+
+def downgrade():
+    op.add_column(
+        "github_oidc_providers",
+        sa.Column("owner", sa.VARCHAR(), autoincrement=False, nullable=True),
+    )
+    op.add_column(
+        "github_oidc_providers",
+        sa.Column("owner_id", sa.VARCHAR(), autoincrement=False, nullable=True),
+    )
+    op.drop_constraint(
+        "_github_oidc_provider_uc", "github_oidc_providers", type_="unique"
+    )
+    op.create_unique_constraint(
+        "_github_oidc_provider_uc",
+        "github_oidc_providers",
+        ["repository_name", "owner", "workflow_filename"],
+    )
+    op.drop_column("github_oidc_providers", "repository_owner_id")
+    op.drop_column("github_oidc_providers", "repository_owner")

--- a/warehouse/migrations/versions/bb986a64761a_rename_githubprovider_fields.py
+++ b/warehouse/migrations/versions/bb986a64761a_rename_githubprovider_fields.py
@@ -17,8 +17,6 @@ Revises: 9f0f99509d92
 Create Date: 2022-04-22 22:00:53.832695
 """
 
-import sqlalchemy as sa
-
 from alembic import op
 
 revision = "bb986a64761a"
@@ -26,42 +24,34 @@ down_revision = "9f0f99509d92"
 
 
 def upgrade():
-    op.add_column(
-        "github_oidc_providers",
-        sa.Column("repository_owner", sa.String(), nullable=True),
-    )
-    op.add_column(
-        "github_oidc_providers",
-        sa.Column("repository_owner_id", sa.String(), nullable=True),
-    )
     op.drop_constraint(
         "_github_oidc_provider_uc", "github_oidc_providers", type_="unique"
+    )
+    op.alter_column(
+        "github_oidc_providers", "owner_id", new_column_name="repository_owner_id"
+    )
+    op.alter_column(
+        "github_oidc_providers", "owner", new_column_name="repository_owner"
     )
     op.create_unique_constraint(
         "_github_oidc_provider_uc",
         "github_oidc_providers",
         ["repository_name", "repository_owner", "workflow_filename"],
     )
-    op.drop_column("github_oidc_providers", "owner_id")
-    op.drop_column("github_oidc_providers", "owner")
 
 
 def downgrade():
-    op.add_column(
-        "github_oidc_providers",
-        sa.Column("owner", sa.VARCHAR(), autoincrement=False, nullable=True),
-    )
-    op.add_column(
-        "github_oidc_providers",
-        sa.Column("owner_id", sa.VARCHAR(), autoincrement=False, nullable=True),
-    )
     op.drop_constraint(
         "_github_oidc_provider_uc", "github_oidc_providers", type_="unique"
+    )
+    op.alter_column(
+        "github_oidc_providers", "repository_owner_id", new_column_name="owner_id"
+    )
+    op.alter_column(
+        "github_oidc_providers", "repository_owner", new_column_name="owner"
     )
     op.create_unique_constraint(
         "_github_oidc_provider_uc",
         "github_oidc_providers",
         ["repository_name", "owner", "workflow_filename"],
     )
-    op.drop_column("github_oidc_providers", "repository_owner_id")
-    op.drop_column("github_oidc_providers", "repository_owner")

--- a/warehouse/migrations/versions/bb986a64761a_rename_githubprovider_fields.py
+++ b/warehouse/migrations/versions/bb986a64761a_rename_githubprovider_fields.py
@@ -13,7 +13,7 @@
 rename GitHubProvider fields
 
 Revision ID: bb986a64761a
-Revises: 9f0f99509d92
+Revises: 18158aef6578
 Create Date: 2022-04-22 22:00:53.832695
 """
 
@@ -22,7 +22,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision = "bb986a64761a"
-down_revision = "9f0f99509d92"
+down_revision = "18158aef6578"
 
 
 def upgrade():

--- a/warehouse/migrations/versions/bb986a64761a_rename_githubprovider_fields.py
+++ b/warehouse/migrations/versions/bb986a64761a_rename_githubprovider_fields.py
@@ -13,7 +13,7 @@
 rename GitHubProvider fields
 
 Revision ID: bb986a64761a
-Revises: 18158aef6578
+Revises: 9f0f99509d92
 Create Date: 2022-04-22 22:00:53.832695
 """
 
@@ -22,7 +22,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision = "bb986a64761a"
-down_revision = "18158aef6578"
+down_revision = "9f0f99509d92"
 
 
 def upgrade():

--- a/warehouse/oidc/models.py
+++ b/warehouse/oidc/models.py
@@ -153,6 +153,7 @@ class GitHubProvider(OIDCProvider):
 
     __unchecked_claims__ = {
         "actor",
+        "actor_id",
         "jti",
         "sub",
         "ref",
@@ -164,7 +165,6 @@ class GitHubProvider(OIDCProvider):
         "base_ref",
         "event_name",
         "ref_type",
-        "actor_id",
         "repository_id",
         # TODO(#11096): Support reusable workflows.
         "job_workflow_ref",

--- a/warehouse/oidc/models.py
+++ b/warehouse/oidc/models.py
@@ -132,7 +132,7 @@ class GitHubProvider(OIDCProvider):
     __table_args__ = (
         UniqueConstraint(
             "repository_name",
-            "owner",
+            "repository_owner",
             "workflow_filename",
             name="_github_oidc_provider_uc",
         ),
@@ -140,13 +140,15 @@ class GitHubProvider(OIDCProvider):
 
     id = Column(UUID(as_uuid=True), ForeignKey(OIDCProvider.id), primary_key=True)
     repository_name = Column(String)
-    owner = Column(String)
-    owner_id = Column(String)
+    repository_owner = Column(String)
+    repository_owner_id = Column(String)
     workflow_filename = Column(String)
 
     __verifiable_claims__ = {
         "repository": str.__eq__,
         "workflow": str.__eq__,
+        "repository_owner": str.__eq__,
+        "repository_owner_id": str.__eq__,
     }
 
     __unchecked_claims__ = {
@@ -162,6 +164,8 @@ class GitHubProvider(OIDCProvider):
         "base_ref",
         "event_name",
         "ref_type",
+        "actor_id",
+        "repository_id",
         # TODO(#11096): Support reusable workflows.
         "job_workflow_ref",
     }
@@ -172,7 +176,7 @@ class GitHubProvider(OIDCProvider):
 
     @property
     def repository(self):
-        return f"{self.owner}/{self.repository_name}"
+        return f"{self.repository_owner}/{self.repository_name}"
 
     @property
     def workflow(self):


### PR DESCRIPTION
GitHub has added claims that allow us to attest to the repository owner's stable ID, which in turn allows us to prevent "account resurrection"-style attacks.

Needs test updates, but this should be functionally complete. The migration is primarily to make the comparisons during claim verification more straightforward.