### PR TITLE
test: run against postgres 12.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,9 +53,13 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:10.1
+        image: postgres:12.8
         ports:
           - 5432:5432
+        env:
+          POSTGRES_HOST_AUTH_METHOD: trust  # never do this in production!
+        # Set health checks to wait until postgres has started
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     name: ${{ matrix.name }}
     steps:
       - name: Check out repository

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,10 +25,12 @@ services:
       - ./dev/vault:/etc/vault
 
   db:
-    image: postgres:10.1
+    image: postgres:12.8
     ports:
       # 5432 may already in use by another PostgreSQL on host
       - "5433:5432"
+    environment:
+      POSTGRES_HOST_AUTH_METHOD: trust  # never do this in production!
     healthcheck:
       test: ["CMD", "pg_isready", "-U", "postgres", "-d", "postgres"]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -187,7 +187,7 @@ def database(request):
     pg_port = config.get("port") or os.environ.get("PGPORT", 5432)
     pg_user = config.get("user")
     pg_db = config.get("db", "tests")
-    pg_version = config.get("version", 10.1)
+    pg_version = config.get("version", 12.8)
 
     janitor = DatabaseJanitor(pg_user, pg_host, pg_port, pg_db, pg_version)
 

--- a/warehouse/migrations/versions/701c2fba1f5f_cascade_release_deletion_to_files.py
+++ b/warehouse/migrations/versions/701c2fba1f5f_cascade_release_deletion_to_files.py
@@ -24,7 +24,9 @@ down_revision = "b74a66a8f312"
 
 
 def upgrade():
-    op.drop_constraint("release_files_name_fkey", "release_files", type_="foreignkey")
+    op.execute(
+        "ALTER TABLE release_files DROP CONSTRAINT IF EXISTS release_files_name_fkey"
+    )
     op.create_foreign_key(
         "release_files_name_fkey",
         "release_files",

--- a/warehouse/migrations/versions/b74a66a8f312_cascade_release_deletion_to_release_.py
+++ b/warehouse/migrations/versions/b74a66a8f312_cascade_release_deletion_to_release_.py
@@ -24,8 +24,9 @@ down_revision = "29d87a24d79e"
 
 
 def upgrade():
-    op.drop_constraint(
-        "release_classifiers_name_fkey", "release_classifiers", type_="foreignkey"
+    op.execute(
+        "ALTER TABLE release_classifiers "
+        "DROP CONSTRAINT IF EXISTS release_classifiers_name_fkey"
     )
     op.create_foreign_key(
         "release_classifiers_name_fkey",

--- a/warehouse/migrations/versions/b75709859292_add_ondelete_cascade_for_description_.py
+++ b/warehouse/migrations/versions/b75709859292_add_ondelete_cascade_for_description_.py
@@ -24,8 +24,9 @@ down_revision = "7165e957cddc"
 
 
 def upgrade():
-    op.drop_constraint(
-        "description_urls_name_fkey", "description_urls", type_="foreignkey"
+    op.execute(
+        "ALTER TABLE description_urls "
+        "DROP CONSTRAINT IF EXISTS description_urls_name_fkey"
     )
     op.create_foreign_key(
         "description_urls_name_fkey",

--- a/warehouse/migrations/versions/c0302a8a0878_cascade_release_deletion_to_dependencies.py
+++ b/warehouse/migrations/versions/c0302a8a0878_cascade_release_deletion_to_dependencies.py
@@ -24,8 +24,9 @@ down_revision = "701c2fba1f5f"
 
 
 def upgrade():
-    op.drop_constraint(
-        "release_dependencies_name_fkey", "release_dependencies", type_="foreignkey"
+    op.execute(
+        "ALTER TABLE release_dependencies "
+        "DROP CONSTRAINT IF EXISTS release_dependencies_name_fkey"
     )
     op.create_foreign_key(
         "release_dependencies_name_fkey",


### PR DESCRIPTION
Production is currently running 12.8, so move us to be inline with that
version.

Refs: https://github.com/pypa/warehouse/pull/10491#issuecomment-1127689561

Signed-off-by: Mike Fiedler <miketheman@gmail.com>