### PR TITLE
Add bulk release/file yank and delete actions in project management

### DIFF
--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -164,7 +164,7 @@ msgstr ""
 msgid "Successful WebAuthn assertion"
 msgstr ""
 
-#: warehouse/accounts/views.py:631 warehouse/manage/views/__init__.py:860
+#: warehouse/accounts/views.py:631 warehouse/manage/views/__init__.py:872
 msgid "Recovery code accepted. The supplied code cannot be used again."
 msgstr ""
 
@@ -535,143 +535,214 @@ msgid ""
 "less."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:320
+#: warehouse/manage/views/__init__.py:332
 msgid "Account details updated"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:351
+#: warehouse/manage/views/__init__.py:363
 #, python-brace-format
 msgid "Email ${email_address} added - check your email for a verification link"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:807
+#: warehouse/manage/views/__init__.py:819
 msgid "Recovery codes already generated"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:809
+#: warehouse/manage/views/__init__.py:821
 msgid "Generating new recovery codes will invalidate your existing codes."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:917
+#: warehouse/manage/views/__init__.py:929
 msgid "Verify your email to create an API token."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1019
+#: warehouse/manage/views/__init__.py:1031
 msgid "API Token does not exist."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1051
+#: warehouse/manage/views/__init__.py:1063
 msgid "Invalid credentials. Try again"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1170
+#: warehouse/manage/views/__init__.py:1182
 msgid "Invalid alternate repository location details"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1208
+#: warehouse/manage/views/__init__.py:1220
 #, python-brace-format
 msgid "Added alternate repository '${name}'"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1241
-#: warehouse/manage/views/__init__.py:1502
-#: warehouse/manage/views/__init__.py:1587
-#: warehouse/manage/views/__init__.py:1688
-#: warehouse/manage/views/__init__.py:1788
+#: warehouse/manage/views/__init__.py:1253
+#: warehouse/manage/views/__init__.py:1510
+#: warehouse/manage/views/__init__.py:1716
+#: warehouse/manage/views/__init__.py:1801
+#: warehouse/manage/views/__init__.py:1902
+#: warehouse/manage/views/__init__.py:2002
+#: warehouse/manage/views/__init__.py:2103
 msgid "Confirm the request"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1253
+#: warehouse/manage/views/__init__.py:1265
 msgid "Invalid alternate repository id"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1264
+#: warehouse/manage/views/__init__.py:1276
 msgid "Invalid alternate repository for project"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1273
+#: warehouse/manage/views/__init__.py:1285
 #, python-brace-format
 msgid ""
 "Could not delete alternate repository - ${confirm} is not the same as "
 "${alt_repo_name}"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1303
+#: warehouse/manage/views/__init__.py:1315
 #, python-brace-format
 msgid "Deleted alternate repository '${name}'"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1371
-#: warehouse/manage/views/__init__.py:1672
-#: warehouse/manage/views/__init__.py:1780
+#: warehouse/manage/views/__init__.py:1383
+#: warehouse/manage/views/__init__.py:1503
+#: warehouse/manage/views/__init__.py:1886
+#: warehouse/manage/views/__init__.py:1994
+#: warehouse/manage/views/__init__.py:2096
 msgid ""
 "Project deletion temporarily disabled. See https://pypi.org/help#admin-"
 "intervention for details."
 msgstr ""
 
 #: warehouse/manage/views/__init__.py:1515
