### PR TITLE
Fix the production container build for new bullseye base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /opt/warehouse/src/
 RUN set -x \
     && apt-get update \
     && apt-get install --no-install-recommends -y \
-        libjpeg-dev nasm
+        libjpeg-dev nasm dh-autoreconf
 
 # However, we do want to trigger a reinstall of our node.js dependencies anytime
 # our package.json changes, so we'll ensure that we're copying that into our


### PR DESCRIPTION
add dh-autoreconf to apt-get install for static to fix install of gifsicle per https://github.com/imagemin/imagemin-gifsicle/issues/37#issuecomment-578115789

Fixes issue introduced in #11472 