### PR TITLE
feat: add issuer_url to oidc service metrics

### DIFF
--- a/tests/unit/oidc/test_services.py
+++ b/tests/unit/oidc/test_services.py
@@ -103,7 +103,7 @@ class TestOIDCPublisherService:
         service = services.OIDCPublisherService(
             session=pretend.stub(),
             publisher="fakepublisher",
-            issuer_url=pretend.stub(),
+            issuer_url="https://none",
             audience="fakeaudience",
             cache_url=pretend.stub(),
             metrics=metrics,
@@ -123,7 +123,7 @@ class TestOIDCPublisherService:
         assert service.metrics.increment.calls == [
             pretend.call(
                 "warehouse.oidc.verify_jwt_signature.malformed_jwt",
-                tags=["publisher:fakepublisher"],
+                tags=["publisher:fakepublisher", "issuer_url:https://none"],
             )
         ]
         assert services.sentry_sdk.capture_message.calls == []
@@ -133,7 +133,7 @@ class TestOIDCPublisherService:
         service = services.OIDCPublisherService(
             session=pretend.stub(),
             publisher="fakepublisher",
-            issuer_url=pretend.stub(),
+            issuer_url="https://none",
             audience="fakeaudience",
             cache_url=pretend.stub(),
             metrics=metrics,
@@ -156,7 +156,7 @@ class TestOIDCPublisherService:
         assert service.metrics.increment.calls == [
             pretend.call(
                 "warehouse.oidc.verify_jwt_signature.invalid_signature",
-                tags=["publisher:fakepublisher"],
+                tags=["publisher:fakepublisher", "issuer_url:https://none"],
             )
         ]
 
@@ -171,7 +171,7 @@ class TestOIDCPublisherService:
         service = services.OIDCPublisherService(
             session=pretend.stub(),
             publisher="fakepublisher",
-            issuer_url=pretend.stub(),
+            issuer_url="https://none",
             audience="fakeaudience",
             cache_url=pretend.stub(),
             metrics=metrics,
@@ -189,11 +189,11 @@ class TestOIDCPublisherService:
         assert service.metrics.increment.calls == [
             pretend.call(
                 "warehouse.oidc.find_publisher.attempt",
-                tags=["publisher:fakepublisher"],
+                tags=["publisher:fakepublisher", "issuer_url:https://none"],
             ),
             pretend.call(
                 "warehouse.oidc.find_publisher.ok",
-                tags=["publisher:fakepublisher"],
+                tags=["publisher:fakepublisher", "issuer_url:https://none"],
             ),
         ]
 
@@ -201,7 +201,7 @@ class TestOIDCPublisherService:
         service = services.OIDCPublisherService(
             session=pretend.stub(),
             publisher="fakepublisher",
-            issuer_url=pretend.stub(),
+            issuer_url="https://none",
             audience="fakeaudience",
             cache_url=pretend.stub(),
             metrics=metrics,
@@ -218,11 +218,11 @@ class TestOIDCPublisherService:
         assert service.metrics.increment.calls == [
             pretend.call(
                 "warehouse.oidc.find_publisher.attempt",
-                tags=["publisher:fakepublisher"],
+                tags=["publisher:fakepublisher", "issuer_url:https://none"],
             ),
             pretend.call(
                 "warehouse.oidc.find_publisher.publisher_not_found",
-                tags=["publisher:fakepublisher"],
+                tags=["publisher:fakepublisher", "issuer_url:https://none"],
             ),
         ]
 
@@ -230,7 +230,7 @@ class TestOIDCPublisherService:
         service = services.OIDCPublisherService(
             session=pretend.stub(),
             publisher="fakepublisher",
-            issuer_url=pretend.stub(),
+            issuer_url="https://none",
             audience="fakeaudience",
             cache_url=pretend.stub(),
             metrics=metrics,
@@ -252,11 +252,11 @@ class TestOIDCPublisherService:
         assert service.metrics.increment.calls == [
             pretend.call(
                 "warehouse.oidc.find_publisher.attempt",
-                tags=["publisher:fakepublisher"],
+                tags=["publisher:fakepublisher", "issuer_url:https://none"],
             ),
             pretend.call(
                 "warehouse.oidc.find_publisher.publisher_not_found",
-                tags=["publisher:fakepublisher"],
+                tags=["publisher:fakepublisher", "issuer_url:https://none"],
             ),
         ]
         assert publisher.verify_claims.calls == [pretend.call(claims, service)]
@@ -354,7 +354,8 @@ class TestOIDCPublisherService:
         assert keys == keyset
         assert metrics.increment.calls == [
             pretend.call(
-                "warehouse.oidc.refresh_keyset.timeout", tags=["publisher:example"]
+                "warehouse.oidc.refresh_keyset.timeout",
+                tags=["publisher:example", "issuer_url:https://example.com"],
             )
         ]
 
@@ -669,7 +670,11 @@ class TestOIDCPublisherService:
         assert metrics.increment.calls == [
             pretend.call(
                 "warehouse.oidc.get_key.error",
-                tags=["publisher:example", "key_id:fake-key-id"],
+                tags=[
+                    "publisher:example",
+                    "key_id:fake-key-id",
+                    "issuer_url:https://example.com",
+                ],
             )
         ]
 

--- a/warehouse/oidc/services.py
+++ b/warehouse/oidc/services.py
@@ -164,7 +164,7 @@ class OIDCPublisherService:
         if timeout:
             self.metrics.increment(
                 "warehouse.oidc.refresh_keyset.timeout",
-                tags=[f"publisher:{self.publisher}"],
+                tags=[f"publisher:{self.publisher}", f"issuer_url:{self.issuer_url}"],
             )
             return keys
 
@@ -235,7 +235,11 @@ class OIDCPublisherService:
         if key_id not in keyset:
             self.metrics.increment(
                 "warehouse.oidc.get_key.error",
-                tags=[f"publisher:{self.publisher}", f"key_id:{key_id}"],
+                tags=[
+                    f"publisher:{self.publisher}",
+                    f"key_id:{key_id}",
+                    f"issuer_url:{self.issuer_url}",
+                ],
             )
             return None
         return jwt.PyJWK(keyset[key_id])
@@ -280,7 +284,7 @@ class OIDCPublisherService:
             # with missing components.
             self.metrics.increment(
                 "warehouse.oidc.verify_jwt_signature.malformed_jwt",
-                tags=[f"publisher:{self.publisher}"],
+                tags=[f"publisher:{self.publisher}", f"issuer_url:{self.issuer_url}"],
             )
             return None
 
@@ -315,7 +319,7 @@ class OIDCPublisherService:
         except Exception as e:
             self.metrics.increment(
                 "warehouse.oidc.verify_jwt_signature.invalid_signature",
-                tags=[f"publisher:{self.publisher}"],
+                tags=[f"publisher:{self.publisher}", f"issuer_url:{self.issuer_url}"],
             )
             if not isinstance(e, jwt.PyJWTError):
                 with sentry_sdk.new_scope() as scope:
@@ -330,7 +334,7 @@ class OIDCPublisherService:
         self, signed_claims: SignedClaims, *, pending: bool = False
     ) -> OIDCPublisher | PendingOIDCPublisher:
         """Returns a publisher for the given claims, or raises an error."""
-        metrics_tags = [f"publisher:{self.publisher}"]
+        metrics_tags = [f"publisher:{self.publisher}", f"issuer_url:{self.issuer_url}"]
         self.metrics.increment(
             "warehouse.oidc.find_publisher.attempt",
             tags=metrics_tags,


### PR DESCRIPTION
To aid with debugging, distinct from `publisher`, so we can continue to group by publisher (type) and issuer_url - distinct issuers.

Resolves #18863