+msgid "Could not manage releases - "
+msgstr ""
+
+#: warehouse/manage/views/__init__.py:1524
+msgid "Select at least one release"
+msgstr ""
+
+#: warehouse/manage/views/__init__.py:1532
+msgid "Could not find one or more releases"
+msgstr ""
+
+#: warehouse/manage/views/__init__.py:1651
+#: warehouse/manage/views/__init__.py:1672
+msgid "Could not find bulk release action"
+msgstr ""
+
+#: warehouse/manage/views/__init__.py:1654
+msgid "No releases matched the selected action"
+msgstr ""
+
+#: warehouse/manage/views/__init__.py:1658
+msgid "Deleted release"
+msgstr ""
+
+#: warehouse/manage/views/__init__.py:1660
+#, python-format
+msgid "Deleted %(number)s releases"
+msgstr ""
+
+#: warehouse/manage/views/__init__.py:1663
+msgid "Yanked release"
+msgstr ""
+
+#: warehouse/manage/views/__init__.py:1665
+#, python-format
+msgid "Yanked %(number)s releases"
+msgstr ""
+
+#: warehouse/manage/views/__init__.py:1668
+msgid "Un-yanked release"
+msgstr ""
+
+#: warehouse/manage/views/__init__.py:1670
+#, python-format
+msgid "Un-yanked %(number)s releases"
+msgstr ""
+
+#: warehouse/manage/views/__init__.py:1729
 msgid "Could not yank release - "
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1600
+#: warehouse/manage/views/__init__.py:1814
 msgid "Could not un-yank release - "
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1701
+#: warehouse/manage/views/__init__.py:1915
 msgid "Could not delete release - "
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1800
+#: warehouse/manage/views/__init__.py:2014
+#: warehouse/manage/views/__init__.py:2120
+#: warehouse/manage/views/__init__.py:2132
 msgid "Could not find file"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1805
+#: warehouse/manage/views/__init__.py:2019
 msgid "Could not delete file - "
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1955
+#: warehouse/manage/views/__init__.py:2108
+msgid "Could not delete files - "
+msgstr ""
+
+#: warehouse/manage/views/__init__.py:2124
+msgid "Select at least one file"
+msgstr ""
+
+#: warehouse/manage/views/__init__.py:2178
+msgid "Deleted file"
+msgstr ""
+
+#: warehouse/manage/views/__init__.py:2181
+#, python-format
+msgid "Deleted %(number)s files"
+msgstr ""
+
+#: warehouse/manage/views/__init__.py:2285
 #, python-brace-format
 msgid "Team '${team_name}' already has ${role_name} role for project"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2062
+#: warehouse/manage/views/__init__.py:2392
 #, python-brace-format
 msgid "User '${username}' already has ${role_name} role for project"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2129
+#: warehouse/manage/views/__init__.py:2459
 #, python-brace-format
 msgid "${username} is now ${role} of the '${project_name}' project."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2161
+#: warehouse/manage/views/__init__.py:2491
 #, python-brace-format
 msgid ""
 "User '${username}' does not have a verified primary email address and "
 "cannot be added as a ${role_name} for project"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2174
+#: warehouse/manage/views/__init__.py:2504
 #: warehouse/manage/views/organizations.py:981
 #, python-brace-format
 msgid "User '${username}' already has an active invite. Please try again later."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2239
+#: warehouse/manage/views/__init__.py:2569
 #: warehouse/manage/views/organizations.py:1056
 #, python-brace-format
 msgid "Invitation sent to '${username}'"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2271
+#: warehouse/manage/views/__init__.py:2601
 msgid "Could not find role invitation."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2282
+#: warehouse/manage/views/__init__.py:2612
 msgid "Invitation already expired."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2315
+#: warehouse/manage/views/__init__.py:2645
 #: warehouse/manage/views/organizations.py:1243
 #, python-brace-format
 msgid "Invitation revoked from '${username}'."
@@ -1091,10 +1162,10 @@ msgstr ""
 #: warehouse/templates/manage/account/webauthn-provision.html:51
 #: warehouse/templates/manage/account/webauthn-provision.html:68
 #: warehouse/templates/manage/manage_base.html:210
-#: warehouse/templates/manage/project/release.html:162
-#: warehouse/templates/manage/project/release.html:226
-#: warehouse/templates/manage/project/releases.html:137
-#: warehouse/templates/manage/project/releases.html:190
+#: warehouse/templates/manage/project/release.html:192
+#: warehouse/templates/manage/project/release.html:256
+#: warehouse/templates/manage/project/releases.html:148
+#: warehouse/templates/manage/project/releases.html:264
 #: warehouse/templates/packaging/detail.html:444
 #: warehouse/templates/packaging/detail.html:462
 #: warehouse/templates/packaging/detail.html:478
