### PR TITLE
Implement PEP 691

### DIFF
--- a/tests/functional/test_templates.py
+++ b/tests/functional/test_templates.py
@@ -32,6 +32,7 @@ FILTERS = {
     "format_package_type": "warehouse.filters:format_package_type",
     "parse_version": "warehouse.filters:parse_version",
     "localize_datetime": "warehouse.filters:localize_datetime",
+    "canonicalize_name": "packaging.utils:canonicalize_name",
 }
 
 

--- a/tests/unit/legacy/api/test_simple.py
+++ b/tests/unit/legacy/api/test_simple.py
@@ -11,8 +11,10 @@
 # limitations under the License.
 
 import pretend
+import pytest
 
 from pyramid.httpexceptions import HTTPMovedPermanently
+from pyramid.testing import DummyRequest
 
 from warehouse.legacy.api import simple
 
@@ -25,15 +27,58 @@ from ....common.db.packaging import (
 )
 
 
+class TestContentNegotiation:
+    @pytest.mark.parametrize("header", [None, "text/plain"])
+    def test_defaults_text_html(self, header):
+        """
+        Ensures that, at least until we want to change the default, that we
+        default to text/html.
+        """
+        request = DummyRequest(accept=header)
+        assert simple._select_content_type(request) == "text/html"
+
+    @pytest.mark.parametrize(
+        "header, expected",
+        [
+            ("text/html", "text/html"),
+            (
+                "application/vnd.pypi.simple.v1+html",
+                "application/vnd.pypi.simple.v1+html",
+            ),
+            (
+                "application/vnd.pypi.simple.v1+json",
+                "application/vnd.pypi.simple.v1+json",
+            ),
+            (
+                "text/html, application/vnd.pypi.simple.v1+html, application/vnd.pypi.simple.v1+json",
+                "text/html",
+            ),
+            (
+                "text/html;q=0.01, application/vnd.pypi.simple.v1+html;q=0.2, application/vnd.pypi.simple.v1+json",
+                "application/vnd.pypi.simple.v1+json",
+            ),
+        ],
+    )
+    def test_selects(self, header, expected):
+        request = DummyRequest(accept=header)
+        assert simple._select_content_type(request) == expected
+
+
 class TestSimpleIndex:
     def test_no_results_no_serial(self, db_request):
-        assert simple.simple_index(db_request) == {"projects": []}
+        assert simple.simple_index(db_request) == {
+            "meta": {"_last-serial": 0, "api-version": "1.0"},
+            "projects": [],
+        }
         assert db_request.response.headers["X-PyPI-Last-Serial"] == "0"
 
     def test_no_results_with_serial(self, db_request):
         user = UserFactory.create()
         je = JournalEntryFactory.create(submitted_by=user)
-        assert simple.simple_index(db_request) == {"projects": []}
+        assert simple.simple_index(db_request) == {
+            "meta": {"_last-serial": je.id, "api-version": "1.0"},
+            "projects": [],
+        }
         assert db_request.response.headers["X-PyPI-Last-Serial"] == str(je.id)
 
     def test_with_results_no_serial(self, db_request):
@@ -42,7 +87,8 @@ class TestSimpleIndex:
             for x in [ProjectFactory.create() for _ in range(3)]
         ]
         assert simple.simple_index(db_request) == {
-            "projects": sorted(projects, key=lambda x: x[1])
+            "meta": {"_last-serial": 0, "api-version": "1.0"},
+            "projects": [{"name": x[0]} for x in sorted(projects, key=lambda x: x[1])],
         }
         assert db_request.response.headers["X-PyPI-Last-Serial"] == "0"
 
@@ -55,7 +101,8 @@ class TestSimpleIndex:
         je = JournalEntryFactory.create(submitted_by=user)
 
         assert simple.simple_index(db_request) == {
-            "projects": sorted(projects, key=lambda x: x[1])
+            "meta": {"_last-serial": je.id, "api-version": "1.0"},
+            "projects": [{"name": x[0]} for x in sorted(projects, key=lambda x: x[1])],
         }
         assert db_request.response.headers["X-PyPI-Last-Serial"] == str(je.id)
 
