### PR TITLE
fix(admin): speed up malware index page

### DIFF
--- a/tests/unit/admin/views/test_malware_reports.py
+++ b/tests/unit/admin/views/test_malware_reports.py
@@ -23,6 +23,8 @@ class TestMalwareReportsList:
         result = views.malware_reports_list(db_request)
         assert result["malware_reports"] == []
         assert result["report_counts"] == {}
+        assert result["project_names"] == {}
+        assert result["observer_usernames"] == {}
 
     def test_malware_reports_list_with_observations(self, db_request):
         ProjectObservationFactory.create(kind="is_spam")
@@ -38,6 +40,7 @@ class TestMalwareReportsList:
         assert {m.id for m in result["malware_reports"]} == expected
         assert result["report_counts"][project.id] == 3
         assert result["report_counts"][None] == 1
+        assert result["project_names"][project.id] == project.name
 
 
 class TestMalwareReportsProjectList:

--- a/warehouse/admin/templates/admin/malware_reports/list.html
+++ b/warehouse/admin/templates/admin/malware_reports/list.html
@@ -35,8 +35,8 @@
               <tr>
                 <td>
                   {% if report.related_id %}
-                    <a href="{{ request.route_path('admin.malware_reports.project.list', project_name=report.related.name) }}">
-                      {{ report.related.name }}
+                    <a href="{{ request.route_path('admin.malware_reports.project.list', project_name=project_names[report.related_id]) }}">
+                      {{ project_names[report.related_id] }}
                     </a>
                   {% else %}
                     <code>{{ report.display_name }}</code>
@@ -49,7 +49,12 @@
                   <time datetime="{{ report.created }}">{{ report.created }}</time>
                 </td>
                 <td>
-                  <a href="{{ request.route_path('admin.user.detail', username=report.observer.parent.username) }}">{{ report.observer.parent.username }}</a>
+                  {% set username = observer_usernames.get(report.observer_id) %}
+                  {% if username %}
+                    <a href="{{ request.route_path('admin.user.detail', username=username) }}">{{ username }}</a>
+                  {% else %}
+                    <span class="text-muted">unknown</span>
+                  {% endif %}
                 </td>
                 <td>
                   <a href="{{ request.route_path('admin.malware_reports.detail', observation_id=report.id) }}"

--- a/warehouse/admin/views/malware_reports.py
+++ b/warehouse/admin/views/malware_reports.py
@@ -12,11 +12,14 @@ from typing import TYPE_CHECKING
 
 from pyramid.httpexceptions import HTTPSeeOther
 from pyramid.view import view_config
+from sqlalchemy import select
 
+from warehouse.accounts.models import User
 from warehouse.authnz import Permissions
 from warehouse.helpdesk.interfaces import IHelpDeskService
-from warehouse.observations.models import Observation, ObservationKind
+from warehouse.observations.models import Observation, ObservationKind, Observer
 from warehouse.observations.tasks import report_observation_to_helpscout
+from warehouse.packaging.models import Project
 from warehouse.utils.project import (
     confirm_project,
     prohibit_and_remove_project,
@@ -25,8 +28,6 @@ from warehouse.utils.project import (
 
 if TYPE_CHECKING:
     from pyramid.request import Request
-
-    from warehouse.packaging.models import Project
 
 
 @view_config(
@@ -57,7 +58,40 @@ def malware_reports_list(request):
 
     report_counts = Counter(obs.related_id for obs in malware_observations)
 
-    return {"malware_reports": malware_observations, "report_counts": report_counts}
+    # Batch-resolve project names to avoid N+1 lazy loads in the template.
+    project_ids = {obs.related_id for obs in malware_observations if obs.related_id}
+    if project_ids:
+        project_names = dict(
+            request.db.execute(
+                select(Project.id, Project.name).where(Project.id.in_(project_ids))
+            ).all()
+        )
+    else:
+        project_names = {}
+
+    # Batch-resolve observer usernames via the observer → association → user path.
+    observer_ids = {obs.observer_id for obs in malware_observations}
+    if observer_ids:
+        observer_usernames = dict(
+            request.db.execute(
+                select(Observer.id, User.username)
+                .select_from(Observer)
+                .outerjoin(
+                    User,
+                    User.observer_association_id == Observer._association_id,
+                )
+                .where(Observer.id.in_(observer_ids))
+            ).all()
+        )
+    else:
+        observer_usernames = {}
+
+    return {
+        "malware_reports": malware_observations,
+        "report_counts": report_counts,
+        "project_names": project_names,
+        "observer_usernames": observer_usernames,
+    }
 
 
 @view_config(


### PR DESCRIPTION
Slowed down with many entries - with over 800, the page loads take ~8 seconds.
The view now batch-resolves project names and observer usernames in 2 extra queries (3 total), replacing what was previously 1 + 2N lazy loads (observer => association => user per row, plus project per row).

The template reads from pre-resolved dicts instead of traversing relationships.

Follows #19695