### PR TITLE
allow support users to edit org apps

### DIFF
--- a/warehouse/admin/templates/admin/organization_applications/detail.html
+++ b/warehouse/admin/templates/admin/organization_applications/detail.html
@@ -318,14 +318,14 @@
               <label class="custom-control-label" for="organizationApplicationTurboMode">Turbo Mode</label>
             </div>
           </div>
-          {% if request.user.is_superuser %}
+          {% if request.has_permission(Permissions.AdminOrganizationsWrite) %}
           <div class="form-group">
             <button
               type="button"
               class="btn btn-warning btn-block"
               id="editModalButton"
               data-toggle="modal"
-              data-target="#editModal" {{ 'disabled' if not request.has_permission(Permissions.AdminOrganizationsWrite) or organization_application.status.value in ['approved', 'declined'] }}
+              data-target="#editModal" {{ 'disabled' if organization_application.status.value in ['approved', 'declined'] }}
               title="Edit organization request"
             >
               <i class="fa-solid fa-pen-to-square"></i> Edit


### PR DESCRIPTION
Allows support users to see edit button

before
<img width="384" height="330" alt="image" src="https://github.com/user-attachments/assets/71157bf1-bdc5-4016-b17c-1cade9d98de5" />

after
<img width="1095" height="600" alt="image" src="https://github.com/user-attachments/assets/f2512d5a-1260-410f-a2f5-e233bb4bdc57" />

Closes #18737
