### PR TITLE
feat(admin): observer reputation dashboard

### DIFF
--- a/tests/unit/admin/test_routes.py
+++ b/tests/unit/admin/test_routes.py
@@ -407,6 +407,16 @@ def test_includeme():
             domain=warehouse,
         ),
         pretend.call(
+            "admin.observers.reputation",
+            "/admin/observers/reputation/",
+            domain=warehouse,
+        ),
+        pretend.call(
+            "admin.observers.detail",
+            "/admin/observers/{observer_id}/",
+            domain=warehouse,
+        ),
+        pretend.call(
             "admin.observations.list",
             "/admin/observations/",
             domain=warehouse,

--- a/tests/unit/admin/views/test_observers.py
+++ b/tests/unit/admin/views/test_observers.py
@@ -1,0 +1,538 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from datetime import datetime, timezone
+
+import pytest
+
+from pyramid.httpexceptions import HTTPNotFound
+
+from warehouse.admin.views import observers as views
+
+from ....common.db.accounts import UserFactory
+from ....common.db.observations import ObserverFactory
+from ....common.db.packaging import ProjectObservationFactory
+
+
+class TestClassifyObservation:
+    """Tests for the _classify_observation helper function."""
+
+    @pytest.mark.parametrize(
+        ("actions", "related_id", "expected"),
+        [
+            # No actions cases
+            (None, "some-uuid", "pending"),  # project exists
+            (None, None, "true_positive"),  # project removed
+            ({}, "some-uuid", "pending"),  # empty actions, project exists
+            # Single action cases
+            (
+                {123: {"action": "remove_malware", "actor": "admin"}},
+                "some-uuid",
+                "true_positive",
+            ),
+            (
+                {123: {"action": "verdict_not_malware", "actor": "admin"}},
+                "some-uuid",
+                "false_positive",
+            ),
+            (
+                {123: {"action": "some_other_action", "actor": "admin"}},
+                "some-uuid",
+                "pending",
+            ),
+            # Precedence: remove_malware wins over verdict_not_malware
+            (
+                {
+                    123: {"action": "verdict_not_malware", "actor": "admin"},
+                    124: {"action": "remove_malware", "actor": "admin"},
+                },
+                "some-uuid",
+                "true_positive",
+            ),
+        ],
+    )
+    def test_classify_observation(self, actions, related_id, expected):
+        assert views._classify_observation(actions, related_id) == expected
+
+
+class TestParseDaysParam:
+    """Tests for the _parse_days_param helper function."""
+
+    @pytest.mark.parametrize(
+        ("params", "expected"),
+        [
+            ({}, 30),  # default
+            ({"days": "30"}, 30),  # valid
+            ({"days": "60"}, 60),  # valid
+            ({"days": "90"}, 90),  # valid
+            ({"days": "45"}, 30),  # invalid number defaults
+            ({"days": "invalid"}, 30),  # non-numeric defaults
+            ({"days": ""}, 30),  # empty string defaults
+        ],
+    )
+    def test_parse_days_param(self, db_request, params, expected):
+        db_request.params = params
+        assert views._parse_days_param(db_request) == expected
+
+    @pytest.mark.parametrize(
+        ("params", "expected"),
+        [
+            ({"days": "0"}, 0),  # lifetime valid for detail
+            ({"days": "30"}, 30),
+            ({"days": "90"}, 90),
+            ({"days": "45"}, 30),  # invalid still defaults
+        ],
+    )
+    def test_parse_days_param_with_detail_allowed(self, db_request, params, expected):
+        """Test parsing days with ALLOWED_DAYS_DETAIL (includes 0 for lifetime)."""
+        db_request.params = params
+        result = views._parse_days_param(db_request, views.ALLOWED_DAYS_DETAIL)
+        assert result == expected
+
+
+class TestGetObserverStats:
+    def test_get_observer_stats_empty(self, db_request):
+        """Test with no observations returns empty list."""
+        observations = views._get_malware_observations(db_request, days=90)
+        result = views._get_observer_stats(db_request, observations)
+        assert result == []
+
+    def test_get_observer_stats_with_observations(self, db_request):
+        """Test with observations returns correct stats."""
+        user = UserFactory.create()
+        observer = ObserverFactory.create()
+        user.observer = observer
+
+        # Create some malware observations
+        ProjectObservationFactory.create(kind="is_malware", observer=observer)
+        ProjectObservationFactory.create(kind="is_malware", observer=observer)
+
+        observations = views._get_malware_observations(db_request, days=90)
+        result = views._get_observer_stats(db_request, observations)
+
+        assert len(result) == 1
+        assert result[0]["observer_id"] == observer.id
+        assert result[0]["total_observations"] == 2
+        assert result[0]["pending"] == 2
+        assert result[0]["true_positives"] == 0
+        assert result[0]["false_positives"] == 0
+        assert result[0]["score"] == 0  # No true/false positives yet
+
+    def test_get_observer_stats_with_removed_project(self, db_request):
+        """Test that removed projects count as true positives."""
+        user = UserFactory.create()
+        observer = ObserverFactory.create()
+        user.observer = observer
+
+        # Create an observation for a removed project (related_id is None)
+        ProjectObservationFactory.create(
+            kind="is_malware", observer=observer, related=None
+        )
+
+        observations = views._get_malware_observations(db_request, days=90)
+        result = views._get_observer_stats(db_request, observations)
+
+        assert len(result) == 1
+        assert result[0]["true_positives"] == 1
+        assert result[0]["pending"] == 0
+
+    def test_get_observer_stats_with_verdict_not_malware(self, db_request):
+        """Test that verdict_not_malware counts as false positive."""
+        user = UserFactory.create()
+        observer = ObserverFactory.create()
+        user.observer = observer
+
+        now = datetime.now(tz=timezone.utc)
+        ProjectObservationFactory.create(
+            kind="is_malware",
+            observer=observer,
+            actions={
+                int(now.timestamp()): {
+                    "action": "verdict_not_malware",
+                    "actor": "admin",
+                    "reason": "Not malware",
+                    "created_at": str(now),
+                }
+            },
+        )
+
+        observations = views._get_malware_observations(db_request, days=90)
+        result = views._get_observer_stats(db_request, observations)
+
+        assert len(result) == 1
+        assert result[0]["false_positives"] == 1
+        assert result[0]["true_positives"] == 0
+
+    def test_get_observer_stats_with_verdict_remove_malware(self, db_request):
+        """Test that remove_malware counts as true positive."""
+        user = UserFactory.create()
+        observer = ObserverFactory.create()
+        user.observer = observer
+
+        now = datetime.now(tz=timezone.utc)
+        ProjectObservationFactory.create(
+            kind="is_malware",
+            observer=observer,
+            actions={
+                int(now.timestamp()): {
+                    "action": "remove_malware",
+                    "actor": "admin",
+                    "created_at": str(now),
+                }
+            },
+        )
+
+        observations = views._get_malware_observations(db_request, days=90)
+        result = views._get_observer_stats(db_request, observations)
+
+        assert len(result) == 1
+        assert result[0]["true_positives"] == 1
+        assert result[0]["false_positives"] == 0
+
+    def test_get_observer_stats_accuracy_calculation(self, db_request):
+        """Test that accuracy and score are calculated correctly."""
+        user = UserFactory.create()
+        observer = ObserverFactory.create()
+        user.observer = observer
+
+        now = datetime.now(tz=timezone.utc)
+        # 3 true positives
+        for _ in range(3):
+            ProjectObservationFactory.create(
+                kind="is_malware",
+                observer=observer,
+                actions={
+                    int(now.timestamp()): {
+                        "action": "remove_malware",
+                        "actor": "admin",
+                        "created_at": str(now),
+                    }
+                },
+            )
+        # 1 false positive
+        ProjectObservationFactory.create(
+            kind="is_malware",
+            observer=observer,
+            actions={
+                int(now.timestamp()): {
+                    "action": "verdict_not_malware",
+                    "actor": "admin",
+                    "reason": "Not malware",
+                    "created_at": str(now),
+                }
+            },
+        )
+
+        observations = views._get_malware_observations(db_request, days=90)
+        result = views._get_observer_stats(db_request, observations)
+
+        assert len(result) == 1
+        assert result[0]["accuracy_rate"] == 75.0  # 3/4 = 75%
+        assert result[0]["score"] == 5  # (3 * 2) - 1 = 5
+
+    def test_get_observer_stats_excludes_non_malware(self, db_request):
+        """Test that non-malware observations are excluded."""
+        observer = ObserverFactory.create()
+
+        # Create a non-malware observation
+        ProjectObservationFactory.create(kind="is_spam", observer=observer)
+
+        observations = views._get_malware_observations(db_request, days=90)
+        result = views._get_observer_stats(db_request, observations)
+
+        assert result == []
+
+    def test_get_observer_stats_respects_time_period(self, db_request):
+        """Test that old observations are excluded."""
+        user = UserFactory.create()
+        observer = ObserverFactory.create()
+        user.observer = observer
+
+        # Create a recent observation
+        ProjectObservationFactory.create(kind="is_malware", observer=observer)
+
+        observations = views._get_malware_observations(db_request, days=90)
+        result = views._get_observer_stats(db_request, observations)
+
+        assert len(result) == 1
+        assert result[0]["total_observations"] == 1
+
+
+class TestObserverReputationDashboard:
+    def test_dashboard_empty(self, db_request):
+        """Test dashboard with no observations."""
+        result = views.observer_reputation_dashboard(db_request)
+
+        assert result["days"] == 30
+        assert result["observer_stats"] == []
+        assert result["summary"]["total_observations"] == 0
+        assert result["summary"]["observer_count"] == 0
+
+    def test_dashboard_with_observations(self, db_request):
+        """Test dashboard with observations."""
+        user = UserFactory.create()
+        observer = ObserverFactory.create()
+        user.observer = observer
+
+        ProjectObservationFactory.create(kind="is_malware", observer=observer)
+        ProjectObservationFactory.create(kind="is_malware", observer=observer)
+
+        result = views.observer_reputation_dashboard(db_request)
+
+        assert result["days"] == 30
+        assert len(result["observer_stats"]) == 1
+        assert result["summary"]["total_observations"] == 2
+        assert result["summary"]["observer_count"] == 1
+
+    @pytest.mark.parametrize(
+        ("params", "expected_days"),
+        [
+            ({"days": "30"}, 30),  # valid
+            ({"days": "60"}, 60),  # valid
+            ({"days": "invalid"}, 30),  # invalid defaults
+            ({"days": "45"}, 30),  # unsupported defaults
+        ],
+    )
+    def test_dashboard_days_parameter(self, db_request, params, expected_days):
+        """Test dashboard handles days parameter correctly."""
+        db_request.params = params
+        result = views.observer_reputation_dashboard(db_request)
+        assert result["days"] == expected_days
+
+
+class TestObserverDetail:
+    def test_detail_missing_observer_id(self, db_request):
+        """Test detail view when observer_id is not in matchdict."""
+        db_request.matchdict = {}
+
+        with pytest.raises(HTTPNotFound):
+            views.observer_detail(db_request)
+
+    def test_detail_not_found(self, db_request):
+        """Test detail view with non-existent observer."""
+        db_request.matchdict = {"observer_id": "00000000-0000-0000-0000-000000000000"}
+
+        with pytest.raises(HTTPNotFound):
+            views.observer_detail(db_request)
+
+    def test_detail_with_observer(self, db_request):
+        """Test detail view with existing observer."""
+        user = UserFactory.create()
+        observer = ObserverFactory.create()
+        user.observer = observer
+
+        db_request.matchdict = {"observer_id": str(observer.id)}
+
+        result = views.observer_detail(db_request)
+
+        assert result["observer"] == observer
+        assert result["username"] == user.username
+        assert result["days"] == 30
+        assert result["stats"]["total"] == 0
+        assert result["stats"]["score"] == 0
+        assert "time_series" in result
+        assert result["time_series"]["labels"] == []
+
+    def test_detail_with_observations(self, db_request):
+        """Test detail view with observations."""
+        user = UserFactory.create()
+        observer = ObserverFactory.create()
+        user.observer = observer
+
+        ProjectObservationFactory.create(kind="is_malware", observer=observer)
+
+        db_request.matchdict = {"observer_id": str(observer.id)}
+
+        result = views.observer_detail(db_request)
+
+        assert result["stats"]["total"] == 1
+        assert result["stats"]["pending"] == 1
+        assert len(result["observations"]["pending"]) == 1
+
+    @pytest.mark.parametrize(
+        ("params", "expected_days"),
+        [
+            ({"days": "30"}, 30),
+            ({"days": "60"}, 60),
+            ({"days": "0"}, 0),  # lifetime
+            ({"days": "invalid"}, 30),  # invalid defaults to 30
+        ],
+    )
+    def test_detail_days_parameter(self, db_request, params, expected_days):
+        """Test detail view handles days parameter correctly."""
+        observer = ObserverFactory.create()
+        db_request.matchdict = {"observer_id": str(observer.id)}
+        db_request.params = params
+
+        result = views.observer_detail(db_request)
+
+        assert result["days"] == expected_days
+
+    def test_detail_categorizes_observations(self, db_request):
+        """Test that observations are correctly categorized."""
+        user = UserFactory.create()
+        observer = ObserverFactory.create()
+        user.observer = observer
+
+        now = datetime.now(tz=timezone.utc)
+
+        # True positive (removed)
+        ProjectObservationFactory.create(
+            kind="is_malware",
+            observer=observer,
+            actions={
+                int(now.timestamp()): {
+                    "action": "remove_malware",
+                    "actor": "admin",
+                    "created_at": str(now),
+                }
+            },
+        )
+
+        # False positive
+        ProjectObservationFactory.create(
+            kind="is_malware",
+            observer=observer,
+            actions={
+                int(now.timestamp()): {
+                    "action": "verdict_not_malware",
+                    "actor": "admin",
+                    "reason": "Not malware",
+                    "created_at": str(now),
+                }
+            },
+        )
+
+        # Pending
+        ProjectObservationFactory.create(kind="is_malware", observer=observer)
+
+        db_request.matchdict = {"observer_id": str(observer.id)}
+
+        result = views.observer_detail(db_request)
+
+        assert result["stats"]["true_positives"] == 1
+        assert result["stats"]["false_positives"] == 1
+        assert result["stats"]["pending"] == 1
+        assert len(result["observations"]["true_positives"]) == 1
+        assert len(result["observations"]["false_positives"]) == 1
+        assert len(result["observations"]["pending"]) == 1
+
+
+class TestAggregateWeeklyTimeSeries:
+    def test_time_series_empty(self, db_request):
+        """Test time series with no observations."""
+        result = views._aggregate_weekly_time_series([])
+
+        assert result["labels"] == []
+        assert result["true_positives"] == []
+        assert result["false_positives"] == []
+        assert result["pending"] == []
+
+    def test_time_series_with_observations(self, db_request):
+        """Test time series with observations."""
+        observer = ObserverFactory.create()
+
+        ProjectObservationFactory.create(kind="is_malware", observer=observer)
+
+        observations = views._get_malware_observations(db_request, days=90)
+        result = views._aggregate_weekly_time_series(observations)
+
+        assert len(result["labels"]) >= 1
+        assert sum(result["pending"]) == 1  # New observation is pending
+
+
+class TestGetObserverTimeSeries:
+    def test_time_series_empty(self, db_request):
+        """Test time series with no observations for observer."""
+        observer = ObserverFactory.create()
+
+        result = views._get_observer_time_series(db_request, observer, days=90)
+
+        assert result["labels"] == []
+        assert result["true_positives"] == []
+        assert result["false_positives"] == []
+        assert result["pending"] == []
+
+    def test_time_series_with_observations(self, db_request):
+        """Test time series with observations for observer."""
+        observer = ObserverFactory.create()
+
+        ProjectObservationFactory.create(kind="is_malware", observer=observer)
+
+        result = views._get_observer_time_series(db_request, observer, days=90)
+
+        assert len(result["labels"]) >= 1
+        assert sum(result["pending"]) == 1
+        assert sum(result["true_positives"]) == 0
+        assert sum(result["false_positives"]) == 0
+
+    def test_time_series_lifetime(self, db_request):
+        """Test time series with days=0 (lifetime) returns all observations."""
+        observer = ObserverFactory.create()
+
+        ProjectObservationFactory.create(kind="is_malware", observer=observer)
+
+        result = views._get_observer_time_series(db_request, observer, days=0)
+
+        assert len(result["labels"]) >= 1
+        assert sum(result["pending"]) == 1
+
+
+class TestGetObserverDetailStats:
+    def test_detail_stats_empty(self, db_request):
+        """Test detail stats with no observations."""
+        observer = ObserverFactory.create()
+
+        result = views._get_observer_detail_stats(db_request, observer, days=90)
+
+        assert result["true_positives"] == []
+        assert result["false_positives"] == []
+        assert result["pending"] == []
+
+    def test_detail_stats_lifetime(self, db_request):
+        """Test detail stats with days=0 (lifetime) returns all observations."""
+        user = UserFactory.create()
+        observer = ObserverFactory.create()
+        user.observer = observer
+
+        ProjectObservationFactory.create(kind="is_malware", observer=observer)
+
+        result = views._get_observer_detail_stats(db_request, observer, days=0)
+
+        # Should return the observation even with days=0
+        assert len(result["pending"]) == 1
+
+    def test_detail_stats_categorization(self, db_request):
+        """Test that detail stats correctly categorize observations."""
+        user = UserFactory.create()
+        observer = ObserverFactory.create()
+        user.observer = observer
+
+        now = datetime.now(tz=timezone.utc)
+
+        # Create one of each type
+        ProjectObservationFactory.create(
+            kind="is_malware", observer=observer, related=None
+        )  # removed = true positive
+
+        ProjectObservationFactory.create(
+            kind="is_malware",
+            observer=observer,
+            actions={
+                int(now.timestamp()): {
+                    "action": "verdict_not_malware",
+                    "actor": "admin",
+                    "reason": "test",
+                    "created_at": str(now),
+                }
+            },
+        )  # false positive
+
+        ProjectObservationFactory.create(
+            kind="is_malware", observer=observer
+        )  # pending
+
+        result = views._get_observer_detail_stats(db_request, observer, days=90)
+
+        assert len(result["true_positives"]) == 1
+        assert len(result["false_positives"]) == 1
+        assert len(result["pending"]) == 1

--- a/tests/unit/test_csp.py
+++ b/tests/unit/test_csp.py
@@ -156,6 +156,7 @@ class TestCSPTween:
                 "frame-src": ["'none'"],
                 "img-src": ["'self'"],
                 "connect-src": [],
+                "style-src": ["'self'"],
             },
             "camo.url": "http://localhost:9000",
         }
