### PR TITLE
lint: fix typos and include lint checking

### DIFF
--- a/bin/lint
+++ b/bin/lint
@@ -20,3 +20,4 @@ python -m mypy -p warehouse
 # lint our pyproject.toml file (as well as any other toml files)
 tombi lint --error-on-warnings
 tombi format --check --diff
+codespell

--- a/docs/blog/posts/2023-09-18-inbound-malware-reporting.md
+++ b/docs/blog/posts/2023-09-18-inbound-malware-reporting.md
@@ -134,7 +134,7 @@ Again, since the nature of email isn't 100% accurate in this case,
 we'll rely on calculating the duration of time (in minutes)
 between the first message of a thread and the last message of a thread.
 This doesn't account for the occasional behavior of a reporter
-re-using the same thread to report more packages,
+reusing the same thread to report more packages,
 nor does it reflect any other back-and-forth communication
 between admins and reporters.
 As such, removing any threads that have more than 4 total messages

--- a/docs/blog/posts/2024-08-16-safety-and-security-engineer-year-in-review.md
+++ b/docs/blog/posts/2024-08-16-safety-and-security-engineer-year-in-review.md
@@ -243,7 +243,7 @@ with the added benefit of making it easier for others to contribute.
 As well as "routine" work - handling inbound reports, analysis, and response.
 
 I also attended some conferences, round tables, and meetings, including