@@ -82,7 +129,8 @@ class TestSimpleDetail:
         JournalEntryFactory.create(submitted_by=user)
 
         assert simple.simple_detail(project, db_request) == {
-            "project": project,
+            "meta": {"_last-serial": 0, "api-version": "1.0"},
+            "name": project.normalized_name,
             "files": [],
         }
         assert db_request.response.headers["X-PyPI-Last-Serial"] == "0"
@@ -94,7 +142,8 @@ class TestSimpleDetail:
         je = JournalEntryFactory.create(name=project.name, submitted_by=user)
 
         assert simple.simple_detail(project, db_request) == {
-            "project": project,
+            "meta": {"_last-serial": je.id, "api-version": "1.0"},
+            "name": project.normalized_name,
             "files": [],
         }
         assert db_request.response.headers["X-PyPI-Last-Serial"] == str(je.id)
@@ -110,13 +159,25 @@ class TestSimpleDetail:
         ]
         # let's assert the result is ordered by string comparison of filename
         files = sorted(files, key=lambda key: key.filename)
+        urls_iter = (f"/file/{f.filename}" for f in files)
         db_request.matchdict["name"] = project.normalized_name
+        db_request.route_url = lambda *a, **kw: next(urls_iter)
         user = UserFactory.create()
         JournalEntryFactory.create(submitted_by=user)
 
         assert simple.simple_detail(project, db_request) == {
-            "project": project,
-            "files": files,
+            "meta": {"_last-serial": 0, "api-version": "1.0"},
+            "name": project.normalized_name,
+            "files": [
+                {
+                    "filename": f.filename,
+                    "url": f"/file/{f.filename}",
+                    "hashes": {"sha256": f.sha256_digest},
+                    "requires-python": f.requires_python,
+                    "yanked": False,
+                }
+                for f in files
+            ],
         }
         assert db_request.response.headers["X-PyPI-Last-Serial"] == "0"
 
@@ -131,13 +192,25 @@ class TestSimpleDetail:
         ]
         # let's assert the result is ordered by string comparison of filename
         files = sorted(files, key=lambda key: key.filename)
+        urls_iter = (f"/file/{f.filename}" for f in files)
         db_request.matchdict["name"] = project.normalized_name
+        db_request.route_url = lambda *a, **kw: next(urls_iter)
         user = UserFactory.create()
         je = JournalEntryFactory.create(name=project.name, submitted_by=user)
 
         assert simple.simple_detail(project, db_request) == {
-            "project": project,
-            "files": files,
+            "meta": {"_last-serial": je.id, "api-version": "1.0"},
+            "name": project.normalized_name,
+            "files": [
+                {
+                    "filename": f.filename,
+                    "url": f"/file/{f.filename}",
+                    "hashes": {"sha256": f.sha256_digest},
+                    "requires-python": f.requires_python,
+                    "yanked": False,
+                }
+                for f in files
+            ],
         }
         assert db_request.response.headers["X-PyPI-Last-Serial"] == str(je.id)
 
@@ -185,13 +258,25 @@ class TestSimpleDetail:
         for files_release in zip(egg_files, tar_files, wheel_files):
             files += files_release
 
+        urls_iter = (f"/file/{f.filename}" for f in files)
         db_request.matchdict["name"] = project.normalized_name
+        db_request.route_url = lambda *a, **kw: next(urls_iter)
         user = UserFactory.create()
         je = JournalEntryFactory.create(name=project.name, submitted_by=user)
 
         assert simple.simple_detail(project, db_request) == {
-            "project": project,
-            "files": files,
+            "meta": {"_last-serial": je.id, "api-version": "1.0"},
+            "name": project.normalized_name,
+            "files": [
+                {
+                    "filename": f.filename,
+                    "url": f"/file/{f.filename}",
+                    "hashes": {"sha256": f.sha256_digest},
+                    "requires-python": f.requires_python,
+                    "yanked": False,
+                }
+                for f in files
+            ],
         }
 
         assert db_request.response.headers["X-PyPI-Last-Serial"] == str(je.id)

