### PR TITLE
feat(dev): enable livereload when html changes

### DIFF
--- a/warehouse/admin/templates/admin/base.html
+++ b/warehouse/admin/templates/admin/base.html
@@ -1,4 +1,10 @@
 {# SPDX-License-Identifier: Apache-2.0 -#}
+{# Template-wide variables #}
+{% if request.registry.settings.get("warehouse.domain") == "test.pypi.org" %}
+  {% set testPyPI = true %}
+{% elif request.registry.settings.get("warehouse.env").value == "development" %}
+  {% set devPyPI = true %}
+{% endif %}
 <!DOCTYPE html>
 <html lang="en">
   <head>


### PR DESCRIPTION
When developing locally, it's nice to have the HTML contents reload on file change without having to manually refresh.