### PR TITLE
Prohibit username on nuke

### DIFF
--- a/tests/unit/accounts/test_forms.py
+++ b/tests/unit/accounts/test_forms.py
@@ -373,7 +373,23 @@ class TestRegistrationForm:
         form = forms.RegistrationForm(
             data={"username": "foo"},
             user_service=pretend.stub(
-                find_userid=pretend.call_recorder(lambda name: 1)
+                find_userid=pretend.call_recorder(lambda name: 1),
+                username_is_prohibited=lambda a: False,
+            ),
+            breach_service=pretend.stub(check_password=lambda pw, tags=None: False),
+        )
+        assert not form.validate()
+        assert (
+            str(form.username.errors.pop())
+            == "This username is already being used by another account. "
+            "Choose a different username."
+        )
+
+    def test_username_prohibted(self, pyramid_config):
+        form = forms.RegistrationForm(
+            data={"username": "foo"},
+            user_service=pretend.stub(
+                username_is_prohibited=lambda a: True,
             ),
             breach_service=pretend.stub(check_password=lambda pw, tags=None: False),
         )
@@ -389,7 +405,8 @@ class TestRegistrationForm:
         form = forms.RegistrationForm(
             data={"username": username},
             user_service=pretend.stub(
-                find_userid=pretend.call_recorder(lambda _: None)
+                find_userid=pretend.call_recorder(lambda _: None),
+                username_is_prohibited=lambda a: False,
             ),
             breach_service=pretend.stub(check_password=lambda pw, tags=None: False),
         )

--- a/tests/unit/accounts/test_services.py
+++ b/tests/unit/accounts/test_services.py
@@ -42,7 +42,7 @@ from warehouse.accounts.interfaces import (
     TooManyEmailsAdded,
     TooManyFailedLogins,
 )
-from warehouse.accounts.models import DisableReason
+from warehouse.accounts.models import DisableReason, ProhibitedUserName
 from warehouse.metrics import IMetricsService, NullMetrics
 from warehouse.rate_limiting.interfaces import IRateLimiter
 
@@ -132,6 +132,20 @@ class TestDatabaseUserService:
 
         assert limiter.test.calls == []
         assert limiter.resets_in.calls == []
+
+    def test_username_is_not_prohibited(self, user_service):
+        assert user_service.username_is_prohibited("my_username") is False
+
+    def test_username_is_prohibited(self, user_service):
+        user = UserFactory.create()
+        user_service.db.add(
+            ProhibitedUserName(
+                name="my_username",
+                comment="blah",
+                prohibited_by=user,
+            )
+        )
+        assert user_service.username_is_prohibited("my_username") is True
 
     def test_find_userid_nonexistent_user(self, user_service):
         assert user_service.find_userid("my_username") is None

--- a/tests/unit/accounts/test_views.py
+++ b/tests/unit/accounts/test_views.py
@@ -1342,6 +1342,7 @@ class TestRegister:
                 merge=lambda _: {},
                 enabled=False,
                 verify_response=pretend.call_recorder(lambda _: None),
+                username_is_prohibited=lambda a: False,
                 find_userid=pretend.call_recorder(lambda _: None),
                 find_userid_by_email=pretend.call_recorder(lambda _: None),
                 update_user=lambda *args, **kwargs: None,

--- a/warehouse/accounts/forms.py
+++ b/warehouse/accounts/forms.py
@@ -103,7 +103,10 @@ class NewUsernameMixin:
     )
 
     def validate_username(self, field):