--- a/tests/unit/legacy/api/test_simple.py
+++ b/tests/unit/legacy/api/test_simple.py
@@ -50,11 +50,13 @@ class TestContentNegotiation:
                 "application/vnd.pypi.simple.v1+json",
             ),
             (
-                "text/html, application/vnd.pypi.simple.v1+html, application/vnd.pypi.simple.v1+json",
+                "text/html, application/vnd.pypi.simple.v1+html, "
+                "application/vnd.pypi.simple.v1+json",
                 "text/html",
             ),
             (
-                "text/html;q=0.01, application/vnd.pypi.simple.v1+html;q=0.2, application/vnd.pypi.simple.v1+json",
+                "text/html;q=0.01, application/vnd.pypi.simple.v1+html;q=0.2, "
+                "application/vnd.pypi.simple.v1+json",
                 "application/vnd.pypi.simple.v1+json",
             ),
         ],

--- a/tests/unit/legacy/api/test_simple.py
+++ b/tests/unit/legacy/api/test_simple.py
@@ -64,15 +64,36 @@ class TestContentNegotiation:
         assert simple._select_content_type(request) == expected
 
 
+CONTENT_TYPE_PARAMS = [
+    ("text/html", None),
+    ("application/vnd.pypi.simple.v1+html", None),
+    ("application/vnd.pypi.simple.v1+json", "json"),
+]
+
+
 class TestSimpleIndex:
-    def test_no_results_no_serial(self, db_request):
+    @pytest.mark.parametrize(
+        "content_type,renderer_override",
+        CONTENT_TYPE_PARAMS,
+    )
+    def test_no_results_no_serial(self, db_request, content_type, renderer_override):
+        db_request.accept = content_type
         assert simple.simple_index(db_request) == {
             "meta": {"_last-serial": 0, "api-version": "1.0"},
             "projects": [],
         }
         assert db_request.response.headers["X-PyPI-Last-Serial"] == "0"
+        assert db_request.response.content_type == content_type
 
-    def test_no_results_with_serial(self, db_request):
+        if renderer_override is not None:
+            db_request.override_renderer == renderer_override
+
+    @pytest.mark.parametrize(
+        "content_type,renderer_override",
+        CONTENT_TYPE_PARAMS,
+    )
+    def test_no_results_with_serial(self, db_request, content_type, renderer_override):
+        db_request.accept = content_type
         user = UserFactory.create()
         je = JournalEntryFactory.create(submitted_by=user)
         assert simple.simple_index(db_request) == {
@@ -80,8 +101,17 @@ class TestSimpleIndex:
             "projects": [],
         }
         assert db_request.response.headers["X-PyPI-Last-Serial"] == str(je.id)
+        assert db_request.response.content_type == content_type
 
-    def test_with_results_no_serial(self, db_request):
+        if renderer_override is not None:
+            db_request.override_renderer == renderer_override
+
+    @pytest.mark.parametrize(
+        "content_type,renderer_override",
+        CONTENT_TYPE_PARAMS,
+    )
+    def test_with_results_no_serial(self, db_request, content_type, renderer_override):
+        db_request.accept = content_type
         projects = [
             (x.name, x.normalized_name)
             for x in [ProjectFactory.create() for _ in range(3)]
@@ -91,8 +121,19 @@ class TestSimpleIndex:
             "projects": [{"name": x[0]} for x in sorted(projects, key=lambda x: x[1])],
         }
         assert db_request.response.headers["X-PyPI-Last-Serial"] == "0"
+        assert db_request.response.content_type == content_type
 
