### PR TITLE
fix: use event tags and collect user ID

### DIFF
--- a/tests/unit/admin/views/test_organizations.py
+++ b/tests/unit/admin/views/test_organizations.py
@@ -19,6 +19,7 @@ from tests.common.db.organizations import (
 )
 from tests.common.db.subscriptions import StripeCustomerFactory
 from warehouse.admin.views import organizations as views
+from warehouse.events.tags import EventTag
 from warehouse.organizations.models import (
     OIDCIssuerType,
     OrganizationManualActivation,
@@ -1788,10 +1789,11 @@ class TestAddOIDCIssuer:
         assert record_event.calls == [
             pretend.call(
                 request=db_request,
-                tag="admin:organization:oidc_issuer:add",
+                tag=EventTag.Organization.OIDCPublisherAdded,
                 additional={
                     "issuer_type": "gitlab",
                     "issuer_url": "https://gitlab.company.com",
+                    "submitted_by_user_id": str(admin_user.id),
                 },
             )
         ]
@@ -1949,10 +1951,11 @@ class TestDeleteOIDCIssuer:
         assert record_event.calls == [
             pretend.call(
                 request=db_request,
-                tag="admin:organization:oidc_issuer:delete",
+                tag=EventTag.Organization.OIDCPublisherRemoved,
                 additional={
                     "issuer_type": "gitlab",
                     "issuer_url": "https://gitlab.company.com",
+                    "deleted_by_user_id": str(admin_user.id),
                 },
             )
         ]

--- a/warehouse/admin/views/organizations.py
+++ b/warehouse/admin/views/organizations.py
@@ -23,6 +23,7 @@ from warehouse.constants import (
     ONE_MIB,
     UPLOAD_LIMIT_CAP,
 )
+from warehouse.events.tags import EventTag
 from warehouse.manage.forms import OrganizationNameMixin, SaveOrganizationForm
 from warehouse.organizations.interfaces import IOrganizationService
 from warehouse.organizations.models import (
@@ -1287,6 +1288,7 @@ class OrganizationOIDCIssuerForm(wtforms.Form):
 )
 def add_oidc_issuer(request):
     organization_service = request.find_service(IOrganizationService, context=None)
+    user_service = request.find_service(IUserService)
 
     organization_id = request.matchdict["organization_id"]
     organization = organization_service.get_organization(organization_id)
@@ -1339,10 +1341,11 @@ def add_oidc_issuer(request):
     # Record the event
     organization.record_event(
         request=request,
-        tag="admin:organization:oidc_issuer:add",
+        tag=EventTag.Organization.OIDCPublisherAdded,
         additional={
             "issuer_type": form.issuer_type.data.value,
             "issuer_url": form.issuer_url.data,
+            "submitted_by_user_id": str(user_service.get_admin_user().id),
         },
     )
 
@@ -1367,6 +1370,7 @@ def add_oidc_issuer(request):
 )
 def delete_oidc_issuer(request):
     organization_service = request.find_service(IOrganizationService, context=None)
+    user_service = request.find_service(IUserService)
 
     organization_id = request.matchdict["organization_id"]
     organization = organization_service.get_organization(organization_id)
@@ -1395,10 +1399,11 @@ def delete_oidc_issuer(request):
     # Record the event before deleting
     organization.record_event(
         request=request,
-        tag="admin:organization:oidc_issuer:delete",
+        tag=EventTag.Organization.OIDCPublisherRemoved,
         additional={
             "issuer_type": issuer.issuer_type.value,
             "issuer_url": issuer.issuer_url,
+            "deleted_by_user_id": str(user_service.get_admin_user().id),
         },
     )
 

--- a/warehouse/events/tags.py
+++ b/warehouse/events/tags.py
@@ -181,6 +181,11 @@ class EventTag:
         TeamRoleAdd = "organization:team_role:add"
         TeamRoleRemove = "organization:team_role:remove"
 
+        OIDCPublisherAdded = "organization:oidc:publisher-added"
+        OIDCPublisherRemoved = "organization:oidc:publisher-removed"
+        PendingOIDCPublisherAdded = "organization:oidc:pending-publisher-added"
+        PendingOIDCPublisherRemoved = "organization:oidc:pending-publisher-removed"
+
     class Team(EventTagEnum):
         """Tags for Organization events.
 


### PR DESCRIPTION
Convert to use tags from enum, and record the admin user ID for displaying in security history template.

Refs: #18841