### PR TITLE
Update URL for `pypi-attestations` repository

### DIFF
--- a/docs/dev/security/attestation-internals.rst
+++ b/docs/dev/security/attestation-internals.rst
@@ -291,7 +291,7 @@ Attestation object verification is described at a high level in :pep:`740`.
   Users are **strongly discouraged** from implementing the steps below in an
   ad-hoc manner, since they involve error-prone X.509 and transparency log
   operations. Instead, we **strongly encourage** integrators to use
-  either `pypi-attestation-models`_ or `sigstore-python`_'s pre-existing APIs
+  either `pypi-attestations`_ or `sigstore-python`_'s pre-existing APIs
   for attestation manipulation, signing, and verification.
 
 Using the details above, we can provide the steps with slightly more accuracy:
@@ -343,6 +343,6 @@ and any operations on its associated distribution should halt.
 
 .. _`DSSE PAE encoding`: https://github.com/secure-systems-lab/dsse/blob/v1.0.0/protocol.md
 
-.. _`pypi-attestation-models`: https://github.com/trailofbits/pypi-attestation-models
+.. _`pypi-attestations`: https://github.com/pypi/pypi-attestations
 
 .. _`sigstore-python`: https://github.com/sigstore/sigstore-python

--- a/docs/user/attestations/producing-attestations.md
+++ b/docs/user/attestations/producing-attestations.md
@@ -231,11 +231,11 @@ Before uploading attestations to the index, please:
 
 [official workflows described above]: #the-easy-way
 
-[pypi-attestations]: https://github.com/trailofbits/pypi-attestations
+[pypi-attestations]: https://github.com/pypi/pypi-attestations
 
 [ambient identity]: https://github.com/sigstore/sigstore-python#signing-with-ambient-credentials
 
-[pypi-attestations' documentation]: https://trailofbits.github.io/pypi-attestations/pypi_attestations.html
+[pypi-attestations' documentation]: https://pypi.github.io/pypi-attestations/pypi_attestations.html
 
 [Sigstore bundles]: https://github.com/sigstore/protobuf-specs/blob/main/protos/sigstore_bundle.proto
 


### PR DESCRIPTION
Once [pypi-attestations](https://github.com/trailofbits/pypi-attestations) is moved to the `pypi` org, this PR updates the URLs in the documentation (as well as updating the use of an outdated name for the project).

~Draft until the repo is moved~: Repo is now moved: https://github.com/pypi/pypi-attestations/

cc @di 