### PR TITLE
Revamp security page

### DIFF
--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -534,7 +534,6 @@ msgstr ""
 #: warehouse/templates/pages/help.html:892
 #: warehouse/templates/pages/help.html:893
 #: warehouse/templates/pages/help.html:898
-#: warehouse/templates/pages/security.html:36
 #: warehouse/templates/pages/sponsors.html:33
 #: warehouse/templates/pages/sponsors.html:37
 #: warehouse/templates/pages/sponsors.html:41
@@ -6630,9 +6629,9 @@ msgstr ""
 
 #: warehouse/templates/pages/security.html:24
 msgid ""
-"If you believe you've identified a security issue with Warehouse, "
-"<strong>DO NOT</strong> report the issue in any public forum, including "
-"(but not limited to):"
+"If you believe you've identified a security issue with PyPI, <strong>DO "
+"NOT</strong> report the issue in any public forum, including (but not "
+"limited to):"
 msgstr ""
 
 #: warehouse/templates/pages/security.html:27
@@ -6648,38 +6647,68 @@ msgid "Official or unofficial mailing lists"
 msgstr ""
 
 #: warehouse/templates/pages/security.html:35
-#, python-format
-msgid ""
-"Instead, email <a href=\"%(href)s\">security at python dot org</a> "
-"directly, providing as much relevant information as possible."
+msgid "If you've identified a security issue with a project hosted on PyPI"
 msgstr ""
 
 #: warehouse/templates/pages/security.html:36
 #, python-format
 msgid ""
-"Messages may be optionally encrypted with GPG using key fingerprints "
-"available <a href=\"%(href)s\" title=\"%(title)s\" target=\"_blank\" "
-"rel=\"noopener\">at the Python Security page</a>."
+"Email <a href=\"%(href)s\">security@pypi.org</a>, providing the following"
+" details:"
 msgstr ""
 
 #: warehouse/templates/pages/security.html:38
-msgid "What happens next?"
+msgid "A URL to the project in question"
+msgstr ""
+
+#: warehouse/templates/pages/security.html:39
+msgid "An explanation of what makes the project a security issue"
 msgstr ""
 
 #: warehouse/templates/pages/security.html:40
+#, python-format
+msgid ""
+"If applicable: a link to the problematic lines in the project's "
+"distributions via <a href=\"%(href)s\">inspector.pypi.io</a>"
+msgstr ""
+
+#: warehouse/templates/pages/security.html:42
+msgid ""
+"Valid malware reports may include examples of typo-squatting, dependency "
+"confusion, data exfiltration, obfustication, command/control, etc."
+msgstr ""
+
+#: warehouse/templates/pages/security.html:44
+msgid ""
+"If you've identified a security issue with PyPI itself (not a project "
+"hosted on PyPI)"
+msgstr ""
+
+#: warehouse/templates/pages/security.html:45
+#, python-format
+msgid ""
+"Email <a href=\"%(href)s\">security@pypi.org</a>, providing as much "
+"relevant information as possible, including reproducing steps."
+msgstr ""
+
+#: warehouse/templates/pages/security.html:47
+msgid "What happens next?"
+msgstr ""
+
+#: warehouse/templates/pages/security.html:48
 msgid ""
 "Once you've submitted an issue via email, you should receive an "
 "acknowledgment within 48 hours."
 msgstr ""
 
-#: warehouse/templates/pages/security.html:41
+#: warehouse/templates/pages/security.html:49
 msgid ""
 "Depending on the action to be taken, you may receive further follow-up "
 "emails."
 msgstr ""
 
-#: warehouse/templates/pages/security.html:44
-msgid "This security policy was last updated on March 14, 2018."
+#: warehouse/templates/pages/security.html:52
+msgid "This security policy was last updated on June 2022."
 msgstr ""
 
 #: warehouse/templates/pages/sitemap.html:21

--- a/warehouse/templates/pages/security.html
+++ b/warehouse/templates/pages/security.html
@@ -21,7 +21,7 @@
 
       <p>{% trans %}We take security very seriously and ask that you follow our security policy carefully.{% endtrans %}</p>
       <div class="callout-block callout-block--danger">
-        <p><strong>{% trans %}Important!{% endtrans %}</strong> {% trans %}If you believe you've identified a security issue with Warehouse, <strong>DO NOT</strong> report the issue in any public forum, including (but not limited to):{% endtrans %}</p>
+        <p><strong>{% trans %}Important!{% endtrans %}</strong> {% trans %}If you believe you've identified a security issue with PyPI, <strong>DO NOT</strong> report the issue in any public forum, including (but not limited to):{% endtrans %}</p>
 
         <ul class="unstyled">
           <li><i class="fa fa-times danger" aria-hidden="true"></i> {% trans %}Our GitHub issue tracker{% endtrans %}</li>
@@ -32,16 +32,24 @@
 
       <br>
 
-      <p>{% trans href='mailto:security@python.org' %}Instead, email <a href="{{ href }}">security at python dot org</a> directly, providing as much relevant information as possible.{% endtrans %}</p>
-      <p>{% trans href='https://www.python.org/dev/security/', title=gettext('External link') %}Messages may be optionally encrypted with GPG using key fingerprints available <a href="{{ href }}" title="{{ title }}" target="_blank" rel="noopener">at the Python Security page</a>.{% endtrans %}</p>
+      <h2>{% trans %}If you've identified a security issue with a project hosted on PyPI{% endtrans %}</h2>
+      <p>{% trans href='mailto:security@pypi.org' %}Email <a href="{{ href }}">security@pypi.org</a>, providing the following details:{% endtrans %}</p>
+      <ul>
+          <li>{% trans %}A URL to the project in question{% endtrans %}</li>
+          <li>{% trans %}An explanation of what makes the project a security issue{% endtrans %}</li>
+          <li>{% trans href='https://inspector.pypi.io/' %}If applicable: a link to the problematic lines in the project's distributions via <a href="{{ href }}">inspector.pypi.io</a>{% endtrans %}</li>
+      </ul>
+      <p>{% trans %}Valid malware reports may include examples of typo-squatting, dependency confusion, data exfiltration, obfustication, command/control, etc.{% endtrans %}</p>
+
+      <h2>{% trans %}If you've identified a security issue with PyPI itself (not a project hosted on PyPI){% endtrans %}</h2>
+      <p>{% trans href='mailto:security@pypi.org' %}Email <a href="{{ href }}">security@pypi.org</a>, providing as much relevant information as possible, including reproducing steps.{% endtrans %}</p>
 
       <h2>{% trans %}What happens next?{% endtrans %}</h2>
-
       <p>{% trans %}Once you've submitted an issue via email, you should receive an acknowledgment within 48 hours.{% endtrans %}</p>
       <p>{% trans %}Depending on the action to be taken, you may receive further follow-up emails.{% endtrans %}</p>
 
       <br>
-      <p><strong>{% trans %}This security policy was last updated on March 14, 2018.{% endtrans %}</strong></p>
+      <p><i>{% trans %}This security policy was last updated on June 2022.{% endtrans %}</i></p>
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
This PR revamps PyPI's security page. Specifically:

- Moves the reporting email from `security@python.org` to `security@pypi.org`, removes the GPG signing suggestion
- Adds details about reporting malware, including including links to the inspector