@@ -1327,7 +1398,7 @@ msgstr ""
 #: warehouse/templates/manage/organization/settings.html:291
 #: warehouse/templates/manage/organization/settings.html:297
 #: warehouse/templates/manage/project/documentation.html:13
-#: warehouse/templates/manage/project/release.html:209
+#: warehouse/templates/manage/project/release.html:239
 #: warehouse/templates/manage/project/settings.html:78
 #: warehouse/templates/manage/project/settings.html:124
 #: warehouse/templates/manage/project/settings.html:365
@@ -3038,8 +3109,8 @@ msgstr ""
 #: warehouse/templates/manage/account.html:539
 #: warehouse/templates/manage/manage_base.html:344
 #: warehouse/templates/manage/manage_base.html:347
-#: warehouse/templates/manage/project/release.html:158
-#: warehouse/templates/manage/project/releases.html:186
+#: warehouse/templates/manage/project/release.html:188
+#: warehouse/templates/manage/project/releases.html:260
 #: warehouse/templates/manage/project/settings.html:63
 #: warehouse/templates/manage/unverified-account.html:186
 #: warehouse/templates/manage/unverified-account.html:189
@@ -3280,7 +3351,7 @@ msgstr ""
 
 #: warehouse/templates/includes/manage/manage-project-menu.html:9
 #: warehouse/templates/manage/project/release.html:21
-#: warehouse/templates/manage/project/releases.html:161
+#: warehouse/templates/manage/project/releases.html:172
 msgid "Releases"
 msgstr ""
 
@@ -3481,8 +3552,8 @@ msgstr ""
 
 #: warehouse/templates/manage/account.html:84
 #: warehouse/templates/manage/account.html:177
-#: warehouse/templates/manage/project/release.html:74
-#: warehouse/templates/manage/project/releases.html:53
+#: warehouse/templates/manage/project/release.html:81
+#: warehouse/templates/manage/project/releases.html:64
 #: warehouse/templates/manage/unverified-account.html:69
 #: warehouse/templates/manage/unverified-account.html:147
 msgid "Options"
@@ -3873,7 +3944,7 @@ msgid "Two factor method:"
 msgstr ""
 
 #: warehouse/templates/manage/account.html:668
-#: warehouse/templates/manage/project/release.html:61
+#: warehouse/templates/manage/project/release.html:68
 #: warehouse/templates/manage/unverified-account.html:293
 msgid "None"
 msgstr ""
@@ -4333,7 +4404,7 @@ msgstr ""
 #: warehouse/templates/manage/organizations.html:128
 #: warehouse/templates/manage/organizations.html:134
 #: warehouse/templates/manage/organizations.html:183
-#: warehouse/templates/manage/project/releases.html:76
+#: warehouse/templates/manage/project/releases.html:87
 #: warehouse/templates/manage/projects.html:99
 #: warehouse/templates/manage/projects.html:105
 #: warehouse/templates/manage/team/projects.html:49
@@ -4726,7 +4797,7 @@ msgstr ""
 #: warehouse/templates/manage/organization/projects.html:67
 #: warehouse/templates/manage/organization/teams.html:44
 #: warehouse/templates/manage/organizations.html:106
-#: warehouse/templates/manage/project/releases.html:83
+#: warehouse/templates/manage/project/releases.html:94
 #: warehouse/templates/manage/projects.html:111
 #: warehouse/templates/manage/projects.html:116
 #: warehouse/templates/manage/team/projects.html:61
@@ -5166,7 +5237,10 @@ msgstr ""
 #: warehouse/templates/manage/organization/publishing.html:156
 #: warehouse/templates/manage/project/documentation.html:21
 #: warehouse/templates/manage/project/publishing.html:153
-#: warehouse/templates/manage/project/release.html:139
+#: warehouse/templates/manage/project/release.html:146
+#: warehouse/templates/manage/project/release.html:161
+#: warehouse/templates/manage/project/releases.html:185
+#: warehouse/templates/manage/project/releases.html:229
 #: warehouse/templates/pages/stats.html:65
 msgid "Project name"
 msgstr ""
@@ -6361,8 +6435,8 @@ msgid "Delete expired invitation for %(user)s"
 msgstr ""
 
 #: warehouse/templates/manage/organization/roles.html:352