@@ -177,7 +178,9 @@ class TestCSPTween:
                 "connect-src http://localhost:9000; "
                 "default-src 'none'; "
                 "frame-src https://inspector.pypi.io; "
-                "img-src 'self' data:"
+                "img-src 'self' data:; "
+                "style-src 'self' "
+                "'sha256-kwpt3lQZ21rs4cld7/uEm9qI5yAbjYzx+9FGm/XmwNU='"
             )
         }
 

--- a/warehouse/admin/routes.py
+++ b/warehouse/admin/routes.py
@@ -417,6 +417,16 @@ def includeme(config):
         domain=warehouse,
     )
 
+    # Observer Reputation pages
+    config.add_route(
+        "admin.observers.reputation", "/admin/observers/reputation/", domain=warehouse
+    )
+    config.add_route(
+        "admin.observers.detail",
+        "/admin/observers/{observer_id}/",
+        domain=warehouse,
+    )
+
     # Observation related Admin pages
     config.add_route(
         "admin.observations.list", "/admin/observations/", domain=warehouse

--- a/warehouse/admin/static/css/admin.scss
+++ b/warehouse/admin/static/css/admin.scss
@@ -66,3 +66,10 @@
     cursor: help;
   }
 }
+
+/* Chart container for CSP-compliant Chart.js rendering */
+.chart-container {
+  position: relative;
+  height: 300px;
+  width: 100%;
+}

