### PR TITLE
chore: migrate email domain to case-insentive

### DIFF
--- a/warehouse/accounts/models.py
+++ b/warehouse/accounts/models.py
@@ -450,7 +450,7 @@ class ProhibitedEmailDomain(db.Model):
     __repr__ = make_repr("domain")
 
     created: Mapped[datetime_now]
-    domain: Mapped[str] = mapped_column(unique=True)
+    domain: Mapped[str] = mapped_column(CITEXT, unique=True)
     is_mx_record: Mapped[bool_false] = mapped_column(
         comment="Prohibit any domains that have this domain as an MX record?"
     )

--- a/warehouse/migrations/versions/ee66c00f12e6_change_prohibited_email_domain_to_citext.py
+++ b/warehouse/migrations/versions/ee66c00f12e6_change_prohibited_email_domain_to_citext.py
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Change prohibited_email_domains.domain to CITEXT
+
+Revision ID: ee66c00f12e6
+Revises: 31ac9b5e1e8b
+Create Date: 2026-02-03
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+from sqlalchemy.dialects.postgresql import CITEXT
+
+revision = "ee66c00f12e6"
+down_revision = "31ac9b5e1e8b"
+
+
+def upgrade():
+    op.alter_column(
+        "prohibited_email_domains",
+        "domain",
+        existing_type=sa.String(),
+        type_=CITEXT(),
+        existing_nullable=False,
+    )
+
+
+def downgrade():
+    op.alter_column(
+        "prohibited_email_domains",
+        "domain",
+        existing_type=CITEXT(),
+        type_=sa.String(),
+        existing_nullable=False,
+    )


### PR DESCRIPTION
Since domain names aren't case-sensitive, we can ensure they are stored and evaluated as such, so we don't need to normalize things when comparing them.