### PR TITLE
validation: Allow comma-separated Project-URL

### DIFF
--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -226,7 +226,11 @@ class TestValidation:
 
     @pytest.mark.parametrize(
         "project_url",
-        ["Home, https://pypi.python.org/", ("A" * 32) + ", https://example.com/"],
+        [
+            "Home, https://pypi.python.org/",
+            "Home,https://pypi.python.org/",
+            ("A" * 32) + ", https://example.com/",
+        ],
     )
     def test_validate_project_url_valid(self, project_url):
         legacy._validate_project_url(project_url)
@@ -234,7 +238,6 @@ class TestValidation:
     @pytest.mark.parametrize(
         "project_url",
         [
-            "Home,https://pypi.python.org/",
             "https://pypi.python.org/",
             ", https://pypi.python.org/",
             "Home, ",

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -323,7 +323,7 @@ def _validate_requires_external_list(form, field):
 
 def _validate_project_url(value):
     try:
-        label, url = value.split(", ", 1)
+        label, url = (x.strip() for x in value.split(",", maxsplit=1))
     except ValueError:
         raise wtforms.validators.ValidationError(
             "Use both a label and an URL."


### PR DESCRIPTION
According to the spec \[0\]:
> Project-URL (multiple-use)
  A string containing a browsable URL for the project and a label for
it, separated by a comma.
  Example:
  Project-URL: Bug Tracker, http://bitbucket.org/tarek/distribute/issues/

Though the example is ambiguous the comma-separated values should be
accepted.

\[0\]: https://packaging.python.org/en/latest/specifications/core-metadata/#project-url-multiple-use

Closes: https://github.com/pypa/warehouse/issues/11513