-#: warehouse/templates/manage/project/release.html:96
-#: warehouse/templates/manage/project/releases.html:98
+#: warehouse/templates/manage/project/release.html:103
+#: warehouse/templates/manage/project/releases.html:109
 #: warehouse/templates/manage/project/settings.html:239
 msgid "Delete"
 msgstr ""
@@ -6695,7 +6769,7 @@ msgstr ""
 
 #: warehouse/templates/manage/project/history.html:77
 #: warehouse/templates/manage/project/history.html:108
-#: warehouse/templates/manage/project/release.html:103
+#: warehouse/templates/manage/project/release.html:110
 msgid "Filename:"
 msgstr ""
 
@@ -6978,7 +7052,7 @@ msgid "Version %(version)s"
 msgstr ""
 
 #: warehouse/templates/manage/project/release.html:25
-#: warehouse/templates/manage/project/releases.html:169
+#: warehouse/templates/manage/project/releases.html:216
 msgid "Yanked releases"
 msgstr ""
 
@@ -6992,52 +7066,57 @@ msgid "Files for release %(version)s of %(project_name)s"
 msgstr ""
 
 #: warehouse/templates/manage/project/release.html:39
-#: warehouse/templates/manage/project/release.html:50
-msgid "Filename, size"
+#: warehouse/templates/manage/project/releases.html:10
+msgid "Select"
 msgstr ""
 
 #: warehouse/templates/manage/project/release.html:40
-#: warehouse/templates/manage/project/release.html:56
-msgid "Type"
+#: warehouse/templates/manage/project/release.html:57
+msgid "Filename, size"
 msgstr ""
 
 #: warehouse/templates/manage/project/release.html:41
-#: warehouse/templates/manage/project/release.html:60
-msgid "Python version"
+#: warehouse/templates/manage/project/release.html:63
+msgid "Type"
 msgstr ""
 
 #: warehouse/templates/manage/project/release.html:42
-#: warehouse/templates/manage/project/release.html:64
+#: warehouse/templates/manage/project/release.html:67
+msgid "Python version"
+msgstr ""
+
+#: warehouse/templates/manage/project/release.html:43
+#: warehouse/templates/manage/project/release.html:71
 msgid "Upload date"
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:73
+#: warehouse/templates/manage/project/release.html:80
 msgid "View file options"
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:81
+#: warehouse/templates/manage/project/release.html:88
 msgid "File options"
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:86
+#: warehouse/templates/manage/project/release.html:93
 msgid "Download"
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:90
+#: warehouse/templates/manage/project/release.html:97
 msgid "Delete file from"
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:92
+#: warehouse/templates/manage/project/release.html:99
 msgid "Delete file"
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:111
+#: warehouse/templates/manage/project/release.html:118
 msgid ""
 "I understand that my users will no longer be able to install this file "
 "for this release of this project."
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:118
+#: warehouse/templates/manage/project/release.html:125
 #, python-format
 msgid ""
 "I understand that I will <a href=%(href)s target=\"_blank\" "
@@ -7045,48 +7124,56 @@ msgid ""
 "name</a> %(filename)s."
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:125
-#: warehouse/templates/manage/project/release.html:257
+#: warehouse/templates/manage/project/release.html:132
+#: warehouse/templates/manage/project/release.html:287
 msgid "I understand that I will not be able to undo this."
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:132
-#: warehouse/templates/manage/project/release.html:263
+#: warehouse/templates/manage/project/release.html:139
+#: warehouse/templates/manage/project/release.html:293
 msgid "I understand that the PyPI administrators will not be able to undo this."
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:150
+#: warehouse/templates/manage/project/release.html:153
+msgid "Bulk file actions"
+msgstr ""
+
+#: warehouse/templates/manage/project/release.html:172
+msgid "Delete selected files"
+msgstr ""
+
+#: warehouse/templates/manage/project/release.html:180
 msgid "Uploading new files"
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:152
+#: warehouse/templates/manage/project/release.html:182
 msgid "No files found"
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:155
-#: warehouse/templates/manage/project/releases.html:183
+#: warehouse/templates/manage/project/release.html:185
+#: warehouse/templates/manage/project/releases.html:257
 #: warehouse/templates/manage/project/settings.html:60
 msgid "Dismiss"
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:162
+#: warehouse/templates/manage/project/release.html:192
 #, python-format
 msgid ""
 "Learn how to upload files on the <a href=\"%(href)s\" title=\"%(title)s\""
 " target=\"_blank\" rel=\"noopener\">Python Packaging User Guide</a>"
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:165
+#: warehouse/templates/manage/project/release.html:195
 msgid "Release settings"
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:168
-#: warehouse/templates/manage/project/release.html:202
-#: warehouse/templates/manage/project/releases.html:111
+#: warehouse/templates/manage/project/release.html:198
+#: warehouse/templates/manage/project/release.html:232
+#: warehouse/templates/manage/project/releases.html:122
 msgid "Yank release"
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:171
+#: warehouse/templates/manage/project/release.html:201
 #, python-format
 msgid ""
 "Yanking will mark this release (and %(count)s file within it) to be "
