### PR TITLE
base: replace PEP 541 link with user documentation link

### DIFF
--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -954,13 +954,12 @@ msgstr ""
 #: warehouse/templates/404.html:34 warehouse/templates/500.html:28
 #: warehouse/templates/accounts/two-factor.html:55
 #: warehouse/templates/base.html:274 warehouse/templates/base.html:275
-#: warehouse/templates/base.html:276 warehouse/templates/base.html:277
-#: warehouse/templates/base.html:287 warehouse/templates/base.html:288
-#: warehouse/templates/base.html:301 warehouse/templates/base.html:302
-#: warehouse/templates/base.html:304 warehouse/templates/base.html:313
-#: warehouse/templates/base.html:315 warehouse/templates/base.html:316
-#: warehouse/templates/base.html:317 warehouse/templates/base.html:327
-#: warehouse/templates/base.html:340
+#: warehouse/templates/base.html:277 warehouse/templates/base.html:287
+#: warehouse/templates/base.html:288 warehouse/templates/base.html:301
+#: warehouse/templates/base.html:302 warehouse/templates/base.html:304
+#: warehouse/templates/base.html:313 warehouse/templates/base.html:315
+#: warehouse/templates/base.html:316 warehouse/templates/base.html:317
+#: warehouse/templates/base.html:327 warehouse/templates/base.html:340
 #: warehouse/templates/includes/accounts/profile-callout.html:18
 #: warehouse/templates/includes/file-details.html:101
 #: warehouse/templates/index.html:100 warehouse/templates/index.html:104
@@ -1259,11 +1258,11 @@ msgid "Uploading packages"
 msgstr ""
 
 #: warehouse/templates/base.html:276
-msgid "User guide"
+msgid "User documentation"
 msgstr ""
 
 #: warehouse/templates/base.html:277
-msgid "Project name retention"
+msgid "User guide"
 msgstr ""
 
 #: warehouse/templates/base.html:278

--- a/warehouse/templates/base.html
+++ b/warehouse/templates/base.html
@@ -273,8 +273,8 @@
             <ul>
               <li><a href="https://packaging.python.org/tutorials/installing-packages/" title="{% trans %}External link{% endtrans %}" target="_blank" rel="noopener">{% trans %}Installing packages{% endtrans %}</a></li>
               <li><a href="https://packaging.python.org/tutorials/packaging-projects/" title="{% trans %}External link{% endtrans %}" target="_blank" rel="noopener">{% trans %}Uploading packages{% endtrans %}</a></li>
+              <li><a href="{{ request.user_docs_url('/') }}">{% trans %}User documentation{% endtrans %}</a></li>
               <li><a href="https://packaging.python.org/" title="{% trans %}External link{% endtrans %}" target="_blank" rel="noopener">{% trans %}User guide{% endtrans %}</a></li>
-              <li><a href="https://www.python.org/dev/peps/pep-0541/" title="{% trans %}External link{% endtrans %}" target="_blank" rel="noopener">{% trans %}Project name retention{% endtrans %}</a></li>
               <li><a href="{{ request.route_path('help')}}">{% trans %}FAQs{% endtrans %}</a></li>
             </ul>
           </nav>


### PR DESCRIPTION
To keep things balanced between the different columns, I've removed the link to [PEP 541](https://peps.python.org/pep-0541/) and replaced it with a link to the user docs.

This has the downside of removing a link to the index's name retention polcies. However, I think there are two possible resolutions here:

1. Add the retention policies within the user docs (i.e. by copying them from the PEP and adding a "living" banner to the PEP, similar to other packaging PEPs)
2. Add the retention policies to <https://policies.python.org> (under the PyPI group) instead, since they're conceptually related to the other policies (AUP, T&C).

Curious what others think about either of the above 🙂 

Closes #17959.