--- a/warehouse/admin/static/js/observer_charts.js
+++ b/warehouse/admin/static/js/observer_charts.js
@@ -1,0 +1,194 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* global Chart */
+
+// Initialize observer charts if present on the page
+$(function() {
+  // Check if Chart.js is available
+  if (typeof Chart === "undefined") {
+    return;
+  }
+
+  // Dashboard chart (reputation page) - grouped bar chart
+  initDashboardChart();
+
+  // Observer detail chart - stacked bar chart
+  initObserverDetailChart();
+});
+
+function initDashboardChart() {
+  const chartCanvas = document.getElementById("reportsChart");
+  const chartDataScript = document.getElementById("reportsChartData");
+
+  if (!chartCanvas || !chartDataScript) {
+    return;
+  }
+
+  let chartData;
+  try {
+    chartData = JSON.parse(chartDataScript.textContent);
+  } catch (e) {
+    return;
+  }
+
+  const labels = chartData.labels || [];
+  const truePositives = chartData.truePositives || [];
+  const falsePositives = chartData.falsePositives || [];
+  const pending = chartData.pending || [];
+
+  if (labels.length === 0) {
+    return;
+  }
+
+  const ctx = chartCanvas.getContext("2d");
+
+  new Chart(ctx, {
+    type: "bar",
+    data: {
+      labels: labels,
+      datasets: [
+        {
+          label: "True Positives",
+          data: truePositives,
+          backgroundColor: "rgba(40, 167, 69, 0.8)",
+          borderColor: "rgb(40, 167, 69)",
+          borderWidth: 1,
+        },
+        {
+          label: "False Positives",
+          data: falsePositives,
+          backgroundColor: "rgba(220, 53, 69, 0.8)",
+          borderColor: "rgb(220, 53, 69)",
+          borderWidth: 1,
+        },
+        {
+          label: "Pending",
+          data: pending,
+          backgroundColor: "rgba(255, 193, 7, 0.8)",
+          borderColor: "rgb(255, 193, 7)",
+          borderWidth: 1,
+        },
+      ],
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      scales: {
+        xAxes: [{
+          stacked: true,
+          scaleLabel: {
+            display: true,
+            labelString: "Week Starting",
+          },
+        }],
+        yAxes: [{
+          stacked: true,
+          ticks: {
+            beginAtZero: true,
+          },
+          scaleLabel: {
+            display: true,
+            labelString: "Number of Reports",
+          },
+        }],
+      },
+      legend: {
+        position: "top",
+      },
+      tooltips: {
+        mode: "index",
+        intersect: false,
+      },
+    },
+  });
+}
+
+function initObserverDetailChart() {
+  const chartCanvas = document.getElementById("observerChart");
+  const chartDataScript = document.getElementById("observerChartData");
+
+  if (!chartCanvas || !chartDataScript) {
+    return;
+  }
+
+  let chartData;
+  try {
+    chartData = JSON.parse(chartDataScript.textContent);
+  } catch (e) {
+    return;
+  }
+
+  const labels = chartData.labels || [];
+  const truePositives = chartData.truePositives || [];
+  const falsePositives = chartData.falsePositives || [];
+  const pending = chartData.pending || [];
+
+  if (labels.length === 0) {
+    return;
+  }
+
+  const ctx = chartCanvas.getContext("2d");
+
+  new Chart(ctx, {
+    type: "bar",
+    data: {
+      labels: labels,
+      datasets: [
+        {
+          label: "True Positives",
+          data: truePositives,
+          backgroundColor: "rgba(40, 167, 69, 0.8)",
+          borderColor: "rgb(40, 167, 69)",
+          borderWidth: 1,
+        },
+        {
+          label: "False Positives",
+          data: falsePositives,
+          backgroundColor: "rgba(220, 53, 69, 0.8)",
+          borderColor: "rgb(220, 53, 69)",
+          borderWidth: 1,
+        },
+        {
+          label: "Pending",
+          data: pending,
+          backgroundColor: "rgba(255, 193, 7, 0.8)",
+          borderColor: "rgb(255, 193, 7)",
+          borderWidth: 1,
+        },
+      ],
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      scales: {
+        xAxes: [{
+          stacked: true,
+          scaleLabel: {
+            display: true,
+            labelString: "Week Starting",
+          },
+        }],
+        yAxes: [{
+          stacked: true,
+          ticks: {
+            beginAtZero: true,
+            stepSize: 1,
+          },
+          scaleLabel: {
+            display: true,
+            labelString: "Number of Reports",
+          },
+        }],
+      },
+      legend: {
+        position: "top",
+      },
+      title: {
+        display: false,
+      },
+      tooltips: {
+        mode: "index",
+        intersect: false,
+      },
+    },
+  });
+}

