### PR TITLE
chore: ignore noisy commits

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,5 @@
+# .git-blame-ignore-revs
+# Reformatted codebase with black (#3367)
+40fbc32fef7c7ffe41cd18f3f8951578555db1aa
+# Collapsed license headers across codebase (#18217)
+f59df186dc62274b5831a72f639a1e92bbe3f94c


### PR DESCRIPTION
Part 3 of a 3-part dance from #18148 (part 1 #18205, part 2 #18217)

Uses https://docs.github.com/en/repositories/working-with-files/using-files/viewing-and-understanding-files#ignore-commits-in-the-blame-view

warehouse developers can opt in to this ignore on their local systems with:

    git config blame.ignoreRevsFile .git-blame-ignore-revs

Added a historical one for when the codebase was blackened.