### PR TITLE
Add a new table to hold project URLs

### DIFF
--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -3091,6 +3091,7 @@ class TestFileUpload:
         ]
         assert set(release.requires_dist) == {"foo", "bar (>1.0)"}
         assert set(release.project_urls) == {"Test, https://example.com/"}
+        assert release.project_urls_new == {"Test": "https://example.com/"}
         assert set(release.requires_external) == {"Cheese (>1.0)"}
         assert set(release.provides) == {"testing"}
         assert release.version == expected_version

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -1123,6 +1123,12 @@ def file_upload(request):
                 request.db.add(missing_classifier)
                 release_classifiers.append(missing_classifier)
 
+        # Parse the Project URLs structure into a key/value dict
+        project_urls = {
+            name.strip(): url.strip()
+            for name, url in (us.split(",", 1) for us in form.project_urls.data)
+        }
+
         release = Release(
             project=project,
             _classifiers=release_classifiers,
@@ -1151,6 +1157,7 @@ def file_upload(request):
                 html=rendered or "",
                 rendered_by=readme.renderer_version(),
             ),
+            project_urls_new=project_urls,
             **{
                 k: getattr(form, k).data
                 for k in {

--- a/warehouse/migrations/versions/7a8c380cefa4_add_releaseurl.py
+++ b/warehouse/migrations/versions/7a8c380cefa4_add_releaseurl.py
@@ -1,0 +1,54 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+add ReleaseURL
+
+Revision ID: 7a8c380cefa4
+Revises: d1c00b634ac8
+Create Date: 2022-06-10 22:02:49.522320
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "7a8c380cefa4"
+down_revision = "d1c00b634ac8"
+
+
+def upgrade():
+    op.create_table(
+        "release_urls",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            server_default=sa.text("gen_random_uuid()"),
+            nullable=False,
+        ),
+        sa.Column("release_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("name", sa.String(length=32), nullable=False),
+        sa.Column("url", sa.Text(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["release_id"], ["releases.id"], onupdate="CASCADE", ondelete="CASCADE"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("release_id", "name"),
+    )
+    op.create_index(
+        op.f("ix_release_urls_release_id"), "release_urls", ["release_id"], unique=False
+    )
+
+
+def downgrade():
+    op.drop_index(op.f("ix_release_urls_release_id"), table_name="release_urls")
+    op.drop_table("release_urls")


### PR DESCRIPTION
To implement https://github.com/pypa/warehouse/issues/8090, we'll need to split project urls out from "dependencies" (who knows why it was ever there to begin with).

This is step #1 of that process, it doesn't do anything but add the new table, and setup uploading so that it will start writing values to that table. Later PRs will handle backfill and removing the old column.