### PR TITLE
chore(deps): upgrade celery and kombu to latest

### DIFF
--- a/requirements/main.in
+++ b/requirements/main.in
@@ -6,7 +6,7 @@ b2sdk
 Babel
 bcrypt
 boto3
-celery[redis]>=5.3.5,<5.6
+celery[redis]>=5.6.2,<5.7
 celery-redbeat
 certifi
 click
@@ -24,7 +24,7 @@ html5lib
 humanize
 itsdangerous
 Jinja2>=2.8
-kombu[redis]>=5.4,<5.6  # https://github.com/jazzband/pip-tools/issues/1577
+kombu[redis]>=5.6,<5.7  # https://github.com/jazzband/pip-tools/issues/1577
 limits
 linehaul
 lxml

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -200,9 +200,9 @@ cbor2==5.8.0 \
     --hash=sha256:f95fed480b2a0d843f294d2a1ef4cc0f6a83c7922927f9f558e1f5a8dc54b7ca \
     --hash=sha256:fddee9103a17d7bed5753f0c7fc6663faa506eb953e50d8287804eccf7b048e6
     # via webauthn
-celery[redis]==5.5.3 \
-    --hash=sha256:0b5761a07057acee94694464ca482416b959568904c9dfa41ce8413a7d65d525 \
-    --hash=sha256:6c972ae7968c2b5281227f01c3a3f984037d21c5129d07bf3550cc2afc6b10a5
+celery[redis]==5.6.2 \
+    --hash=sha256:3ffafacbe056951b629c7abcf9064c4a2366de0bdfc9fdba421b97ebb68619a5 \
+    --hash=sha256:4a8921c3fcf2ad76317d3b29020772103581ed2454c4c042cc55dcc43585009b
     # via
     #   -r requirements/main.in
     #   celery-redbeat
@@ -978,9 +978,9 @@ jsonschema-specifications==2025.9.1 \
     # via
     #   jsonschema
     #   openapi-schema-validator
-kombu[redis]==5.5.4 \
-    --hash=sha256:886600168275ebeada93b888e831352fe578168342f0d1d5833d88ba0d847363 \
-    --hash=sha256:a12ed0557c238897d8e518f1d1fdf84bd1516c5e305af2dacd85c2015115feb8
+kombu[redis]==5.6.2 \
+    --hash=sha256:8060497058066c6f5aed7c26d7cd0d3b574990b09de842a8c5aaed0b92cc5a55 \
+    --hash=sha256:efcfc559da324d41d61ca311b0c64965ea35b4c55cc04ee36e55386145dace93
     # via
     #   -r requirements/main.in
     #   celery
@@ -2379,6 +2379,10 @@ tzdata==2025.3 \
     --hash=sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1 \
     --hash=sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7
     # via kombu
+tzlocal==5.3.1 \
+    --hash=sha256:cceffc7edecefea1f595541dbd6e990cb1ea3d19bf01b2809f362a03dd7921fd \
+    --hash=sha256:eb1a66c3ef5847adf7a834f1be0800581b683b5608e74f86ecbcef8ab91bb85d
+    # via celery
 ua-parser==1.0.1 \
     --hash=sha256:b059f2cb0935addea7e551251cbbf42e9a8872f86134163bc1a4f79e0945ffea \
     --hash=sha256:f9d92bf19d4329019cef91707aecc23c6d65143ad7e29a233f0580fb0d15547d


### PR DESCRIPTION
Refs: https://docs.celeryq.dev/en/stable/history/whatsnew-5.6.html#news

Specifically for a memory leak fix:
https://github.com/celery/celery/pull/9799