### PR TITLE
Denormalize Release.is_prerelease

### DIFF
--- a/warehouse/migrations/versions/4490777c984f_migrate_existing_data_for_release_is_.py
+++ b/warehouse/migrations/versions/4490777c984f_migrate_existing_data_for_release_is_.py
@@ -1,0 +1,52 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Migrate Existing Data for Release.is_prerelease
+
+Revision ID: 4490777c984f
+Revises: b0dbcd2f5c77
+Create Date: 2022-06-27 17:49:09.835384
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "4490777c984f"
+down_revision = "b0dbcd2f5c77"
+
+
+def upgrade():
+    op.execute(
+        """
+        UPDATE releases
+        SET is_prerelease = pep440_is_prerelease(version)
+        WHERE is_prerelease IS NULL
+        """
+    )
+    op.alter_column(
+        "releases",
+        "is_prerelease",
+        existing_type=sa.BOOLEAN(),
+        server_default=sa.text("false"),
+        nullable=False,
+    )
+
+
+def downgrade():
+    op.alter_column(
+        "releases",
+        "is_prerelease",
+        existing_type=sa.BOOLEAN(),
+        server_default=None,
+        nullable=True,
+    )

--- a/warehouse/migrations/versions/b0dbcd2f5c77_add_a_column_for_denormalizing_release_.py
+++ b/warehouse/migrations/versions/b0dbcd2f5c77_add_a_column_for_denormalizing_release_.py
@@ -1,0 +1,53 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Add a column for denormalizing Release.is_prerelease
+
+Revision ID: b0dbcd2f5c77
+Revises: 8bee9c119e41
+Create Date: 2022-06-27 17:19:00.117464
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "b0dbcd2f5c77"
+down_revision = "8bee9c119e41"
+
+
+def upgrade():
+    op.add_column("releases", sa.Column("is_prerelease", sa.Boolean(), nullable=True))
+
+    op.execute(
+        """ CREATE OR REPLACE FUNCTION maintain_releases_is_prerelease()
+            RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.is_prerelease :=  pep440_is_prerelease(NEW.version);
+                    RETURN NEW;
+                END;
+            $$
+            LANGUAGE plpgsql
+        """
+    )
+
+    op.execute(
+        """ CREATE TRIGGER releases_update_is_prerelease
+            BEFORE INSERT OR UPDATE OF version ON releases
+            FOR EACH ROW
+            EXECUTE PROCEDURE maintain_releases_is_prerelease()
+        """
+    )
+
+
+def downgrade():
+    op.drop_column("releases", "is_prerelease")

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -418,7 +418,7 @@ class Release(db.Model):
     )
     version = Column(Text, nullable=False)
     canonical_version = Column(Text, nullable=False)
-    is_prerelease = orm.column_property(func.pep440_is_prerelease(version))
+    is_prerelease = Column(Boolean, nullable=False, server_default=sql.false())
     author = Column(Text)
     author_email = Column(Text)
     maintainer = Column(Text)


### PR DESCRIPTION
Note, this is two commits, and is meant to be split into two PRs, the first one adds the column, and the second one will backfill data and switch us over to using the new column.

I've left both commits in this PR for now to make it easier to review. Between the two PRs we can, if needed, manually backfill data in chunks before landing the second PR.