### PR TITLE
Fixup: typo: reciept -> receipt

### DIFF
--- a/docs/user/organization-accounts/pricing-and-payments.md
+++ b/docs/user/organization-accounts/pricing-and-payments.md
@@ -14,7 +14,7 @@ title: Pricing and Payments
 
 ### Payment Terms
 
-Invoiced monthly, based on usage. Payment is due upon reciept and will be charged to the billing information on file.
+Invoiced monthly, based on usage. Payment is due upon receipt and will be charged to the billing information on file.
 
 ## Community Organizations
 


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Typo fixup for the word `receipt` on the Pricing and Payments page.

### Briefly summarize the changes
1. This change is a spelling correction.

### How have the changes been tested?
1. Untested.

**List any issues that this change relates to**
N/A