### PR TITLE
Add deprecation admonition for license classifiers

### DIFF
--- a/warehouse/templates/pages/classifiers.html
+++ b/warehouse/templates/pages/classifiers.html
@@ -7,6 +7,24 @@
   <div class="horizontal-section">
     <div class="narrow-container">
       <h1 class="page-title">{% trans %}Classifiers{% endtrans %}</h1>
+      <div class="callout-block callout-block--info">
+        <p>
+          <strong>{% trans %}License classifiers are deprecated.{% endtrans %}</strong>
+        </p>
+        <p>
+          {% trans pep639_href='https://peps.python.org/pep-0639/', ppug_href='https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license', title=gettext('External link') %}
+            As defined in <a href="{{ pep639_href }}"
+    title="{{ title }}"
+    target="_blank"
+    rel="noopener"><abbr title="Python enhancement proposal">PEP</abbr> 639</a>,
+            License classifiers are deprecated and will be removed in a future release of PyPI.
+            See the <a href="{{ ppug_href }}"
+    title="{{ title }}"
+    target="_blank"
+    rel="noopener">Python Packaging User Guide</a> for how to specify licenses.
+          {% endtrans %}
+        </p>
+      </div>
       <p>
         {% trans %}Each project's maintainers provide PyPI with a list of "Trove classifiers" to categorize each release, describing who it's for, what systems it can run on, and how mature it is.{% endtrans %}
       </p>


### PR DESCRIPTION
## Summary

This PR adds a deprecation admonition on the classifiers page warning users that license classifiers are deprecated per PEP-639.

Fixes #17868

## Changes

- Added a callout-block (info style) on the classifiers page
- References PEP-639 for the deprecation notice
- Links to the Python Packaging User Guide for recommended alternatives

## Why this is needed

Users encountering deprecation notices when upgrading packages were confused because there was no mention of this deprecation on the PyPI classifiers page. This admonition helps direct users to the proper documentation.

## Testing

- [ ] Verify the admonition displays correctly on the classifiers page
- [ ] Verify links to PEP-639 and Python Packaging User Guide work
- [ ] Verify translation tags are properly applied for i18n

## Checklist

- [x] I already have a committer account on test.pypi.org
- [ ] I have read and understand the [Contributing guide](https://warehouse.pypa.io/development/submitting-patches.html)
- [ ] I have added tests for my changes
- [ ] I have run the test suite locally
- [ ] I have run the pre-commit hooks locally
- [ ] I have added/updated documentation as needed
