### PR TITLE
canonically serve JSON urls via normalized project names

### DIFF
--- a/tests/unit/legacy/api/test_json.py
+++ b/tests/unit/legacy/api/test_json.py
@@ -46,7 +46,7 @@ class TestJSONProject:
         project = ProjectFactory.create()
 
         name = project.name.lower()
-        if name == project.name:
+        if name == project.normalized_name:
             name = project.name.upper()
 
         db_request.matchdict = {"name": name}
@@ -59,7 +59,9 @@ class TestJSONProject:
         assert isinstance(resp, HTTPMovedPermanently)
         assert resp.headers["Location"] == "/project/the-redirect/"
         _assert_has_cors_headers(resp.headers)
-        assert db_request.current_route_path.calls == [pretend.call(name=project.name)]
+        assert db_request.current_route_path.calls == [
+            pretend.call(name=project.normalized_name)
+        ]
 
     def test_missing_release(self, db_request):
         project = ProjectFactory.create()
@@ -195,7 +197,7 @@ class TestJSONProjectSlash:
         project = ProjectFactory.create()
 
         name = project.name.lower()
-        if name == project.name:
+        if name == project.normalized_name:
             name = project.name.upper()
 
         db_request.matchdict = {"name": name}
@@ -208,7 +210,9 @@ class TestJSONProjectSlash:
         assert isinstance(resp, HTTPMovedPermanently)
         assert resp.headers["Location"] == "/project/the-redirect/"
         _assert_has_cors_headers(resp.headers)
-        assert db_request.current_route_path.calls == [pretend.call(name=project.name)]
+        assert db_request.current_route_path.calls == [
+            pretend.call(name=project.normalized_name)
+        ]
 
 
 class TestJSONRelease:
@@ -217,7 +221,7 @@ class TestJSONRelease:
         release = ReleaseFactory.create(project=project, version="3.0")
 
         name = release.project.name.lower()
-        if name == release.project.name:
+        if name == release.project.normalized_name:
             name = release.project.name.upper()
 
         db_request.matchdict = {"name": name}
@@ -231,7 +235,7 @@ class TestJSONRelease:
         assert resp.headers["Location"] == "/project/the-redirect/3.0/"
         _assert_has_cors_headers(resp.headers)
         assert db_request.current_route_path.calls == [
-            pretend.call(name=release.project.name)
+            pretend.call(name=release.project.normalized_name)
         ]
 
     def test_detail_renders(self, pyramid_config, db_request, db_session):
@@ -583,7 +587,7 @@ class TestJSONReleaseSlash:
         release = ReleaseFactory.create(project=project, version="3.0")
 
         name = release.project.name.lower()
-        if name == release.project.name:
+        if name == release.project.normalized_name:
             name = release.project.name.upper()
 
         db_request.matchdict = {"name": name}
@@ -597,5 +601,5 @@ class TestJSONReleaseSlash:
         assert resp.headers["Location"] == "/project/the-redirect/3.0/"
         _assert_has_cors_headers(resp.headers)
         assert db_request.current_route_path.calls == [
-            pretend.call(name=release.project.name)
+            pretend.call(name=release.project.normalized_name)
         ]

--- a/tests/unit/test_views.py
+++ b/tests/unit/test_views.py
@@ -123,6 +123,21 @@ class TestHTTPExceptionView:
             assert response.content_type == "text/plain"
             assert response.text == "404 Not Found"
 
+    def test_json_404(self):
+        csp = {}
+        services = {"csp": pretend.stub(merge=csp.update)}
+        context = HTTPNotFound()
+        for path in (
+            "/pypi/not_found_package/json",
+            "/pypi/not_found_package/1.0.0/json",
+        ):
+            request = pretend.stub(find_service=lambda name: services[name], path=path)
+            response = httpexception_view(context, request)
+            assert response.status_code == 404
+            assert response.status == "404 Not Found"
+            assert response.content_type == "application/json"
+            assert response.text == '{"message": "Not Found"}'
+
 
 class TestForbiddenView:
     def test_logged_in_returns_exception(self, pyramid_config):

--- a/warehouse/legacy/api/json.py
+++ b/warehouse/legacy/api/json.py
@@ -57,9 +57,12 @@ _CACHE_DECORATOR = [
     decorator=_CACHE_DECORATOR,
 )
 def json_project(project, request):
-    if project.name != request.matchdict.get("name", project.name):
+    if project.normalized_name != request.matchdict.get(
+        "name", project.normalized_name
+    ):
         return HTTPMovedPermanently(
-            request.current_route_path(name=project.name), headers=_CORS_HEADERS
+            request.current_route_path(name=project.normalized_name),
+            headers=_CORS_HEADERS,
         )
 
     try:
@@ -99,9 +102,12 @@ def json_project_slash(project, request):
 def json_release(release, request):
     project = release.project
 
-    if project.name != request.matchdict.get("name", project.name):
+    if project.normalized_name != request.matchdict.get(
+        "name", project.normalized_name
+    ):
         return HTTPMovedPermanently(
-            request.current_route_path(name=project.name), headers=_CORS_HEADERS
+            request.current_route_path(name=project.normalized_name),
+            headers=_CORS_HEADERS,
         )
 
     # Apply CORS headers.

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -1,10 +1,10 @@
-#: warehouse/views.py:113
+#: warehouse/views.py:124
 msgid ""
 "Two-factor authentication must be enabled on your account to perform this"
 " action."
 msgstr ""
 
-#: warehouse/views.py:276
+#: warehouse/views.py:287
 msgid "Locale updated"
 msgstr ""
 

--- a/warehouse/views.py
+++ b/warehouse/views.py
@@ -56,9 +56,9 @@ from warehouse.utils.http import is_safe_url
 from warehouse.utils.paginate import ElasticsearchPage, paginate_url_factory
 from warehouse.utils.row_counter import RowCount
 
-
 @view_config(context=HTTPException)
 @notfound_view_config(append_slash=HTTPMovedPermanently)
+@notfound_view_config(path_info='^/pypi/([^\/]+)\/?([^\/]+)?/json\/?$', append_slash=False)
 def httpexception_view(exc, request):
     # This special case exists for the easter egg that appears on the 404
     # response page. We don't generally allow youtube embeds, but we make an


### PR DESCRIPTION
something like 25 requests per second to the PyPI backends are *just* serving redirects from one spelling of a project name in the JSON api to another. since the CDN cannot determine the project name at edge, we must send these requests to the backends. canonicalizing the project name in the URL for JSON will allow the CDN to be deterministic in where to send a request from the edge. (Example: `/pypi/SampleProject/json`, `/pypi/sAmPlEpRoJeCt/json`, and `/pypi/sampleproject/json` will all backend to `/pypi/sampleproject/json`) 

paired with forthcoming changes to our CDN configuration, we will begin serving JSON responses for any project name from the canonical URL that the project name normalizes to.

then the next step will be to announce this potentially breaking change and set a date at which we start serving the redirect from the edge.