### PR TITLE
added comment to use TESTPYPI_ID_TOKEN for TestPyPI

### DIFF
--- a/docs/user/trusted-publishers/using-a-publisher.md
+++ b/docs/user/trusted-publishers/using-a-publisher.md
@@ -405,6 +405,7 @@ below describe the setup process for each supported Trusted Publisher.
       dependencies:
         - build-job
       id_tokens:
+        # Use "TESTPYPI_ID_TOKEN" if uploading to TestPyPI
         PYPI_ID_TOKEN:
           # Use "testpypi" if uploading to TestPyPI
           aud: pypi


### PR DESCRIPTION
Closes #19565

This PR aims to improve the docs for trusted publishing to TestPyPi with GitLab.

`$ make lint` produces `Success: no issues found in 403 source files`.
`make dev-docs user-docs` as well as `docker compose up user-docs` produce no errors.

Thanks a lot in advance! Please let me know if there are any issues.

