### PR TITLE
chore: update Python version for read the docs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,4 +14,4 @@ python:
 build:
   os: ubuntu-20.04
   tools:
-    python: "3.8"
+    python: "3.10"


### PR DESCRIPTION
Update the version to match the same one we use in production, since that's the version we compile our packages against.