--- a/warehouse/admin/static/js/warehouse.js
+++ b/warehouse/admin/static/js/warehouse.js
@@ -15,10 +15,14 @@ import "admin-lte/plugins/datatables-buttons/js/buttons.colVis";
 import "admin-lte/plugins/datatables-rowgroup/js/dataTables.rowGroup";
 import "admin-lte/plugins/datatables-rowgroup/js/rowGroup.bootstrap4";
 
+// Import Chart JS
+import "admin-lte/plugins/chart.js/Chart";
+
 // Import AdminLTE JS
 import "admin-lte/build/js/AdminLTE";
 
 import "./treeview";
+import "./observer_charts";
 
 // Get our timeago function
 import timeAgo from "warehouse/utils/timeago";

--- a/warehouse/admin/templates/admin/base.html
+++ b/warehouse/admin/templates/admin/base.html
@@ -157,6 +157,12 @@
                 </a>
               </li>
               <li class="nav-item">
+                <a href="{{ request.route_path('admin.observers.reputation') }}" class="nav-link">
+                  <i class="nav-icon fa-solid fa-chart-bar"></i>
+                  <p>Observer Reputation</p>
+                </a>
+              </li>
+              <li class="nav-item">
                 <a href="{{ request.route_path('admin.observations.list') }}" class="nav-link">
                   <i class="nav-icon fa-solid fa-eye"></i>
                   <p>All Observations</p>

