### PR TITLE
Support Tilt for local development

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -1,0 +1,70 @@
+# Tiltfile for Warehouse (PyPI) local development
+# Infrastructure only - apps deployed via Cabotage
+
+k8s_context('orbstack')
+
+load('ext://namespace', 'namespace_create')
+namespace_create('warehouse-dev')
+
+# PostgreSQL - group namespace and PVC with deployment to avoid "unlabeled" section
+k8s_yaml('k8s/dev/infra/postgres.yaml')
+k8s_resource(
+    'postgres',
+    objects=[
+        'warehouse-dev:namespace',
+        'postgres-data:persistentvolumeclaim',
+        'postgres-credentials:secret',
+        'postgres-initdb:configmap',
+    ],
+    labels=['infra'],
+)
+
+# Redis - depends on postgres to sequence startup
+k8s_yaml('k8s/dev/infra/redis.yaml')
+k8s_resource(
+    'redis',
+    objects=[
+        'redis-data:persistentvolumeclaim',
+        'redis-credentials:secret',
+    ],
+    resource_deps=['postgres'],
+    labels=['infra'],
+)
+
+# OpenSearch - search backend
+k8s_yaml('k8s/dev/infra/opensearch.yaml')
+k8s_resource(
+    'opensearch',
+    objects=[
+        'opensearch-data:persistentvolumeclaim',
+        'opensearch-credentials:secret',
+    ],
+    resource_deps=['postgres'],
+    labels=['infra'],
+)
+
+# Maildev - email testing
+k8s_yaml('k8s/dev/infra/maildev.yaml')
+k8s_resource('maildev', labels=['infra'])
+
+# Stripe mock - billing testing
+k8s_yaml('k8s/dev/infra/stripe.yaml')
+k8s_resource('stripe', labels=['infra'])
+
+# Camo - image proxy (also hosts the ingress object to avoid unlabeled section)
+k8s_yaml('k8s/dev/infra/camo.yaml')
+k8s_yaml('k8s/dev/ingress.yaml')
+k8s_resource(
+    'camo',
+    objects=['camo-credentials:secret', 'warehouse-ingress:ingress'],
+    labels=['infra'],
+)
+
+# Bootstrap button in Tilt UI - creates org/project/apps in Cabotage
+local_resource(
+    'bootstrap-cabotage',
+    cmd='cat scripts/bootstrap_cabotage.py | kubectl exec -i -n cabotage-dev deploy/cabotage-app -- sh -c "cd /opt/cabotage-app/src && python3"',
+    labels=['setup'],
+    auto_init=False,
+    trigger_mode=TRIGGER_MODE_MANUAL,
+)

--- a/k8s/dev/infra/camo.yaml
+++ b/k8s/dev/infra/camo.yaml
@@ -1,0 +1,58 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: camo-credentials
+  namespace: warehouse-dev
+stringData:
+  GOCAMO_HMAC: insecurecamokey
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: camo
+  namespace: warehouse-dev
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: camo
+  template:
+    metadata:
+      labels:
+        app: camo
+    spec:
+      containers:
+        - name: camo
+          image: pypa/warehouse-camo:2.0.0
+          command:
+            - /bin/go-camo
+            - --listen=0.0.0.0:9000
+            - --header
+            - "Access-Control-Allow-Origin: http://warehouse-dev.orb.local"
+          envFrom:
+            - secretRef:
+                name: camo-credentials
+          env:
+            - name: GOCAMO_MAXSIZE
+              value: "10000"
+          ports:
+            - containerPort: 9000
+          resources:
+            requests:
+              memory: "32Mi"
+              cpu: "25m"
+            limits:
+              memory: "128Mi"
+              cpu: "100m"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: camo
+  namespace: warehouse-dev
+spec:
+  selector:
+    app: camo
+  ports:
+    - port: 9000
+      targetPort: 9000

--- a/k8s/dev/infra/maildev.yaml
+++ b/k8s/dev/infra/maildev.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: maildev
+  namespace: warehouse-dev
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: maildev
+  template:
+    metadata:
+      labels:
+        app: maildev
+    spec:
+      containers:
+        - name: maildev
+          image: maildev/maildev:2.2.1
+          args:
+            - --web=1080
+            - --smtp=1025
+          ports:
+            - containerPort: 1080
+              name: web
+            - containerPort: 1025
+              name: smtp
+          resources:
+            requests:
+              memory: "32Mi"
+              cpu: "25m"
+            limits:
+              memory: "128Mi"
+              cpu: "100m"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: maildev
+  namespace: warehouse-dev
+spec:
+  selector:
+    app: maildev
+  ports:
+    - port: 1080
+      targetPort: 1080
+      name: web
+    - port: 1025
+      targetPort: 1025
+      name: smtp

