### PR TITLE
Bump GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,7 @@ updates:
   ignore:
   # Always ignore elasticsearch, future versions are always incompatible with our provider
   - dependency-name: "elasticsearch"
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: "daily"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
     name: ${{ matrix.name }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install platform dependencies
         run: |
           sudo apt -y update
@@ -66,13 +66,13 @@ jobs:
         if: ${{ matrix.needs-python }}
         run: |
            echo "WAREHOUSE_PYTHON_VERSION=$(<.python-version)" >> $GITHUB_ENV
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v3
         if: ${{ matrix.needs-python }}
         with:
           python-version: ${{ env.WAREHOUSE_PYTHON_VERSION }}
       - name: Cache Python dependencies
         if: ${{ matrix.needs-python }}
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: warehouse-cache-pip
         with:
@@ -88,7 +88,7 @@ jobs:
           pip install -U pip setuptools wheel
           pip install -r requirements.txt --no-deps
           pip install -r requirements/dev.txt
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         if: ${{ matrix.needs-node }}
         with:
           node-version: 14.15.5

--- a/.github/workflows/combine-prs.yml
+++ b/.github/workflows/combine-prs.yml
@@ -22,7 +22,7 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - uses: actions/github-script@v3
+      - uses: actions/github-script@v6
         id: fetch-branch-names
         name: Fetch branch names
         with:
@@ -81,7 +81,7 @@ jobs:
             console.log('Combined: ' + combined);
             return combined
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2.3.3
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       # Creates a branch with other PR branches merged together
@@ -106,7 +106,7 @@ jobs:
           git pull origin $sourcebranches --no-edit
           git push origin $COMBINE_BRANCH_NAME
       # Creates a PR with the new combined branch
-      - uses: actions/github-script@v3
+      - uses: actions/github-script@v6
         name: Create Combined Pull Request
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/combine-prs.yml
+++ b/.github/workflows/combine-prs.yml
@@ -6,10 +6,12 @@ on:
     inputs:
       mustBeGreen:
         description: 'Only combine PRs that are green (status is success)'
+        type: boolean
         required: true
         default: true
       combineBranchName:
         description: 'Name of the branch to combine PRs into'
+        type: string
         required: true
         default: 'combine-prs-branch'
 


### PR DESCRIPTION
Changes:
- ci(CI): bump GitHub Actions actions
- ci(dependabot): add GitHub Actions
- ci(Combine PRs): bump GitHub Actions actions
- ci(Combine PRs): add type to inputs

Bumping `actions/github-script` from v3 -> v6 looks like it _should_ be fine, based on the changelog.