### PR TITLE
feat: emit pypi ownership data in JSON API

### DIFF
--- a/docs/dev/api-reference/xml-rpc.md
+++ b/docs/dev/api-reference/xml-rpc.md
@@ -116,11 +116,6 @@ package.
     The following methods are considered unsupported and will be deprecated
     in the future.
 
-### `package_roles(package_name)`
-
-Retrieve a list of `[role, user]` for a given `package_name`.
-Role is either `Maintainer` or `Owner`.
-
 ### `user_packages(user)`
 
 Retrieve a list of `[role, package_name]` for a given `user`.
@@ -183,3 +178,8 @@ URLs for a given release.
 Use the [JSON API](https://docs.pypi.org/api/json/) or
 [Index API](https://docs.pypi.org/api/index-api/) to query for metadata of a
 given release.
+
+### `package_roles(package_name)`
+
+Use the [JSON API](https://docs.pypi.org/api/json/) `ownership` key to
+query for roles of a given project.

--- a/docs/user/api/json.md
+++ b/docs/user/api/json.md
@@ -269,7 +269,14 @@ Accept: application/json
               "yanked_reason": null
             }
         ],
-        "vulnerabilities": []
+        "vulnerabilities": [],
+        "ownership": {
+            "roles": [
+                {"role": "Owner", "user": "theacodes"},
+                {"role": "Maintainer", "user": "pypa-bot"}
+            ],
+            "organization": "pypa"
+        }
     }
     ```
 
@@ -430,9 +437,29 @@ Accept: application/json
             "yanked_reason": null
           }
         ],
-        "vulnerabilities": []
+        "vulnerabilities": [],
+        "ownership": {
+            "roles": [
+                {"role": "Owner", "user": "theacodes"},
+                {"role": "Maintainer", "user": "pypa-bot"}
+            ],
+            "organization": "pypa"
+        }
     }
     ```
+
+#### Ownership
+
+The `ownership` key provides information about the project's roles and
+organization membership. It contains two fields:
+
+* `roles`: A list of `{"role": "<role>", "user": "<username>"}` objects
+  representing the project's owners and maintainers.
+  Roles are sorted with `Owner` before `Maintainer`,
+  then alphabetically by username within each role.
+  This is an empty list when the project has no roles assigned.
+* `organization`: The URL slug of the organization that owns the project (e.g. `"pypa"`),
+  or `null` if the project is not owned by an organization.
 
 #### Known vulnerabilities
 
@@ -498,4 +525,5 @@ For example, here is what a withdrawn vulnerability might look like:
 
 
 [Index API]: ./index-api.md
+[`package_roles`]: https://docs.pypi.org/api/xml-rpc/#package_rolespackage_name
 [known vulnerabilities]: https://github.com/pypa/advisory-database

--- a/tests/unit/packaging/test_init.py
+++ b/tests/unit/packaging/test_init.py
@@ -7,7 +7,7 @@ from celery.schedules import crontab
 from warehouse import packaging
 from warehouse.accounts.models import Email, User
 from warehouse.manage.tasks import update_role_invitation_status
-from warehouse.organizations.models import Organization
+from warehouse.organizations.models import Organization, OrganizationProject
 from warehouse.packaging.interfaces import (
     IDocsStorage,
     IFileStorage,
@@ -150,6 +150,12 @@ def test_includeme(monkeypatch):
             cache_keys=["project/{obj.project.normalized_name}"],
             purge_keys=[
                 key_factory("project/{obj.project.normalized_name}"),
+            ],
+        ),
+        pretend.call(
+            OrganizationProject,
+            purge_keys=[
+                key_factory("project/{attr.normalized_name}", if_attr_exists="project"),
             ],
         ),
     ]

--- a/warehouse/packaging/__init__.py
+++ b/warehouse/packaging/__init__.py
@@ -7,7 +7,7 @@ from warehouse import db
 from warehouse.accounts.models import Email, User
 from warehouse.cache.origin import key_factory, receive_set
 from warehouse.manage.tasks import update_role_invitation_status
-from warehouse.organizations.models import Organization
+from warehouse.organizations.models import Organization, OrganizationProject
 from warehouse.packaging.interfaces import (
     IDocsStorage,
     IFileStorage,
@@ -167,6 +167,12 @@ def includeme(config):
         cache_keys=["project/{obj.project.normalized_name}"],
         purge_keys=[
             key_factory("project/{obj.project.normalized_name}"),
+        ],
+    )
+    config.register_origin_cache_keys(
+        OrganizationProject,
+        purge_keys=[
+            key_factory("project/{attr.normalized_name}", if_attr_exists="project"),
         ],
     )
 


### PR DESCRIPTION
This replaces the XML-RPC `package_roles` method with a modern,
cacheable alternative.