### PR TITLE
Validate Alternate Repository Location URLS (PEP 708)

### DIFF
--- a/warehouse/api/simple.py
+++ b/warehouse/api/simple.py
@@ -18,6 +18,11 @@ from sqlalchemy import func
 
 from warehouse.cache.http import add_vary, cache_control
 from warehouse.cache.origin import origin_cache
+from warehouse.constants import (
+    MIME_PYPI_SIMPLE_V1_HTML,
+    MIME_PYPI_SIMPLE_V1_JSON,
+    MIME_TEXT_HTML,
+)
 from warehouse.packaging.models import JournalEntry, Project
 from warehouse.packaging.utils import (
     _simple_detail,
@@ -25,10 +30,6 @@ from warehouse.packaging.utils import (
     _valid_simple_detail_context,
 )
 from warehouse.utils.cors import _CORS_HEADERS
-
-MIME_TEXT_HTML = "text/html"
-MIME_PYPI_SIMPLE_V1_HTML = "application/vnd.pypi.simple.v1+html"
-MIME_PYPI_SIMPLE_V1_JSON = "application/vnd.pypi.simple.v1+json"
 
 
 def _select_content_type(request: Request) -> str:

--- a/warehouse/constants.py
+++ b/warehouse/constants.py
@@ -14,3 +14,12 @@ ONE_MIB = 1 * 1024 * 1024
 ONE_GIB = 1 * 1024 * 1024 * 1024
 MAX_FILESIZE = 100 * ONE_MIB
 MAX_PROJECT_SIZE = 10 * ONE_GIB
+
+MIME_TEXT_HTML = "text/html"
+MIME_PYPI_SIMPLE_V1_HTML = "application/vnd.pypi.simple.v1+html"
+MIME_PYPI_SIMPLE_V1_JSON = "application/vnd.pypi.simple.v1+json"
+
+MIME_PYPI_SIMPLE_V1_ALL = [
+    MIME_PYPI_SIMPLE_V1_JSON,
+    MIME_PYPI_SIMPLE_V1_HTML,
+]

--- a/warehouse/manage/views/__init__.py
+++ b/warehouse/manage/views/__init__.py
@@ -1129,7 +1129,7 @@ class ManageProjectSettingsViews:
         self.add_alternate_repository_form_class = AddAlternateRepositoryForm
 
     @view_config(request_method="GET")
-    def manage_project_settings(self):
+    def manage_project_settings(self, add_alternate_repository_form=None):
         if not self.request.organization_access:
             # Disable transfer of project to any organization.
             organization_choices = set()
@@ -1153,7 +1153,11 @@ class ManageProjectSettingsViews:
                 active_organizations_owned | active_organizations_managed
             ) - current_organization
 
-        add_alt_repo_form = self.add_alternate_repository_form_class()
+        add_alt_repo_form = (
+            self.add_alternate_repository_form_class()
+            if add_alternate_repository_form is None
+            else add_alternate_repository_form
+        )
 
         return {
             "project": self.project,
@@ -1182,12 +1186,7 @@ class ManageProjectSettingsViews:
                 self.request._("Invalid alternate repository location details"),
                 queue="error",
             )
-            return HTTPSeeOther(
-                self.request.route_path(
-                    "manage.project.settings",
-                    project_name=self.project.name,
-                )
-            )
+            return self.manage_project_settings(add_alternate_repository_form=form)
 
         # add the alternate repository location entry
         alt_repo = AlternateRepository(


### PR DESCRIPTION
User behavior for this configuration has shown that most URLs supplied are not simple indexes at all, predominately they have been source repository links.

This is a bare-bones approach to validating that the URL is actually a simple index.