### PR TITLE
avoid duplicating homepage/download links

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# This is only used for dependabot and Travis CI
+# This is only used for dependabot and Github Actions CI
 -r requirements/main.txt
 -r requirements/deploy.txt
 -r requirements/docs.txt

--- a/tests/unit/packaging/test_models.py
+++ b/tests/unit/packaging/test_models.py
@@ -252,6 +252,35 @@ class TestRelease:
                     ]
                 ),
             ),
+            # similar spellings of homepage/download label doesn't duplicate urls
+            (
+                "https://example.com/home/",
+                "https://example.com/download/",
+                [
+                    "homepage, https://example.com/home/",
+                    "download-URL ,https://example.com/download/",
+                ],
+                OrderedDict(
+                    [
+                        ("Homepage", "https://example.com/home/"),
+                        ("Download", "https://example.com/download/"),
+                    ]
+                ),
+            ),
+            # the duplicate removal only happens if the urls are equal too!
+            (
+                "https://example.com/home1/",
+                None,
+                [
+                    "homepage, https://example.com/home2/",
+                ],
+                OrderedDict(
+                    [
+                        ("Homepage", "https://example.com/home1/"),
+                        ("homepage", "https://example.com/home2/"),
+                    ]
+                ),
+            ),
             # ignore invalid links
             (
                 None,

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -462,6 +462,16 @@ class Release(db.Model):
             name, _, url = urlspec.partition(",")
             name = name.strip()
             url = url.strip()
+
+            # avoid duplicating homepage/download links in case the same
+            # url is specified in the pkginfo twice (in the Home-page
+            # or Download-URL field and again in the Project-URL fields)
+            comp_name = name.casefold().replace("-", "").replace("_", "")
+            if comp_name == "homepage" and url == _urls.get("Homepage"):
+                continue
+            if comp_name == "downloadurl" and url == _urls.get("Download"):
+                continue
+
             if name and url:
                 _urls[name] = url
 


### PR DESCRIPTION
In case the same url is specified in the pkginfo twice (in the Home-page or Download-URL field and again in one of the Project-URL fields)

This situation happens easily because PEP-621 [doesn't offer any way to specify Home-page](https://peps.python.org/pep-0621/#have-a-separate-url-home-page-field), but setuptools backfills project urls into Home-page.

closes #11220