@@ -7097,26 +7184,26 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: warehouse/templates/manage/project/release.html:177
+#: warehouse/templates/manage/project/release.html:207
 msgid ""
 "Yanking will mark this release to be ignored when installing in most "
 "common scenarios."
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:181
+#: warehouse/templates/manage/project/release.html:211
 #, python-format
 msgid ""
 "This release will still be installable for users pinning to this exact "
 "version, e.g. when using <code>%(project_name)s==%(version)s</code>."
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:184
+#: warehouse/templates/manage/project/release.html:214
 #, python-format
 msgid "For more information, see <a href=\"%(href)s\">PEP 592</a>."
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:190
-#: warehouse/templates/manage/project/releases.html:114
+#: warehouse/templates/manage/project/release.html:220
+#: warehouse/templates/manage/project/releases.html:125
 #, python-format
 msgid ""
 "You may provide a reason for yanking this release, which will be "
@@ -7124,54 +7211,55 @@ msgid ""
 "<code>%(project_name)s==%(version)s</code>."
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:194
-#: warehouse/templates/manage/project/releases.html:118
+#: warehouse/templates/manage/project/release.html:224
+#: warehouse/templates/manage/project/releases.html:129
+#: warehouse/templates/manage/project/releases.html:194
 msgid "Reason (optional)"
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:202
-#: warehouse/templates/manage/project/release.html:267
-#: warehouse/templates/manage/project/releases.html:9
-#: warehouse/templates/manage/project/releases.html:108
-#: warehouse/templates/manage/project/releases.html:126
-#: warehouse/templates/manage/project/releases.html:146
+#: warehouse/templates/manage/project/release.html:232
+#: warehouse/templates/manage/project/release.html:297
+#: warehouse/templates/manage/project/releases.html:12
+#: warehouse/templates/manage/project/releases.html:119
+#: warehouse/templates/manage/project/releases.html:137
+#: warehouse/templates/manage/project/releases.html:157
 msgid "Version"
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:207
-#: warehouse/templates/manage/project/release.html:267
-#: warehouse/templates/manage/project/releases.html:128
+#: warehouse/templates/manage/project/release.html:237
+#: warehouse/templates/manage/project/release.html:297
+#: warehouse/templates/manage/project/releases.html:139
 msgid "Delete release"
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:211
+#: warehouse/templates/manage/project/release.html:241
 #, python-format
 msgid "Deleting will irreversibly delete this release along with %(count)s file."
 msgid_plural "Deleting will irreversibly delete this release along with %(count)s files."
 msgstr[0] ""
 msgstr[1] ""
 
