### PR TITLE
Disallow `pull_request_target` event for GitHub publishers

### DIFF
--- a/tests/unit/oidc/models/test_github.py
+++ b/tests/unit/oidc/models/test_github.py
@@ -430,23 +430,6 @@ class TestGitHubPublisher:
         check = github.GitHubPublisher.__required_verifiable_claims__["repository"]
         assert check(truth, claim, pretend.stub()) == valid
 
-    def test_check_event_name_emits_metrics(self, metrics):
-        check = github.GitHubPublisher.__required_verifiable_claims__["event_name"]
-        publisher_service = pretend.stub(metrics=metrics)
-
-        assert check(
-            "throwaway",
-            "pull_request_target",
-            pretend.stub(),
-            publisher_service=publisher_service,
-        )
-        assert metrics.increment.calls == [
-            pretend.call(
-                "warehouse.oidc.claim",
-                tags=["publisher:GitHub", "event_name:pull_request_target"],
-            ),
-        ]
-
     def test_check_event_name_invalid(self):
         check = github.GitHubPublisher.__required_verifiable_claims__["event_name"]
 

--- a/warehouse/oidc/models/github.py
+++ b/warehouse/oidc/models/github.py
@@ -27,8 +27,6 @@ from warehouse.oidc.urls import verify_url_from_reference
 if typing.TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
-    from warehouse.oidc.services import OIDCPublisherService
-
 GITHUB_OIDC_ISSUER_URL = "https://token.actions.githubusercontent.com"
 
 # This expression matches the workflow filename component of a GitHub
@@ -128,19 +126,10 @@ def _check_environment(
 
 
 def _check_event_name(
-    ground_truth: str, signed_claim: str, _all_signed_claims: SignedClaims, **kwargs
-) -> bool:
-    # Log the event name
-    publisher_service: OIDCPublisherService = kwargs["publisher_service"]
-    publisher_service.metrics.increment(
-        "warehouse.oidc.claim", tags=["publisher:GitHub", f"event_name:{signed_claim}"]
-    )
-    # Always permit all event names for now
-    return True
-
-
-def _check_event_name(
-    ground_truth: str, signed_claim: str, _all_signed_claims: SignedClaims, **_kwargs,
+    ground_truth: str,
+    signed_claim: str,
+    _all_signed_claims: SignedClaims,
+    **_kwargs,
 ) -> bool:
     if signed_claim == "pull_request_target":
         raise InvalidPublisherError(


### PR DESCRIPTION
With [measurements showing low volume](https://github.com/pypi/warehouse/issues/18904#issuecomment-3935706252) and thus low impact, implement the disallow on current code.

Resolves #18904
Closes #18886