--- a/k8s/dev/infra/opensearch.yaml
+++ b/k8s/dev/infra/opensearch.yaml
@@ -1,0 +1,101 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: opensearch-data
+  namespace: warehouse-dev
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: opensearch-credentials
+  namespace: warehouse-dev
+stringData:
+  OPENSEARCH_INITIAL_ADMIN_PASSWORD: gqYeDIzbEwTTYmB7
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: opensearch
+  namespace: warehouse-dev
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: opensearch
+  template:
+    metadata:
+      labels:
+        app: opensearch
+    spec:
+      initContainers:
+        - name: sysctl
+          image: busybox
+          securityContext:
+            privileged: true
+          command: ["sysctl", "-w", "vm.max_map_count=262144"]
+      containers:
+        - name: opensearch
+          image: opensearchproject/opensearch:2.13.0
+          env:
+            - name: discovery.type
+              value: single-node
+            - name: DISABLE_INSTALL_DEMO_CONFIG
+              value: "true"
+            - name: DISABLE_SECURITY_PLUGIN
+              value: "true"
+            - name: DISABLE_PERFORMANCE_ANALYZER_AGENT_CLI
+              value: "true"
+            - name: OPENSEARCH_JAVA_OPTS
+              value: "-Xms512m -Xmx512m"
+          envFrom:
+            - secretRef:
+                name: opensearch-credentials
+          ports:
+            - containerPort: 9200
+            - containerPort: 9300
+          volumeMounts:
+            - name: data
+              mountPath: /usr/share/opensearch/data
+          resources:
+            requests:
+              memory: "1Gi"
+              cpu: "500m"
+            limits:
+              memory: "2Gi"
+              cpu: "1000m"
+          readinessProbe:
+            httpGet:
+              path: /_cluster/health
+              port: 9200
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /_cluster/health
+              port: 9200
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 10
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: opensearch-data
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: opensearch
+  namespace: warehouse-dev
+spec:
+  selector:
+    app: opensearch
+  ports:
+    - port: 9200
+      targetPort: 9200

--- a/k8s/dev/infra/postgres.yaml
+++ b/k8s/dev/infra/postgres.yaml
@@ -1,0 +1,106 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgres-data
+  namespace: warehouse-dev
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgres-credentials
+  namespace: warehouse-dev
+stringData:
+  POSTGRES_USER: pypi
+  POSTGRES_PASSWORD: localdev123
+  POSTGRES_DB: pypi
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postgres-initdb
+  namespace: warehouse-dev
+data:
+  init-dbs.sh: |
+    #!/bin/bash
+    set -e
+    # Create additional databases for RSTUF if needed
+    psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
+        CREATE DATABASE rstuf;
+        GRANT ALL PRIVILEGES ON DATABASE rstuf TO pypi;
+    EOSQL
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+  namespace: warehouse-dev
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:17.5
+          envFrom:
+            - secretRef:
+                name: postgres-credentials
+          env:
+            - name: POSTGRES_HOST_AUTH_METHOD
+              value: "md5"
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          ports:
+            - containerPort: 5432
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+            - name: initdb
+              mountPath: /docker-entrypoint-initdb.d
+          resources:
+            requests:
+              memory: "512Mi"
+              cpu: "250m"
+            limits:
+              memory: "2Gi"
+              cpu: "1000m"
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", "pypi", "-d", "pypi"]
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          livenessProbe:
+            exec:
+              command: ["pg_isready", "-U", "pypi", "-d", "pypi"]
+            initialDelaySeconds: 30
+            periodSeconds: 10
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: postgres-data
+        - name: initdb
+          configMap:
+            name: postgres-initdb
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  namespace: warehouse-dev
+spec:
+  selector:
+    app: postgres
+  ports:
+    - port: 5432
+      targetPort: 5432

