### PR TITLE
Backfill ReleaseURL table and start using it

### DIFF
--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -3090,8 +3090,7 @@ class TestFileUpload:
             "Programming Language :: Python",
         ]
         assert set(release.requires_dist) == {"foo", "bar (>1.0)"}
-        assert set(release.project_urls) == {"Test, https://example.com/"}
-        assert release.project_urls_new == {"Test": "https://example.com/"}
+        assert release.project_urls == {"Test": "https://example.com/"}
         assert set(release.requires_external) == {"Cheese (>1.0)"}
         assert set(release.provides) == {"testing"}
         assert release.version == expected_version

--- a/tests/unit/packaging/test_models.py
+++ b/tests/unit/packaging/test_models.py
@@ -18,7 +18,7 @@ import pytest
 from pyramid.authorization import Allow
 from pyramid.location import lineage
 
-from warehouse.packaging.models import Dependency, DependencyKind, File, ProjectFactory
+from warehouse.packaging.models import File, ProjectFactory, ReleaseURL
 
 from ...common.db.packaging import (
     FileFactory as DBFileFactory,
@@ -281,18 +281,6 @@ class TestRelease:
                     ]
                 ),
             ),
-            # ignore invalid links
-            (
-                None,
-                None,
-                [
-                    " ,https://example.com/home/",
-                    ",https://example.com/home/",
-                    "https://example.com/home/",
-                    "Download,https://example.com/download/",
-                ],
-                OrderedDict([("Download", "https://example.com/download/")]),
-            ),
         ],
     )
     def test_urls(self, db_session, home_page, download_url, project_urls, expected):
@@ -301,11 +289,12 @@ class TestRelease:
         )
 
         for urlspec in project_urls:
+            label, _, url = urlspec.partition(",")
             db_session.add(
-                Dependency(
+                ReleaseURL(
                     release=release,
-                    kind=DependencyKind.project_url.value,
-                    specifier=urlspec,
+                    name=label.strip(),
+                    url=url.strip(),
                 )
             )
 

--- a/warehouse/admin/templates/admin/projects/release_detail.html
+++ b/warehouse/admin/templates/admin/projects/release_detail.html
@@ -199,8 +199,8 @@
         <tr>
           <td>Project-URL</td>
           <td>
-            {% for url in release.project_urls %}
-            <code>{{ url }}</code><br>
+            {% for label, url in release.project_urls.items() %}
+            <code>{{ label }}, {{ url }}</code><br>
             {% endfor %}
           </td>
         </tr>

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -1126,7 +1126,7 @@ def file_upload(request):
         # Parse the Project URLs structure into a key/value dict
         project_urls = {
             name.strip(): url.strip()
-            for name, url in (us.split(",", 1) for us in form.project_urls.data)
+            for name, _, url in (us.partition(",") for us in form.project_urls.data)
         }
 
         release = Release(
@@ -1143,7 +1143,6 @@ def file_upload(request):
                         "provides_dist": DependencyKind.provides_dist,
                         "obsoletes_dist": DependencyKind.obsoletes_dist,
                         "requires_external": DependencyKind.requires_external,
-                        "project_urls": DependencyKind.project_url,
                     },
                 )
             ),
@@ -1157,7 +1156,7 @@ def file_upload(request):
                 html=rendered or "",
                 rendered_by=readme.renderer_version(),
             ),