-#: warehouse/templates/manage/project/release.html:217
+#: warehouse/templates/manage/project/release.html:247
 msgid "Deleting will irreversibly delete this release."
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:220
-#: warehouse/templates/manage/project/releases.html:131
+#: warehouse/templates/manage/project/release.html:250
+#: warehouse/templates/manage/project/releases.html:142
 msgid ""
 "You will not be able to re-upload a new distribution of the same type "
 "with the same version number."
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:223
-#: warehouse/templates/manage/project/releases.html:134
+#: warehouse/templates/manage/project/release.html:253
+#: warehouse/templates/manage/project/releases.html:145
 msgid ""
 "Deletion will break any downstream projects relying on a pinned version "
 "of this package. It is intended as a last resort to address legal issues "
 "or remove harmful releases."
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:226
-#: warehouse/templates/manage/project/releases.html:137
+#: warehouse/templates/manage/project/release.html:256
+#: warehouse/templates/manage/project/releases.html:148
 #, python-format
 msgid ""
 "Consider <a href=\"%(yank_href)s\" title=\"%(title)s\" target=\"_blank\" "
@@ -7180,20 +7268,20 @@ msgid ""
 "rel=\"noopener\">post release</a> instead."
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:239
+#: warehouse/templates/manage/project/release.html:269
 #, python-format
 msgid ""
 "I understand that I am permanently deleting all files for the "
 "%(release_version)s release of this project."
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:245
+#: warehouse/templates/manage/project/release.html:275
 msgid ""
 "I understand that my users will no longer be able to install this release"
 " of this project."
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:251
+#: warehouse/templates/manage/project/release.html:281
 #, python-format
 msgid ""
 "I understand that I will <a href=\"%(href)s\" target=\"_blank\" "
@@ -7206,72 +7294,90 @@ msgstr ""
 msgid "Releases for %(project_name)s"
 msgstr ""
 
-#: warehouse/templates/manage/project/releases.html:10
+#: warehouse/templates/manage/project/releases.html:13
 msgid "Release date"
 msgstr ""
 
-#: warehouse/templates/manage/project/releases.html:11
+#: warehouse/templates/manage/project/releases.html:14
 msgid "Files"
 msgstr ""
 
-#: warehouse/templates/manage/project/releases.html:13
+#: warehouse/templates/manage/project/releases.html:16
 msgid "Yanked reason"
 msgstr ""
 
-#: warehouse/templates/manage/project/releases.html:23
+#: warehouse/templates/manage/project/releases.html:34
 msgid "Manage version"
 msgstr ""
 
-#: warehouse/templates/manage/project/releases.html:29
+#: warehouse/templates/manage/project/releases.html:40
 #, python-format
 msgid "%(count)s file"
 msgid_plural "%(count)s files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: warehouse/templates/manage/project/releases.html:42
+#: warehouse/templates/manage/project/releases.html:53
 msgid "No files"
 msgstr ""
 
-#: warehouse/templates/manage/project/releases.html:52
+#: warehouse/templates/manage/project/releases.html:63
 msgid "View release options"
 msgstr ""
 
-#: warehouse/templates/manage/project/releases.html:60
+#: warehouse/templates/manage/project/releases.html:71
 #, python-format
 msgid "Options for %(version)s"
 msgstr ""
 
-#: warehouse/templates/manage/project/releases.html:63
+#: warehouse/templates/manage/project/releases.html:74
 msgid "Un-yank Release"
 msgstr ""
 
-#: warehouse/templates/manage/project/releases.html:68
+#: warehouse/templates/manage/project/releases.html:79
 msgid "Un-yank"
 msgstr ""
 
-#: warehouse/templates/manage/project/releases.html:90
+#: warehouse/templates/manage/project/releases.html:101
 msgid "Yank"
 msgstr ""
 
-#: warehouse/templates/manage/project/releases.html:107
+#: warehouse/templates/manage/project/releases.html:118
 msgid "Un-yank release"
 msgstr ""
 
-#: warehouse/templates/manage/project/releases.html:155
+#: warehouse/templates/manage/project/releases.html:166
 #, python-format
 msgid "Manage '%(project_name)s' releases"
 msgstr ""
 
-#: warehouse/templates/manage/project/releases.html:178
+#: warehouse/templates/manage/project/releases.html:177
+#: warehouse/templates/manage/project/releases.html:221
+msgid "Bulk release actions"
+msgstr ""
+
+#: warehouse/templates/manage/project/releases.html:205
+msgid "Yank selected releases"
+msgstr ""
+
+#: warehouse/templates/manage/project/releases.html:209
+#: warehouse/templates/manage/project/releases.html:244
+msgid "Delete selected releases"
+msgstr ""
+
+#: warehouse/templates/manage/project/releases.html:240
+msgid "Un-yank selected releases"
+msgstr ""
+
+#: warehouse/templates/manage/project/releases.html:252
 msgid "Creating a new release"
 msgstr ""
 