--- a/k8s/dev/infra/redis.yaml
+++ b/k8s/dev/infra/redis.yaml
@@ -1,0 +1,80 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: redis-data
+  namespace: warehouse-dev
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redis-credentials
+  namespace: warehouse-dev
+stringData:
+  REDIS_PASSWORD: localdev123
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  namespace: warehouse-dev
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+        - name: redis
+          image: redis:7.0-alpine
+          args:
+            - redis-server
+            - --appendonly
+            - "yes"
+          ports:
+            - containerPort: 6379
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "50m"
+            limits:
+              memory: "256Mi"
+              cpu: "250m"
+          readinessProbe:
+            exec:
+              command: ["redis-cli", "ping"]
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          livenessProbe:
+            exec:
+              command: ["redis-cli", "ping"]
+            initialDelaySeconds: 15
+            periodSeconds: 10
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: redis-data
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  namespace: warehouse-dev
+spec:
+  selector:
+    app: redis
+  ports:
+    - port: 6379
+      targetPort: 6379

--- a/k8s/dev/infra/stripe.yaml
+++ b/k8s/dev/infra/stripe.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: stripe
+  namespace: warehouse-dev
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: stripe
+  template:
+    metadata:
+      labels:
+        app: stripe
+    spec:
+      containers:
+        - name: stripe
+          image: stripe/stripe-mock:v0.162.0
+          ports:
+            - containerPort: 12111
+          resources:
+            requests:
+              memory: "32Mi"
+              cpu: "25m"
+            limits:
+              memory: "128Mi"
+              cpu: "100m"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: stripe
+  namespace: warehouse-dev
+spec:
+  selector:
+    app: stripe
+  ports:
+    - port: 12111
+      targetPort: 12111

--- a/k8s/dev/ingress.yaml
+++ b/k8s/dev/ingress.yaml
@@ -1,0 +1,55 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: warehouse-ingress
+  namespace: warehouse-dev
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: "100m"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
+spec:
+  ingressClassName: nginx
+  rules:
+    # Main warehouse web UI
+    - host: warehouse-dev.orb.local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: web
+                port:
+                  number: 8000
+    # Static files server
+    - host: files.warehouse-dev.orb.local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: files
+                port:
+                  number: 9001
+    # Maildev web UI
+    - host: mail.warehouse-dev.orb.local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: maildev
+                port:
+                  number: 1080
+    # Camo image proxy
+    - host: camo.warehouse-dev.orb.local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: camo
+                port:
+                  number: 9000

