### PR TITLE
fix: reverse index to journals to speed up triggers

### DIFF
--- a/warehouse/migrations/versions/7cf64da2632a_add_reverse_id_index_for_journals.py
+++ b/warehouse/migrations/versions/7cf64da2632a_add_reverse_id_index_for_journals.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Add reverse ID index for journals
+
+Revision ID: 7cf64da2632a
+Revises: 4c20f2342bba
+Create Date: 2025-11-14 18:14:43.440919
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "7cf64da2632a"
+down_revision = "4c20f2342bba"
+
+
+def upgrade():
+    # CREATE INDEX CONCURRENTLY cannot happen inside a transaction. We'll close
+    # our transaction here and issue the statement.
+    op.get_bind().commit()
+
+    with op.get_context().autocommit_block():
+        op.create_index(
+            "journals_name_id_idx",
+            "journals",
+            ["name", sa.literal_column("id DESC")],
+            unique=False,
+            postgresql_concurrently=True,
+        )
+
+
+def downgrade():
+    op.drop_index("journals_name_id_idx", table_name="journals")

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -1086,6 +1086,12 @@ class JournalEntry(db.ModelBase):
                 cls._submitted_by,
                 cls.submitted_date.desc(),
             ),
+            # Reverse index on ID, most recent project's journal entry for triggers
+            Index(
+                "journals_name_id_idx",
+                cls.name,
+                cls.id.desc(),
+            ),
         )
 
     id: Mapped[int] = mapped_column(primary_key=True)


### PR DESCRIPTION
When a journal entry changes, the `update_project_last_serial` trigger fires, which runs `maintain_project_last_serial()`.

This function looks for the `max(id)` for a given `name`, meaning it first has to find all records for `name`, and then find the highest `id` (at the "end" of the records).

By creating a compound index that has the name first, and then the most recent `id` at the **top** of the index should return much faster, speeding up any trigger/function executions, which are sadly somewhat opaque to our instrumentation.