-Fastly Altitude 2023, AWS re:Invent 2023, PyCon US 2024, and AWS re:Inforce 2024,
+Fastly Altitude 2023, AWS re:Invent 2023, PyCon US 2024, and AWS re:Inforce 2024, <!-- codespell:ignore -->
 amongst some.
 I've also been getting more involved with the
 [OpenSSF](https://openssf.org/)

--- a/docs/blog/posts/2024-11-14-pypi-now-supports-digital-attestations.md
+++ b/docs/blog/posts/2024-11-14-pypi-now-supports-digital-attestations.md
@@ -96,7 +96,7 @@ tools was performed by [Trail of Bits], with special thanks to contributors
 Thanks to the the [Sigstore project] for their work popularizing identity-based signing, hosting a public-good transparency log, and continued support of the [Python client for Sigstore].
 
 Many thanks to [Sviatoslav Sydorenko] as well for his support and ongoing
-maintenence of the [pypa/gh-action-pypi-publish] action, as well his support
+maintenance of the [pypa/gh-action-pypi-publish] action, as well his support
 for implementing PEP 740 in the action.
 
 ---

--- a/docs/blog/posts/2024-12-11-ultralytics-attack-analysis.md
+++ b/docs/blog/posts/2024-12-11-ultralytics-attack-analysis.md
@@ -55,7 +55,7 @@ If you are publishing software to PyPI then you can harden your build and publis
 In addition to the specific recommendations above, we strongly recommend general account security best practices such as:
 
 * **Use 2FA / MFA, preferably using a hardware key or authenticator app for all accounts associated with open source contributions.** This includes your email address and accounts for source forge(s) like GitHub or GitLab. Avoid SMS and text-message-based 2FA schemes if possible, as they are susceptible to SIM-swapping. PyPI already requires the use of 2FA to publish packages.
-* **Don’t reuse passwords, use a password manager.** Re-using passwords for services means that a compromise to one service will compromise your account(s) elsewhere.
+* **Don’t reuse passwords, use a password manager.** Reusing passwords for services means that a compromise to one service will compromise your account(s) elsewhere.
 
 Prevention is important, but just as important is preparedness. Here’s what to do if your own project is compromised:
 

--- a/docs/blog/posts/2025-08-14-project-status-markers.md
+++ b/docs/blog/posts/2025-08-14-project-status-markers.md
@@ -121,7 +121,7 @@ which have both index-side and installer-side semantics:
   will not offer it for installation, and installers are encouraged to
   produce a warning when users attempt to install it[^warning].
 * **deprecated**: Indicates that the project is considered obsolete,
-  and may have been superceded by another project. Unlike archived projects,
+  and may have been superseded by another project. Unlike archived projects,
   deprecated projects can still be uploaded to, but installers are encouraged
   to inform users about the project's deprecation.
 

--- a/docs/dev/development/token-scanning.md
+++ b/docs/dev/development/token-scanning.md
@@ -11,7 +11,7 @@ User-facing documentation about this feature is available here:
 ## How to test it manually
 
 A fake token reporting service is launched by Docker Compose. Head your browser to
-`http://localhost:8964`. Create/reorder/... one ore more public keys, make
+<http://localhost:8964>. Create/reorder/... one or more public keys, make
 sure one key is marked as current, then write your payload, using the following
 format:
 

--- a/docs/user/api/index.md
+++ b/docs/user/api/index.md
@@ -97,7 +97,7 @@ def wheel_url(name, version, build_tag, python_tag, abi_tag, platform_tag):
     return f'{host}/packages/{python_tag}/{name[0]}/{name}/{filename}'
 ```
 
-Example predicable URL use:
+Example predictable URL use:
 
 ```bash
 $ curl -I https://files.pythonhosted.org/packages/source/v/virtualenv/virtualenv-15.2.0.tar.gz

--- a/docs/user/project-management/name-retention.md
+++ b/docs/user/project-management/name-retention.md
@@ -143,7 +143,7 @@ considered invalid and will be removed from the Index:
 - project uses obfuscation to hide or mask functionality; or
 - project is abusing the Package Index for purposes it was not intended.
 
-The Package Index maintainers pre-emptively declare certain package names as
+The Package Index maintainers preemptively declare certain package names as
 unavailable for security reasons.
 
 ### Intellectual property policy

--- a/docs/user/trusted-publishers/troubleshooting.md
+++ b/docs/user/trusted-publishers/troubleshooting.md
@@ -60,7 +60,7 @@ endpoint:
   as configured when the publisher was configured on PyPI.
 * `invalid-publisher` for a previously-working project: this usually indicates
   a typo or that something has changed on either side. One example we've seen
-  is when a source repository is renamed, and the configration on PyPI
+  is when a source repository is renamed, and the configuration on PyPI
   continues to use the old repository name. For GitHub, check that the
   `repository_owner`, `repository` and workflow filename values are the same on
   both sides.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,21 @@
+[tool.codespell]
+ignore-multiline-regex = "codespell:ignore-begin.*codespell:ignore-end"
+ignore-words-list = "deriver"
+skip = [
+  "*.po",
+  "./coverage/*",
+  "./dev/*",
+  "./docs/dev/_build/*",
+  "./docs/blog-site/*",
+  "./docs/dev-site/*",
+  "./docs/user-site/*",
+  "./htmlcov/*",
+  "./node_modules/**",
+  "./package-lock.json",
+  "./warehouse/admin/static/dist/*",
+  "./warehouse/static/dist/*",
+]
+
 [tool.coverage.run]
 branch = true
 dynamic_context = "test_function"

--- a/requirements/lint.in
+++ b/requirements/lint.in
@@ -1,5 +1,6 @@
 ruff
 ast-grep-cli
+codespell
 djlint
 flake8
 mypy

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -116,6 +116,10 @@ click==8.3.2 \
     --hash=sha256:14162b8b3b3550a7d479eafa77dfd3c38d9dc8951f6f69c78913a8f9a7540fd5 \
     --hash=sha256:1924d2c27c5653561cd2cae4548d1406039cb79b858b747cfea24924bbc1616d
     # via djlint
+codespell==2.4.1 \
+    --hash=sha256:299fcdcb09d23e81e35a671bbe746d5ad7e8385972e65dbb833a2eaac33c01e5 \
+    --hash=sha256:3dadafa67df7e4a3dbf51e0d7315061b80d265f9552ebd699b3dd6834b47e425
+    # via -r requirements/lint.in
 colorama==0.4.6 \
     --hash=sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44 \
     --hash=sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -722,7 +722,7 @@ class _TestApp(_webtest.TestApp):
 
 @pytest.fixture
 def tm():
-    # Create a new transaction manager for dependant test cases
+    # Create a new transaction manager for dependent test cases
     tm = transaction.TransactionManager(explicit=True)
     tm.begin()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -828,11 +828,13 @@ class _MockRedis:
     def set(self, key, value=None, *_args, **_kwargs):
         if _kwargs.get("nx", False) and key in self.cache:
             return None
+        # codespell:ignore-begin 'exat'
         # Real Redis immediately evicts a key when exat is in the past.
         exat = _kwargs.get("exat")
         if exat is not None and exat <= time.time():
             self.cache.pop(key, None)
             return True
+        # codespell:ignore-end
         self.cache[key] = value
         return True
 

--- a/tests/frontend/delete_confirm_controller_test.js
+++ b/tests/frontend/delete_confirm_controller_test.js
@@ -31,7 +31,7 @@ describe("DeleteConfirm controller", () => {
 
   describe("functionality", function() {
     describe("checking one box", function() {
-      it("doesnt enable the button", function() {
+      it("doesn't enable the button", function() {
         const inputOne = document.getElementById("input-one");
         expect(inputOne).not.toBeChecked();
         fireEvent.click(inputOne);

--- a/tests/frontend/horizontal_tabs_controller_test.js
+++ b/tests/frontend/horizontal_tabs_controller_test.js
@@ -37,7 +37,7 @@ describe("Horizontal tabs controller", () => {
     application.register("horizontal-tabs", HorizontalTabsController);
   });
 
-  describe("on initializtion", () => {
+  describe("on initialization", () => {
     it("the first tab is shown", () => {
       const tabs = document.querySelectorAll(".tab");
       const content = document.querySelectorAll(".horizontal-tabs__tabcontent");
@@ -76,7 +76,7 @@ describe("Horizontal tabs controller", () => {
     });
   });
 
-  describe("on initializtion with errors", () => {
+  describe("on initialization with errors", () => {
     beforeEach(() => {
       // Add some errors to the second tab
       const secondTabPanel = document.querySelectorAll(".horizontal-tabs__tabcontent")[1];

--- a/tests/frontend/password_breach_controller_test.js
+++ b/tests/frontend/password_breach_controller_test.js
@@ -72,7 +72,7 @@ describe("Password breach controller", () => {
     describe("entering a password with less than 3 characters", () => {
       it("does not call the HIBP API", async () => {
         const passwordField = document.querySelector("#password");
-        fireEvent.input(passwordField, { target: { value: "fo" } });
+        fireEvent.input(passwordField, { target: { value: "of" } });
 
         await delay(25);  // arbitrary number of ms, too low may cause failures
         expect(fetch.mock.calls.length).toEqual(0);

--- a/tests/frontend/viewport_toggle_controller_test.js
+++ b/tests/frontend/viewport_toggle_controller_test.js
@@ -22,7 +22,7 @@ const viewportContent = `
 
 
 function startStimulus() {
-  // set the HTML before satarting the application, as the controller uses the
+  // set the HTML before starting the application, as the controller uses the
   // `connect()` function.
   document.body.innerHTML = viewportContent;
   const application = Application.start();

--- a/tests/unit/admin/views/test_observations.py
+++ b/tests/unit/admin/views/test_observations.py
@@ -862,7 +862,7 @@ class TestGetAutoQuarantineStats:
         assert result["quarantine_rate"] == 50.0
 
     def test_invalid_related_name_format(self, db_request):
-        """Test with observations that have unparseable related_name format.
+        """Test with observations that have unparsable related_name format.
 
         When related_name doesn't match the expected Project(name='...') format,
         the observation is skipped for quarantine stats.
@@ -1311,7 +1311,7 @@ class TestGetTimelineData:
     """Tests for _get_timeline_data function."""
 
     def test_invalid_related_names_skip_journal_lookup(self, db_request):
-        """Test that observations with unparseable related_name skip journal lookup.
+        """Test that observations with unparsable related_name skip journal lookup.
 
         When no valid project names can be parsed from related_name,
         the function returns early without querying journal entries.

--- a/tests/unit/admin/views/test_users.py
+++ b/tests/unit/admin/views/test_users.py
@@ -112,7 +112,7 @@ class TestEmailForm:
 class TestUserForm:
     def test_validate(self):
         form = views.UserForm()
-        assert form.validate(), str(form.erros)
+        assert form.validate(), str(form.errors)
 
 
 class TestUserDetail:

--- a/tests/unit/api/test_simple.py
+++ b/tests/unit/api/test_simple.py
@@ -232,7 +232,7 @@ class TestSimpleDetail:
         db_request.matchdict["name"] = project.normalized_name
         user = UserFactory.create()
         je = JournalEntryFactory.create(name=project.name, submitted_by=user)
-        als = [
+        alts = [
             AlternateRepositoryFactory.create(project=project),
             AlternateRepositoryFactory.create(project=project),
         ]
@@ -243,7 +243,7 @@ class TestSimpleDetail:
             "project-status": {"status": "active"},
             "files": [],
             "versions": [],
-            "alternate-locations": sorted(al.url for al in als),
+            "alternate-locations": sorted(al.url for al in alts),
         }
         context = _update_context(context, content_type, renderer_override)
         assert simple.simple_detail(project, db_request) == context

--- a/tests/unit/email/test_services.py
+++ b/tests/unit/email/test_services.py
@@ -129,7 +129,7 @@ class TestSMTPEmailSender:
         service = sender_class(mailer, sender="DevPyPI <noreply@example.com>")
 
         service.send(
-            "sombody@example.com",
+            "somebody@example.com",
             EmailMessage(
                 subject="a subject", body_text="a body", body_html="a html body"
             ),
@@ -142,7 +142,7 @@ class TestSMTPEmailSender:
         assert msg.subject == "a subject"
         assert msg.body == "a body"
         assert msg.html == "a html body"
-        assert msg.recipients == ["sombody@example.com"]
+        assert msg.recipients == ["somebody@example.com"]
         assert msg.sender == "DevPyPI <noreply@example.com>"
 
     def test_last_sent(self, sender_class):
@@ -160,7 +160,7 @@ class TestConsoleAndSMTPEmailSender:
         )
 
         service.send(
-            "sombody@example.com",
+            "somebody@example.com",
             EmailMessage(
                 subject="a subject",
                 body_text="a body",
@@ -172,7 +172,7 @@ class TestConsoleAndSMTPEmailSender:
 Email sent
 Subject: a subject
 From: DevPyPI <noreply@example.com>
-To: sombody@example.com
+To: somebody@example.com
 HTML: Visualize at http://localhost:1080
 Text: a body"""
         assert captured.out.strip() == expected.strip()

--- a/tests/unit/events/test_models.py
+++ b/tests/unit/events/test_models.py
@@ -76,7 +76,7 @@ class TestUserAgentInfo:
             ),
             (
                 (
-                    "Mozilla/5.0 (X11; CrOS x86_64 8172.45.0) AppleWebKit/537.36 "
+                    "Mozilla/5.0 (X11; CrOS x86_64 8172.45.0) AppleWebKit/537.36 "  # codespell:ignore # noqa: E501
                     "(KHTML, like Gecko) Chrome/51.0.2704.64 Safari/537.36"
                 ),
                 {

--- a/tests/unit/forklift/test_metadata.py
+++ b/tests/unit/forklift/test_metadata.py
@@ -178,7 +178,7 @@ class TestValidation:
     def test_deprecated_classifiers_with_replacement(self, backfill):
         data = (
             b"Metadata-Version: 2.1\nName: spam\nVersion: 2.0\n"
-            b"Classifier: Natural Language :: Ukranian\n"
+            b"Classifier: Natural Language :: Ukranian\n"  # codespell:ignore
         )
 
         if not backfill:
@@ -187,7 +187,9 @@ class TestValidation:
             _assert_invalid_metadata(excinfo.value, "classifier")
         else:
             meta = metadata.parse(data, backfill=True)
-            assert meta.classifiers == ["Natural Language :: Ukranian"]
+            assert meta.classifiers == [
+                "Natural Language :: Ukranian"  # codespell:ignore
+            ]
 
     @pytest.mark.parametrize("backfill", [True, False])
     def test_deprecated_classifiers_no_replacement(self, backfill):

--- a/tests/unit/integration/secrets/test_utils.py
+++ b/tests/unit/integration/secrets/test_utils.py
@@ -64,11 +64,11 @@ def test_invalid_token_leak_request():
         (
             {"type": "not_found", "token": "a", "url": "b"},
             "Matcher with code not_found not found. "
-            "Available codes are: failer, pypi_api_token",
+            "Available codes are: failure, pypi_api_token",
             "invalid_matcher",
         ),
         (
-            {"type": "failer", "token": "a", "url": "b"},
+            {"type": "failure", "token": "a", "url": "b"},
             "Cannot extract token from received match",
             "extraction",
         ),
@@ -76,14 +76,15 @@ def test_invalid_token_leak_request():
 )
 def test_token_leak_disclosure_request_from_api_record_error(record, error, reason):
     class MyFailingMatcher(utils.TokenLeakMatcher):
-        name = "failer"
+        name = "failure"
 
         def extract(self, text):
             raise utils.ExtractionFailedError
 
     with pytest.raises(utils.InvalidTokenLeakRequestError) as exc:
         utils.TokenLeakDisclosureRequest.from_api_record(
-            record, matchers={"failer": MyFailingMatcher(), **utils.TOKEN_LEAK_MATCHERS}
+            record,
+            matchers={"failure": MyFailingMatcher(), **utils.TOKEN_LEAK_MATCHERS},
         )
 
     assert str(exc.value) == error

--- a/tests/unit/integration/vulnerabilities/osv/test_views.py
+++ b/tests/unit/integration/vulnerabilities/osv/test_views.py
@@ -145,7 +145,8 @@ class TestReportVulnerabilities:
         assert response.status_int == 400
         assert metrics.increment.calls == [
             pretend.call(
-                "warehouse.vulnerabilties.error.payload.json_error", tags=["origin:osv"]
+                "warehouse.vulnerabilities.error.payload.json_error",
+                tags=["origin:osv"],
             )
         ]
 

--- a/tests/unit/macaroons/test_services.py
+++ b/tests/unit/macaroons/test_services.py
@@ -110,13 +110,13 @@ class TestDatabaseMacaroonService:
         [
             "pypi-aaaa",  # Invalid macaroon
             # Macaroon properly formatted but not found.
-            # The string is purposedly cut to avoid triggering the github token
+            # The string is purposely cut to avoid triggering the github token
             # disclosure feature that this very function implements.
             "py"
             "pi-AgEIcHlwaS5vcmcCJGQ0ZDhhNzA2LTUxYTEtNDg0NC1hNDlmLTEyZDRiYzNkYjZmOQAABi"
             "D6hJOpYl9jFI4jBPvA8gvV1mSu1Ic3xMHmxA4CSA2w_g",
-            # Macaroon that is malformed and has an invaild (non utf-8) identifier
-            # The string is purposedly cut to avoid triggering the github token
+            # Macaroon that is malformed and has an invalid (non utf-8) identifier
+            # The string is purposely cut to avoid triggering the github token
             # disclosure feature that this very function implements.
             "py"
             "pi-MDAwZWxvY2F0aW9uIAowMDM0aWRlbnRpZmllciBhmTAyMWY0YS0xYWQzLTQ3OGEtYjljZi1"
@@ -145,8 +145,8 @@ class TestDatabaseMacaroonService:
         "raw_macaroon",
         [
             "pypi-thiswillnotdeserialize",
-            # Macaroon that is malformed and has an invaild (non utf-8) identifier
-            # The string is purposedly cut to avoid triggering the github token
+            # Macaroon that is malformed and has an invalid (non utf-8) identifier
+            # The string is purposely cut to avoid triggering the github token
             # disclosure feature that this very function implements.
             "py"
             "pi-MDAwZWxvY2F0aW9uIAowMDM0aWRlbnRpZmllciBhmTAyMWY0YS0xYWQzLTQ3OGEtYjljZi1"

--- a/tests/unit/manage/test_views.py
+++ b/tests/unit/manage/test_views.py
@@ -121,7 +121,7 @@ class TestManageUnverifiedAccount:
     @pytest.mark.parametrize(
         ("has_old_primary", "expected_old_address"),
         [
-            (True, "typo@exmaple.com"),
+            (True, "typo@exmaple.com"),  # codespell:ignore exmaple
             (False, None),
         ],
     )
@@ -129,7 +129,12 @@ class TestManageUnverifiedAccount:
         self, monkeypatch, has_old_primary, expected_old_address
     ):
         old_email = (
-            pretend.stub(id=1, email="typo@exmaple.com", verified=False, primary=True)
+            pretend.stub(
+                id=1,
+                email="typo@exmaple.com",  # codespell:ignore exmaple
+                verified=False,
+                primary=True,
+            )
             if has_old_primary
             else None
         )

--- a/tests/unit/oidc/forms/test_activestate.py
+++ b/tests/unit/oidc/forms/test_activestate.py
@@ -128,7 +128,7 @@ class TestActiveStatePublisherForm:
         )
         requests = pretend.stub(
             post=pretend.call_recorder(lambda o, **kw: response),
-            expception=_requests.exceptions,
+            exception=_requests.exceptions,
             Timeout=Timeout,
             HTTPError=HTTPError,
             ConnectionError=ConnectionError,
@@ -160,7 +160,7 @@ class TestActiveStatePublisherForm:
         )
         requests = pretend.stub(
             post=pretend.call_recorder(lambda o, **kw: response),
-            expception=_requests.exceptions,
+            exception=_requests.exceptions,
             Timeout=Timeout,
             HTTPError=HTTPError,
             ConnectionError=ConnectionError,

--- a/tests/unit/oidc/forms/test_activestate.py
+++ b/tests/unit/oidc/forms/test_activestate.py
@@ -128,7 +128,6 @@ class TestActiveStatePublisherForm:
         )
         requests = pretend.stub(
             post=pretend.call_recorder(lambda o, **kw: response),
-            exception=_requests.exceptions,
             Timeout=Timeout,
             HTTPError=HTTPError,
             ConnectionError=ConnectionError,
@@ -160,7 +159,6 @@ class TestActiveStatePublisherForm:
         )
         requests = pretend.stub(
             post=pretend.call_recorder(lambda o, **kw: response),
-            exception=_requests.exceptions,
             Timeout=Timeout,
             HTTPError=HTTPError,
             ConnectionError=ConnectionError,

--- a/tests/unit/oidc/test_services.py
+++ b/tests/unit/oidc/test_services.py
@@ -931,8 +931,8 @@ class TestOIDCPublisherService:
         """
         A token whose ``exp`` just passed (but is still within leeway) must
         have its JTI key persist in Redis. If the TTL doesn't account for
-        the leeway, the key would be set with a past ``exat`` and Redis
-        would immediately evict it, allowing replay.
+        the leeway, the key would be set with a past ``exat``  # codespell:ignore exat
+        and Redis would immediately evict it, allowing replay.
         """
         service = services.OIDCPublisherService(
             session=pretend.stub(),

--- a/tests/unit/oidc/test_views.py
+++ b/tests/unit/oidc/test_views.py
@@ -1099,7 +1099,7 @@ def test_is_from_reusable_workflow(
         # configured when claims contain an environment
         (GitHubPublisherFactory, "", "new_env", True),
         (GitLabPublisherFactory, "", "new_env", True),
-        # Should not send if claims don't have an environent
+        # Should not send if claims don't have an environment
         (GitHubPublisherFactory, "", "", False),
         (GitLabPublisherFactory, "", "", False),
         # Should not send if publishers already have an environment

--- a/tests/unit/utils/test_http.py
+++ b/tests/unit/utils/test_http.py
@@ -15,7 +15,7 @@ class TestIsSafeUrl:
             "http://example.com",
             "http:///example.com",
             "https://example.com",
-            "ftp://exampel.com",
+            "ftp://example.com",
             r"\\example.com",
             r"\\\example.com",
             r"/\\/example.com",
@@ -41,7 +41,7 @@ class TestIsSafeUrl:
         [
             "/view/?param=http://example.com",
             "/view/?param=https://example.com",
-            "/view?param=ftp://exampel.com",
+            "/view?param=ftp://example.com",
             "https://testserver/",
             "HTTPS://testserver/",
             "//testserver/",

--- a/warehouse/admin/templates/admin/organization_applications/detail.html
+++ b/warehouse/admin/templates/admin/organization_applications/detail.html
@@ -396,7 +396,7 @@
               </label>
               <div class="col-12">
                 <table class="table">
-                  <tr><th>Application</th><th>Status</th><th>Submitted</th><th>Requestor</th></tr>
+                  <tr><th>Application</th><th>Status</th><th>Submitted</th><th>Requester</th></tr>
                   {% for application in conflicting_applications %}
                     <tr>
                       <td>

--- a/warehouse/admin/views/users.py
+++ b/warehouse/admin/views/users.py
@@ -607,7 +607,7 @@ def user_recover_account_initiate(user, request):
             )
 
             request.session.flash(
-                f"Initiatied account recovery for {user.username!r}", queue="success"
+                f"Initiated account recovery for {user.username!r}", queue="success"
             )
 
             return HTTPSeeOther(

--- a/warehouse/email/services.py
+++ b/warehouse/email/services.py
@@ -79,7 +79,7 @@ class SMTPEmailSender:
         )
 
     def last_sent(self, to, subject):
-        # We don't store previously sent emails, so nothing to comapre against
+        # We don't store previously sent emails, so nothing to compare against
         return None
 
 

--- a/warehouse/events/models.py
+++ b/warehouse/events/models.py
@@ -77,7 +77,7 @@ class UserAgentInfo:
 
     def display(self) -> str:
         """
-        Construct a resonable user-agent description,
+        Construct a reasonable user-agent description,
         depending on optional values
         """
 

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -1221,7 +1221,7 @@ def file_upload(request):
                     f"Invalid source distribution filename: {filename}",
                 )
 
-            # The previous function fails to accomodate the edge case where
+            # The previous function fails to accommodate the edge case where
             # versions may contain hyphens, so we handle that here based on
             # what we were expecting. This requires there to be at least two
             # hyphens in the filename: one between the project name & version
@@ -1394,7 +1394,7 @@ def file_upload(request):
             filename = os.path.basename(temporary_filename)
             # Get the name and version from the original filename. Eventually this
             # should use packaging.utils.parse_wheel_filename(filename), but until then
-            # we can't use this as it adds additional normailzation to the project name
+            # we can't use this as it adds additional normalization to the project name
             # and version.
             name, version, _ = filename.split("-", 2)
 

--- a/warehouse/forklift/metadata.py
+++ b/warehouse/forklift/metadata.py
@@ -86,7 +86,7 @@ def parse(
     else:
         raise NoMetadataError
 
-    # Validate the metadata using our custom rules, which we layer ontop of the
+    # Validate the metadata using our custom rules, which we layer on top of the
     # built in rules to add PyPI specific constraints above and beyond what the
     # core metadata requirements are.
     _validate_metadata(metadata, backfill=backfill)
@@ -95,7 +95,7 @@ def parse(
 
 
 def _validate_metadata(metadata: Metadata, *, backfill: bool = False):
-    # Add our own custom validations ontop of the standard validations from
+    # Add our own custom validations on top of the standard validations from
     # packaging.metadata.
     errors: list[InvalidMetadata] = []
 
@@ -372,7 +372,7 @@ def parse_form_metadata(data: MultiDict) -> Metadata:
             except KeyError:
                 unparsed[name] = value
         # Nothing that we've done has managed to parse this, so it'll just
-        # throw it in our unparseable data and move on.
+        # throw it in our unparsable data and move on.
         else:
             unparsed[name] = value
 

--- a/warehouse/integrations/vulnerabilities/osv/views.py
+++ b/warehouse/integrations/vulnerabilities/osv/views.py
@@ -43,7 +43,7 @@ def report_vulnerabilities(request):
         vulnerability_reports = request.json_body
     except json.decoder.JSONDecodeError:
         metrics.increment(
-            "warehouse.vulnerabilties.error.payload.json_error", tags=["origin:osv"]
+            "warehouse.vulnerabilities.error.payload.json_error", tags=["origin:osv"]
         )
         return HTTPBadRequest(body="Invalid JSON")
 

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -9268,7 +9268,7 @@ msgstr ""
 #: warehouse/templates/pages/help.html:1079
 msgid ""
 "Deletion of a project, release or file on PyPI is permanent and "
-"irreversable, without exception. Deletion of a project makes it "
+"irreversible, without exception. Deletion of a project makes it "
 "uninstallable, and releases the project name for use by any other PyPI "
 "user. Deleted files <a href=\"#file-name-reuse\">cannot be re-"
 "uploaded</a>. Deleted projects, releases or files cannot be restored by "

--- a/warehouse/macaroons/caveats/_core.py
+++ b/warehouse/macaroons/caveats/_core.py
@@ -90,7 +90,7 @@ class _CaveatRegistry:
     def add(self, tag: int, cls: type[Caveat]):
         if tag in self._tags:
             raise TypeError(
-                f"Cannot re-use tag: {tag}, already used by {self._tags[tag]}"
+                f"Cannot reuse tag: {tag}, already used by {self._tags[tag]}"
             )
 
         self._tags[tag] = cls

--- a/warehouse/migrations/versions/1ce6d45d7ef_readd_the_unique_constraint_on_pep426_.py
+++ b/warehouse/migrations/versions/1ce6d45d7ef_readd_the_unique_constraint_on_pep426_.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 """
-readd the unique constraint on pep426 normalization
+re-add the unique constraint on pep426 normalization
 
 Revision ID: 1ce6d45d7ef
 Revises: 23a3c4ffe5d

--- a/warehouse/migrations/versions/42e76a605cac_remove_the_rego_otk_table_abd_related_.py
+++ b/warehouse/migrations/versions/42e76a605cac_remove_the_rego_otk_table_abd_related_.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 """
-Remove the rego_otk table abd related index
+Remove the rego_otk table and related index
 
 Revision ID: 42e76a605cac
 Revises: 895279cc4490

--- a/warehouse/oidc/models/_core.py
+++ b/warehouse/oidc/models/_core.py
@@ -141,7 +141,7 @@ class OIDCPublisherMixin:
     # A set of claim names which must be present, but can't be verified
     __required_unverifiable_claims__: set[str] = set()
 
-    # Simlar to __verificable_claims__, but these claims are optional
+    # Similar to __required_verifiable_claims__, but these claims are optional
     __optional_verifiable_claims__: dict[str, CheckClaimCallable[Any]] = {}
 
     # Claims that have already been verified during the JWT signature

--- a/warehouse/oidc/services.py
+++ b/warehouse/oidc/services.py
@@ -205,7 +205,7 @@ class OIDCPublisherService:
             # ``exp``, so we add an extra 5-second margin on top.
             result = r.set(
                 f"/warehouse/oidc/{self.issuer_url}/{jti}",
-                exat=expiration + _JWT_LEEWAY + 5,
+                exat=expiration + _JWT_LEEWAY + 5,  # codespell:ignore exat
                 value="",  # empty value to lower memory usage
                 nx=True,
             )

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -1112,7 +1112,7 @@ class JournalEntry(db.ModelBase):
 @db.listens_for(db.Session, "before_flush")
 def ensure_monotonic_journals(config, session, flush_context, instances):
     # We rely on `journals.id` to be a monotonically increasing integer,
-    # however the way that SERIAL is implemented, it does not guarentee
+    # however the way that SERIAL is implemented, it does not guarantee
     # that is the case.
     #
     # Ultimately SERIAL fetches the next integer regardless of what happens

--- a/warehouse/predicates.py
+++ b/warehouse/predicates.py
@@ -30,9 +30,7 @@ class DomainPredicate:
 class HeadersPredicate:
     def __init__(self, val: list[str], config):
         if not val:
-            raise ConfigurationError(
-                "Excpected at least one value in headers predicate"
-            )
+            raise ConfigurationError("Expected at least one value in headers predicate")
 
         self.sub_predicates = [
             predicates.HeaderPredicate(subval, config) for subval in val

--- a/warehouse/rate_limiting/__init__.py
+++ b/warehouse/rate_limiting/__init__.py
@@ -88,7 +88,7 @@ class RateLimiter:
             reset = datetime.fromtimestamp(resets_at, tz=UTC)
 
             # If our current datetime is either greater than or equal to when
-            # the limit resets, then we will skipp it since it has either
+            # the limit resets, then we will skip it since it has either
             # already reset, or it is resetting now.
             if current >= reset:
                 continue

--- a/warehouse/routes.py
+++ b/warehouse/routes.py
@@ -611,7 +611,7 @@ def includeme(config):
         domain=warehouse,
     )
     config.add_route(
-        "integrations.github.disclose-token",  # For backwards compatiblity
+        "integrations.github.disclose-token",  # For backwards compatibility
         "/_/github/disclose-token",
         domain=warehouse,
     )

--- a/warehouse/static/js/warehouse/controllers/collapsible_controller.js
+++ b/warehouse/static/js/warehouse/controllers/collapsible_controller.js
@@ -4,7 +4,7 @@ import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
   /**
-   * Get element's collasped status from the cookie.
+   * Get element's collapsed status from the cookie.
    * @private
    */
   _getCollapsedCookie() {

--- a/warehouse/static/sass/blocks/_centered-heading.scss
+++ b/warehouse/static/sass/blocks/_centered-heading.scss
@@ -6,7 +6,7 @@
 @use "../tools/typography";
 
 /*
-  A heading aligned in the center, with a sub title and horziontal rule:
+  A heading aligned in the center, with a sub title and horizontal rule:
 
   <div class="centered-heading">
     <h1 class="centered-heading__title">Title</h1>

--- a/warehouse/static/sass/blocks/_dropdown.scss
+++ b/warehouse/static/sass/blocks/_dropdown.scss
@@ -23,7 +23,7 @@
     </ul>
   </nav>
 
-  Accessbility:
+  Accessibility:
     - .dropdown - aria-label: label the entire dropdown. E.g. "Main navigation"
     - .dropdown__trigger - aria-label: label the button. E.g. "Show menu"
     - .dropdown__trigger - aria-haspopup: indicates that the button has a popup element attached

--- a/warehouse/static/sass/blocks/_project-description.scss
+++ b/warehouse/static/sass/blocks/_project-description.scss
@@ -390,7 +390,8 @@ $pygments-black:         #000;
     color: $darkest-blue;
   }
 
-  .nd { /* Name.Decorator */
+  // stylelint-disable-next-line comment-empty-line-before -- codespell syntax
+  .nd { /* Name.Decorator */ /* codespell:ignore nd */
     color: $mid-grey;
   }
 

--- a/warehouse/templates/email/token-compromised-leak/body.html
+++ b/warehouse/templates/email/token-compromised-leak/body.html
@@ -37,7 +37,7 @@
   <p>
     This is an automated message. Our partner {{ origin.name }} analyzes all the data it
     receives for unintentional {{ site_name }} token publications and warns us every time
-    it finds one. We check every disclosure we recieve and take action when the token
+    it finds one. We check every disclosure we receive and take action when the token
     appears
     valid.
   </p>

--- a/warehouse/templates/email/token-compromised-leak/body.txt
+++ b/warehouse/templates/email/token-compromised-leak/body.txt
@@ -37,7 +37,7 @@ How do you know this?
 
 This is an automated message. Our partner {{ origin.name }} analyzes all the data it receives
 for unintentional {{ site_name }} token publications and warns us every time it finds
-one. We check every disclosure we recieve and take action when the token appears valid.
+one. We check every disclosure we receive and take action when the token appears valid.
 
 For more information, see our FAQ at {{ request.help_url(_anchor='compromised-token') }}
 

--- a/warehouse/templates/manage/manage_base.html
+++ b/warehouse/templates/manage/manage_base.html
@@ -219,7 +219,7 @@
     {% block breadcrumbs %}
       <nav aria-label="{% trans %}Breadcrumbs{% endtrans %}" class="breadcrumbs">
         <ul>
-          {# Last breadcrumb can be overriden #}
+          {# Last breadcrumb can be overridden #}
           {% block breadcrumb %}
             <li class="breadcrumbs__breadcrumb">{% trans %}Your account{% endtrans %}</li>
           {% endblock %}

--- a/warehouse/templates/manage/organization/manage_organization_base.html
+++ b/warehouse/templates/manage/organization/manage_organization_base.html
@@ -17,7 +17,7 @@
           <li class="breadcrumbs__breadcrumb">
             <a href="{{ request.route_path('manage.organizations') }}">{% trans %}Your account{% endtrans %}</a>
           </li>
-          {# Last breadcrumb can be overriden #}
+          {# Last breadcrumb can be overridden #}
           {% block breadcrumb %}
             <li class="breadcrumbs__breadcrumb">
               <i class="fa fa-sm fa-sitemap" aria-hidden="true"></i>

--- a/warehouse/templates/manage/project/manage_project_base.html
+++ b/warehouse/templates/manage/project/manage_project_base.html
@@ -24,7 +24,7 @@
               </a>
             </li>
           {% endif %}
-          {# Last breadcrumb can be overriden #}
+          {# Last breadcrumb can be overridden #}
           {% block breadcrumb %}
             <li class="breadcrumbs__breadcrumb">
               <i class="fa fa-cubes" aria-hidden="true"></i>

--- a/warehouse/templates/manage/team/manage_team_base.html
+++ b/warehouse/templates/manage/team/manage_team_base.html
@@ -22,7 +22,7 @@
               {{ team.organization.name }}
             </a>
           </li>
-          {# Last breadcrumb can be overriden #}
+          {# Last breadcrumb can be overridden #}
           {% block breadcrumb %}
             <li class="breadcrumbs__breadcrumb">
               <i class="fa fa-users" aria-hidden="true"></i>

--- a/warehouse/templates/pages/help.html
+++ b/warehouse/templates/pages/help.html
@@ -1077,7 +1077,7 @@ print(f"BLAKE2b-256: {blake2b_hash}\nSHA256: {sha256_hash}")</pre>
 <h3 id="deletion">{{ deletion() }}</h3>
 <p>
   {% trans %}
-  Deletion of a project, release or file on PyPI is permanent and irreversable, without exception.
+  Deletion of a project, release or file on PyPI is permanent and irreversible, without exception.
   Deletion of a project makes it uninstallable, and releases the project name for use by any other PyPI user.
   Deleted files <a href="#file-name-reuse">cannot be re-uploaded</a>.
   Deleted projects, releases or files cannot be restored by PyPI administrators.


### PR DESCRIPTION
Supports both `reformat` and `lint`.

Ref: https://pypi.org/project/codespell/

Closes #11568
Closes #11884 