### PR TITLE
fix: ensure JTI anti-replay key outlives JWT leeway window

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@
 import os
 import os.path
 import re
+import time
 import xmlrpc.client
 
 from collections import defaultdict
@@ -830,6 +831,11 @@ class _MockRedis:
     def set(self, key, value=None, *_args, **_kwargs):
         if _kwargs.get("nx", False) and key in self.cache:
             return None
+        # Real Redis immediately evicts a key when exat is in the past.
+        exat = _kwargs.get("exat")
+        if exat is not None and exat <= time.time():
+            self.cache.pop(key, None)
+            return True
         self.cache[key] = value
         return True
 

--- a/tests/unit/oidc/test_services.py
+++ b/tests/unit/oidc/test_services.py
@@ -94,7 +94,7 @@ class TestOIDCPublisherService:
                 ),
                 issuer=issuer_url,
                 audience="fakeaudience",
-                leeway=30,
+                leeway=services._JWT_LEEWAY,
             )
         ]
 
@@ -859,6 +859,40 @@ class TestOIDCPublisherService:
 
         # The key must still exist in Redis so a subsequent replay is blocked
         assert service.jwt_identifier_exists(jwt_identifier) is True
+
+    def test_store_jwt_identifier_evicts_when_fully_expired(
+        self, metrics, mockredis, monkeypatch
+    ):
+        """
+        When a token is so far past ``exp`` that even ``exp + leeway + margin``
+        is in the past, Redis immediately evicts the key. Verify mockredis
+        models this behavior so future regressions in the TTL calculation
+        are caught.
+        """
+        service = services.OIDCPublisherService(
+            session=pretend.stub(),
+            publisher="fakepublisher",
+            issuer_url="https://fake.example.com",
+            audience="fakeaudience",
+            cache_url="redis://fake.example.com",
+            metrics=metrics,
+        )
+
+        monkeypatch.setattr(services.redis, "StrictRedis", mockredis)
+
+        # exp is far enough in the past that exp + leeway + 5 is also past
+        expiration = (
+            int(datetime.datetime.now(tz=datetime.UTC).timestamp())
+            - services._JWT_LEEWAY
+            - 10
+        )
+
+        jwt_identifier = "long-expired-jti"
+        result = service.store_jwt_identifier(jwt_identifier, expiration=expiration)
+        assert result is True
+
+        # The key should NOT persist — Redis evicts it immediately
+        assert service.jwt_identifier_exists(jwt_identifier) is False
 
 
 class TestNullOIDCPublisherService:

--- a/tests/unit/oidc/test_services.py
+++ b/tests/unit/oidc/test_services.py
@@ -830,6 +830,36 @@ class TestOIDCPublisherService:
         result = service.store_jwt_identifier(jwt_identifier, expiration=expiration)
         assert result is False
 
+    def test_store_jwt_identifier_persists_when_exp_is_recent_past(
+        self, metrics, mockredis, monkeypatch
+    ):
+        """
+        A token whose ``exp`` just passed (but is still within leeway) must
+        have its JTI key persist in Redis. If the TTL doesn't account for
+        the leeway, the key would be set with a past ``exat`` and Redis
+        would immediately evict it, allowing replay.
+        """
+        service = services.OIDCPublisherService(
+            session=pretend.stub(),
+            publisher="fakepublisher",
+            issuer_url="https://fake.example.com",
+            audience="fakeaudience",
+            cache_url="redis://fake.example.com",
+            metrics=metrics,
+        )
+
+        monkeypatch.setattr(services.redis, "StrictRedis", mockredis)
+
+        # exp is 10 seconds in the past — within the leeway window
+        expiration = int(datetime.datetime.now(tz=datetime.UTC).timestamp()) - 10
+
+        jwt_identifier = "replay-attempt-jti"
+        result = service.store_jwt_identifier(jwt_identifier, expiration=expiration)
+        assert result is True
+
+        # The key must still exist in Redis so a subsequent replay is blocked
+        assert service.jwt_identifier_exists(jwt_identifier) is True
+
 
 class TestNullOIDCPublisherService:
     def test_interface_matches(self):

--- a/warehouse/oidc/services.py
+++ b/warehouse/oidc/services.py
@@ -20,6 +20,12 @@ from warehouse.oidc.models import OIDCPublisher, PendingOIDCPublisher
 from warehouse.oidc.utils import find_publisher_by_issuer
 from warehouse.utils.exceptions import InsecureOIDCPublisherWarning
 
+# Maximum clock-skew tolerance (in seconds) applied when verifying JWT expiration.
+# PyJWT will accept tokens up to this many seconds past their ``exp`` claim.
+# This value is shared with ``store_jwt_identifier`` so the Redis anti-replay
+# key always outlives the window in which the token is accepted.
+_JWT_LEEWAY = 30
+
 if typing.TYPE_CHECKING:
     from pyramid.request import Request
     from sqlalchemy.orm import Session
@@ -274,12 +280,12 @@ class OIDCPublisherService:
         Returns True if the JTI was newly stored, False if it already existed.
         """
         with redis.StrictRedis.from_url(self.cache_url) as r:
-            # Defensive: to prevent races, we expire the JTI slightly after
-            # the token expiration date. Thus, the lock will not be
-            # released before the token invalidation.
+            # The key must outlive the full window during which PyJWT accepts
+            # the token. PyJWT allows up to ``_JWT_LEEWAY`` seconds past
+            # ``exp``, so we add an extra 5-second margin on top.
             result = r.set(
                 f"/warehouse/oidc/{self.issuer_url}/{jti}",
-                exat=expiration + 5,
+                exat=expiration + _JWT_LEEWAY + 5,
                 value="",  # empty value to lower memory usage
                 nx=True,
             )
@@ -328,7 +334,7 @@ class OIDCPublisherService:
                 ),
                 issuer=issuer_url,
                 audience=self.audience,
-                leeway=30,
+                leeway=_JWT_LEEWAY,
             )
             return SignedClaims(signed_payload)
         except Exception as e:


### PR DESCRIPTION
The Redis anti-replay key expired at exp+5, but PyJWT accepts tokens up to 30s past exp (leeway). This left a 25s window where the key was evicted but the token still passed verification, allowing replay.

Extract _JWT_LEEWAY as a shared constant and set the Redis TTL to exp + leeway + 5 so the key always outlives the acceptance window.