-        if self.user_service.find_userid(field.data) is not None:
+        if (
+            self.user_service.username_is_prohibited(field.data)
+            or self.user_service.find_userid(field.data) is not None
+        ):
             raise wtforms.validators.ValidationError(
                 _(
                     "This username is already being used by another "

--- a/warehouse/accounts/models.py
+++ b/warehouse/accounts/models.py
@@ -25,6 +25,7 @@ from sqlalchemy import (
     Integer,
     LargeBinary,
     String,
+    Text,
     UniqueConstraint,
     orm,
     select,
@@ -237,3 +238,29 @@ class Email(db.ModelBase):
         nullable=True,
     )
     transient_bounces = Column(Integer, nullable=False, server_default=sql.text("0"))
+
+
+class ProhibitedUserName(db.Model):
+
+    __tablename__ = "prohibited_user_names"
+    __table_args__ = (
+        CheckConstraint(
+            "length(name) <= 50", name="prohibited_users_valid_username_length"
+        ),
+        CheckConstraint(
+            "name ~* '^([A-Z0-9]|[A-Z0-9][A-Z0-9._-]*[A-Z0-9])$'",
+            name="prohibited_users_valid_username",
+        ),
+    )
+
+    __repr__ = make_repr("name")
+
+    created = Column(
+        DateTime(timezone=False), nullable=False, server_default=sql.func.now()
+    )
+    name = Column(Text, unique=True, nullable=False)
+    _prohibited_by = Column(
+        "prohibited_by", UUID(as_uuid=True), ForeignKey("users.id"), index=True
+    )
+    prohibited_by = orm.relationship(User)
+    comment = Column(Text, nullable=False, server_default="")

--- a/warehouse/admin/views/users.py
+++ b/warehouse/admin/views/users.py
@@ -25,7 +25,7 @@ from sqlalchemy.orm.exc import NoResultFound
 
 from warehouse import forms
 from warehouse.accounts.interfaces import IUserService
-from warehouse.accounts.models import DisableReason, Email, User
+from warehouse.accounts.models import DisableReason, Email, ProhibitedUserName, User
 from warehouse.email import send_password_compromised_email
 from warehouse.packaging.models import JournalEntry, Project, Role
 from warehouse.utils.paginate import paginate_url_factory
@@ -226,6 +226,13 @@ def user_delete(request):
 
     for journal in journals:
         journal.submitted_by = deleted_user
+
+    # Prohibit the username
+    request.db.add(
+        ProhibitedUserName(
+            name=user.username.lower(), comment="nuked", prohibited_by=request.user
+        )
+    )
 
     # Delete the user
     request.db.delete(user)

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -27,65 +27,65 @@ msgid ""
 "letter or number. Choose a different username."
 msgstr ""
 
-#: warehouse/accounts/forms.py:108
+#: warehouse/accounts/forms.py:111
 msgid ""
 "This username is already being used by another account. Choose a "
 "different username."
 msgstr ""
 
-#: warehouse/accounts/forms.py:142
+#: warehouse/accounts/forms.py:145
 msgid "The password is invalid. Try again."
 msgstr ""
 
-#: warehouse/accounts/forms.py:146 warehouse/accounts/views.py:87
+#: warehouse/accounts/forms.py:149 warehouse/accounts/views.py:87
 msgid "There have been too many unsuccessful login attempts. Try again later."
 msgstr ""
 
-#: warehouse/accounts/forms.py:168
+#: warehouse/accounts/forms.py:171
 msgid "Your passwords don't match. Try again."
 msgstr ""
 
-#: warehouse/accounts/forms.py:199 warehouse/accounts/forms.py:210
+#: warehouse/accounts/forms.py:202 warehouse/accounts/forms.py:213
 msgid "The email address isn't valid. Try again."
 msgstr ""
 
-#: warehouse/accounts/forms.py:218
+#: warehouse/accounts/forms.py:221
 msgid "You can't use an email address from this domain. Use a different email."
 msgstr ""
 
-#: warehouse/accounts/forms.py:229
+#: warehouse/accounts/forms.py:232
 msgid ""
 "This email address is already being used by this account. Use a different"
 " email."
 msgstr ""
 
-#: warehouse/accounts/forms.py:236
+#: warehouse/accounts/forms.py:239
 msgid ""
 "This email address is already being used by another account. Use a "
 "different email."
 msgstr ""
 
-#: warehouse/accounts/forms.py:258 warehouse/manage/forms.py:76
+#: warehouse/accounts/forms.py:261 warehouse/manage/forms.py:76
 msgid "The name is too long. Choose a name with 100 characters or less."
 msgstr ""
 
-#: warehouse/accounts/forms.py:327
+#: warehouse/accounts/forms.py:330
 msgid "Invalid TOTP code."
 msgstr ""
 
-#: warehouse/accounts/forms.py:344
+#: warehouse/accounts/forms.py:347
 msgid "Invalid WebAuthn assertion: Bad payload"
 msgstr ""
 
-#: warehouse/accounts/forms.py:402
+#: warehouse/accounts/forms.py:405
 msgid "Invalid recovery code."
 msgstr ""
 
-#: warehouse/accounts/forms.py:410
+#: warehouse/accounts/forms.py:413
 msgid "Recovery code has been previously used."
 msgstr ""
 
-#: warehouse/accounts/forms.py:429
+#: warehouse/accounts/forms.py:432
 msgid "No user found with that username or email"
 msgstr ""
 

--- a/warehouse/migrations/versions/ad71523546f9_add_prohibited_username_table.py
+++ b/warehouse/migrations/versions/ad71523546f9_add_prohibited_username_table.py
@@ -1,0 +1,71 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Add prohibited username table
+
+Revision ID: ad71523546f9
+Revises: 6e003184453d
+Create Date: 2022-05-19 21:28:31.695167
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "ad71523546f9"
+down_revision = "6e003184453d"
+
+
+def upgrade():
+    op.create_table(
+        "prohibited_user_names",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            server_default=sa.text("gen_random_uuid()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "created", sa.DateTime(), server_default=sa.text("now()"), nullable=False
+        ),
+        sa.Column("name", sa.Text(), nullable=False),
+        sa.Column("prohibited_by", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("comment", sa.Text(), server_default="", nullable=False),
+        sa.CheckConstraint(
+            "name ~* '^([A-Z0-9]|[A-Z0-9][A-Z0-9._-]*[A-Z0-9])$'",
+            name="prohibited_users_valid_username",
+        ),
+        sa.CheckConstraint(
+            "length(name) <= 50", name="prohibited_users_valid_username_length"
+        ),
+        sa.ForeignKeyConstraint(
+            ["prohibited_by"],
+            ["users.id"],
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("name"),
+    )
+    op.create_index(
+        op.f("ix_prohibited_user_names_prohibited_by"),
+        "prohibited_user_names",
+        ["prohibited_by"],
+        unique=False,
+    )
+
+
+def downgrade():
+    op.drop_index(
+        op.f("ix_prohibited_user_names_prohibited_by"),
+        table_name="prohibited_user_names",
+    )
+    op.drop_table("prohibited_user_names")


### PR DESCRIPTION
This PR creates a new `prohibited_user_names` table, prohibits a username when the user is nuked, and prevents a prohibited username from being re-registered.