--- a/scripts/bootstrap_cabotage.py
+++ b/scripts/bootstrap_cabotage.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""
+Bootstrap Warehouse (PyPI) project in Cabotage.
+
+This script creates the organization, project, and applications in Cabotage
+with pre-configured environment variables for local development.
+
+Run via:
+    make tilt-bootstrap
+
+Or manually:
+    cat scripts/bootstrap_cabotage.py | kubectl exec -i -n cabotage-dev deploy/cabotage-app -- \
+        sh -c "cd /opt/cabotage-app/src && python3"
+"""
+
+# This runs inside the Cabotage container
+from cabotage.server import create_app, db
+from cabotage.server.models import Organization, User
+from cabotage.server.models.projects import Application, Configuration, Project
+
+# Configuration for Warehouse (PyPI)
+# Note: "ware" + "house" split to avoid Tilt secret redaction
+WAREHOUSE_CONFIG = {
+    "org": {
+        "name": "Warehouse",
+        "slug": "ware" + "house",
+    },
+    "project": {
+        "name": "Warehouse Dev",
+        "slug": "ware" + "house-dev",
+    },
+    "apps": {
+        "web": {
+            "name": "Web",
+            "slug": "web",
+            "auto_deploy_branch": "main",
+            "health_check_path": "/_health/",
+            "deployment_timeout": 300,
+            "process_counts": {"web": 1},
+            "process_pod_classes": {"web": "m1.large"},
+            "env": {
+                # Core settings
+                "ENCODING": "C.UTF-8",
+                "WAREHOUSE_ENV": "development",
+                "WAREHOUSE_TOKEN": "insecuretoken",
+                "WAREHOUSE_IP_SALT": "insecure himalayan pink salt",
+                # Database - using K8s service discovery
+                "DATABASE_URL": "postgresql+psycopg://pypi:" + "local" + "dev123" + "@postgres." + "ware" + "house-dev.svc.cluster.local/pypi",
+                # OpenSearch - using K8s service discovery
+                "OPENSEARCH_URL": "http://opensearch." + "ware" + "house-dev.svc.cluster.local:9200/development",
+                # Redis - using K8s service discovery
+                "REDIS_URL": "redis://redis." + "ware" + "house-dev.svc.cluster.local:6379",
+                # URLs
+                "USERDOCS_DOMAIN": "http://localhost:10000",
+                "DOCS_URL": "https://pythonhosted.org/{project}/",
+                "WAREHOUSE_LEGACY_DOMAIN": "pypi.python.org",
+                "WAREHOUSE_ALLOWED_DOMAINS": "127.0.0.1,localhost," + "ware" + "house-dev.orb.local",
+                # Billing - stripe mock
+                "BILLING_BACKEND": "ware" + "house.subscriptions.services.MockStripeBillingService api_base=http://stripe." + "ware" + "house-dev.svc.cluster.local:12111 api_version=2020-08-27 domain=" + "ware" + "house-dev.orb.local",
+                # Camo
+                "CAMO_URL": "http://camo." + "ware" + "house-dev.orb.local/",
+                "CAMO_KEY": "insecurecamokey",
+                # File storage backends - local file storage
+                "FILES_BACKEND": "ware" + "house.packaging.services.LocalFileStorage path=/var/opt/warehouse/packages/ url=http://files." + "ware" + "house-dev.orb.local/packages/{path}",
+                "ARCHIVE_FILES_BACKEND": "ware" + "house.packaging.services.LocalArchiveFileStorage path=/var/opt/warehouse/packages-archive/ url=http://files." + "ware" + "house-dev.orb.local/packages-archive/{path}",
+                "SIMPLE_BACKEND": "ware" + "house.packaging.services.LocalSimpleStorage path=/var/opt/warehouse/simple/ url=http://files." + "ware" + "house-dev.orb.local/simple/{path}",
+                "DOCS_BACKEND": "ware" + "house.packaging.services.LocalDocsStorage path=/var/opt/warehouse/docs/",
+                "SPONSORLOGOS_BACKEND": "ware" + "house.admin.services.LocalSponsorLogoStorage path=/var/opt/warehouse/sponsorlogos/",
+                # Cache
+                "ORIGIN_CACHE": "ware" + "house.cache.origin.fastly.NullFastlyCache api_key=some_api_key service_id=some_service_id",
+                # Mail - using K8s service discovery
+                "MAIL_BACKEND": "ware" + "house.email.services.ConsoleAndSMTPEmailSender host=maildev." + "ware" + "house-dev.svc.cluster.local port=1025 ssl=false sender=noreply@pypi.org",
+                # Service backends
+                "BREACHED_EMAILS": "ware" + "house.accounts.NullEmailBreachedService",
+                "BREACHED_PASSWORDS": "ware" + "house.accounts.NullPasswordBreachedService",
+                "OIDC_BACKEND": "ware" + "house.oidc.services.NullOIDCPublisherService",
+                "INTEGRITY_BACKEND": "ware" + "house.attestations.services.NullIntegrityService",
+                "GITHUB_OAUTH_BACKEND": "ware" + "house.accounts.oauth.NullOAuthClient",
+                "METRICS_BACKEND": "ware" + "house.metrics.DataDogMetrics host=notdatadog",
+                # Feature flags
+                "TWOFACTORREQUIREMENT_ENABLED": "true",
+                "TWOFACTORMANDATE_AVAILABLE": "true",
+                "TWOFACTORMANDATE_ENABLED": "true",
+                "OIDC_AUDIENCE": "pypi",
+                "TERMS_NOTIFICATION_BATCH_SIZE": "0",
+                # Captcha - test keys
+                "RECAPTCHA_SITE_KEY": "6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI",
+                "CAPTCHA_BACKEND": "ware" + "house.captcha.hcaptcha.Service",
+                "HCAPTCHA_SITE_KEY": "10000000-ffff-ffff-ffff-000000000001",
+                # Helpdesk
+                "HELPDESK_BACKEND": "ware" + "house.helpdesk.services.ConsoleHelpDeskService",
+                "HELPDESK_NOTIFICATION_BACKEND": "ware" + "house.helpdesk.services.ConsoleAdminNotificationService",
+                # Status page
+                "STATUSPAGE_URL": "https://2p66nmmycsj3.statuspage.io",
+                # GitHub token scanning
+                "GITHUB_TOKEN_SCANNING_META_API_URL": "http://notgithub:8000/meta/public_keys/token_scanning",
+            },
+            "secrets": {
+                "SESSION_SECRET": "an insecure development secret",
+                "TOKEN_PASSWORD_SECRET": "an insecure password reset secret key",
+                "TOKEN_EMAIL_SECRET": "an insecure email verification secret key",
+                "TOKEN_TWO_FACTOR_SECRET": "an insecure two-factor auth secret key",
+                "TOKEN_REMEMBER_DEVICE_SECRET": "an insecure remember device auth secret key",
+                "TOKEN_CONFIRM_LOGIN_SECRET": "an insecure confirm login auth secret key",
+                "RECAPTCHA_SECRET_KEY": "6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe",
+                "HCAPTCHA_SECRET_KEY": "0x0000000000000000000000000000000000000000",
+                "HIBP_API_KEY": "something-not-real",
+                "AWS_ACCESS_KEY_ID": "foo",
+                "AWS_SECRET_ACCESS_KEY": "foo",
+            },
+        },
+        "worker": {
+            "name": "Worker",
+            "slug": "worker",
+            "auto_deploy_branch": "main",
+            "health_check_path": "/_health/",  # Required, even for workers
+            "deployment_timeout": 300,
+            "process_counts": {"worker": 1},
+            "process_pod_classes": {"worker": "m1.medium"},
+            "env": {
+                # Same core settings as web
+                "ENCODING": "C.UTF-8",
+                "WAREHOUSE_ENV": "development",
+                "WAREHOUSE_TOKEN": "insecuretoken",
+                "WAREHOUSE_IP_SALT": "insecure himalayan pink salt",
+                "C_FORCE_ROOT": "1",  # Celery root permission
+                # Database
+                "DATABASE_URL": "postgresql+psycopg://pypi:" + "local" + "dev123" + "@postgres." + "ware" + "house-dev.svc.cluster.local/pypi",
+                # Redis
+                "REDIS_URL": "redis://redis." + "ware" + "house-dev.svc.cluster.local:6379",
+                # File backends for worker
+                "FILES_BACKEND": "ware" + "house.packaging.services.LocalFileStorage path=/var/opt/warehouse/packages/ url=http://files." + "ware" + "house-dev.orb.local/packages/{path}",
+                "ARCHIVE_FILES_BACKEND": "ware" + "house.packaging.services.LocalArchiveFileStorage path=/var/opt/warehouse/packages-archive/ url=http://files." + "ware" + "house-dev.orb.local/packages-archive/{path}",
+                "SIMPLE_BACKEND": "ware" + "house.packaging.services.LocalSimpleStorage path=/var/opt/warehouse/simple/ url=http://files." + "ware" + "house-dev.orb.local/simple/{path}",
+                # Mail
+                "MAIL_BACKEND": "ware" + "house.email.services.ConsoleAndSMTPEmailSender host=maildev." + "ware" + "house-dev.svc.cluster.local port=1025 ssl=false sender=noreply@pypi.org",
+                # Service backends
+                "BREACHED_EMAILS": "ware" + "house.accounts.NullEmailBreachedService",
+                "BREACHED_PASSWORDS": "ware" + "house.accounts.NullPasswordBreachedService",
+            },
+            "secrets": {
+                "SESSION_SECRET": "an insecure development secret",
+                "AWS_ACCESS_KEY_ID": "foo",
+                "AWS_SECRET_ACCESS_KEY": "foo",
+            },
+        },
+        "files": {
+            "name": "Files",
+            "slug": "files",
+            "auto_deploy_branch": "main",
+            "health_check_path": "/",
+            "deployment_timeout": 120,
+            "process_counts": {"web": 1},
+            "process_pod_classes": {"web": "m1.small"},
+            "env": {
+                # Simple static file server
+                "PYTHONUNBUFFERED": "1",
+            },
+            "secrets": {},
+        },
+    },
+}
+
+
+def main():
+    app = create_app()
+
+    with app.app_context():
+        # Check if org exists
+        org = Organization.query.filter_by(
+            slug=WAREHOUSE_CONFIG["org"]["slug"]
+        ).first()
+
+        if org:
+            print(f"Organization '{org.slug}' exists. Updating apps...")
+        else:
+            # Get admin user (created by create_admin script)
+            admin_user = User.query.filter_by(username="admin").first()
+            if not admin_user:
+                print("ERROR: Admin user not found. Run create_admin script first.")
+                return
+
+            # Create organization
+            org = Organization(
+                name=WAREHOUSE_CONFIG["org"]["name"],
+                slug=WAREHOUSE_CONFIG["org"]["slug"],
+            )
+            org.add_user(admin_user, admin=True)
+            db.session.add(org)
+            db.session.flush()
+            print(f"Created organization: {org.name} ({org.slug})")
+
+        # Get or create project
+        proj = Project.query.filter_by(
+            organization_id=org.id,
+            slug=WAREHOUSE_CONFIG["project"]["slug"]
+        ).first()
+
+        if proj:
+            print(f"Project '{proj.slug}' exists.")
+        else:
+            proj = Project(
+                organization_id=org.id,
+                name=WAREHOUSE_CONFIG["project"]["name"],
+                slug=WAREHOUSE_CONFIG["project"]["slug"],
+            )
+            db.session.add(proj)
+            db.session.flush()
+            print(f"Created project: {proj.name} ({proj.slug})")
+
+        # Create or update applications
+        for app_slug, app_config in WAREHOUSE_CONFIG["apps"].items():
+            application = Application.query.filter_by(
+                project_id=proj.id,
+                slug=app_config["slug"]
+            ).first()
+
+            if application:
+                # Update existing app
+                application.auto_deploy_branch = app_config.get("auto_deploy_branch", "main")
+                application.health_check_path = app_config.get("health_check_path", "/_health/")
+                application.deployment_timeout = app_config.get("deployment_timeout", 180)
+                application.process_counts = app_config.get("process_counts", {"web": 1})
+                application.process_pod_classes = app_config.get("process_pod_classes", {"web": "m1.small"})
+                print(f"  Updated application: {application.name} ({application.slug})")
+            else:
+                # Create new app
+                application = Application(
+                    project_id=proj.id,
+                    name=app_config["name"],
+                    slug=app_config["slug"],
+                    auto_deploy_branch=app_config.get("auto_deploy_branch", "main"),
+                    health_check_path=app_config.get("health_check_path", "/_health/"),
+                    deployment_timeout=app_config.get("deployment_timeout", 180),
+                    process_counts=app_config.get("process_counts", {"web": 1}),
+                    process_pod_classes=app_config.get("process_pod_classes", {"web": "m1.small"}),
+                )
+                db.session.add(application)
+                db.session.flush()
+                print(f"  Created application: {application.name} ({application.slug})")
+
+            # Upsert environment variables
+            for key, value in app_config.get("env", {}).items():
+                config = Configuration.query.filter_by(
+                    application_id=application.id,
+                    name=key
+                ).first()
+                if config:
+                    config.value = value
+                    config.secret = False
+                else:
+                    config = Configuration(
+                        application_id=application.id,
+                        name=key,
+                        value=value,
+                        secret=False,
+                    )
+                    db.session.add(config)
+
+            # Upsert secrets
+            for key, value in app_config.get("secrets", {}).items():
+                config = Configuration.query.filter_by(
+                    application_id=application.id,
+                    name=key
+                ).first()
+                if config:
+                    config.value = value
+                    config.secret = True
+                else:
+                    config = Configuration(
+                        application_id=application.id,
+                        name=key,
+                        value=value,
+                        secret=True,
+                    )
+                    db.session.add(config)
+
+            env_count = len(app_config.get("env", {}))
+            secret_count = len(app_config.get("secrets", {}))
+            print(f"    Synced {env_count} env vars, {secret_count} secrets")
+
+        db.session.commit()
+        print("\nBootstrap complete!")
+        # Split string to avoid Tilt secret redaction
+        print("Visit: http://cabotage.192-168-139-2.nip.io/organizations/" + "ware" + "house")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bootstrap_cabotage.py
+++ b/scripts/bootstrap_cabotage.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
 """
 Bootstrap Warehouse (PyPI) project in Cabotage.
 


### PR DESCRIPTION
I find myself needing multiple services when working across projects and ports almost always conflict (i.e., working on warehouse + pycon-site + pycon check in + python.org) whether that be conflicting on the web service, database, or otherwise.

In comes [Tilt](https://tilt.dev/), which allows us to more accurately reflect production deployments and avoid this port conflict 

When bootstrapped with a local cabotage instance it will generate a URL based on ingress IP. I'm using [nip.io](https://nip.io/) (https://sslip.io/) to help with some DNS issues. (but maybe it's not needed)

<img width="1186" height="990" alt="image" src="https://github.com/user-attachments/assets/3be6b91a-e34a-4846-a2d1-3c46db545789" />
