### PR TITLE
fix: verify issuer_url early

### DIFF
--- a/tests/unit/oidc/test_services.py
+++ b/tests/unit/oidc/test_services.py
@@ -200,6 +200,36 @@ class TestOIDCPublisherService:
             ),
         ]
 
+    def test_find_publisher_issuer_url_mismatch(self, metrics):
+        service = services.OIDCPublisherService(
+            session=pretend.stub(),
+            publisher="fakepublisher",
+            issuer_url="https://canonical.example.com",
+            audience="fakeaudience",
+            cache_url=pretend.stub(),
+            metrics=metrics,
+        )
+
+        claims = SignedClaims({"iss": "https://attacker.example.com"})
+        with pytest.raises(errors.InvalidPublisherError, match="does not match"):
+            service.find_publisher(claims)
+        assert service.metrics.increment.calls == [
+            pretend.call(
+                "warehouse.oidc.find_publisher.attempt",
+                tags=[
+                    "publisher:fakepublisher",
+                    "issuer_url:https://attacker.example.com",
+                ],
+            ),
+            pretend.call(
+                "warehouse.oidc.find_publisher.issuer_url_mismatch",
+                tags=[
+                    "publisher:fakepublisher",
+                    "issuer_url:https://attacker.example.com",
+                ],
+            ),
+        ]
+
     def test_find_publisher_issuer_lookup_fails(self, metrics, monkeypatch):
         issuer_url = "https://none"
         service = services.OIDCPublisherService(
@@ -267,10 +297,11 @@ class TestOIDCPublisherService:
         assert publisher.verify_claims.calls == [pretend.call(claims, service)]
 
     def test_find_publisher_reuse_token_fails(self, monkeypatch, mockredis, metrics):
+        issuer_url = "https://none"
         service = services.OIDCPublisherService(
             session=pretend.stub(),
             publisher="fakepublisher",
-            issuer_url=pretend.stub(),
+            issuer_url=issuer_url,
             audience="fakeaudience",
             cache_url="redis://fake.example.com",
             metrics=metrics,
@@ -292,7 +323,7 @@ class TestOIDCPublisherService:
 
         claims = SignedClaims(
             {
-                "iss": "foo",
+                "iss": issuer_url,
                 "iat": 1516239022,
                 "nbf": 1516239022,
                 "exp": expiration,

--- a/warehouse/oidc/services.py
+++ b/warehouse/oidc/services.py
@@ -364,6 +364,20 @@ class OIDCPublisherService:
             tags=metrics_tags,
         )
 
+        # Verify that the JWT's issuer matches this service's canonical issuer URL.
+        # Without this check, a custom issuer (e.g. GHES) registered with a
+        # provider type like "github" could forge JWTs that match publishers
+        # registered under the canonical GitHub issuer.
+        if signed_claims["iss"] != self.issuer_url:
+            self.metrics.increment(
+                "warehouse.oidc.find_publisher.issuer_url_mismatch",
+                tags=metrics_tags,
+            )
+            raise InvalidPublisherError(
+                f"JWT issuer {signed_claims['iss']!r} does not match "
+                f"expected issuer {self.issuer_url!r}"
+            )
+
         try:
             publisher = find_publisher_by_issuer(
                 self.db, self.issuer_url, signed_claims, pending=pending


### PR DESCRIPTION
While GitLab has support for an `issuerl_url` column and will validate against that during lookups, we should validate that the supplied `issuerl_url` matches the ones we have for other implementations before we implement them to prevent accidental input by an admin setting up a new Issuer URL for an organization.