### PR TITLE
Add `UserUniqueLogin.ip_address_id column`

### DIFF
--- a/warehouse/accounts/models.py
+++ b/warehouse/accounts/models.py
@@ -512,6 +512,11 @@ class UserUniqueLogin(db.Model):
     )
     user: Mapped[User] = orm.relationship(back_populates="unique_logins")
 
+    ip_address_id: Mapped[int] = mapped_column(
+        ForeignKey("ip_addresses.id", onupdate="CASCADE", ondelete="CASCADE"),
+        nullable=True,
+        index=True,
+    )
     ip_address: Mapped[str] = mapped_column(String, nullable=False)
     created: Mapped[datetime_now]
     last_used: Mapped[datetime_now]

--- a/warehouse/migrations/versions/df52c3746740_add_useruniquelogin_ip_address_id_column.py
+++ b/warehouse/migrations/versions/df52c3746740_add_useruniquelogin_ip_address_id_column.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Add UserUniqueLogin.ip_address_id column
+
+Revision ID: df52c3746740
+Revises: a25f3d5186a9
+Create Date: 2025-12-02 16:11:17.059400
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "df52c3746740"
+down_revision = "a25f3d5186a9"
+
+
+def upgrade():
+    op.add_column(
+        "user_unique_logins", sa.Column("ip_address_id", sa.UUID(), nullable=True)
+    )
+    op.create_index(
+        op.f("ix_user_unique_logins_ip_address_id"),
+        "user_unique_logins",
+        ["ip_address_id"],
+        unique=False,
+    )
+    op.create_foreign_key(
+        None,
+        "user_unique_logins",
+        "ip_addresses",
+        ["ip_address_id"],
+        ["id"],
+        onupdate="CASCADE",
+        ondelete="CASCADE",
+    )
+
+
+def downgrade():
+    op.drop_constraint(None, "user_unique_logins", type_="foreignkey")
+    op.drop_index(
+        op.f("ix_user_unique_logins_ip_address_id"), table_name="user_unique_logins"
+    )
+    op.drop_column("user_unique_logins", "ip_address_id")


### PR DESCRIPTION
First in a series of migrations to associate `UserUniqueLogin` with the `IPAddress` table.