### PR TITLE
fix: Remove unused `datetime` import from `accounts/interfaces.py`

### DIFF
--- a/warehouse/accounts/interfaces.py
+++ b/warehouse/accounts/interfaces.py
@@ -1,7 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-from datetime import datetime
-
 from zope.interface import Attribute, Interface
 
 from warehouse.rate_limiting.interfaces import RateLimiterException


### PR DESCRIPTION
## Description

Removes an unused import that was flagged by linting tools.

### The Issue

The `datetime` class was imported at the top of `warehouse/accounts/interfaces.py` but never actually used in the code. It was only mentioned in docstrings (e.g., "Returns POSIX timestamp corresponding to the datetime that...").

This was causing linting warnings:
```
F401 [*] `datetime.datetime` imported but unused
```

### The Fix

Simply remove the unused import line:
```python
from datetime import datetime  # ← Removed
```

### Testing

- No functional changes - this is a pure cleanup
- The file still imports and works correctly
- All interfaces remain unchanged