### PR TITLE
Fix simple html formatting

### DIFF
--- a/warehouse/templates/api/simple/detail.html
+++ b/warehouse/templates/api/simple/detail.html
@@ -10,16 +10,11 @@
   </head>
   <body>
     <h1>Links for {{ name }}</h1>
+    {# djlint:off #}
     {% for file in files -%}
-      <a href="{{ file.url }}#sha256={{ file.hashes.sha256 }}"
-         {% if file.get('requires-python') %}data-requires-python="{{ file['requires-python'] }}"{% endif %}
-         {% if file.yanked %}data-yanked="{% if file.yanked is string %}{{ file.yanked }}{% endif %}
-         "
-         {% endif %}
-         {% if file['core-metadata'] %}data-dist-info-metadata="sha256={{ file['core-metadata']['sha256'] }}" data-core-metadata="sha256={{ file['core-metadata']['sha256'] }}"{% endif %}
-         {% if file.get('provenance') %}data-provenance="{{ file['provenance'] }}"{% endif %}>{{ file.filename }}</a>
-      <br />
+    <a href="{{ file.url }}#sha256={{ file.hashes.sha256 }}"{% if file.get('requires-python') %} data-requires-python="{{ file['requires-python'] }}" {% endif %}{% if file.yanked %}data-yanked="{% if file.yanked is string %}{{ file.yanked }}{% endif %}" {% endif %}{% if file['core-metadata'] %}data-dist-info-metadata="sha256={{ file['core-metadata']['sha256'] }}" data-core-metadata="sha256={{ file['core-metadata']['sha256'] }}"{% endif %}{% if file.get('provenance') %} data-provenance="{{ file['provenance'] }}"{% endif %}>{{ file.filename }}</a><br />
     {% endfor -%}
+    {# djlint:on #}
   </body>
 </html>
 <!--SERIAL {{ meta['_last-serial'] }}-->


### PR DESCRIPTION
In #18266, the html formatting of the simple index page broke; notice the missing whitespace before `data-dist-info-metadata`:

```
<a href="https://files.pythonhosted.org/packages/7c/61/9d574b10d9368ecb1a0c923952aa593510a20df4940aa615b3a71337c8db/numpy-2.3.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl#sha256=54dfc8681c1906d239e95ab1508d0a533c4a9505e52ee2d71a5472b04437ef97"
data-requires-python="&gt;=3.11"data-dist-info-metadata="sha256=354540ba72b4a8d4d997afaa32848bc1f37d8e5daba4ea647d9702cd1faf5095" data-core-metadata="sha256=354540ba72b4a8d4d997afaa32848bc1f37d8e5daba4ea647d9702cd1faf5095">numpy-2.3.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl</a>
      <br />
<a href="https://files.pythonhosted.org/packages/39/de/bcad52ce972dc26232629ca3a99721fd4b22c1d2bda84d5db6541913ef9c/numpy-2.3.0-pp311-pypy311_pp73-win_amd64.whl#sha256=e017a8a251ff4d18d71f139e28bdc7c31edba7a507f72b1414ed902cbe48c74d"
data-requires-python="&gt;=3.11"data-dist-info-metadata="sha256=83249f08c9dc7b3e1c91c7de20f430987f2959e20c528a155f78304be184ec5a" data-core-metadata="sha256=83249f08c9dc7b3e1c91c7de20f430987f2959e20c528a155f78304be184ec5a">numpy-2.3.0-pp311-pypy311_pp73-win_amd64.whl</a>
      <br />
<a href="https://files.pythonhosted.org/packages/f3/db/8e12381333aea300890829a0a36bfa738cac95475d88982d538725143fd9/numpy-2.3.0.tar.gz#sha256=581f87f9e9e9db2cba2141400e160e9dd644ee248788d6f90636eeb8fd9260a6"
data-requires-python="&gt;=3.11">numpy-2.3.0.tar.gz</a>
      <br />
```

For now, I've restored the previous concise one-distribution-a-line formatting from before #18266, but we can also allow djlint and insert the whitespaces by hand.