-#: warehouse/templates/manage/project/releases.html:180
+#: warehouse/templates/manage/project/releases.html:254
 msgid "No releases found"
 msgstr ""
 
-#: warehouse/templates/manage/project/releases.html:190
+#: warehouse/templates/manage/project/releases.html:264
 #, python-format
 msgid ""
 "Learn how to create a new release on the <a href=\"%(href)s\" "

--- a/warehouse/templates/manage/project/release.html
+++ b/warehouse/templates/manage/project/release.html
@@ -36,6 +36,7 @@
       <caption class="sr-only">{% trans version=release.version, project_name=project.name %}Files for release {{ version }} of {{ project_name }}{% endtrans %}</caption>
       <thead>
         <tr>
+          <th scope="col">{% trans %}Select{% endtrans %}</th>
           <th scope="col">{% trans %}Filename, size{% endtrans %}</th>
           <th scope="col">{% trans %}Type{% endtrans %}</th>
           <th scope="col">{% trans %}Python version{% endtrans %}</th>
@@ -46,6 +47,12 @@
       <tbody>
         {% for file in files %}
           <tr>
+            <td>
+              <input type="checkbox"
+                     name="file_ids"
+                     value="{{ file.id }}"
+                     form="bulk-delete-files-form">
+            </td>
             <th scope="row">
               <span class="table__mobile-label">{% trans %}Filename, size{% endtrans %}</span>
               <a href="{{ request.route_url('packaging.file', path=file.path) }}">{{ file.filename }}</a>
@@ -142,6 +149,29 @@
         {% endfor %}
       </tbody>
     </table>
+    <div class="callout-block callout-block--bottom-margin">
+      <h3>{% trans %}Bulk file actions{% endtrans %}</h3>
+      <form id="bulk-delete-files-form"
+            method="post"
+            action="{{ request.current_route_path() }}">
+        <input name="csrf_token"
+               type="hidden"
+               value="{{ request.session.get_csrf_token() }}">
+        <div class="form-group">
+          <label for="bulk-confirm-project-name">{% trans %}Project name{% endtrans %}</label>
+          <input id="bulk-confirm-project-name"
+                 name="confirm_project_name"
+                 type="text"
+                 autocomplete="off"
+                 autocapitalize="off"
+                 spellcheck="false">
+        </div>
+        <button type="submit"
+                class="button button--danger"
+                name="bulk_delete_files"
+                value="1">{% trans %}Delete selected files{% endtrans %}</button>
+      </form>
+    </div>
   {% endif %}
   <div class="callout-block"
        data-controller="dismissable"

