### PR TITLE
Link to the stable version of the SPDX spec

### DIFF
--- a/warehouse/templates/includes/packaging/project-data.html
+++ b/warehouse/templates/includes/packaging/project-data.html
@@ -218,7 +218,7 @@
                 <i>
                   <a target="_blank" href="https://spdx.org/licenses/">SPDX</a>
                   <a target="_blank"
-                     href="https://spdx.github.io/spdx-spec/v2-draft/SPDX-license-expressions/">{% trans %}License Expression{% endtrans %}</a>
+                     href="https://spdx.github.io/spdx-spec/v3.0.1/annexes/spdx-license-expressions/">{% trans %}License Expression{% endtrans %}</a>
                 </i>
               </small>
             </span>


### PR DESCRIPTION
Currently, the link goes to a draft. Point it to the latest stable release instead.