### PR TITLE
feat(admin): sort malware reports by count

### DIFF
--- a/tests/unit/admin/views/test_malware_reports.py
+++ b/tests/unit/admin/views/test_malware_reports.py
@@ -20,16 +20,22 @@ from ....common.db.packaging import (
 
 class TestMalwareReportsList:
     def test_malware_reports_list(self, db_request):
-        assert views.malware_reports_list(db_request) == {"malware_reports": []}
+        result = views.malware_reports_list(db_request)
+        assert result["malware_reports"] == []
+        assert result["report_counts"] == {}
 
     def test_malware_reports_list_with_observations(self, db_request):
         ProjectObservationFactory.create(kind="is_spam")
         ProjectObservationFactory.create(kind="is_malware", actions={"foo": "bar"})
         ProjectObservationFactory.create(kind="is_malware", related=None)
-        malware = ProjectObservationFactory.create_batch(size=3, kind="is_malware")
+        project = ProjectFactory.create()
+        malware = ProjectObservationFactory.create_batch(
+            size=3, kind="is_malware", related=project
+        )
 
-        malware_reports = views.malware_reports_list(db_request)["malware_reports"]
-        assert {m.id for m in malware_reports} == {m.id for m in malware}
+        result = views.malware_reports_list(db_request)
+        assert {m.id for m in result["malware_reports"]} == {m.id for m in malware}
+        assert result["report_counts"][project.id] == 3
 
 
 class TestMalwareReportsProjectList:

--- a/warehouse/admin/static/js/warehouse.js
+++ b/warehouse/admin/static/js/warehouse.js
@@ -175,7 +175,7 @@ if (malwareReportsTable.length) {
   let table = malwareReportsTable.DataTable({
     displayLength: 25,
     lengthChange: false,
-    order: [[0, "asc"], [2, "desc"]],  // alpha name, recent date
+    order: [[1, "desc"], [0, "asc"], [3, "desc"]],  // report count, alpha name, recent date
     responsive: true,
     rowGroup: {
       dataSrc: 0,
@@ -185,8 +185,8 @@ if (malwareReportsTable.length) {
       },
     },
   });
-  // hide the project name, since it's in the group title
-  table.columns([0]).visible(false);
+  // hide the project name and count, since they're in the group title
+  table.columns([0, 1]).visible(false);
   new $.fn.dataTable.Buttons(table, {buttons: ["copy", "csv", "colvis"]});
   table.buttons().container().appendTo($(".col-md-6:eq(0)", table.table().container()));
 }

--- a/warehouse/admin/templates/admin/malware_reports/list.html
+++ b/warehouse/admin/templates/admin/malware_reports/list.html
@@ -23,6 +23,7 @@
           <thead>
             <tr>
               <th>Project Name</th>
+              <th>Reports</th>
               <th>Summary</th>
               <th>Created</th>
               <th>Reported By</th>
@@ -37,6 +38,7 @@
                     {{ report.related.name }}
                   </a>
                 </td>
+                <td>{{ report_counts[report.related_id] }}</td>
                 <td>{{ report.summary }}</td>
                 <td>
                   <time datetime="{{ report.created }}">{{ report.created }}</time>

--- a/warehouse/admin/views/malware_reports.py
+++ b/warehouse/admin/views/malware_reports.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import re
 
+from collections import Counter
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
@@ -54,7 +55,9 @@ def malware_reports_list(request):
         .all()
     )
 
-    return {"malware_reports": malware_observations}
+    report_counts = Counter(obs.related_id for obs in malware_observations)
+
+    return {"malware_reports": malware_observations, "report_counts": report_counts}
 
 
 @view_config(


### PR DESCRIPTION
In order to identify corroborated reports more easily, add the count to the data table as a hidden column, and then sort by it.

This way, any corroborated reports float to the top, making them more prominently found for reviews.