### PR TITLE
Validate WHEEL file tags

### DIFF
--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -16,6 +16,7 @@ from textwrap import dedent
 from types import SimpleNamespace
 from unittest import mock
 
+import packaging
 import pretend
 import psycopg
 import pytest
@@ -82,10 +83,18 @@ def _get_tar_testdata(compression_type=""):
     return temp_f.getvalue()
 
 
-def _get_whl_testdata(name="fake_package", version="1.0"):
+def _format_tags(tags: str) -> str:
+    tags = packaging.tags.parse_tag(tags)
+    return "\n".join(f"Tag: {tag}" for tag in tags)
+
+
+def _get_whl_testdata(
+    name="fake_package", version="1.0", tags=_format_tags("py3-none-any")
+):
     temp_f = io.BytesIO()
     with zipfile.ZipFile(file=temp_f, mode="w") as zfp:
         zfp.writestr(f"{name}-{version}.dist-info/METADATA", "Fake metadata")
+        zfp.writestr(f"{name}-{version}.dist-info/WHEEL", tags)
         zfp.writestr(f"{name}-{version}.dist-info/licenses/LICENSE.MIT", "Fake License")
         zfp.writestr(
             f"{name}-{version}.dist-info/licenses/LICENSE.APACHE", "Fake License"
@@ -95,6 +104,7 @@ def _get_whl_testdata(name="fake_package", version="1.0"):
             dedent(
                 f"""\
                 {name}-{version}.dist-info/METADATA,
+                {name}-{version}.dist-info/WHEEL,
                 {name}-{version}.dist-info/licenses/LICENSE.MIT,
                 {name}-{version}.dist-info/licenses/LICENSE.APACHE,
                 {name}-{version}.dist-info/RECORD,
@@ -367,40 +377,88 @@ class TestFileValidation:
             "File exceeds compression ratio of 50",
         )
 
-    def test_wheel_no_wheel_file(self, tmpdir):
-        f = str(tmpdir.join("test-1.0-py3-none-any.whl"))
+    @pytest.mark.parametrize(
+        ("tags_filename", "tags_file", "error"),
+        [
+            (
+                "py3-none-macosx_11_0_arm64",
+                "Tag: py3-none-macosx_13_0_arm64",
+                "Wheel filename and WHEEL file tags mismatch: "
+                + "py3-none-macosx_11_0_arm64 vs. py3-none-macosx_13_0_arm64",
+            ),
+            (
+                "py2-none-any",
+                "Tag: py2-none-any\nTag: py3-none-any",
+                "WHEEL file has tags not in wheel filename: py3-none-any",
+            ),
+            (
+                "py2.py3-none-any",
+                "Tag: py3-none-any",
+                "Wheel filename has tags not in WHEEL file: py2-none-any",
+            ),
+            (
+                "py2.py3-none-any",
+                "Tag: py2.py3-none-any",
+                "Tags in WHEEL file must be expanded, not compressed: py2.py3-none-any",
+            ),
+        ],
+    )
+    def test_upload_wheel_tag_mismatches(
+        self,
+        pyramid_config,
+        db_request,
+        tags_filename,
+        tags_file,
+        error,
+    ):
+        user = UserFactory.create()
+        EmailFactory.create(user=user)
+        project = ProjectFactory.create()
+        release = ReleaseFactory.create(project=project, version="1.0")
+        RoleFactory.create(user=user, project=project)
 
-        with zipfile.ZipFile(f, "w") as zfp:
-            zfp.writestr("something.txt", b"Just a placeholder file")
-
-        assert legacy._is_valid_dist_file(f, "bdist_wheel", NullMetrics()) == (
-            False,
-            "WHEEL not found at test-1.0.dist-info/WHEEL",
+        filename = "{}-{}-{}.whl".format(
+            project.normalized_name.replace("-", "_"), release.version, tags_filename
         )
-
-    def test_wheel_has_wheel_file(self, tmpdir):
-        f = str(tmpdir.join("test-1.0-py3-none-any.whl"))
-
-        with zipfile.ZipFile(f, "w") as zfp:
-            zfp.writestr("something.txt", b"Just a placeholder file")
-            zfp.writestr("test-1.0.dist-info/WHEEL", b"this is the package info")
-
-        assert legacy._is_valid_dist_file(f, "bdist_wheel", NullMetrics()) == (
-            True,
-            None,
+        data = _get_whl_testdata(
+            name=project.normalized_name.replace("-", "_"),
+            version="1.0",
+            tags=tags_file,
         )
+        digest = hashlib.md5(data).hexdigest()
 
-    def test_invalid_wheel_filename(self, tmpdir):
-        f = str(tmpdir.join("cheese.whl"))
-
-        with zipfile.ZipFile(f, "w") as zfp:
-            zfp.writestr("something.txt", b"Just a placeholder file")
-            zfp.writestr("test-1.0.dist-info/WHEEL", b"this is the package info")
-
-        assert legacy._is_valid_dist_file(f, "bdist_wheel", NullMetrics()) == (
-            False,
-            "Unable to parse name and version from wheel filename",
+        pyramid_config.testing_securitypolicy(identity=user)
+        db_request.user = user
+        db_request.user_agent = "warehouse-tests/6.6.6"
+        db_request.POST = MultiDict(
+            {
+                "metadata_version": "2.4",
+                "name": project.name,
+                "version": "1.0",
+                "summary": "This is my summary!",
+                "filetype": "bdist_wheel",
+                "md5_digest": digest,
+                "content": pretend.stub(
+                    filename=filename,
+                    file=io.BytesIO(data),
+                    type="application/zip",
+                ),
+            }
         )
+        db_request.POST.extend([("pyversion", "py3")])
+
+        storage_service = pretend.stub(store=lambda path, filepath, meta: None)
+        db_request.find_service = lambda svc, name=None, context=None: {
+            IFileStorage: storage_service,
+        }.get(svc)
+
+        with pytest.raises(HTTPBadRequest) as excinfo:
+            legacy.file_upload(db_request)
+
+        resp = excinfo.value
+
+        assert resp.status_code == 400
+        assert resp.status == f"400 Invalid distribution file. {error}"
 
     def test_incorrect_number_of_top_level_directories_sdist_tar(self, tmpdir):
         tar_fn = str(tmpdir.join("test.tar.gz"))
@@ -3069,7 +3127,9 @@ class TestFileUpload:
             project.normalized_name.replace("-", "_"), release.version, plat
         )
         filebody = _get_whl_testdata(
-            name=project.normalized_name.replace("-", "_"), version=release.version
+            name=project.normalized_name.replace("-", "_"),
+            version=release.version,
+            tags=_format_tags(f"cp34-none-{plat}"),
         )
         filestoragehash = _storage_hash(filebody)
 
@@ -3419,7 +3479,9 @@ class TestFileUpload:
             release.version,
         )
         filebody = _get_whl_testdata(
-            name=project.normalized_name.replace("-", "_"), version=release.version
+            name=project.normalized_name.replace("-", "_"),
+            version=release.version,
+            tags=_format_tags("cp34-none-any"),
         )
         filestoragehash = _storage_hash(filebody)
 
@@ -3719,6 +3781,10 @@ class TestFileUpload:
             zfp.writestr("some_file", "some_data")
             zfp.writestr(f"{project_name}-{release.version}.dist-info/METADATA", "")
             zfp.writestr(
+                f"{project_name}-{release.version}.dist-info/WHEEL",
+                "Tag: cp34-none-any",
+            )
+            zfp.writestr(
                 f"{project_name}-{release.version}.dist-info/RECORD",
                 f"{project_name}-{release.version}.dist-info/RECORD,",
             )
@@ -3794,10 +3860,15 @@ class TestFileUpload:
 
             zfp.writestr(f"{project_name}-{release.version}.dist-info/METADATA", "")
             zfp.writestr(
+                f"{project_name}-{release.version}.dist-info/WHEEL",
+                "Tag: cp34-none-any",
+            )
+            zfp.writestr(
                 f"{project_name}-{release.version}.dist-info/RECORD",
                 dedent(
                     f"""\
                     {project_name}-{release.version}.dist-info/METADATA,
+                    {project_name}-{release.version}.dist-info/WHEEL,
                     {project_name}-{release.version}.dist-info/RECORD,
                     """,
                 ),
@@ -3864,10 +3935,15 @@ class TestFileUpload:
         with zipfile.ZipFile(file=temp_f, mode="w") as zfp:
             zfp.writestr(f"{project_name}-{release.version}.dist-info/METADATA", "")
             zfp.writestr(
+                f"{project_name}-{release.version}.dist-info/WHEEL",
+                "Tag: cp34-none-any",
+            )
+            zfp.writestr(
                 f"{project_name}-{release.version}.dist-info/RECORD",
                 dedent(
                     f"""\
                 {project_name}-{release.version}.dist-info\\METADATA,
+                {project_name}-{release.version}.dist-info\\WHEEL,
                 {project_name}-{release.version}.dist-info\\RECORD,
                 """,
                 ),
@@ -3939,6 +4015,10 @@ class TestFileUpload:
 
             zfp.writestr(f"{project_name}-{release.version}.dist-info/METADATA", "")
             zfp.writestr(
+                f"{project_name}-{release.version}.dist-info/WHEEL",
+                "Tag: cp34-none-any",
+            )
+            zfp.writestr(
                 f"{project_name}-{release.version}.dist-info/{exempt_filename}", ""
             )
             zfp.writestr(
@@ -3946,6 +4026,7 @@ class TestFileUpload:
                 dedent(
                     f"""\
                     {project_name}-{release.version}.dist-info/METADATA,
+                    {project_name}-{release.version}.dist-info/WHEEL,
                     {project_name}-{release.version}.dist-info/RECORD,
                     """,
                 ),
@@ -4012,6 +4093,10 @@ class TestFileUpload:
         with zipfile.ZipFile(file=temp_f, mode="w") as zfp:
             zfp.writestr("some_file", "some_data")
             zfp.writestr(f"{project_name}-{release.version}.dist-info/METADATA", "")
+            zfp.writestr(
+                f"{project_name}-{release.version}.dist-info/WHEEL",
+                "Tag: cp34-none-any",
+            )
             zfp.writestr(f"not-dist-info/{exempt_filename}", "")
             zfp.writestr(
                 f"{project_name}-{release.version}.dist-info/RECORD",

--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -83,34 +83,40 @@ def _get_tar_testdata(compression_type=""):
     return temp_f.getvalue()
 
 
-def _format_tags(tags: str) -> str:
+def _format_tags(tags: str) -> bytes:
+    """
+    Build a mock WHEEL file from the given tags.
+    """
     tags = packaging.tags.parse_tag(tags)
-    return "\n".join(f"Tag: {tag}" for tag in tags)
+    formatted = "Wheel-Version: 1.0\n" + "\n".join(f"Tag: {tag}" for tag in tags)
+    return formatted.encode("utf-8")
 
 
 def _get_whl_testdata(
-    name="fake_package", version="1.0", tags=_format_tags("py3-none-any")
+    name="fake_package",
+    version="1.0",
+    tags: bytes | None = _format_tags("py3-none-any"),
 ):
     temp_f = io.BytesIO()
     with zipfile.ZipFile(file=temp_f, mode="w") as zfp:
         zfp.writestr(f"{name}-{version}.dist-info/METADATA", "Fake metadata")
-        zfp.writestr(f"{name}-{version}.dist-info/WHEEL", tags)
+        if tags:
+            zfp.writestr(f"{name}-{version}.dist-info/WHEEL", tags)
         zfp.writestr(f"{name}-{version}.dist-info/licenses/LICENSE.MIT", "Fake License")
         zfp.writestr(
             f"{name}-{version}.dist-info/licenses/LICENSE.APACHE", "Fake License"
         )
-        zfp.writestr(
-            f"{name}-{version}.dist-info/RECORD",
-            dedent(
-                f"""\
-                {name}-{version}.dist-info/METADATA,
-                {name}-{version}.dist-info/WHEEL,
-                {name}-{version}.dist-info/licenses/LICENSE.MIT,
-                {name}-{version}.dist-info/licenses/LICENSE.APACHE,
-                {name}-{version}.dist-info/RECORD,
-                """,
-            ),
+        record = dedent(
+            f"""\
+            {name}-{version}.dist-info/METADATA,
+            {name}-{version}.dist-info/licenses/LICENSE.MIT,
+            {name}-{version}.dist-info/licenses/LICENSE.APACHE,
+            {name}-{version}.dist-info/RECORD,
+            """,
         )
+        if tags:
+            record += f"{name}-{version}.dist-info/WHEEL,\n"
+        zfp.writestr(f"{name}-{version}.dist-info/RECORD", record)
     return temp_f.getvalue()
 
 
@@ -382,24 +388,34 @@ class TestFileValidation:
         [
             (
                 "py3-none-macosx_11_0_arm64",
-                "Tag: py3-none-macosx_13_0_arm64",
+                b"Tag: py3-none-macosx_13_0_arm64",
                 "Wheel filename and WHEEL file tags mismatch: "
                 + "py3-none-macosx_11_0_arm64 vs. py3-none-macosx_13_0_arm64",
             ),
             (
                 "py2-none-any",
-                "Tag: py2-none-any\nTag: py3-none-any",
+                b"Tag: py2-none-any\nTag: py3-none-any",
                 "WHEEL file has tags not in wheel filename: py3-none-any",
             ),
             (
                 "py2.py3-none-any",
-                "Tag: py3-none-any",
+                b"Tag: py3-none-any",
                 "Wheel filename has tags not in WHEEL file: py2-none-any",
             ),
             (
                 "py2.py3-none-any",
-                "Tag: py2.py3-none-any",
+                b"Tag: py2.py3-none-any",
                 "Tags in WHEEL file must be expanded, not compressed: py2.py3-none-any",
+            ),
+            (
+                "py3-none-macosx_11_0_arm64",
+                b"\xff\x00\xff",
+                "WHEEL file is not valid UTF-8",
+            ),
+            (
+                "py3-none-macosx_11_0_arm64",
+                None,
+                "WHEEL not found at <NAME>-1.0.dist-info/WHEEL",
             ),
         ],
     )
@@ -417,11 +433,10 @@ class TestFileValidation:
         release = ReleaseFactory.create(project=project, version="1.0")
         RoleFactory.create(user=user, project=project)
 
-        filename = "{}-{}-{}.whl".format(
-            project.normalized_name.replace("-", "_"), release.version, tags_filename
-        )
+        name = project.normalized_name.replace("-", "_")
+        filename = f"{name}-{release.version}-{tags_filename}.whl"
         data = _get_whl_testdata(
-            name=project.normalized_name.replace("-", "_"),
+            name=name,
             version="1.0",
             tags=tags_file,
         )
@@ -458,7 +473,10 @@ class TestFileValidation:
         resp = excinfo.value
 
         assert resp.status_code == 400
-        assert resp.status == f"400 Invalid distribution file. {error}"
+        rendered_error = f"400 Invalid distribution file. {error}".replace(
+            "<NAME>", name
+        )
+        assert resp.status == rendered_error
 
     def test_incorrect_number_of_top_level_directories_sdist_tar(self, tmpdir):
         tar_fn = str(tmpdir.join("test.tar.gz"))

--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -390,27 +390,29 @@ class TestFileValidation:
                 "py3-none-macosx_11_0_arm64",
                 b"Tag: py3-none-macosx_13_0_arm64",
                 "Wheel filename and WHEEL file tags mismatch: "
-                + "py3-none-macosx_11_0_arm64 vs. py3-none-macosx_13_0_arm64",
+                + "'py3-none-macosx_11_0_arm64' vs. 'py3-none-macosx_13_0_arm64'",
             ),
             (
                 "py2-none-any",
                 b"Tag: py2-none-any\nTag: py3-none-any",
-                "WHEEL file has tags not in wheel filename: py3-none-any",
+                "WHEEL file has tags not in wheel filename: 'py3-none-any'",
             ),
             (
                 "py2.py3-none-any",
                 b"Tag: py3-none-any",
-                "Wheel filename has tags not in WHEEL file: py2-none-any",
+                "Wheel filename has tags not in WHEEL file: 'py2-none-any'",
             ),
             (
                 "py2.py3-none-any",
                 b"Tag: py2.py3-none-any",
-                "Tags in WHEEL file must be expanded, not compressed: py2.py3-none-any",
+                "Tags in WHEEL file must be expanded, not compressed: "
+                + "'py2.py3-none-any'",
             ),
             (
                 "py3-none-macosx_11_0_arm64",
                 b"\xff\x00\xff",
-                "WHEEL file is not valid UTF-8",
+                "Wheel filename and WHEEL file tags mismatch: "
+                + "'py3-none-macosx_11_0_arm64' vs. ''",
             ),
             (
                 "py3-none-macosx_11_0_arm64",

--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -411,8 +411,7 @@ class TestFileValidation:
             (
                 "py3-none-macosx_11_0_arm64",
                 b"\xff\x00\xff",
-                "Wheel filename and WHEEL file tags mismatch: "
-                + "'py3-none-macosx_11_0_arm64' vs. ''",
+                "WHEEL file is not UTF-8 encoded",
             ),
             (
                 "py3-none-macosx_11_0_arm64",

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -10,6 +10,7 @@ import zipfile
 
 import packaging.requirements
 import packaging.specifiers
+import packaging.tags
 import packaging.utils
 import packaging.version
 import packaging_legacy.version
@@ -347,19 +348,6 @@ def _is_valid_dist_file(filename, filetype, metrics, *, scan=True):
                         zfp.read(target_file)
                     except KeyError:
                         return False, f"PKG-INFO not found at {target_file}"
-                if filename.endswith(".whl"):
-                    try:
-                        name, version, _ = os.path.basename(filename).split("-", 2)
-                    except ValueError:
-                        return (
-                            False,
-                            "Unable to parse name and version from wheel filename",
-                        )
-                    target_file = os.path.join(f"{name}-{version}.dist-info", "WHEEL")
-                    try:
-                        zfp.read(target_file)
-                    except KeyError:
-                        return False, f"WHEEL not found at {target_file}"
 
                 # Scan archive members for YARA rule matches while open
                 if scan:
@@ -431,6 +419,61 @@ def _is_valid_dist_file(filename, filetype, metrics, *, scan=True):
 
     # If we haven't yet decided it's not valid, then we'll assume it is and
     # allow it.
+    return True, None
+
+
+def _is_valid_wheel_file(
+    contents: bytes, tags: frozenset[packaging.tags.Tag]
+) -> tuple[bool, str | None]:
+    """
+    Check whether the WHEEL file matches the wheel filename tags.
+
+    A mismatch can happen when manually editing the wheel filename without also editing
+    the dist-info WHEEL file.
+    """
+    filename_tags = {str(tag) for tag in tags}
+    dist_info_tags = set()
+    try:
+        decoded = contents.decode("utf-8")
+    except UnicodeDecodeError:
+        return False, "WHEEL file is not valid UTF-8"
+
+    for line in decoded.splitlines():
+        if line.startswith("Tag:"):
+            tag = line.removeprefix("Tag:").strip()
+            if "." in tag:
+                return (
+                    False,
+                    f"Tags in WHEEL file must be expanded, not compressed: {tag}",
+                )
+            dist_info_tags.add(tag)
+
+    # Handle the case that there's no overlap, usually two different tags.
+    if not (dist_info_tags & filename_tags):
+        formatted_filename_tags = ", ".join(sorted(filename_tags))
+        formatted_dist_info_tags = ", ".join(sorted(dist_info_tags))
+        return (
+            False,
+            "Wheel filename and WHEEL file tags mismatch: "
+            + f"{formatted_filename_tags} vs. {formatted_dist_info_tags}",
+        )
+
+    only_dist_info_tags = dist_info_tags - filename_tags
+    if only_dist_info_tags:
+        formatted_tags = ", ".join(sorted(only_dist_info_tags))
+        return (
+            False,
+            f"WHEEL file has tags not in wheel filename: {formatted_tags}",
+        )
+
+    only_filename_tags = filename_tags - dist_info_tags
+    if only_filename_tags:
+        formatted_tags = ", ".join(sorted(only_filename_tags))
+        return (
+            False,
+            f"Wheel filename has tags not in WHEEL file: {formatted_tags}",
+        )
+
     return True, None
 
 
@@ -1555,6 +1598,27 @@ def file_upload(request):
             metadata_file_hashes = {
                 k: h.hexdigest().lower() for k, h in metadata_file_hashes.items()
             }
+
+            with zipfile.ZipFile(temporary_filename) as zfp:
+                target_file = os.path.join(f"{name}-{version}.dist-info", "WHEEL")
+                try:
+                    wheel_file = zfp.read(target_file)
+                    valid, reason = _is_valid_wheel_file(wheel_file, tags)
+                except KeyError:
+                    valid = False
+                    reason = f"WHEEL not found at {target_file}"
+
+                if not valid:
+                    request.metrics.increment(
+                        "warehouse.upload.failed",
+                        tags=[
+                            "reason:invalid-distribution-file",
+                            f"filetype:{form.filetype.data}",
+                        ],
+                    )
+                    raise _exc_with_message(
+                        HTTPBadRequest, f"Invalid distribution file. {reason}"
+                    )
 
         # If the user provided attestations, verify them
         # We persist these attestations subsequently, only after the

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 import datetime
+import email.parser
+import email.policy
 import hashlib
 import hmac
 import os.path
@@ -422,9 +424,7 @@ def _is_valid_dist_file(filename, filetype, metrics, *, scan=True):
     return True, None
 
 
-def _is_valid_wheel_file(
-    contents: bytes, tags: frozenset[packaging.tags.Tag]
-) -> tuple[bool, str | None]:
+def _validate_wheel_file(contents: bytes, tags: frozenset[packaging.tags.Tag]):
     """
     Check whether the WHEEL file matches the wheel filename tags.
 
@@ -433,48 +433,39 @@ def _is_valid_wheel_file(
     """
     filename_tags = {str(tag) for tag in tags}
     dist_info_tags = set()
-    try:
-        decoded = contents.decode("utf-8")
-    except UnicodeDecodeError:
-        return False, "WHEEL file is not valid UTF-8"
 
-    for line in decoded.splitlines():
-        if line.startswith("Tag:"):
-            tag = line.removeprefix("Tag:").strip()
-            if "." in tag:
-                return (
-                    False,
-                    f"Tags in WHEEL file must be expanded, not compressed: {tag}",
-                )
-            dist_info_tags.add(tag)
+    data = email.parser.BytesParser(policy=email.policy.compat32).parsebytes(contents)
+    for key, value in data.items():
+        if key != "Tag":
+            continue
+        if "." in value:
+            raise ValueError(
+                f"Tags in WHEEL file must be expanded, not compressed: '{value}'",
+            )
+        dist_info_tags.add(value)
 
     # Handle the case that there's no overlap, usually two different tags.
     if not (dist_info_tags & filename_tags):
-        formatted_filename_tags = ", ".join(sorted(filename_tags))
-        formatted_dist_info_tags = ", ".join(sorted(dist_info_tags))
-        return (
-            False,
+        formatted_filename_tags = "', '".join(sorted(filename_tags))
+        formatted_dist_info_tags = "', '".join(sorted(dist_info_tags))
+        raise ValueError(
             "Wheel filename and WHEEL file tags mismatch: "
-            + f"{formatted_filename_tags} vs. {formatted_dist_info_tags}",
+            + f"'{formatted_filename_tags}' vs. '{formatted_dist_info_tags}'",
         )
 
     only_dist_info_tags = dist_info_tags - filename_tags
     if only_dist_info_tags:
-        formatted_tags = ", ".join(sorted(only_dist_info_tags))
-        return (
-            False,
-            f"WHEEL file has tags not in wheel filename: {formatted_tags}",
+        formatted_tags = "', '".join(sorted(only_dist_info_tags))
+        raise ValueError(
+            f"WHEEL file has tags not in wheel filename: '{formatted_tags}'",
         )
 
     only_filename_tags = filename_tags - dist_info_tags
     if only_filename_tags:
-        formatted_tags = ", ".join(sorted(only_filename_tags))
-        return (
-            False,
-            f"Wheel filename has tags not in WHEEL file: {formatted_tags}",
+        formatted_tags = "', '".join(sorted(only_filename_tags))
+        raise ValueError(
+            f"Wheel filename has tags not in WHEEL file: '{formatted_tags}'",
         )
-
-    return True, None
 
 
 def _is_duplicate_file(db_session, filename, hashes):
@@ -1603,12 +1594,20 @@ def file_upload(request):
                 target_file = os.path.join(f"{name}-{version}.dist-info", "WHEEL")
                 try:
                     wheel_file = zfp.read(target_file)
-                    valid, reason = _is_valid_wheel_file(wheel_file, tags)
+                    _validate_wheel_file(wheel_file, tags)
                 except KeyError:
-                    valid = False
-                    reason = f"WHEEL not found at {target_file}"
-
-                if not valid:
+                    request.metrics.increment(
+                        "warehouse.upload.failed",
+                        tags=[
+                            "reason:invalid-distribution-file",
+                            f"filetype:{form.filetype.data}",
+                        ],
+                    )
+                    raise _exc_with_message(
+                        HTTPBadRequest,
+                        f"Invalid distribution file. WHEEL not found at {target_file}",
+                    )
+                except ValueError as reason:
                     request.metrics.increment(
                         "warehouse.upload.failed",
                         tags=[

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -434,7 +434,12 @@ def _validate_wheel_file(contents: bytes, tags: frozenset[packaging.tags.Tag]):
     filename_tags = {str(tag) for tag in tags}
     dist_info_tags = set()
 
-    data = email.parser.BytesParser(policy=email.policy.compat32).parsebytes(contents)
+    try:
+        content = contents.decode("utf-8")
+    except UnicodeDecodeError:
+        raise ValueError("WHEEL file is not UTF-8 encoded")
+
+    data = email.parser.Parser(policy=email.policy.compat32).parsestr(content)
     for key, value in data.items():
         if key != "Tag":
             continue

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -439,7 +439,7 @@ def _validate_wheel_file(contents: bytes, tags: frozenset[packaging.tags.Tag]):
     except UnicodeDecodeError:
         raise ValueError("WHEEL file is not UTF-8 encoded")
 
-    data = email.parser.Parser(policy=email.policy.compat32).parsestr(content)
+    data = email.parser.HeaderParser(policy=email.policy.compat32).parsestr(content)
     for key, value in data.items():
         if key != "Tag":
             continue


### PR DESCRIPTION
It can happen that the filename and the dist-info `WHEEL` file mismatch, either because the author manually changed the wheel filename, or due to a bug in the build backend implementation.

This caused a number of bugs in uv and pip, which expected the `WHEEL` file to contain accurate tags in the basic `Key: Value` format:

* https://github.com/astral-sh/uv/issues/2149
* https://github.com/astral-sh/uv/issues/6615
* https://github.com/astral-sh/uv/issues/15832
* https://github.com/astral-sh/uv/issues/16581
* https://github.com/astral-sh/uv/issues/16823
* https://github.com/pypa/pip/issues/13709
* https://github.com/astral-sh/uv/issues/17711

Another notable example is https://github.com/ziglang/zig-pypi/pull/40, where the author wasn't aware of the expanded tags requirement.

This PR adds validation that enforces the basic `Key: Value` format, that the tags in the `WHEEL` file are expanded and that the tags match.

---

Speaking of https://github.com/ziglang/zig-pypi/pull/40, https://github.com/pypi/support/issues/8180 would really valuable to have, zig is an important part of the toolchain of building manylinux-compliant python packages using rust.