### PR TITLE
refactor(packaging): Use SQLAlchemy event for Filename registry (Fixes #576)

### DIFF
--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -1516,7 +1516,6 @@ def file_upload(request):
                     f"Invalid attestations supplied during upload: {e}",
                 )
 
-
         # Store the information about the file in the database.
         file_ = File(
             release=release,

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -25,12 +25,12 @@ from sqlalchemy import (
     Text,
     UniqueConstraint,
     cast,
+    event,
     func,
     or_,
     orm,
     select,
     sql,
-    event,
 )
 from sqlalchemy.dialects.postgresql import (
     ARRAY,
@@ -1217,6 +1217,7 @@ class AlternateRepository(db.Model):
     url: Mapped[str]
     description: Mapped[str]
 
+
 @event.listens_for(File, "after_insert")
 def add_filename_to_registry(mapper, connection, target):
     """
@@ -1226,12 +1227,9 @@ def add_filename_to_registry(mapper, connection, target):
     successfully inserted into the database.
 
     We use a direct connection-level insert (`connection.execute()`)
-    instead of `session.add(Filename(...))` to avoid an `SAWarning`. 
-    Modifying the session *during* the flush process (which is when 
-    this hook runs) is not a supported operation. This method 
+    instead of `session.add(Filename(...))` to avoid an `SAWarning`.
+    Modifying the session *during* the flush process (which is when
+    this hook runs) is not a supported operation. This method
     bypasses the session's unit-of-work tracking and is safe here.
     """
-    connection.execute(
-        Filename.__table__.insert(),
-        {"filename": target.filename}
-    )
+    connection.execute(Filename.__table__.insert(), {"filename": target.filename})


### PR DESCRIPTION
Fixes #576.

This PR refactors the logic for adding new filenames to the `file_registry` (`Filename` model).

As suggested by the issue, this logic was previously handled inline in the `file_upload` view, which is not ideal. This PR moves the logic to a SQLAlchemy event listener.

**Changes:**

1.  Removed the `request.db.add(Filename(filename=filename))` call from `warehouse/forklift/legacy.py`.
2.  Added an `@event.listens_for(File, "after_insert")` hook to `warehouse/packaging/models.py`.

This new hook automatically inserts the `File.filename` into the `file_registry` table when a new `File` is created.

To resolve the `SAWarning` about modifying a session during a flush, the hook uses a direct `connection.execute()` operation.

---
**Proof / Test Output:**

The existing tests in `tests/unit/forklift/test_legacy.py` still pass, which confirms the filename logging logic was successfully moved.

<img width="942" height="129" alt="image" src="https://github.com/user-attachments/assets/617f9f83-79db-4f69-9d22-511b6860b895" />