-    def test_with_results_with_serial(self, db_request):
+        if renderer_override is not None:
+            db_request.override_renderer == renderer_override
+
+    @pytest.mark.parametrize(
+        "content_type,renderer_override",
+        CONTENT_TYPE_PARAMS,
+    )
+    def test_with_results_with_serial(
+        self, db_request, content_type, renderer_override
+    ):
+        db_request.accept = content_type
         projects = [
             (x.name, x.normalized_name)
             for x in [ProjectFactory.create() for _ in range(3)]
@@ -105,6 +146,10 @@ class TestSimpleIndex:
             "projects": [{"name": x[0]} for x in sorted(projects, key=lambda x: x[1])],
         }
         assert db_request.response.headers["X-PyPI-Last-Serial"] == str(je.id)
+        assert db_request.response.content_type == content_type
+
+        if renderer_override is not None:
+            db_request.override_renderer == renderer_override
 
 
 class TestSimpleDetail:
@@ -122,7 +167,12 @@ class TestSimpleDetail:
         assert resp.headers["Location"] == "/foobar/"
         assert pyramid_request.current_route_path.calls == [pretend.call(name="foo")]
 
-    def test_no_files_no_serial(self, db_request):
+    @pytest.mark.parametrize(
+        "content_type,renderer_override",
+        CONTENT_TYPE_PARAMS,
+    )
+    def test_no_files_no_serial(self, db_request, content_type, renderer_override):
+        db_request.accept = content_type
         project = ProjectFactory.create()
         db_request.matchdict["name"] = project.normalized_name
         user = UserFactory.create()
@@ -134,8 +184,17 @@ class TestSimpleDetail:
             "files": [],
         }
         assert db_request.response.headers["X-PyPI-Last-Serial"] == "0"
+        assert db_request.response.content_type == content_type
 
-    def test_no_files_with_serial(self, db_request):
+        if renderer_override is not None:
+            db_request.override_renderer == renderer_override
+
+    @pytest.mark.parametrize(
+        "content_type,renderer_override",
+        CONTENT_TYPE_PARAMS,
+    )
+    def test_no_files_with_serial(self, db_request, content_type, renderer_override):
+        db_request.accept = content_type
         project = ProjectFactory.create()
         db_request.matchdict["name"] = project.normalized_name
         user = UserFactory.create()
@@ -147,8 +206,17 @@ class TestSimpleDetail:
             "files": [],
         }
         assert db_request.response.headers["X-PyPI-Last-Serial"] == str(je.id)
+        assert db_request.response.content_type == content_type
 
-    def test_with_files_no_serial(self, db_request):
+        if renderer_override is not None:
+            db_request.override_renderer == renderer_override
+
+    @pytest.mark.parametrize(
+        "content_type,renderer_override",
+        CONTENT_TYPE_PARAMS,
+    )
+    def test_with_files_no_serial(self, db_request, content_type, renderer_override):
+        db_request.accept = content_type
         project = ProjectFactory.create()
         releases = [ReleaseFactory.create(project=project) for _ in range(3)]
         files = [
@@ -180,8 +248,17 @@ class TestSimpleDetail:
             ],
         }
         assert db_request.response.headers["X-PyPI-Last-Serial"] == "0"
+        assert db_request.response.content_type == content_type
 
-    def test_with_files_with_serial(self, db_request):
+        if renderer_override is not None:
+            db_request.override_renderer == renderer_override
+
+    @pytest.mark.parametrize(
+        "content_type,renderer_override",
+        CONTENT_TYPE_PARAMS,
+    )
+    def test_with_files_with_serial(self, db_request, content_type, renderer_override):
+        db_request.accept = content_type
         project = ProjectFactory.create()
         releases = [ReleaseFactory.create(project=project) for _ in range(3)]
         files = [
@@ -213,8 +290,19 @@ class TestSimpleDetail:
             ],
         }
         assert db_request.response.headers["X-PyPI-Last-Serial"] == str(je.id)
+        assert db_request.response.content_type == content_type
 
-    def test_with_files_with_version_multi_digit(self, db_request):
+        if renderer_override is not None:
+            db_request.override_renderer == renderer_override
+
+    @pytest.mark.parametrize(
+        "content_type,renderer_override",
+        CONTENT_TYPE_PARAMS,
+    )
+    def test_with_files_with_version_multi_digit(
+        self, db_request, content_type, renderer_override
+    ):
+        db_request.accept = content_type
         project = ProjectFactory.create()
         release_versions = [
             "0.3.0rc1",
@@ -280,3 +368,7 @@ class TestSimpleDetail:
         }
 
         assert db_request.response.headers["X-PyPI-Last-Serial"] == str(je.id)
