### PR TITLE
feat(views): Add IP-based rate limit tracking for 404 errors

### DIFF
--- a/warehouse/config.py
+++ b/warehouse/config.py
@@ -595,6 +595,12 @@ def configure(settings=None):
         "SEARCH_RATELIMIT_STRING",
         default="5 per second",
     )
+    maybe_set(
+        settings,
+        "warehouse.notfound.ip_ratelimit_string",
+        "NOTFOUND_RATELIMIT_STRING",
+        default="50 per 5 minutes",
+    )
 
     # OIDC feature flags and settings
     maybe_set(settings, "warehouse.oidc.audience", "OIDC_AUDIENCE")
@@ -824,6 +830,9 @@ def configure(settings=None):
     config.include(".static")
 
     config.include(".search")
+
+    # Register views module (includes 404 rate limiting)
+    config.include(".views")
 
     # Register the support for AWS, Backblaze,and Google Cloud
     config.include(".aws")

--- a/warehouse/views.py
+++ b/warehouse/views.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import collections
+import logging
 import re
 import typing
 
@@ -66,6 +67,8 @@ from warehouse.utils.row_counter import RowCount
 if typing.TYPE_CHECKING:
     from pyramid.request import Request
 
+logger = logging.getLogger(__name__)
+
 JSON_REGEX = r"^/pypi/([^\/]+)\/?([^\/]+)?/json\/?$"
 json_path = re.compile(JSON_REGEX)
 
@@ -92,6 +95,26 @@ def httpexception_view(exc, request):
                 "script-src": ["https://www.youtube.com", "https://s.ytimg.com"],
             }
         )
+
+        # Track 404 rate limits per IP address for observation.
+        # This is currently in observation mode - we emit metrics and logs
+        # but do not block requests. Once we have tuned the rate limit values,
+        # blocking can be enabled.
+        metrics = request.find_service(IMetricsService, context=None)
+        ratelimiter = request.find_service(IRateLimiter, name="notfound.ip", context=None)
+        ratelimiter.hit(request.remote_addr)
+        metrics.increment("warehouse.notfound.ratelimiter.hit")
+        if not ratelimiter.test(request.remote_addr):
+            metrics.increment("warehouse.notfound.ratelimiter.exceeded")
+            logger.warning(
+                "404 rate limit exceeded",
+                extra={
+                    "remote_addr": request.remote_addr,
+                    "path": request.path,
+                    "project_name": project_name,
+                },
+            )
+
     try:
         # Lightweight version of 404 page for `/simple/`
         if isinstance(exc, HTTPNotFound) and request.path.startswith("/simple/"):
@@ -607,3 +630,10 @@ def force_status(request):
         raise exception_response(int(request.matchdict["status"]))
     except KeyError:
         raise exception_response(404) from None
+
+
+def includeme(config):
+    ratelimit_string = config.registry.settings.get(
+        "warehouse.notfound.ip_ratelimit_string"
+    )
+    config.register_rate_limiter(ratelimit_string, "notfound.ip")


### PR DESCRIPTION
This adds an observation-mode rate limit implementation for excessive 404
errors from a given client IP. Currently the implementation:

- Tracks 404 requests per IP using the existing rate limiting infrastructure
- Emits metrics (warehouse.notfound.ratelimiter.hit and
  warehouse.notfound.ratelimiter.exceeded) for monitoring
- Logs warnings when rate limits are exceeded for investigation

The rate limit is currently configured at 50 requests per 5 minutes
(configurable via NOTFOUND_RATELIMIT_STRING env var) and operates in
observation mode only - it does not block requests. Once the tunable
values are determined from live data, blocking can be enabled.

This helps identify misconfigured clients and crawlers that abuse the
index by generating excessive 404s.

https://claude.ai/code/session_01F8syZGanCFSwRMVwCD1493