### PR TITLE
Link Inspector from file details view

### DIFF
--- a/tests/functional/test_project.py
+++ b/tests/functional/test_project.py
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from http import HTTPStatus
+
+from tests.common.db.packaging import FileFactory, ProjectFactory, ReleaseFactory
+
+
+def test_project_release_file_details_links_to_inspector(webtest):
+    project = ProjectFactory.create(name="sampleproject")
+    release = ReleaseFactory.create(project=project, version="1.2.3")
+    file = FileFactory.create(
+        release=release,
+        filename=f"{project.name}-{release.version}.tar.gz",
+        packagetype="sdist",
+        python_version="source",
+    )
+
+    response = webtest.get(
+        f"/project/{project.normalized_name}/{release.version}/", status=HTTPStatus.OK
+    )
+
+    inspector_url = (
+        f"https://inspector.pypi.io/project/{project.normalized_name}/"
+        f"{release.version}/packages/{file.path}/"
+    )
+    inspector_link = response.html.find("a", {"href": inspector_url})
+
+    assert inspector_link is not None
+    assert inspector_link.text == "View in Inspector"

--- a/warehouse/templates/includes/file-details.html
+++ b/warehouse/templates/includes/file-details.html
@@ -51,6 +51,11 @@
       <li>
         Download URL: <a href="{{ request.route_url('packaging.file', path=file.path) }}">{{ file.filename }}</a>
       </li>
+      <li>
+        Inspector URL: <a href="https://inspector.pypi.io/project/{{ file.release.project.normalized_name }}/{{ file.release.version }}/packages/{{ file.path }}/"
+                          target="_blank"
+                          rel="noopener">View in Inspector</a>
+      </li>
       <li>{% trans upload_time=humanize(file.upload_time) %} Upload date: {{ upload_time }} {% endtrans %}</li>
       <li>
         {% trans size=file.size|filesizeformat() if file.size else 0|filesizeformat() %} Size: {{ size }} {% endtrans %}


### PR DESCRIPTION
Closes #19032

## Summary
- add an Inspector link to the project file details metadata section
- use the same inspector URL pattern already used in admin release detail
- add a functional test to verify the inspector link is rendered for a release file

## Testing
- T=tests/functional/test_project.py make tests