### PR TITLE
docs: Fix a few typos

### DIFF
--- a/tests/frontend/viewport_toggle_controller_test.js
+++ b/tests/frontend/viewport_toggle_controller_test.js
@@ -33,7 +33,7 @@ const viewportContent = `
 
 
 function startStimulus() {
-  // set the HTML before satarting the application, as the controller uses the
+  // set the HTML before starting the application, as the controller uses the
   // `connect()` function.
   document.body.innerHTML = viewportContent;
   const application = Application.start();

--- a/warehouse/email/ses/models.py
+++ b/warehouse/email/ses/models.py
@@ -177,7 +177,7 @@ class EmailStatus:
         collector=lambda iterable: list(iterable)[-1],
     )
 
-    # This happens sometimes. The email will stay unverfied, but this allows us
+    # This happens sometimes. The email will stay unverified, but this allows us
     # to record the event
     bounced.upon(
         deliver,

--- a/warehouse/legacy/api/json.py
+++ b/warehouse/legacy/api/json.py
@@ -107,7 +107,7 @@ def _json_data(request, project, release, *, all_releases):
         for r, fs in releases.items()
     }
 
-    # Serialize a list of vulnerabilties for this release
+    # Serialize a list of vulnerabilities for this release
     vulnerabilities = [
         {
             "id": vulnerability_record.id,

--- a/warehouse/rate_limiting/__init__.py
+++ b/warehouse/rate_limiting/__init__.py
@@ -102,7 +102,7 @@ class RateLimiter:
             reset = datetime.fromtimestamp(resets_at, tz=timezone.utc)
 
             # If our current datetime is either greater than or equal to when
-            # the limit resets, then we will skipp it since it has either
+            # the limit resets, then we will skip it since it has either
             # already reset, or it is resetting now.
             if current >= reset:
                 continue


### PR DESCRIPTION
There are small typos in:
- tests/frontend/viewport_toggle_controller_test.js
- warehouse/email/ses/models.py
- warehouse/legacy/api/json.py
- warehouse/rate_limiting/__init__.py

Fixes:
- Should read `vulnerabilities` rather than `vulnerabilties`.
- Should read `unverified` rather than `unverfied`.
- Should read `starting` rather than `satarting`.
- Should read `skip` rather than `skipp`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md