### PR TITLE
feat(admin): improve prohibited name release behavior

### DIFF
--- a/warehouse/admin/templates/admin/prohibited_project_names/list.html
+++ b/warehouse/admin/templates/admin/prohibited_project_names/list.html
@@ -54,23 +54,75 @@
         <td>{{ prohibited_project_name.comment }}</td>
         <td>{{ prohibited_project_name.observation_kind }}</td>
         <td>
-          <form method="POST" action="{{ request.route_path('admin.prohibited_project_names.remove') }}">
-            <input name="csrf_token" type="hidden" value="{{ request.session.get_csrf_token() }}">
-            <input name="prohibited_project_name_id" type="hidden" value="{{ prohibited_project_name.id }}">
-            <input name="next" type="hidden" value="{{ request.current_route_path() }}">
-            <button type="submit" class="btn btn-link" title="{{ 'Submitting requires superuser privileges' if not request.has_permission(Permissions.AdminProhibitedProjectsWrite) }}" {{ "disabled" if not request.has_permission(Permissions.AdminProhibitedProjectsWrite) }}>
-              <i class="fa fa-times"></i>
-            </button>
-          </form>
-          <form method="POST" action="{{ request.route_path('admin.prohibited_project_names.release') }}">
-            <input name="csrf_token" type="hidden" value="{{ request.session.get_csrf_token() }}">
-            <input name="project_name" type="hidden" value="{{ prohibited_project_name.name }}">
-            <input name="next" type="hidden" value="{{ request.current_route_path() }}">
-            <button type="submit" class="btn btn-link" title="{{ 'Submitting requires additional privileges' if not request.has_permission(Permissions.AdminProhibitedProjectsRelease) }}" {{ "disabled" if not request.has_permission(Permissions.AdminProhibitedProjectsRelease) }}>
-              <i class="fa fa-hands"></i>
-            </button>
-            <input name="username" type="text" {{ "disabled" if not request.has_permission(Permissions.AdminProhibitedProjectsRelease) }}>
-          </form>
+          <div class="d-flex align-items-center">
+          <button type="button" class="btn btn-danger btn-sm mr-1" data-toggle="modal" data-target="#removeModal-{{ prohibited_project_name.id }}" data-bs-toggle="tooltip" title="{{ 'Submitting requires superuser privileges' if not request.has_permission(Permissions.AdminProhibitedProjectsWrite) else 'Remove from prohibited list' }}" {{ "disabled" if not request.has_permission(Permissions.AdminProhibitedProjectsWrite) }}>
+            <i class="fa fa-trash"></i> Remove
+          </button>
+          <button type="button" class="btn btn-primary btn-sm" data-toggle="modal" data-target="#releaseModal-{{ prohibited_project_name.id }}" data-bs-toggle="tooltip" title="{{ 'Submitting requires additional privileges' if not request.has_permission(Permissions.AdminProhibitedProjectsRelease) else 'Release name to a new owner' }}" {{ "disabled" if not request.has_permission(Permissions.AdminProhibitedProjectsRelease) }}>
+            <i class="fa fa-hands"></i> Release
+          </button>
+          <div class="modal fade" id="removeModal-{{ prohibited_project_name.id }}" tabindex="-1" role="dialog">
+            <form method="POST" action="{{ request.route_path('admin.prohibited_project_names.remove') }}">
+              <input name="csrf_token" type="hidden" value="{{ request.session.get_csrf_token() }}">
+              <input name="prohibited_project_name_id" type="hidden" value="{{ prohibited_project_name.id }}">
+              <input name="next" type="hidden" value="{{ request.current_route_path() }}">
+              <div class="modal-dialog" role="document">
+                <div class="modal-content">
+                  <div class="modal-header">
+                    <h4 class="modal-title">Remove <strong>{{ prohibited_project_name.name }}</strong>?</h4>
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                      <span aria-hidden="true">&times;</span>
+                    </button>
+                  </div>
+                  <div class="modal-body">
+                    <p>
+                      This will remove <strong>{{ prohibited_project_name.name }}</strong> from the prohibited list. The name will become available for anyone to register.
+                    </p>
+                  </div>
+                  <div class="modal-footer justify-content-between">
+                    <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
+                    <button type="submit" class="btn btn-danger">
+                      <i class="fa fa-trash"></i> Remove
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </form>
+          </div>
+          <div class="modal fade" id="releaseModal-{{ prohibited_project_name.id }}" tabindex="-1" role="dialog">
+            <form method="POST" action="{{ request.route_path('admin.prohibited_project_names.release') }}">
+              <input name="csrf_token" type="hidden" value="{{ request.session.get_csrf_token() }}">
+              <input name="project_name" type="hidden" value="{{ prohibited_project_name.name }}">
+              <input name="next" type="hidden" value="{{ request.current_route_path() }}">
+              <div class="modal-dialog" role="document">
+                <div class="modal-content">
+                  <div class="modal-header">
+                    <h4 class="modal-title">Release <strong>{{ prohibited_project_name.name }}</strong>?</h4>
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                      <span aria-hidden="true">&times;</span>
+                    </button>
+                  </div>
+                  <div class="modal-body">
+                    <p>
+                      This will remove <strong>{{ prohibited_project_name.name }}</strong> from the prohibited list and create a new project owned by the specified user.
+                    </p>
+                    <hr>
+                    <div class="form-group">
+                      <label for="releaseUsername-{{ prohibited_project_name.id }}">New owner username</label>
+                      <input type="text" id="releaseUsername-{{ prohibited_project_name.id }}" name="username" class="form-control" placeholder="Enter PyPI username"  autocapitalize="off" autocomplete="off" data-1p-ignore required>
+                    </div>
+                  </div>
+                  <div class="modal-footer justify-content-between">
+                    <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
+                    <button type="submit" class="btn btn-primary">
+                      <i class="fa fa-hands"></i> Release project name
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </form>
+          </div>
+          </div>
         </td>
       </tr>
       {% endfor %}


### PR DESCRIPTION
Instead of a relatively opaque set of actions, improve the overall behavior with icons.

Each icon now has a label, a tooltip, and pops open a modal that explains a little more and provides the operator more context and an opportunity to confirm/cancel.

Resolves #19609