### PR TITLE
macaroons/security_policy: avoid exceptions during user lookup

### DIFF
--- a/tests/unit/macaroons/test_security_policy.py
+++ b/tests/unit/macaroons/test_security_policy.py
@@ -18,6 +18,7 @@ from pyramid.interfaces import IAuthorizationPolicy, ISecurityPolicy
 from pyramid.security import Denied
 from zope.interface.verify import verifyClass
 
+from warehouse.accounts.interfaces import IUserService
 from warehouse.macaroons import security_policy
 from warehouse.macaroons.interfaces import IMacaroonService
 from warehouse.macaroons.services import InvalidMacaroonError
@@ -111,21 +112,32 @@ class TestMacaroonSecurityPolicy:
             security_policy, "_extract_http_macaroon", extract_http_macaroon
         )
 
+        userid = pretend.stub()
         user = pretend.stub()
         macaroon_service = pretend.stub(
-            find_from_raw=pretend.call_recorder(lambda m: pretend.stub(user=user))
+            find_userid=pretend.call_recorder(lambda m: userid)
         )
+        user_service = pretend.stub(get_user=pretend.call_recorder(lambda uid: user))
+
+        def find_service(interface, **kw):
+            if interface == IMacaroonService:
+                return macaroon_service
+            else:
+                return user_service
+
         request = pretend.stub(
             add_response_callback=pretend.call_recorder(lambda cb: None),
-            find_service=pretend.call_recorder(lambda i, **kw: macaroon_service),
+            find_service=pretend.call_recorder(find_service),
         )
 
         assert policy.identity(request) is user
         assert extract_http_macaroon.calls == [pretend.call(request)]
         assert request.find_service.calls == [
-            pretend.call(IMacaroonService, context=None)
+            pretend.call(IMacaroonService, context=None),
+            pretend.call(IUserService, context=None),
         ]
-        assert macaroon_service.find_from_raw.calls == [pretend.call(raw_macaroon)]
+        assert macaroon_service.find_userid.calls == [pretend.call(raw_macaroon)]
+        assert user_service.get_user.calls == [pretend.call(userid)]
 
         assert add_vary_cb.calls == [pretend.call("Authorization")]
         assert request.add_response_callback.calls == [pretend.call(vary_cb)]


### PR DESCRIPTION
We previously tried to save a DB call by going through
`find_from_raw`, which raises on a malformed macaroon.

Needs tests.

Followup from #11218 and #11313.