-            project_urls_new=project_urls,
+            project_urls=project_urls,
             **{
                 k: getattr(form, k).data
                 for k in {

--- a/warehouse/legacy/api/json.py
+++ b/warehouse/legacy/api/json.py
@@ -10,8 +10,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from collections import OrderedDict
-
 from pyramid.httpexceptions import HTTPMovedPermanently, HTTPNotFound
 from pyramid.view import view_config
 from sqlalchemy.orm import Load
@@ -198,7 +196,7 @@ def json_release(release, request):
             "downloads": {"last_day": -1, "last_week": -1, "last_month": -1},
             "package_url": request.route_url("packaging.project", name=project.name),
             "project_url": request.route_url("packaging.project", name=project.name),
-            "project_urls": OrderedDict(release.urls) if release.urls else None,
+            "project_urls": release.urls if release.urls else None,
             "release_url": request.route_url(
                 "packaging.release", name=project.name, version=release.version
             ),

--- a/warehouse/legacy/api/xmlrpc/views.py
+++ b/warehouse/legacy/api/xmlrpc/views.py
@@ -429,7 +429,10 @@ def release_data(request, package_name: str, version: str):
         "docs_url": _clean_for_xml(release.project.documentation_url),
         "home_page": _clean_for_xml(release.home_page),
         "download_url": _clean_for_xml(release.download_url),
-        "project_url": [_clean_for_xml(url) for url in release.project_urls],
+        "project_url": [
+            _clean_for_xml(f"{label}, {url}")
+            for label, url in release.project_urls.items()
+        ],
         "author": _clean_for_xml(release.author),
         "author_email": _clean_for_xml(release.author_email),
         "maintainer": _clean_for_xml(release.maintainer),

--- a/warehouse/migrations/versions/94c844c2da96_backfill_releaseurls.py
+++ b/warehouse/migrations/versions/94c844c2da96_backfill_releaseurls.py
@@ -1,0 +1,45 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Backfill ReleaseURLs
+
+Revision ID: 94c844c2da96
+Revises: 7a8c380cefa4
+Create Date: 2022-06-10 23:54:30.955026
+"""
+
+from alembic import op
+
+revision = "94c844c2da96"
+down_revision = "7a8c380cefa4"
+
+
+def upgrade():
+    op.create_check_constraint(
+        "release_urls_valid_name", "release_urls", "char_length(name) BETWEEN 1 AND 32"
+    )
+    op.execute(
+        r"""
+        INSERT INTO release_urls (release_id, name, url)
+            SELECT release_id,
+                (regexp_match(specifier, '^([^,]+)\s*,\s*(.*)$'))[1],
+                (regexp_match(specifier, '^([^,]+)\s*,\s*(.*)$'))[2]
+            FROM release_dependencies
+            WHERE release_dependencies.kind = 8
+            ON CONFLICT ON CONSTRAINT release_urls_release_id_name_key
+            DO NOTHING;
+        """
+    )
+
+
+def downgrade():
+    pass

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -328,7 +328,7 @@ class Description(db.Model):
 class ReleaseURL(db.Model):
 
     __tablename__ = "release_urls"
-    __table_args__ = (UniqueConstraint("release_id", "name", name="uix_1"),)
+    __table_args__ = (UniqueConstraint("release_id", "name"),)
     __repr__ = make_repr("name", "url")
 
     release_id = Column(

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -284,10 +284,6 @@ class DependencyKind(enum.IntEnum):
     obsoletes_dist = 6
     requires_external = 7
 
-    # TODO: Move project URLs into their own table, since they are not actually
-    #       a "dependency".
-    project_url = 8
-
 
 class Dependency(db.Model):
 
@@ -328,7 +324,13 @@ class Description(db.Model):
 class ReleaseURL(db.Model):
 
     __tablename__ = "release_urls"
-    __table_args__ = (UniqueConstraint("release_id", "name"),)
+    __table_args__ = (
+        UniqueConstraint("release_id", "name"),
+        CheckConstraint(
+            "char_length(name) BETWEEN 1 AND 32",
+            name="release_urls_valid_name",
+        ),
+    )
     __repr__ = make_repr("name", "url")
 
     release_id = Column(
@@ -414,7 +416,7 @@ class Release(db.Model):
     )
     classifiers = association_proxy("_classifiers", "classifier")
 
-    _project_urls_new = orm.relationship(
+    _project_urls = orm.relationship(
         ReleaseURL,
         backref="release",
         collection_class=attribute_mapped_collection("name"),
@@ -422,8 +424,8 @@ class Release(db.Model):
         order_by=lambda: ReleaseURL.name.asc(),
         passive_deletes=True,
     )
-    project_urls_new = association_proxy(
-        "_project_urls_new",
+    project_urls = association_proxy(
+        "_project_urls",
         "url",
         creator=lambda k, v: ReleaseURL(name=k, url=v),  # type: ignore
     )
@@ -472,9 +474,6 @@ class Release(db.Model):
     _requires_external = _dependency_relation(DependencyKind.requires_external)
     requires_external = association_proxy("_requires_external", "specifier")
 
-    _project_urls = _dependency_relation(DependencyKind.project_url)
-    project_urls = association_proxy("_project_urls", "specifier")
-
     uploader_id = Column(
         ForeignKey("users.id", onupdate="CASCADE", ondelete="SET NULL"),
         nullable=True,
@@ -492,11 +491,7 @@ class Release(db.Model):
         if self.download_url:
             _urls["Download"] = self.download_url
 
-        for urlspec in self.project_urls:
-            name, _, url = urlspec.partition(",")
-            name = name.strip()
-            url = url.strip()
-
+        for name, url in self.project_urls.items():
             # avoid duplicating homepage/download links in case the same
             # url is specified in the pkginfo twice (in the Home-page
             # or Download-URL field and again in the Project-URL fields)
@@ -506,8 +501,7 @@ class Release(db.Model):
             if comp_name == "downloadurl" and url == _urls.get("Download"):
                 continue
 
-            if name and url:
-                _urls[name] = url
+            _urls[name] = url
 
         return _urls
 


### PR DESCRIPTION
Follow up to https://github.com/pypa/warehouse/pull/11564, now that new releases are writing data into ``ReleaseURL``, this will fill in old data, then stop using the old ``Dependency`` table for Project URLs.

The ``Dependency`` table is kept around for the dependency data, and the project url data that was in it isn't getting removed at this time, but project url data will not be written or read from it with this PR.

This does remove some validation from ``Release.urls``, but it moves it into the database, and manually inspecting prod PyPI it appears like our existing data is valid so this should be fine.