--- a/warehouse/templates/manage/project/releases.html
+++ b/warehouse/templates/manage/project/releases.html
@@ -1,11 +1,14 @@
 {# SPDX-License-Identifier: Apache-2.0 -#}
 {% extends "manage_project_base.html" %}
 {% set active_tab = "releases" %}
-{% macro release_table(releases, show_yanked_reason=False) %}
+{% macro release_table(releases, show_yanked_reason=False, selection_form_id=None) %}
   <table class="table table--releases">
     <caption class="sr-only">{% trans project_name=project.name %}Releases for {{ project_name }}{% endtrans %}</caption>
     <thead>
       <tr>
+        {% if selection_form_id %}
+          <th scope="col">{% trans %}Select{% endtrans %}</th>
+        {% endif %}
         <th scope="col">{% trans %}Version{% endtrans %}</th>
         <th scope="col">{% trans %}Release date{% endtrans %}</th>
         <th scope="col">{% trans %}Files{% endtrans %}</th>
@@ -18,6 +21,14 @@
     <tbody>
       {% for release in releases %}
         <tr>
+          {% if selection_form_id %}
+            <td>
+              <input type="checkbox"
+                     name="release_versions"
+                     value="{{ release.version }}"
+                     form="{{ selection_form_id }}">
+            </td>
+          {% endif %}
           <th scope="row">
             <a href="{{ request.route_path('manage.project.release', project_name=project.name, version=release.version) }}"
                title="{% trans %}Manage version{% endtrans %}">{{ release.version }}</a>
@@ -161,7 +172,43 @@
       {% trans %}Releases{% endtrans %}
       <span class="badge badge--neutral">{{ releases|length }}</span>
     </h2>
-    {{ release_table(releases) }}
+    {{ release_table(releases, selection_form_id="bulk-release-actions-active") }}
+    <div class="callout-block callout-block--bottom-margin">
+      <h3>{% trans %}Bulk release actions{% endtrans %}</h3>
+      <form id="bulk-release-actions-active"
+            method="post"
+            action="{{ request.current_route_path() }}">
+        <input name="csrf_token"
+               type="hidden"
+               value="{{ request.session.get_csrf_token() }}">
+        <div class="form-group">
+          <label for="bulk-confirm-project-name-active">{% trans %}Project name{% endtrans %}</label>
+          <input id="bulk-confirm-project-name-active"
+                 name="confirm_project_name"
+                 type="text"
+                 autocomplete="off"
+                 autocapitalize="off"
+                 spellcheck="false">
+        </div>
+        <div class="form-group">
+          <label for="bulk-yanked-reason-active">{% trans %}Reason (optional){% endtrans %}</label>
+          <input id="bulk-yanked-reason-active"
+                 name="yanked_reason"
+                 type="text"
+                 autocomplete="off"
+                 autocapitalize="off"
+                 spellcheck="false">
+        </div>
+        <button type="submit"
+                class="button button--primary"
+                name="bulk_release_action"
+                value="yank">{% trans %}Yank selected releases{% endtrans %}</button>
+        <button type="submit"
+                class="button button--danger"
+                name="bulk_release_action"
+                value="delete">{% trans %}Delete selected releases{% endtrans %}</button>
+      </form>
+    </div>
   {% endif %}
   {% set yanked_releases = project.yanked_releases %}
   {% if yanked_releases %}
@@ -169,7 +216,34 @@
       {% trans %}Yanked releases{% endtrans %}
       <span class="badge badge--neutral">{{ yanked_releases|length }}</span>
     </h2>
-    {{ release_table(yanked_releases, show_yanked_reason=True) }}
+    {{ release_table(yanked_releases, show_yanked_reason=True, selection_form_id="bulk-release-actions-yanked") }}
+    <div class="callout-block callout-block--bottom-margin">
+      <h3>{% trans %}Bulk release actions{% endtrans %}</h3>
+      <form id="bulk-release-actions-yanked"
+            method="post"
+            action="{{ request.current_route_path() }}">
+        <input name="csrf_token"
+               type="hidden"
+               value="{{ request.session.get_csrf_token() }}">
+        <div class="form-group">
+          <label for="bulk-confirm-project-name-yanked">{% trans %}Project name{% endtrans %}</label>
+          <input id="bulk-confirm-project-name-yanked"
+                 name="confirm_project_name"
+                 type="text"
+                 autocomplete="off"
+                 autocapitalize="off"
+                 spellcheck="false">
+        </div>
+        <button type="submit"
+                class="button button--primary"
+                name="bulk_release_action"
+                value="unyank">{% trans %}Un-yank selected releases{% endtrans %}</button>
+        <button type="submit"
+                class="button button--danger"
+                name="bulk_release_action"
+                value="delete">{% trans %}Delete selected releases{% endtrans %}</button>
+      </form>
+    </div>
   {% endif %}
   <div class="callout-block"
        data-controller="dismissable"


### PR DESCRIPTION
## Summary
- add bulk selection checkboxes and action forms on manage release pages for releases and files
- add POST handlers for bulk release yank/unyank/delete and bulk file deletion
- preserve existing confirmation and deletion-flag checks for bulk operations
- add unit tests for success paths and validation/error paths
- update translation references after adding new translatable strings

Closes #19469.

## Validation
- `make lint`
- `T=tests/unit/manage/test_views.py make tests`
