### PR TITLE
Handle bad locale request

### DIFF
--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -4,7 +4,7 @@ msgid ""
 " action."
 msgstr ""
 
-#: warehouse/views.py:273
+#: warehouse/views.py:276
 msgid "Locale updated"
 msgstr ""
 

--- a/warehouse/views.py
+++ b/warehouse/views.py
@@ -256,7 +256,10 @@ def index(request):
     uses_session=True,
 )
 def locale(request):
-    form = SetLocaleForm(**request.GET)
+    try:
+        form = SetLocaleForm(locale_id=request.GET.getone("locale_id"))
+    except KeyError:
+        raise HTTPBadRequest("Invalid amount of locale_id parameters provided")
 
     redirect_to = request.referer
     if not is_safe_url(redirect_to, host=request.host):


### PR DESCRIPTION
This PR handles the occasional badly formed request we get to the endpoint that sets the locale, turning it from an exception our end into a 400 response.

Fixes https://sentry.io/organizations/python-software-foundation/issues/3172288676/