### PR TITLE
Reject ZIP/tar polyglot files

### DIFF
--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -494,6 +494,25 @@ class TestFileValidation:
             None,
         )
 
+    def test_tarfile_zipfile_polyglot(self, tmpdir):
+        tar_buf = io.BytesIO()
+        zip_buf = io.BytesIO()
+        with zipfile.ZipFile(zip_buf, "w") as zfp:
+            zfp.writestr("PKG-INFO", b"this is the package info")
+        with tarfile.open(fileobj=tar_buf, mode="w:gz") as tar:
+            tar.add(io.BytesIO(b"this is the package info"), arcname="package/PKG-INFO")
+
+        for filename in ("package.tar.gz", "package.zip"):
+            tar_zip = str(tmpdir.join(filename))
+            with open(tar_zip, "wb") as fp:
+                fp.write(tar_buf.getvalue())
+                fp.write(zip_buf.getvalue())
+
+            assert legacy._is_valid_dist_file(tar_zip, "") == (
+                False,
+                "File is both a zip and a tar file",
+            )
+
 
 class TestIsDuplicateFile:
     def test_is_duplicate_true(self, pyramid_config, db_request):

--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -500,7 +500,11 @@ class TestFileValidation:
         with zipfile.ZipFile(zip_buf, "w") as zfp:
             zfp.writestr("PKG-INFO", b"this is the package info")
         with tarfile.open(fileobj=tar_buf, mode="w:gz") as tar:
-            tar.add(io.BytesIO(b"this is the package info"), arcname="package/PKG-INFO")
+            data_file = tmpdir.join("data-file.txt")
+            with open(data_file, "wb") as f:
+                f.write(b"this is the package info")
+            tar: tarfile.TarFile
+            tar.add(data_file, arcname="package/PKG-INFO")
 
         for filename in ("package.tar.gz", "package.zip"):
             tar_zip = str(tmpdir.join(filename))

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -1249,6 +1249,7 @@ def file_upload(request):
                 tags=[
                     "reason:invalid-distribution-file",
                     f"filetype:{form.filetype.data}",
+                    f"message:{_msg}",
                 ],
             )
             raise _exc_with_message(

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -288,9 +288,14 @@ def _is_valid_dist_file(filename, filetype, *, scan=True):
     Runs a YARA scan on archive members while the archive is already open.
     Returns ``(False, message)`` on the first YARA match.
     """
+    is_zipfile = zipfile.is_zipfile(filename)
+    is_tarfile = tarfile.is_tarfile(filename)
+
+    if is_zipfile and is_tarfile:
+        return False, "File is both a zip and a tar file"
 
     if filename.endswith((".zip", ".whl")):
-        if not zipfile.is_zipfile(filename):
+        if not is_zipfile:
             return False, "File is not a zipfile"
         # Ensure that this is a valid zip file, and that it has a
         # PKG-INFO or WHEEL file.
@@ -378,7 +383,7 @@ def _is_valid_dist_file(filename, filetype, *, scan=True):
             return False, None
 
     elif filename.endswith(".tar.gz"):
-        if not tarfile.is_tarfile(filename):
+        if not is_tarfile:
             return False, "File is not a tarfile"
         # Ensure that this is a valid tar file, and that it contains PKG-INFO.
         # TODO: Ideally Ensure the compression ratio is not absurd

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -288,8 +288,8 @@ def _is_valid_dist_file(filename, filetype, *, scan=True):
     Runs a YARA scan on archive members while the archive is already open.
     Returns ``(False, message)`` on the first YARA match.
     """
-    is_zipfile = zipfile.is_zipfile(filename)
-    is_tarfile = tarfile.is_tarfile(filename)
+    is_zipfile = bool(filename and zipfile.is_zipfile(filename))
+    is_tarfile = bool(filename and tarfile.is_tarfile(filename))
 
     if is_zipfile and is_tarfile:
         return False, "File is both a zip and a tar file"


### PR DESCRIPTION
Files can be both a ZIP and a tar, due to ZIP metadata being at the end of the file.