+        assert db_request.response.content_type == content_type
+
+        if renderer_override is not None:
+            db_request.override_renderer == renderer_override

--- a/warehouse/config.py
+++ b/warehouse/config.py
@@ -418,6 +418,7 @@ def configure(settings=None):
     filters.setdefault("parse_version", "warehouse.filters:parse_version")
     filters.setdefault("localize_datetime", "warehouse.filters:localize_datetime")
     filters.setdefault("is_recent", "warehouse.filters:is_recent")
+    filters.setdefault("canonicalize_name", "packaging.utils:canonicalize_name")
 
     # We also want to register some global functions for Jinja
     jglobals = config.get_settings().setdefault("jinja2.globals", {})

--- a/warehouse/legacy/api/simple.py
+++ b/warehouse/legacy/api/simple.py
@@ -11,20 +11,54 @@
 # limitations under the License.
 
 
+from pyramid.request import Request
 from pyramid.httpexceptions import HTTPMovedPermanently
 from pyramid.view import view_config
 from sqlalchemy import func
 
-from warehouse.cache.http import cache_control
+from warehouse.cache.http import add_vary, cache_control
 from warehouse.cache.origin import origin_cache
 from warehouse.packaging.models import JournalEntry, Project
 from warehouse.packaging.utils import _simple_detail
+
+
+API_VERSION = "1.0"
+
+
+def _select_content_type(request: Request) -> str:
+    # The way this works, is this will return a list of
+    # tuples of (mimetype, qvalue) that is acceptable for
+    # our request, combining the request and the types
+    # that we have passed in.
+    #
+    # When the request does not have an accept header, then
+    # the full list of offers will be returned.
+    #
+    # When the request has accept headers, but none of them
+    # match, it will be an empty list.
+    offers = request.accept.acceptable_offers(
+        [
+            "text/html",
+            "application/vnd.pypi.simple.v1+html",
+            "application/vnd.pypi.simple.v1+json",
+        ]
+    )
+
+    # Default case, we want to return whatevr we want to return
+    # by default when there is no Accept header.
+    if not offers:
+        return "text/html"
+    # We've selected a list of acceptable offers, so we'll take
+    # the first one as our return type.
+    else:
+        return offers[0][0]
 
 
 @view_config(
     route_name="legacy.api.simple.index",
     renderer="legacy/api/simple/index.html",
     decorator=[
+        add_vary("Accept"),
         cache_control(10 * 60),  # 10 minutes
         origin_cache(
             1 * 24 * 60 * 60,  # 1 day
@@ -34,6 +68,12 @@ from warehouse.packaging.utils import _simple_detail
     ],
 )
 def simple_index(request):
+    # Determine what our content-type should be, and setup our request
+    # to return the correct content types.
+    request.response.content_type = _select_content_type(request)
+    if request.response.content_type == "application/vnd.pypi.simple.v1+json":
+        request.override_renderer = "json"
+
     # Get the latest serial number
     serial = request.db.query(func.max(JournalEntry.id)).scalar() or 0
     request.response.headers["X-PyPI-Last-Serial"] = str(serial)
@@ -45,7 +85,17 @@ def simple_index(request):
         .all()
     )
 
