### PR TITLE
perf(simple): reduce HTML template-to-Pyramid round trip work

### DIFF
--- a/warehouse/templates/api/simple/index.html
+++ b/warehouse/templates/api/simple/index.html
@@ -7,7 +7,7 @@
   </head>
   <body>
     {% for project in projects -%}
-    <a href="{{ request.route_path('api.simple.detail', name=project.name|canonicalize_name) }}">{{ project.name }}</a>
+    <a href="/simple/{{ project.name|canonicalize_name }}/">{{ project.name }}</a>
     {% endfor -%}
   </body>
 </html>


### PR DESCRIPTION
The template renderer loop calls the pyramid `route_path()` function over 700k times in a tight loop, when we know exactly what that URL is going to look like, and not change, so no need to make it dynamic.

After setting up 700k projects in my local dev env, I ran:

```shellsession
$ hyperfine --warmup 2 'curl -s -o /dev/null http://localhost/simple/'

Benchmark 1: curl -s -o /dev/null http://localhost/simple/
  Time (mean ± σ):      5.767 s ±  0.070 s    [User: 0.008 s, System: 0.017 s]
  Range (min … max):    5.679 s …  5.910 s    10 runs

# switch to static value, restart stack...

$ hyperfine --warmup 2 'curl -s -o /dev/null http://localhost/simple/'

Benchmark 1: curl -s -o /dev/null http://localhost/simple/
  Time (mean ± σ):      3.133 s ±  0.061 s    [User: 0.010 s, System: 0.018 s]
  Range (min … max):    3.039 s …  3.237 s    10 runs
```

Cuts down ~50% of the time it takes to generate the HTML response.