--- a/warehouse/admin/templates/admin/observers/detail.html
+++ b/warehouse/admin/templates/admin/observers/detail.html
@@ -1,0 +1,311 @@
+{# SPDX-License-Identifier: Apache-2.0 -#}
+
+{% extends "admin/base.html" %}
+
+{% block title %}Observer: {{ username }}{% endblock %}
+
+{% block breadcrumb %}
+  <li class="breadcrumb-item">
+    <a href="{{ request.route_path('admin.observations.list') }}">Observations</a>
+  </li>
+  <li class="breadcrumb-item">
+    <a href="{{ request.route_path('admin.observers.reputation') }}">Observer Reputation</a>
+  </li>
+  <li class="breadcrumb-item active">{{ username }}</li>
+{% endblock %}
+
+{% block content %}
+{# Observer Profile Card #}
+<div class="row">
+  <div class="col-lg-4 col-md-5">
+    <div class="card card-primary card-outline">
+      <div class="card-body box-profile">
+        <h3 class="profile-username text-center">{{ username }}</h3>
+        <p class="text-muted text-center">Observer</p>
+
+        <ul class="list-group list-group-unbordered mb-3">
+          <li class="list-group-item">
+            <b>Observer ID</b> <span class="float-right"><code>{{ observer.id }}</code></span>
+          </li>
+          <li class="list-group-item">
+            <b>Observer Since</b> <span class="float-right">{{ observer.created|format_date() }}</span>
+          </li>
+          {% if user_id %}
+          <li class="list-group-item">
+            <b>User Account</b>
+            <a href="{{ request.route_path('admin.user.detail', username=username) }}" class="float-right">
+              View User <i class="fa fa-external-link-alt"></i>
+            </a>
+          </li>
+          {% endif %}
+        </ul>
+
+        <div class="btn-group btn-group-justified w-100">
+          <a href="{{ request.route_path('admin.observers.detail', observer_id=observer.id, _query={'days': 30}) }}"
+             class="btn btn-sm {{ 'btn-primary' if days == 30 else 'btn-default' }}">30d</a>
+          <a href="{{ request.route_path('admin.observers.detail', observer_id=observer.id, _query={'days': 60}) }}"
+             class="btn btn-sm {{ 'btn-primary' if days == 60 else 'btn-default' }}">60d</a>
+          <a href="{{ request.route_path('admin.observers.detail', observer_id=observer.id, _query={'days': 90}) }}"
+             class="btn btn-sm {{ 'btn-primary' if days == 90 else 'btn-default' }}">90d</a>
+          <a href="{{ request.route_path('admin.observers.detail', observer_id=observer.id, _query={'days': 0}) }}"
+             class="btn btn-sm {{ 'btn-primary' if days == 0 else 'btn-default' }}">Lifetime</a>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  {# Statistics Card #}
+  <div class="col-lg-8 col-md-7">
+    <div class="card">
+      <div class="card-header">
+        <h3 class="card-title">Performance Summary ({% if days == 0 %}Lifetime{% else %}Last {{ days }} Days{% endif %})</h3>
+      </div>
+      <div class="card-body">
+        <div class="row">
+          <div class="col-6 col-lg-4 text-center border-right">
+            <span class="text-muted text-uppercase small">Total Reports</span>
+            <h2 class="mb-0">{{ stats.total }}</h2>
+          </div>
+          <div class="col-6 col-lg-4 text-center border-right">
+            <span class="text-muted text-uppercase small">Score</span>
+            <h2 class="mb-0 {% if stats.score > 0 %}text-success{% elif stats.score < 0 %}text-danger{% endif %}">
+              {{ stats.score }}
+            </h2>
+          </div>
+          <div class="col-12 col-lg-4 text-center mt-3 mt-lg-0">
+            <span class="text-muted text-uppercase small">Accuracy</span>
+            <h2 class="mb-0 {% if stats.accuracy and stats.accuracy >= 80 %}text-success{% elif stats.accuracy and stats.accuracy < 50 %}text-danger{% elif stats.accuracy %}text-warning{% endif %}">
+              {{ stats.accuracy if stats.accuracy is not none else 'N/A' }}{% if stats.accuracy is not none %}%{% endif %}
+            </h2>
+          </div>
+        </div>
+        <hr>
+        <div class="row text-center">
+          <div class="col-4">
+            <span class="text-success"><i class="fa fa-check-circle"></i></span>
+            <span class="text-muted small">True Positives</span>
+            <h4 class="text-success mb-0">{{ stats.true_positives }}</h4>
+          </div>
+          <div class="col-4">
+            <span class="text-danger"><i class="fa fa-times-circle"></i></span>
+            <span class="text-muted small">False Positives</span>
+            <h4 class="text-danger mb-0">{{ stats.false_positives }}</h4>
+          </div>
+          <div class="col-4">
+            <span class="text-warning"><i class="fa fa-hourglass-half"></i></span>
+            <span class="text-muted small">Pending</span>
+            <h4 class="text-warning mb-0">{{ stats.pending }}</h4>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+{# Time Series Chart #}
+<div class="row">
+  <div class="col-12">
+    <div class="card">
+      <div class="card-header">
+        <h3 class="card-title">Reports Over Time (Weekly)</h3>
+      </div>
+      <div class="card-body">
+        {% if time_series.labels %}
+        <div class="chart-container">
+          <canvas id="observerChart"></canvas>
+        </div>
+        <script id="observerChartData" type="application/json">
+          {
+            "labels": {{ time_series.labels | tojson }},
+            "truePositives": {{ time_series.true_positives | tojson }},
+            "falsePositives": {{ time_series.false_positives | tojson }},
+            "pending": {{ time_series.pending | tojson }}
+          }
+        </script>
+        {% else %}
+        <p class="text-muted text-center py-4">No report data available for this time period.</p>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+</div>
+
+{# Observation Tables #}
+<div class="row">
+  {# True Positives - always collapsed by default #}
+  <div class="col-12">
+    <div class="card card-success card-outline collapsed-card">
+      <div class="card-header">
+        <h3 class="card-title">
+          <i class="fa-solid fa-check-circle text-success"></i>
+          True Positives
+          <span class="badge badge-secondary ml-2">{{ stats.true_positives }}</span>
+        </h3>
+        <div class="card-tools">
+          <button type="button" class="btn btn-tool" data-card-widget="collapse">
+            <i class="fas fa-plus"></i>
+          </button>
+        </div>
+      </div>
+      <div class="card-body table-responsive p-0">
+        {% if observations.true_positives %}
+        <table class="table table-hover table-sm">
+          <thead>
+            <tr>
+              <th>Date</th>
+              <th>Project</th>
+              <th>Summary</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for obs in observations.true_positives %}
+            <tr>
+              <td class="text-nowrap">{{ obs.created|format_date() }}</td>
+              <td>
+                <code>{{ obs.related_name }}</code>
+                {% if obs.related_id is none %}<span class="badge badge-danger">Removed</span>{% endif %}
+              </td>
+              <td>{{ obs.summary[:60] }}{% if obs.summary|length > 60 %}...{% endif %}</td>
+              <td>
+                <a href="{{ request.route_path('admin.malware_reports.detail', observation_id=obs.id) }}"
+                   class="btn btn-xs btn-info" title="View Details"><i class="fa fa-eye"></i></a>
+              </td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+        {% else %}
+        <div class="p-3 text-muted">No true positives in this period.</div>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+
+  {# False Positives #}
+  <div class="col-12">
+    <div class="card card-danger card-outline {% if not observations.false_positives %}collapsed-card{% endif %}">
+      <div class="card-header">
+        <h3 class="card-title">
+          <i class="fa-solid fa-times-circle text-danger"></i>
+          False Positives
+          <span class="badge badge-secondary ml-2">{{ stats.false_positives }}</span>
+        </h3>
+        <div class="card-tools">
+          <button type="button" class="btn btn-tool" data-card-widget="collapse">
+            <i class="fas fa-{% if observations.false_positives %}minus{% else %}plus{% endif %}"></i>
+          </button>
+        </div>
+      </div>
+      <div class="card-body table-responsive p-0">
+        {% if observations.false_positives %}
+        <table class="table table-hover table-sm">
+          <thead>
+            <tr>
+              <th>Date</th>
+              <th>Project</th>
+              <th>Verdict By</th>
+              <th>Reason</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for obs in observations.false_positives %}
+            <tr>
+              <td class="text-nowrap">{{ obs.created|format_date() }}</td>
+              <td>
+                {% if obs.related %}
+                  <a href="{{ request.route_path('admin.project.detail', project_name=obs.related.normalized_name) }}">
+                    {{ obs.related_name }}
+                  </a>
+                {% else %}
+                  <code>{{ obs.related_name }}</code>
+                {% endif %}
+              </td>
+              <td>
+                {% for ts, action_data in obs.actions.items() %}
+                  {% if action_data.action == 'verdict_not_malware' %}{{ action_data.actor }}{% endif %}
+                {% endfor %}
+              </td>
+              <td>
+                {% for ts, action_data in obs.actions.items() %}
+                  {% if action_data.action == 'verdict_not_malware' %}
+                    {{ action_data.reason[:40] if action_data.reason else '-' }}{% if action_data.reason and action_data.reason|length > 40 %}...{% endif %}
+                  {% endif %}
+                {% endfor %}
+              </td>
+              <td>
+                <a href="{{ request.route_path('admin.malware_reports.detail', observation_id=obs.id) }}"
+                   class="btn btn-xs btn-info" title="View Details"><i class="fa fa-eye"></i></a>
+              </td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+        {% else %}
+        <div class="p-3 text-muted">No false positives in this period.</div>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+
+  {# Pending #}
+  <div class="col-12">
+    <div class="card card-warning card-outline">
+      <div class="card-header">
+        <h3 class="card-title">
+          <i class="fa-solid fa-hourglass-half text-warning"></i>
+          Pending Review
+          <span class="badge badge-secondary ml-2">{{ stats.pending }}</span>
+        </h3>
+        <div class="card-tools">
+          <button type="button" class="btn btn-tool" data-card-widget="collapse">
+            <i class="fas fa-minus"></i>
+          </button>
+        </div>
+      </div>
+      <div class="card-body table-responsive p-0">
+        {% if observations.pending %}
+        <table class="table table-hover table-sm">
+          <thead>
+            <tr>
+              <th>Date</th>
+              <th>Project</th>
+              <th>Summary</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for obs in observations.pending %}
+            <tr>
+              <td class="text-nowrap">{{ obs.created|format_date() }}</td>
+              <td>
+                {% if obs.related %}
+                  <a href="{{ request.route_path('admin.project.detail', project_name=obs.related.normalized_name) }}">
+                    {{ obs.related_name }}
+                  </a>
+                {% else %}
+                  <code>{{ obs.related_name }}</code>
+                {% endif %}
+              </td>
+              <td>{{ obs.summary[:60] }}{% if obs.summary|length > 60 %}...{% endif %}</td>
+              <td class="text-nowrap">
+                <a href="{{ request.route_path('admin.malware_reports.detail', observation_id=obs.id) }}"
+                   class="btn btn-xs btn-info" title="View Details"><i class="fa fa-eye"></i></a>
+                {% if obs.related %}
+                <a href="{{ request.route_path('admin.malware_reports.project.list', project_name=obs.related.normalized_name) }}"
+                   class="btn btn-xs btn-warning" title="All Reports for Project"><i class="fa fa-list"></i></a>
+                {% endif %}
+              </td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+        {% else %}
+        <div class="p-3 text-muted">No pending observations in this period.</div>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock content %}

--- a/warehouse/admin/templates/admin/observers/reputation.html
+++ b/warehouse/admin/templates/admin/observers/reputation.html
@@ -1,0 +1,207 @@
+{# SPDX-License-Identifier: Apache-2.0 -#}
+
+{% extends "admin/base.html" %}
+
+{% block title %}Observer Reputation{% endblock %}
+
+{% block breadcrumb %}
+  <li class="breadcrumb-item">
+    <a href="{{ request.route_path('admin.observations.list') }}">Observations</a>
+  </li>
+  <li class="breadcrumb-item active">Observer Reputation</li>
+{% endblock %}
+
+{% block content %}
+<div class="row">
+  <div class="col-12">
+    <div class="card">
+      <div class="card-header">
+        <h3 class="card-title">Observer Reputation Dashboard</h3>
+        <div class="card-tools">
+          <div class="btn-group">
+            <a href="{{ request.route_path('admin.observers.reputation', _query={'days': 30}) }}"
+               class="btn btn-sm {{ 'btn-primary' if days == 30 else 'btn-default' }}">30 Days</a>
+            <a href="{{ request.route_path('admin.observers.reputation', _query={'days': 60}) }}"
+               class="btn btn-sm {{ 'btn-primary' if days == 60 else 'btn-default' }}">60 Days</a>
+            <a href="{{ request.route_path('admin.observers.reputation', _query={'days': 90}) }}"
+               class="btn btn-sm {{ 'btn-primary' if days == 90 else 'btn-default' }}">90 Days</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+{# Summary Statistics #}
+<div class="row">
+  <div class="col-lg-3 col-6">
+    <div class="small-box bg-info">
+      <div class="inner">
+        <h3>{{ summary.total_observations }}</h3>
+        <p>Total Malware Reports</p>
+      </div>
+      <div class="icon">
+        <i class="fa-solid fa-dumpster-fire"></i>
+      </div>
+    </div>
+  </div>
+  <div class="col-lg-3 col-6">
+    <div class="small-box bg-success">
+      <div class="inner">
+        <h3>{{ summary.total_true_positives }}</h3>
+        <p>True Positives (Removed)</p>
+      </div>
+      <div class="icon">
+        <i class="fa-solid fa-check-circle"></i>
+      </div>
+    </div>
+  </div>
+  <div class="col-lg-3 col-6">
+    <div class="small-box bg-danger">
+      <div class="inner">
+        <h3>{{ summary.total_false_positives }}</h3>
+        <p>False Positives</p>
+      </div>
+      <div class="icon">
+        <i class="fa-solid fa-times-circle"></i>
+      </div>
+    </div>
+  </div>
+  <div class="col-lg-3 col-6">
+    <div class="small-box bg-warning">
+      <div class="inner">
+        <h3>{{ summary.total_pending }}</h3>
+        <p>Pending Review</p>
+      </div>
+      <div class="icon">
+        <i class="fa-solid fa-hourglass-half"></i>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-lg-3 col-6">
+    <div class="small-box bg-gradient-purple">
+      <div class="inner">
+        <h3>{{ summary.overall_accuracy if summary.overall_accuracy is not none else 'N/A' }}{% if summary.overall_accuracy is not none %}%{% endif %}</h3>
+        <p>Overall Accuracy Rate</p>
+      </div>
+      <div class="icon">
+        <i class="fa-solid fa-chart-line"></i>
+      </div>
+    </div>
+  </div>
+  <div class="col-lg-3 col-6">
+    <div class="small-box bg-gradient-teal">
+      <div class="inner">
+        <h3>{{ summary.observer_count }}</h3>
+        <p>Active Observers</p>
+      </div>
+      <div class="icon">
+        <i class="fa-solid fa-users"></i>
+      </div>
+    </div>
+  </div>
+</div>
+
+{# Time Series Chart #}
+<div class="row">
+  <div class="col-12">
+    <div class="card">
+      <div class="card-header">
+        <h3 class="card-title">Malware Reports Over Time (Weekly)</h3>
+      </div>
+      <div class="card-body">
+        <div class="chart-container">
+          <canvas id="reportsChart"></canvas>
+        </div>
+        <script id="reportsChartData" type="application/json">
+          {
+            "labels": {{ time_series.labels | tojson }},
+            "truePositives": {{ time_series.true_positives | tojson }},
+            "falsePositives": {{ time_series.false_positives | tojson }},
+            "pending": {{ time_series.pending | tojson }}
+          }
+        </script>
+      </div>
+    </div>
+  </div>
+</div>
+
+{# Observer Scoreboard #}
+<div class="row">
+  <div class="col-12">
+    <div class="card">
+      <div class="card-header">
+        <h3 class="card-title">Observer Scoreboard (Last {{ days }} Days)</h3>
+      </div>
+      <div class="card-body">
+        {% if observer_stats %}
+        <div class="table-responsive">
+          <table class="table table-hover table-striped" id="observer-scoreboard">
+            <thead>
+              <tr>
+                <th>Rank</th>
+                <th>Observer</th>
+                <th>Score</th>
+                <th>Total Reports</th>
+                <th>Accuracy</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for stats in observer_stats %}
+              <tr>
+                <td>{{ loop.index }}</td>
+                <td>
+                  {% if stats.user_id %}
+                    <a href="{{ request.route_path('admin.user.detail', username=stats.username) }}">
+                      {{ stats.username }}
+                    </a>
+                  {% else %}
+                    {{ stats.username }}
+                  {% endif %}
+                </td>
+                <td>
+                  {% if stats.score > 0 %}
+                    <span class="badge badge-success">{{ stats.score }}</span>
+                  {% elif stats.score < 0 %}
+                    <span class="badge badge-danger">{{ stats.score }}</span>
+                  {% else %}
+                    <span class="badge badge-secondary">{{ stats.score }}</span>
+                  {% endif %}
+                </td>
+                <td><span class="badge badge-info">{{ stats.total_observations }}</span></td>
+                <td>
+                  {% if stats.accuracy_rate is not none %}
+                    {% if stats.accuracy_rate >= 80 %}
+                      <span class="badge badge-success">{{ stats.accuracy_rate }}%</span>
+                    {% elif stats.accuracy_rate >= 50 %}
+                      <span class="badge badge-warning">{{ stats.accuracy_rate }}%</span>
+                    {% else %}
+                      <span class="badge badge-danger">{{ stats.accuracy_rate }}%</span>
+                    {% endif %}
+                  {% else %}
+                    <span class="badge badge-secondary">N/A</span>
+                  {% endif %}
+                </td>
+                <td>
+                  <a href="{{ request.route_path('admin.observers.detail', observer_id=stats.observer_id, _query={'days': days}) }}"
+                     class="btn btn-sm btn-info">
+                    <i class="fa fa-eye"></i> Details
+                  </a>
+                </td>
+              </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+        {% else %}
+        <p class="text-muted">No observer data available for the selected time period.</p>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock content %}

--- a/warehouse/admin/views/observers.py
+++ b/warehouse/admin/views/observers.py
@@ -1,0 +1,352 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Admin Views for Observer Reputation tracking."""
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+from typing import TYPE_CHECKING
+
+from pyramid.httpexceptions import HTTPNotFound
+from pyramid.view import view_config
+from sqlalchemy import select
+
+from warehouse.authnz import Permissions
+from warehouse.observations.models import Observation, Observer
+
+if TYPE_CHECKING:
+    from pyramid.request import Request
+
+# Valid time periods for filtering
+ALLOWED_DAYS = (30, 60, 90)
+ALLOWED_DAYS_DETAIL = (30, 60, 90, 0)  # 0 = lifetime (no limit)
+DEFAULT_DAYS = 30
+
+
+def _classify_observation(actions: dict | None, related_id) -> str:
+    """
+    Classify an observation as true_positive, false_positive, or pending.
+
+    Classification rules:
+    - true_positive: has 'remove_malware' action OR project removed (related_id=None)
+    - false_positive: has 'verdict_not_malware' action (only if no remove_malware)
+    - pending: no verdict yet
+    """
+    if not actions:
+        return "true_positive" if related_id is None else "pending"
+
+    has_not_malware = False
+    for action_data in actions.values():
+        action = action_data.get("action", "")
+        if action == "remove_malware":
+            return "true_positive"  # Takes precedence, return immediately
+        if action == "verdict_not_malware":
+            has_not_malware = True
+
+    return "false_positive" if has_not_malware else "pending"
+
+
+def _parse_days_param(request: Request, allowed: tuple[int, ...] = ALLOWED_DAYS) -> int:
+    """Parse and validate the days query parameter."""
+    try:
+        days = int(request.params.get("days", DEFAULT_DAYS))
+        return days if days in allowed else DEFAULT_DAYS
+    except (ValueError, TypeError):
+        return DEFAULT_DAYS
+
+
+def _get_malware_observations(request: Request, days: int):
+    """
+    Fetch all malware observations within the time period.
+
+    Returns raw observation data (observer_id, actions, related_id, created).
+    """
+    cutoff_date = datetime.now(tz=timezone.utc) - timedelta(days=days)
+
+    stmt = select(
+        Observation.observer_id,  # type: ignore[attr-defined]
+        Observation.actions,
+        Observation.related_id,  # type: ignore[attr-defined]
+        Observation.created,
+    ).where(
+        Observation.kind == "is_malware",
+        Observation.created >= cutoff_date,
+    )
+    return request.db.execute(stmt).all()
+
+
+def _get_observer_stats(request: Request, observations: list) -> list[dict]:
+    """
+    Aggregate observations into per-observer statistics.
+
+    Returns a sorted list of dicts with observer stats including:
+    - observer_id, username, user_id
+    - total_observations, true_positives, false_positives, pending
+    - accuracy_rate, score
+    """
+    if not observations:
+        return []
+
+    # Aggregate by observer
+    stats_by_observer: dict = defaultdict(
+        lambda: {
+            "total_observations": 0,
+            "true_positives": 0,
+            "false_positives": 0,
+            "pending": 0,
+        }
+    )
+
+    for obs in observations:
+        stats = stats_by_observer[obs.observer_id]
+        stats["total_observations"] += 1
+
+        verdict = _classify_observation(obs.actions, obs.related_id)
+        if verdict == "true_positive":
+            stats["true_positives"] += 1
+        elif verdict == "false_positive":
+            stats["false_positives"] += 1
+        else:
+            stats["pending"] += 1
+
+    # Fetch observer info in single query
+    observer_ids = list(stats_by_observer.keys())
+    stmt = select(Observer).where(Observer.id.in_(observer_ids))
+    observers = request.db.scalars(stmt).all()
+
+    observer_map = {
+        o.id: (
+            (o.parent.username, o.parent.id) if o.parent else (f"Observer {o.id}", None)
+        )
+        for o in observers
+    }
+
+    # Build result with calculated fields
+    result = []
+    for observer_id, stats in stats_by_observer.items():
+        default = (f"Observer {observer_id}", None)
+        username, user_id = observer_map.get(observer_id, default)
+
+        resolved = stats["true_positives"] + stats["false_positives"]
+        accuracy_rate = (
+            round((stats["true_positives"] / resolved) * 100, 1)
+            if resolved > 0
+            else None
+        )
+        score = (stats["true_positives"] * 2) - stats["false_positives"]
+
+        result.append(
+            {
+                "observer_id": observer_id,
+                "username": username,
+                "user_id": user_id,
+                "accuracy_rate": accuracy_rate,
+                "score": score,
+                **stats,
+            }
+        )
+
+    # Sort by: score (desc), accuracy (desc), total observations (desc)
+    result.sort(
+        key=lambda x: (x["score"], x["accuracy_rate"] or 0, x["total_observations"]),
+        reverse=True,
+    )
+
+    return result
+
+
+def _aggregate_weekly_time_series(observations) -> dict:
+    """
+    Aggregate observations into weekly time series data for Chart.js.
+
+    Accepts any iterable of objects with .created, .actions, and .related_id attributes.
+    Returns dict with labels and counts for true_positives, false_positives, pending.
+    """
+    if not observations:
+        return {
+            "labels": [],
+            "true_positives": [],
+            "false_positives": [],
+            "pending": [],
+        }
+
+    weekly_data: dict[str, dict[str, int]] = defaultdict(
+        lambda: {"true_positives": 0, "false_positives": 0, "pending": 0}
+    )
+
+    for obs in observations:
+        # Get the start of the week (Monday)
+        week_start = obs.created - timedelta(days=obs.created.weekday())
+        week_key = week_start.strftime("%Y-%m-%d")
+
+        verdict = _classify_observation(obs.actions, obs.related_id)
+        weekly_data[week_key][
+            verdict.replace("true_positive", "true_positives").replace(
+                "false_positive", "false_positives"
+            )
+        ] += 1
+
+    # Convert to sorted lists for Chart.js
+    sorted_weeks = sorted(weekly_data.keys())
+    return {
+        "labels": sorted_weeks,
+        "true_positives": [weekly_data[w]["true_positives"] for w in sorted_weeks],
+        "false_positives": [weekly_data[w]["false_positives"] for w in sorted_weeks],
+        "pending": [weekly_data[w]["pending"] for w in sorted_weeks],
+    }
+
+
+def _get_observer_detail_stats(request: Request, observer: Observer, days: int) -> dict:
+    """
+    Get detailed observations for a specific observer, grouped by verdict.
+
+    If days=0, returns all observations (lifetime).
+    """
+    stmt = select(Observation).where(
+        Observation.observer_id == observer.id,  # type: ignore[attr-defined]
+        Observation.kind == "is_malware",
+    )
+
+    if days > 0:
+        cutoff_date = datetime.now(tz=timezone.utc) - timedelta(days=days)
+        stmt = stmt.where(Observation.created >= cutoff_date)
+
+    stmt = stmt.order_by(Observation.created.desc())
+    observations = request.db.scalars(stmt).all()
+
+    categorized: dict[str, list] = {
+        "true_positives": [],
+        "false_positives": [],
+        "pending": [],
+    }
+
+    for obs in observations:
+        verdict = _classify_observation(obs.actions, obs.related_id)
+        if verdict == "true_positive":
+            categorized["true_positives"].append(obs)
+        elif verdict == "false_positive":
+            categorized["false_positives"].append(obs)
+        else:
+            categorized["pending"].append(obs)
+
+    return categorized
+
+
+def _get_observer_time_series(request: Request, observer: Observer, days: int) -> dict:
+    """
+    Get weekly time series data for a specific observer's observations.
+
+    If days=0, returns all observations (lifetime).
+    """
+    stmt = select(
+        Observation.created,
+        Observation.actions,
+        Observation.related_id,  # type: ignore[attr-defined]
+    ).where(
+        Observation.observer_id == observer.id,  # type: ignore[attr-defined]
+        Observation.kind == "is_malware",
+    )
+
+    if days > 0:
+        cutoff_date = datetime.now(tz=timezone.utc) - timedelta(days=days)
+        stmt = stmt.where(Observation.created >= cutoff_date)
+
+    stmt = stmt.order_by(Observation.created.asc())
+    observations = request.db.execute(stmt).all()
+
+    return _aggregate_weekly_time_series(observations)
+
+
+@view_config(
+    route_name="admin.observers.reputation",
+    renderer="warehouse.admin:templates/admin/observers/reputation.html",
+    permission=Permissions.AdminObservationsRead,
+    request_method="GET",
+    uses_session=True,
+    require_csrf=True,
+    require_methods=False,
+)
+def observer_reputation_dashboard(request: Request):
+    """Display the Observer reputation dashboard with statistics and charts."""
+    days = _parse_days_param(request)
+
+    # Single query for all observations - used by both stats and time series
+    observations = _get_malware_observations(request, days)
+
+    observer_stats = _get_observer_stats(request, observations)
+    time_series = _aggregate_weekly_time_series(observations)
+
+    # Calculate summary stats from already-computed observer stats
+    total_observations = sum(s["total_observations"] for s in observer_stats)
+    total_true_positives = sum(s["true_positives"] for s in observer_stats)
+    total_false_positives = sum(s["false_positives"] for s in observer_stats)
+    total_pending = sum(s["pending"] for s in observer_stats)
+
+    resolved = total_true_positives + total_false_positives
+    overall_accuracy = (
+        round((total_true_positives / resolved) * 100, 1) if resolved > 0 else None
+    )
+
+    return {
+        "days": days,
+        "observer_stats": observer_stats,
+        "time_series": time_series,
+        "summary": {
+            "total_observations": total_observations,
+            "total_true_positives": total_true_positives,
+            "total_false_positives": total_false_positives,
+            "total_pending": total_pending,
+            "overall_accuracy": overall_accuracy,
+            "observer_count": len(observer_stats),
+        },
+    }
+
+
+@view_config(
+    route_name="admin.observers.detail",
+    renderer="warehouse.admin:templates/admin/observers/detail.html",
+    permission=Permissions.AdminObservationsRead,
+    request_method="GET",
+    uses_session=True,
+    require_csrf=True,
+    require_methods=False,
+)
+def observer_detail(request: Request):
+    """Display detailed observation history for a specific observer."""
+    observer_id = request.matchdict.get("observer_id")
+    if not observer_id:
+        raise HTTPNotFound("Observer not found")
+
+    observer = request.db.get(Observer, observer_id)
+    if not observer:
+        raise HTTPNotFound("Observer not found")
+
+    days = _parse_days_param(request, allowed=ALLOWED_DAYS_DETAIL)
+    categorized = _get_observer_detail_stats(request, observer, days)
+    time_series = _get_observer_time_series(request, observer, days)
+
+    # Calculate stats from categorized observations
+    true_pos_count = len(categorized["true_positives"])
+    false_pos_count = len(categorized["false_positives"])
+    pending_count = len(categorized["pending"])
+    total = true_pos_count + false_pos_count + pending_count
+    resolved = true_pos_count + false_pos_count
+    accuracy = round((true_pos_count / resolved) * 100, 1) if resolved > 0 else None
+    score = (true_pos_count * 2) - false_pos_count
+
+    return {
+        "observer": observer,
+        "username": observer.parent.username if observer.parent else None,
+        "user_id": observer.parent.id if observer.parent else None,
+        "days": days,
+        "observations": categorized,
+        "time_series": time_series,
+        "stats": {
+            "total": total,
+            "true_positives": true_pos_count,
+            "false_positives": false_pos_count,
+            "pending": pending_count,
+            "accuracy": accuracy,
+            "score": score,
+        },
+    }

--- a/warehouse/csp.py
+++ b/warehouse/csp.py
@@ -42,6 +42,10 @@ def content_security_policy_tween_factory(handler, registry):
             policy["img-src"].extend(["data:"])
             # Link checking
             policy["connect-src"].extend([request.registry.settings["camo.url"]])
+            # Chart.js v2.9.4 inline style for canvas sizing
+            policy["style-src"].extend(
+                ["'sha256-kwpt3lQZ21rs4cld7/uEm9qI5yAbjYzx+9FGm/XmwNU='"]
+            )
 
         # We don't want to apply our Content Security Policy to the debug
         # toolbar, that's not part of our application and it doesn't work with


### PR DESCRIPTION
Provide in-interface visibility on Observer behaviors and scoring.

Note: may need tweaking as we learn more about how the data appears in production, and how we interpret it over time.