### PR TITLE
docs, warehouse: improve "pending" publisher docs, messages

### DIFF
--- a/docs/user/trusted-publishers/creating-a-project-through-oidc.md
+++ b/docs/user/trusted-publishers/creating-a-project-through-oidc.md
@@ -25,6 +25,15 @@ trusted publishers. The forms on this page behave
 the same as with publishers for existing projects, except that you also need to
 provide the name of the PyPI project that will be created.
 
+!!! important
+
+    A "pending" publisher does **not** create a project or reserve a
+    project's name **until** it is actually used to publish.
+
+    If you create a "pending" publisher but another user registers the project
+    name before you actually publish to it, your "pending" publisher will be
+    **invalidated**.
+
 === "GitHub Actions"
 
     If you have a repository at

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -4708,7 +4708,14 @@ msgid ""
 "trusted publishers <a href=\"%(href)s\">here</a>."
 msgstr ""
 
-#: warehouse/templates/manage/account/publishing.html:541
+#: warehouse/templates/manage/account/publishing.html:512
+msgid ""
+"Configuring a \"pending\" publisher for a project name does "
+"<strong>not</strong> reserve that name. Until the project is created, any"
+" other user may create it, including via their own \"pending\" publisher."
+msgstr ""
+
+#: warehouse/templates/manage/account/publishing.html:549
 #: warehouse/templates/manage/project/publishing.html:422
 #, python-format
 msgid ""

--- a/warehouse/templates/email/pending-trusted-publisher-invalidated/body.html
+++ b/warehouse/templates/email/pending-trusted-publisher-invalidated/body.html
@@ -15,13 +15,8 @@
 
 {% block content %}
 <p>
-    You registered an pending OpenID Connect publisher for a project
+    You registered a pending trusted publisher for a project
     (<strong>{{ project_name }}</strong>), but someone else has invalidated your
     pending publisher by creating the project before you did.
-</p>
-<p>
-    If you believe this was done in error, you can email
-    <a href="mailto:admin@pypi.org"> admin@pypi.org</a> to communicate with the PyPI
-    administrators.
 </p>
 {% endblock %}

--- a/warehouse/templates/email/pending-trusted-publisher-invalidated/body.txt
+++ b/warehouse/templates/email/pending-trusted-publisher-invalidated/body.txt
@@ -14,12 +14,8 @@
 {% extends "email/_base/body.txt" %}
 
 {% block content %}
-You registered an pending OpenID Connect publisher for a project
+You registered a pending trusted publisher for a project
 ({{ project_name }}), but someone else has invalidated your pending publisher
 by creating the project before you did.
-
-If you believe this was done in error, you can email admin@pypi.org
-to communicate with the PyPI administrators.
-
 {% endblock %}
 

--- a/warehouse/templates/email/pending-trusted-publisher-invalidated/subject.txt
+++ b/warehouse/templates/email/pending-trusted-publisher-invalidated/subject.txt
@@ -14,4 +14,4 @@
 
 {% extends "email/_base/subject.txt" %}
 
-{% block subject %}Pending OpenID Connect publisher invalidated for {{ project_name }}{% endblock %}
+{% block subject %}Pending trusted publisher invalidated for {{ project_name }}{% endblock %}

--- a/warehouse/templates/manage/account/publishing.html
+++ b/warehouse/templates/manage/account/publishing.html
@@ -320,7 +320,7 @@
     Read more about ActiveState's OpenID Connect support <a href="{{ href }}">here</a>.
     {% endtrans %}
   </p>
-  
+
   {{ form_error_anchor(pending_activestate_pubisher_form) }}
   <form method="POST" action="{{ request.route_path('manage.account.publishing') }}#errors">
     <input name="csrf_token" type="hidden" value="{{ request.session.get_csrf_token() }}">
@@ -497,7 +497,7 @@
       {% endtrans %}
     </p>
 
-    <p class="no-bottom-padding">
+    <p>
       {% trans href="https://docs.pypi.org/trusted-publishers/" %}
       These publishers behave similarly to trusted publishers registered
       against specific projects, except that they allow users to <strong>create</strong>
@@ -505,6 +505,14 @@
       the "pending" publisher becomes an ordinary trusted publisher.
       You can read more about "pending" and ordinary trusted publishers
       <a href="{{ href }}">here</a>.
+      {% endtrans %}
+    </p>
+
+    <p class="callout-block callout-block--warning">
+      {% trans %}
+      Configuring a "pending" publisher for a project name does <strong>not</strong> reserve
+      that name. Until the project is created, any other user may create it,
+      including via their own "pending" publisher.
       {% endtrans %}
     </p>
 


### PR DESCRIPTION
Fixes a few lingering flaws in our docs/public explanations of "pending" publishers, per #16157.

Also fixes a place where we refer to a "pending" publisher as a OIDC publisher.

CC @miketheman 