### PR TITLE
Restrict Security Policies based on route type

### DIFF
--- a/tests/unit/accounts/test_core.py
+++ b/tests/unit/accounts/test_core.py
@@ -46,16 +46,6 @@ from ...common.db.oidc import GitHubPublisherFactory
 
 
 class TestLogin:
-    def test_invalid_route(self, pyramid_request, pyramid_services):
-        service = pretend.stub(find_userid=pretend.call_recorder(lambda username: None))
-        pyramid_services.register_service(service, IUserService, None)
-        pyramid_services.register_service(
-            pretend.stub(), IPasswordBreachedService, None
-        )
-        pyramid_request.matched_route = pretend.stub(name="route_name")
-        assert _basic_auth_check("myuser", "mypass", pyramid_request) is False
-        assert service.find_userid.calls == []
-
     def test_with_no_user(self, pyramid_request, pyramid_services):
         service = pretend.stub(find_userid=pretend.call_recorder(lambda username: None))
         pyramid_services.register_service(service, IUserService, None)

--- a/tests/unit/accounts/test_security_policy.py
+++ b/tests/unit/accounts/test_security_policy.py
@@ -58,6 +58,7 @@ class TestBasicAuthSecurityPolicy:
         monkeypatch.setattr(security_policy, "add_vary_callback", add_vary_cb)
 
         request = pretend.stub(
+            is_api=True,
             add_response_callback=pretend.call_recorder(lambda cb: None),
             banned=pretend.stub(by_ip=lambda ip_address: False),
             remote_addr="1.2.3.4",
@@ -87,6 +88,7 @@ class TestBasicAuthSecurityPolicy:
         monkeypatch.setattr(security_policy, "add_vary_callback", add_vary_cb)
 
         request = pretend.stub(
+            is_api=True,
             add_response_callback=pretend.call_recorder(lambda cb: None),
             banned=pretend.stub(by_ip=lambda ip_address: False),
             remote_addr="1.2.3.4",
@@ -98,33 +100,11 @@ class TestBasicAuthSecurityPolicy:
         assert add_vary_cb.calls == [pretend.call("Authorization")]
         assert request.add_response_callback.calls == [pretend.call(vary_cb)]
 
-    @pytest.mark.parametrize(
-        "fake_request",
-        [
-            pretend.stub(
-                matched_route=None,
-                banned=pretend.stub(by_ip=lambda ip_address: False),
-                remote_addr="1.2.3.4",
-            ),
-            pretend.stub(
-                matched_route=pretend.stub(name="an.invalid.route"),
-                banned=pretend.stub(by_ip=lambda ip_address: False),
-                remote_addr="1.2.3.4",
-            ),
-        ],
-    )
-    def test_invalid_request_fail(self, monkeypatch, fake_request):
-        creds = (pretend.stub(), pretend.stub())
-        extract_http_basic_credentials = pretend.call_recorder(lambda request: creds)
-        monkeypatch.setattr(
-            security_policy,
-            "extract_http_basic_credentials",
-            extract_http_basic_credentials,
-        )
+    def test_not_api_request_fail(self):
+        request = pretend.stub(is_api=False)
         policy = security_policy.BasicAuthSecurityPolicy()
-        fake_request.add_response_callback = pretend.call_recorder(lambda cb: None)
 
-        assert policy.identity(fake_request) is None
+        assert policy.identity(request) is None
 
     def test_identity(self, monkeypatch):
         creds = (pretend.stub(), pretend.stub())
@@ -149,6 +129,7 @@ class TestBasicAuthSecurityPolicy:
             get_user_by_username=pretend.call_recorder(lambda u: user)
         )
         request = pretend.stub(
+            is_api=True,
             add_response_callback=pretend.call_recorder(lambda cb: None),
             find_service=pretend.call_recorder(lambda a, **kw: user_service),
             banned=pretend.stub(by_ip=lambda ip_address: False),
@@ -188,6 +169,7 @@ class TestBasicAuthSecurityPolicy:
             get_user_by_username=pretend.call_recorder(lambda u: user)
         )
         request = pretend.stub(
+            is_api=True,
             add_response_callback=pretend.call_recorder(lambda cb: None),
             find_service=pretend.call_recorder(lambda a, **kw: user_service),
             banned=pretend.stub(by_ip=lambda ip_address: True),
@@ -242,59 +224,11 @@ class TestSessionSecurityPolicy:
             pretend.call(request, userid, foo=None)
         ]
 
-    def test_identity_missing_route(self, monkeypatch):
-        session_helper_obj = pretend.stub()
-        session_helper_cls = pretend.call_recorder(lambda: session_helper_obj)
-        monkeypatch.setattr(
-            security_policy, "SessionAuthenticationHelper", session_helper_cls
-        )
-
+    def test_identity_api_route_fail(self):
         policy = security_policy.SessionSecurityPolicy()
-
-        vary_cb = pretend.stub()
-        add_vary_cb = pretend.call_recorder(lambda *v: vary_cb)
-        monkeypatch.setattr(security_policy, "add_vary_callback", add_vary_cb)
-
-        request = pretend.stub(
-            add_response_callback=pretend.call_recorder(lambda cb: None),
-            matched_route=None,
-            banned=pretend.stub(by_ip=lambda ip_address: False),
-            remote_addr="1.2.3.4",
-        )
+        request = pretend.stub(is_api=True)
 
         assert policy.identity(request) is None
-        assert request.authentication_method == AuthenticationMethod.SESSION
-        assert session_helper_cls.calls == [pretend.call()]
-
-        assert add_vary_cb.calls == [pretend.call("Cookie")]
-        assert request.add_response_callback.calls == [pretend.call(vary_cb)]
-
-    def test_identity_invalid_route(self, monkeypatch):
-        session_helper_obj = pretend.stub()
-        session_helper_cls = pretend.call_recorder(lambda: session_helper_obj)
-        monkeypatch.setattr(
-            security_policy, "SessionAuthenticationHelper", session_helper_cls
-        )
-
-        policy = security_policy.SessionSecurityPolicy()
-
-        vary_cb = pretend.stub()
-        add_vary_cb = pretend.call_recorder(lambda *v: vary_cb)
-        monkeypatch.setattr(security_policy, "add_vary_callback", add_vary_cb)
-
-        request = pretend.stub(
-            add_response_callback=pretend.call_recorder(lambda cb: None),
-            matched_route=pretend.stub(name="forklift.legacy.file_upload"),
-            banned=pretend.stub(by_ip=lambda ip_address: False),
-            remote_addr="1.2.3.4",
-        )
-
-        assert policy.identity(request) is None
-        assert request.authentication_method == AuthenticationMethod.SESSION
-        assert session_helper_cls.calls == [pretend.call()]
-
-        assert add_vary_cb.calls == [pretend.call("Cookie")]
-        assert request.add_response_callback.calls == [pretend.call(vary_cb)]
 
     def test_identity_no_userid(self, monkeypatch):
         session_helper_obj = pretend.stub(
@@ -312,6 +246,7 @@ class TestSessionSecurityPolicy:
         monkeypatch.setattr(security_policy, "add_vary_callback", add_vary_cb)
 
         request = pretend.stub(
+            is_api=False,
             add_response_callback=pretend.call_recorder(lambda cb: None),
             matched_route=pretend.stub(name="a.permitted.route"),
             banned=pretend.stub(by_ip=lambda ip_address: False),
@@ -344,6 +279,7 @@ class TestSessionSecurityPolicy:
 
         user_service = pretend.stub(get_user=pretend.call_recorder(lambda uid: None))
         request = pretend.stub(
+            is_api=False,
             add_response_callback=pretend.call_recorder(lambda cb: None),
             matched_route=pretend.stub(name="a.permitted.route"),
             find_service=pretend.call_recorder(lambda i, **kw: user_service),
@@ -384,6 +320,7 @@ class TestSessionSecurityPolicy:
             get_password_timestamp=pretend.call_recorder(lambda uid: timestamp),
         )
         request = pretend.stub(
+            is_api=False,
             add_response_callback=pretend.call_recorder(lambda cb: None),
             matched_route=pretend.stub(name="a.permitted.route"),
             find_service=pretend.call_recorder(lambda i, **kw: user_service),
@@ -435,6 +372,7 @@ class TestSessionSecurityPolicy:
             get_password_timestamp=pretend.call_recorder(lambda uid: timestamp),
         )
         request = pretend.stub(
+            is_api=False,
             add_response_callback=pretend.call_recorder(lambda cb: None),
             matched_route=pretend.stub(name="a.permitted.route"),
             find_service=pretend.call_recorder(lambda i, **kw: user_service),
@@ -480,6 +418,7 @@ class TestSessionSecurityPolicy:
             get_password_timestamp=pretend.call_recorder(lambda uid: timestamp),
         )
         request = pretend.stub(
+            is_api=False,
             add_response_callback=pretend.call_recorder(lambda cb: None),
             matched_route=pretend.stub(name="a.permitted.route"),
             find_service=pretend.call_recorder(lambda i, **kw: user_service),

--- a/tests/unit/forklift/test_init.py
+++ b/tests/unit/forklift/test_init.py
@@ -39,7 +39,10 @@ def test_includeme(forklift_domain, monkeypatch):
     assert config.include.calls == [pretend.call(".action_routing")]
     assert config.add_legacy_action_route.calls == [
         pretend.call(
-            "forklift.legacy.file_upload", "file_upload", domain=forklift_domain
+            "forklift.legacy.file_upload",
+            "file_upload",
+            domain=forklift_domain,
+            is_api=True,
         ),
         pretend.call("forklift.legacy.submit", "submit", domain=forklift_domain),
         pretend.call(

--- a/tests/unit/macaroons/test_security_policy.py
+++ b/tests/unit/macaroons/test_security_policy.py
@@ -76,6 +76,12 @@ class TestMacaroonSecurityPolicy:
         assert policy.forget(pretend.stub()) == []
         assert policy.remember(pretend.stub(), pretend.stub()) == []
 
+    def test_identity_no_api_fail(self):
+        request = pretend.stub(is_api=False)
+        policy = security_policy.MacaroonSecurityPolicy()
+
+        assert policy.identity(request) is None
+
     def test_identity_no_http_macaroon(self, monkeypatch):
         policy = security_policy.MacaroonSecurityPolicy()
 
@@ -89,7 +95,8 @@ class TestMacaroonSecurityPolicy:
         )
 
         request = pretend.stub(
-            add_response_callback=pretend.call_recorder(lambda cb: None)
+            is_api=True,
+            add_response_callback=pretend.call_recorder(lambda cb: None),
         )
 
         assert policy.identity(request) is None
@@ -116,6 +123,7 @@ class TestMacaroonSecurityPolicy:
         )
 
         request = pretend.stub(
+            is_api=True,
             add_response_callback=pretend.call_recorder(lambda cb: None),
             find_service=pretend.call_recorder(lambda iface, **kw: macaroon_service),
         )
@@ -150,6 +158,7 @@ class TestMacaroonSecurityPolicy:
         )
 
         request = pretend.stub(
+            is_api=True,
             add_response_callback=pretend.call_recorder(lambda cb: None),
             find_service=pretend.call_recorder(lambda iface, **kw: macaroon_service),
         )
@@ -187,6 +196,7 @@ class TestMacaroonSecurityPolicy:
         )
 
         request = pretend.stub(
+            is_api=True,
             add_response_callback=pretend.call_recorder(lambda cb: None),
             find_service=pretend.call_recorder(lambda iface, **kw: macaroon_service),
         )

--- a/tests/unit/test_predicates.py
+++ b/tests/unit/test_predicates.py
@@ -22,8 +22,8 @@ from warehouse.predicates import (
     APIPredicate,
     DomainPredicate,
     HeadersPredicate,
-    includeme,
     _is_api_route,
+    includeme,
 )
 from warehouse.subscriptions.models import StripeSubscriptionStatus
 

--- a/tests/unit/test_predicates.py
+++ b/tests/unit/test_predicates.py
@@ -19,9 +19,11 @@ from pyramid.httpexceptions import HTTPSeeOther
 from warehouse.organizations.models import OrganizationType
 from warehouse.predicates import (
     ActiveOrganizationPredicate,
+    APIPredicate,
     DomainPredicate,
     HeadersPredicate,
     includeme,
+    _is_api_route,
 )
 from warehouse.subscriptions.models import StripeSubscriptionStatus
 
@@ -54,6 +56,39 @@ class TestDomainPredicate:
     def test_invalid_value(self):
         predicate = DomainPredicate("upload.pyp.io", None)
         assert not predicate(None, pretend.stub(domain="pypi.io"))
+
+
+class TestAPIPredicate:
+    @pytest.mark.parametrize(
+        ("value", "expected"), [(True, "is_api = True"), (False, "is_api = False")]
+    )
+    def test_text(self, value, expected):
+        pred = APIPredicate(value, None)
+        assert pred.text() == expected
+        assert pred.phash() == expected
+
+    @pytest.mark.parametrize("value", [True, False, None])
+    def test_always_allows(self, value):
+        pred = APIPredicate(value, None)
+        assert pred(None, None)
+
+    def test_request_no_matched_route(self):
+        assert not _is_api_route(pretend.stub(matched_route=None))
+
+    def test_request_matched_route_no_pred(self):
+        request = pretend.stub(matched_route=pretend.stub(predicates=[]))
+        assert not _is_api_route(request)
+
+    def test_request_matched_route_no_api_pred(self):
+        request = pretend.stub(matched_route=pretend.stub(predicates=[pretend.stub()]))
+        assert not _is_api_route(request)
+
+    @pytest.mark.parametrize(("value", "expected"), [(True, True), (False, False)])
+    def test_request_matched_route_with_api_pred(self, value, expected):
+        request = pretend.stub(
+            matched_route=pretend.stub(predicates=[APIPredicate(value, None)])
+        )
+        assert _is_api_route(request) == expected
 
 
 class TestHeadersPredicate:
@@ -189,12 +224,20 @@ class TestActiveOrganizationPredicate:
 
 def test_includeme():
     config = pretend.stub(
+        add_request_method=pretend.call_recorder(lambda fn, name, reify: None),
         add_route_predicate=pretend.call_recorder(lambda name, pred: None),
         add_view_predicate=pretend.call_recorder(lambda name, pred: None),
     )
     includeme(config)
 
-    assert config.add_route_predicate.calls == [pretend.call("domain", DomainPredicate)]
+    assert config.add_request_method.calls == [
+        pretend.call(_is_api_route, name="is_api", reify=True)
+    ]
+
+    assert config.add_route_predicate.calls == [
+        pretend.call("domain", DomainPredicate),
+        pretend.call("is_api", APIPredicate),
+    ]
 
     assert config.add_view_predicate.calls == [
         pretend.call("require_headers", HeadersPredicate),

--- a/warehouse/accounts/security_policy.py
+++ b/warehouse/accounts/security_policy.py
@@ -43,14 +43,6 @@ def _format_exc_status(exc, message):
 
 
 def _basic_auth_check(username, password, request):
-    # A route must be matched
-    if not request.matched_route:
-        return False
-
-    # Basic authentication can only be used for uploading
-    if request.matched_route.name != "forklift.legacy.file_upload":
-        return False
-
     login_service = request.find_service(IUserService, context=None)
     breach_service = request.find_service(IPasswordBreachedService, context=None)
 
@@ -128,6 +120,12 @@ class SessionSecurityPolicy:
         self._acl = ACLHelper()
 
     def identity(self, request):
+        # If our current request *is* any API request, then we will disallow
+        # authenticating with sessions, as an API request should only use API
+        # authentication methods.
+        if request.is_api:
+            return None
+
         # If we're calling into this API on a request, then we want to register
         # a callback which will ensure that the response varies based on the
         # Cookie header.
@@ -135,14 +133,6 @@ class SessionSecurityPolicy:
         request.authentication_method = AuthenticationMethod.SESSION
 
         if request.banned.by_ip(request.remote_addr):
-            return None
-
-        # A route must be matched
-        if not request.matched_route:
-            return None
-
-        # Session authentication cannot be used for uploading
-        if request.matched_route.name == "forklift.legacy.file_upload":
             return None
 
         userid = self._session_helper.authenticated_userid(request)
@@ -195,6 +185,15 @@ class BasicAuthSecurityPolicy:
         self._acl = ACLHelper()
 
     def identity(self, request):
+        # If our current request isn't an API request, then we'll just quickly skip
+        # trying to do anything since we only support basic auth on API routes.
+        # NOTE: Technically we only support it on upload, which is at the moment our
+        #       only API route. We'll end up removing this entirely once we go to 2FA
+        #       only for uploading, so a short term window if we add another API route
+        #       seems fine.
+        if not request.is_api:
+            return None
+
         # If we're calling into this API on a request, then we want to register
         # a callback which will ensure that the response varies based on the
         # Authorization header.

--- a/warehouse/forklift/__init__.py
+++ b/warehouse/forklift/__init__.py
@@ -31,7 +31,10 @@ def includeme(config):
 
     # Add the routes that we'll be using in Forklift.
     config.add_legacy_action_route(
-        "forklift.legacy.file_upload", "file_upload", domain=forklift
+        "forklift.legacy.file_upload",
+        "file_upload",
+        domain=forklift,
+        is_api=True,
     )
     config.add_legacy_action_route("forklift.legacy.submit", "submit", domain=forklift)
     config.add_legacy_action_route(

--- a/warehouse/macaroons/security_policy.py
+++ b/warehouse/macaroons/security_policy.py
@@ -77,6 +77,11 @@ class MacaroonSecurityPolicy:
         self._acl = ACLHelper()
 
     def identity(self, request):
+        # If our current request isn't an API request, then we'll just quickly skip
+        # trying to do anything since we only support basic auth on API routes.
+        if not request.is_api:
+            return None
+
         # If we're calling into this API on a request, then we want to register
         # a callback which will ensure that the response varies based on the
         # Authorization header.


### PR DESCRIPTION
Provides a mechanism to tag whether a *route* is an "API" route or not. The effects of tagging a route as an API route is that session basic authentication will no longer work on that route, but Basic and Macaroon authentication will.

Also adds a `request.is_api` attribute that indicates if the current request is an API request or not.

Currently the only route we tag as an API route is the upload API.


Fixes #7266