### PR TITLE
chore(types): remove excluded library

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,6 @@ module = [
     "pyramid_retry.*",
     "pyramid_rpc.*",
     "pyqrcode.*",
-    "readme_renderer.*", # https://github.com/pypa/readme_renderer/issues/166
     "requests_aws4auth.*",
     "rfc3986.*",
     "stdlib_list.*",


### PR DESCRIPTION
With the release of `readme_renderer` 35.0, we no longer need to exclude
the library from type evaluation.

Refs: https://github.com/pypa/readme_renderer/pull/225
Refs: https://github.com/pypa/readme_renderer/pull/228

Signed-off-by: Mike Fiedler <miketheman@gmail.com>