-    return {"projects": projects}
+    return {
+        "meta": {"api-version": API_VERSION},
+        "projects": {
+            p.name: {
+                "url": request.route_path(
+                    "legacy.api.simple.detail", name=p.normalized_name
+                )
+            }
+            for p in projects
+        },
+    }
 
 
 @view_config(
@@ -53,6 +103,7 @@ def simple_index(request):
     context=Project,
     renderer="legacy/api/simple/detail.html",
     decorator=[
+        add_vary("Accept"),
         cache_control(10 * 60),  # 10 minutes
         origin_cache(
             1 * 24 * 60 * 60,  # 1 day
@@ -70,7 +121,33 @@ def simple_detail(project, request):
             request.current_route_path(name=project.normalized_name)
         )
 
+    # Determine what our content-type should be, and setup our request
+    # to return the correct content types.
+    request.response.content_type = _select_content_type(request)
+    if request.response.content_type == "application/vnd.pypi.simple.v1+json":
+        request.override_renderer = "json"
+
     # Get the latest serial number for this project.
     request.response.headers["X-PyPI-Last-Serial"] = str(project.last_serial)
 
-    return _simple_detail(project, request)
+    # Get our simple data
+    detail = _simple_detail(project, request)
+
+    return {
+        "meta": {"api-version": API_VERSION, "_last-serial": project.last_serial},
+        "name": detail["project"].name,
+        "files": [
+            {
+                "filename": file.filename,
+                "url": request.route_url("packaging.file", path=file.path),
+                "hashes": {
+                    "sha256": file.sha256_digest,
+                },
+                "requires-python": file.release.requires_python,
+                "yanked": file.release.yanked_reason
+                if file.release.yanked and file.release.yanked.reason
+                else file.release.yanked,
+            }
+            for file in detail["files"]
+        ],
+    }

--- a/warehouse/legacy/api/simple.py
+++ b/warehouse/legacy/api/simple.py
@@ -86,15 +86,8 @@ def simple_index(request):
     )
 
     return {
-        "meta": {"api-version": API_VERSION},
-        "projects": {
-            p.name: {
-                "url": request.route_path(
-                    "legacy.api.simple.detail", name=p.normalized_name
-                )
-            }
-            for p in projects
-        },
+        "meta": {"api-version": API_VERSION, "_last-serial": serial},
+        "projects": [{"name": p.name} for p in projects],
     }
 
 
@@ -135,7 +128,7 @@ def simple_detail(project, request):
 
     return {
         "meta": {"api-version": API_VERSION, "_last-serial": project.last_serial},
-        "name": detail["project"].name,
+        "name": detail["project"].normalized_name,
         "files": [
             {
                 "filename": file.filename,

--- a/warehouse/legacy/api/simple.py
+++ b/warehouse/legacy/api/simple.py
@@ -11,15 +11,15 @@
 # limitations under the License.
 
 
-from pyramid.request import Request
 from pyramid.httpexceptions import HTTPMovedPermanently
+from pyramid.request import Request
 from pyramid.view import view_config
 from sqlalchemy import func
 
 from warehouse.cache.http import add_vary, cache_control
 from warehouse.cache.origin import origin_cache
 from warehouse.packaging.models import JournalEntry, Project
-from warehouse.packaging.utils import _simple_detail, _simple_index, API_VERSION
+from warehouse.packaging.utils import API_VERSION, _simple_detail, _simple_index
 
 
 def _select_content_type(request: Request) -> str:

--- a/warehouse/legacy/api/simple.py
+++ b/warehouse/legacy/api/simple.py
@@ -19,7 +19,7 @@ from sqlalchemy import func
 from warehouse.cache.http import add_vary, cache_control
 from warehouse.cache.origin import origin_cache
 from warehouse.packaging.models import JournalEntry, Project
-from warehouse.packaging.utils import API_VERSION, _simple_detail, _simple_index
+from warehouse.packaging.utils import _simple_detail, _simple_index
 
 
 def _select_content_type(request: Request) -> str:

--- a/warehouse/packaging/utils.py
+++ b/warehouse/packaging/utils.py
@@ -19,8 +19,7 @@ from pyramid_jinja2 import IJinja2Environment
 from sqlalchemy.orm import joinedload
 
 from warehouse.packaging.interfaces import ISimpleStorage
-from warehouse.packaging.models import File, Release, Project
-
+from warehouse.packaging.models import File, Project, Release
 
 API_VERSION = "1.0"
 

--- a/warehouse/templates/legacy/api/simple/detail.html
+++ b/warehouse/templates/legacy/api/simple/detail.html
@@ -14,14 +14,14 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta name="pypi:repository-version" content="1.0">
-    <title>Links for {{ project.name }}</title>
+    <meta name="pypi:repository-version" content="{{ meta['api-version'] }}">
+    <title>Links for {{ name }}</title>
   </head>
   <body>
-    <h1>Links for {{ project.name }}</h1>
+    <h1>Links for {{ name }}</h1>
     {% for file in files -%}
-    <a href="{{ request.route_url('packaging.file', path=file.path) }}#sha256={{ file.sha256_digest }}"{% if file.release.requires_python %} data-requires-python="{{ file.release.requires_python }}"{% endif %}{% if file.release.yanked %} data-yanked="{{ file.release.yanked_reason }}"{% endif %}>{{ file.filename }}</a><br/>
+    <a href="{{ file.url }}#sha256={{ file.hashes.sha256 }}" {% if file.requires-python %}data-requires-python="{{ file['requires-python'] }}" {% endif %}{% if file.yanked %}data-yanked="{% if file.yanked is string %}{{ file.yanked }}{% endif %}" {% endif %}>{{ file.filename }}</a><br />
     {% endfor -%}
   </body>
 </html>
-<!--SERIAL {{ project.last_serial }}-->
+<!--SERIAL {{ project.meta._last-serial }}-->

--- a/warehouse/templates/legacy/api/simple/detail.html
+++ b/warehouse/templates/legacy/api/simple/detail.html
@@ -20,8 +20,8 @@
   <body>
     <h1>Links for {{ name }}</h1>
     {% for file in files -%}
-    <a href="{{ file.url }}#sha256={{ file.hashes.sha256 }}" {% if file.requires-python %}data-requires-python="{{ file['requires-python'] }}" {% endif %}{% if file.yanked %}data-yanked="{% if file.yanked is string %}{{ file.yanked }}{% endif %}" {% endif %}>{{ file.filename }}</a><br />
+    <a href="{{ file.url }}#sha256={{ file.hashes.sha256 }}" {% if file.get('requires-python') %}data-requires-python="{{ file['requires-python'] }}" {% endif %}{% if file.yanked %}data-yanked="{% if file.yanked is string %}{{ file.yanked }}{% endif %}" {% endif %}>{{ file.filename }}</a><br />
     {% endfor -%}
   </body>
 </html>
-<!--SERIAL {{ project.meta._last-serial }}-->
+<!--SERIAL {{ meta['_last-serial'] }}-->

--- a/warehouse/templates/legacy/api/simple/index.html
+++ b/warehouse/templates/legacy/api/simple/index.html
@@ -14,12 +14,12 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta name="pypi:repository-version" content="1.0">
+    <meta name="pypi:repository-version" content="{{meta['api-version'] }}">
     <title>Simple index</title>
   </head>
   <body>
-    {% for project in projects -%}
-    <a href="{{ request.route_path('legacy.api.simple.detail', name=project.normalized_name) }}">{{ project.name }}</a>
+    {% for project, data in projects.items() -%}
+    <a href="{{ data.url }}">{{ project }}</a>
     {% endfor -%}
   </body>
 </html>

--- a/warehouse/templates/legacy/api/simple/index.html
+++ b/warehouse/templates/legacy/api/simple/index.html
@@ -18,8 +18,8 @@
     <title>Simple index</title>
   </head>
   <body>
-    {% for project, data in projects.items() -%}
-    <a href="{{ data.url }}">{{ project }}</a>
+    {% for project in projects -%}
+    <a href="{{ request.route_path('legacy.api.simple.detail', name=project.name|canonicalize_name) }}">{{ project.name }}</a>
     {% endfor -%}
   </body>
 </html>


### PR DESCRIPTION
This obviously needs tests prior to landing, and of course PEP 691 itself needs to be accepted, but just an example of what implementing this could look like.

This should fully implement PEP 691, the only deviation is it adds a ``_last-serial`` key to the meta dictionary because PyPI had that on it's HTML pages (though it was in an HTML comment there). 