### PR TITLE
relax wheel filename restriction from #17107

### DIFF
--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -380,7 +380,7 @@ class TestFileValidation:
 
         assert legacy._is_valid_dist_file(f, "bdist_wheel") == (
             False,
-            "Unable to parse name and version from wheel filename"
+            "Unable to parse name and version from wheel filename",
         )
 
     def test_incorrect_number_of_top_level_directories_sdist_tar(self, tmpdir):

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -316,7 +316,10 @@ def _is_valid_dist_file(filename, filetype):
                     try:
                         name, version, _ = os.path.basename(filename).split("-", 2)
                     except ValueError:
-                        return (False, "Unable to parse name and version from wheel filename")
+                        return (
+                            False,
+                            "Unable to parse name and version from wheel filename",
+                        )
                     target_file = os.path.join(f"{name}-{version}.dist-info", "WHEEL")
                     try:
                         zfp.read(target_file)


### PR DESCRIPTION
the restrictions applied in #17107 introduced a bit _too_ strict handling of wheels than we're ready for. using the parse_wheel_filename normalized name/version, which is a new and more strict constraint than intended