### PR TITLE
Fix `bin/static_lint` error when running `make lint`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,8 @@ reformat: .state/docker-build-web
 	docker-compose run --rm web bin/reformat
 
 lint: .state/docker-build-web
-	docker-compose run --rm web bin/lint && bin/static_lint
+	docker-compose run --rm web bin/lint
+	docker-compose run --rm static bin/static_lint
 
 docs: .state/docker-build-web
 	docker-compose run --rm web bin/docs


### PR DESCRIPTION
The `bin/static_lint` step of `make lint` was throwing an error:

    + export LC_ALL=en_US.UTF-8
    + LC_ALL=en_US.UTF-8
    + export LANG=en_US.UTF-8
    + LANG=en_US.UTF-8
    + ./node_modules/.bin/eslint 'warehouse/static/js/**' '**.js' 'tests/frontend/**' --ignore-pattern 'warehouse/static/js/vendor/**'
    bin/static_lint: line 12: ./node_modules/.bin/eslint: No such file or directory
    make: *** [lint] Error 1

Fixed by running `bin/static_lint` in the `static` Docker container.
