### PR TITLE
chore: increase search timeout

### DIFF
--- a/tests/unit/search/test_init.py
+++ b/tests/unit/search/test_init.py
@@ -130,7 +130,7 @@ def test_includeme(monkeypatch):
     ]
     assert len(opensearch_client_init.calls) == 1
     assert opensearch_client_init.calls[0].kwargs["hosts"] == ["https://some.url"]
-    assert opensearch_client_init.calls[0].kwargs["timeout"] == 0.5
+    assert opensearch_client_init.calls[0].kwargs["timeout"] == 1
     assert opensearch_client_init.calls[0].kwargs["retry_on_timeout"] is True
     assert opensearch_client_init.calls[0].kwargs["max_retries"] == 1
     assert (

--- a/warehouse/search/__init__.py
+++ b/warehouse/search/__init__.py
@@ -92,7 +92,7 @@ def includeme(config):
         "hosts": [urllib.parse.urlunparse((p.scheme, p.netloc) + ("",) * 4)],
         "verify_certs": True,
         "ca_certs": certifi.where(),
-        "timeout": 0.5,
+        "timeout": 1,
         "retry_on_timeout": True,
         "serializer": opensearchpy.serializer.serializer,
         "max_retries": 1,


### PR DESCRIPTION
When dropped from 2 seconds to 0.5 seconds in #16812 was a good move overall, it's led to an increase in errors for workers.

We don't currently have a good mechanism to split the configuration here between web and worker, that might be a useful addition at a later date.

Fixes WAREHOUSE-PRODUCTION-209