### PR TITLE
Remove links to no longer active pypi twitter

### DIFF
--- a/docs/mkdocs-blog.yml
+++ b/docs/mkdocs-blog.yml
@@ -82,8 +82,6 @@ extra:
       link: https://fosstodon.org/@pypi
     - icon: fontawesome/brands/bluesky
       link: https://bsky.app/profile/pypi.org
-    - icon: fontawesome/brands/twitter
-      link: https://twitter.com/pypi
     - icon: material/rss
       link: https://blog.pypi.org/feed_rss_created.xml
   # See https://material-plausible-plugin.ale.sh

--- a/docs/mkdocs-user-docs.yml
+++ b/docs/mkdocs-user-docs.yml
@@ -59,8 +59,6 @@ extra:
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/pypi
-    - icon: fontawesome/brands/twitter
-      link: https://twitter.com/pypi
     - icon: fontawesome/brands/mastodon
       link: https://fosstodon.org/@pypi
     - icon: fontawesome/brands/bluesky


### PR DESCRIPTION
The pypi twitter / X account was last used in 2022. The Mastodon and Bluesky accounts are linked and still active.

Let's remove the abandoned Twitter pypi account from the blog and docs footers.