### PR TITLE
test: fix time boundaries

### DIFF
--- a/tests/unit/admin/views/test_observations.py
+++ b/tests/unit/admin/views/test_observations.py
@@ -1272,13 +1272,13 @@ class TestGetTimelineTrends:
             kind="is_malware",
             observer=observer,
             related=project1,
-            created=now - timedelta(hours=24),
+            created=now - timedelta(hours=4),
         )
         ProjectObservationFactory.create(
             kind="is_malware",
             observer=observer,
             related=project2,
-            created=now - timedelta(hours=20),  # same week
+            created=now - timedelta(hours=2),  # same week
         )
 
         project_data = _get_project_data(db_request)


### PR DESCRIPTION
When running on Monday January 26:
  - now - 24 hours = Sunday January 25 → week of Jan 19
  - now - 20 hours = Monday January 26 → week of Jan 26

This ensures both observations are always within the same calendar week regardless of when the test runs.