### PR TITLE
fix: verify issuer_url support for custom issuers

### DIFF
--- a/tests/unit/oidc/test_services.py
+++ b/tests/unit/oidc/test_services.py
@@ -200,14 +200,24 @@ class TestOIDCPublisherService:
             ),
         ]
 
-    def test_find_publisher_issuer_url_mismatch(self, metrics):
+    def test_find_publisher_issuer_url_mismatch(self, metrics, monkeypatch):
+        """Providers that do NOT support custom issuers (e.g. GitHub) must
+        reject JWTs whose issuer differs from the service's canonical URL."""
+        canonical_issuer = "https://canonical.example.com"
         service = services.OIDCPublisherService(
             session=pretend.stub(),
             publisher="fakepublisher",
-            issuer_url="https://canonical.example.com",
+            issuer_url=canonical_issuer,
             audience="fakeaudience",
             cache_url=pretend.stub(),
             metrics=metrics,
+        )
+
+        publisher_cls = pretend.stub(__supports_custom_issuer__=False)
+        monkeypatch.setitem(
+            services.OIDC_PUBLISHER_CLASSES,
+            canonical_issuer,
+            {False: publisher_cls},
         )
 
         claims = SignedClaims({"iss": "https://attacker.example.com"})
@@ -226,6 +236,63 @@ class TestOIDCPublisherService:
                 tags=[
                     "publisher:fakepublisher",
                     "issuer_url:https://attacker.example.com",
+                ],
+            ),
+        ]
+
+    def test_find_publisher_custom_issuer(self, metrics, monkeypatch):
+        """Simulates a self-managed GitLab: the service is registered with the
+        canonical gitlab.com issuer, but the JWT comes from a custom domain
+        that was registered as an OrganizationOIDCIssuer."""
+        canonical_issuer = "https://gitlab.com"
+        custom_issuer = "https://gitlab.example.com"
+
+        service = services.OIDCPublisherService(
+            session=pretend.stub(),
+            publisher="gitlab",
+            issuer_url=canonical_issuer,
+            audience="fakeaudience",
+            cache_url=pretend.stub(),
+            metrics=metrics,
+        )
+
+        claims = SignedClaims({"iss": custom_issuer})
+
+        # The publisher class must support custom issuers
+        publisher_cls = pretend.stub(__supports_custom_issuer__=True)
+        monkeypatch.setitem(
+            services.OIDC_PUBLISHER_CLASSES,
+            canonical_issuer,
+            {False: publisher_cls},
+        )
+
+        publisher = pretend.stub(verify_claims=pretend.call_recorder(lambda c, s: True))
+        find_publisher_by_issuer = pretend.call_recorder(lambda *a, **kw: publisher)
+        monkeypatch.setattr(
+            services, "find_publisher_by_issuer", find_publisher_by_issuer
+        )
+
+        assert service.find_publisher(claims) == publisher
+        # find_publisher_by_issuer is called with the canonical issuer URL
+        # (for OIDC_PUBLISHER_CLASSES lookup), while lookup_by_claims uses
+        # the JWT's iss claim to filter publishers in the DB.
+        assert find_publisher_by_issuer.calls == [
+            pretend.call(service.db, canonical_issuer, claims, pending=False),
+        ]
+        assert publisher.verify_claims.calls == [pretend.call(claims, service)]
+        assert service.metrics.increment.calls == [
+            pretend.call(
+                "warehouse.oidc.find_publisher.attempt",
+                tags=[
+                    "publisher:gitlab",
+                    f"issuer_url:{custom_issuer}",
+                ],
+            ),
+            pretend.call(
+                "warehouse.oidc.find_publisher.ok",
+                tags=[
+                    "publisher:gitlab",
+                    f"issuer_url:{custom_issuer}",
                 ],
             ),
         ]

--- a/warehouse/oidc/models/_core.py
+++ b/warehouse/oidc/models/_core.py
@@ -158,6 +158,12 @@ class OIDCPublisherMixin:
     # not checked as part of verifying the JWT.
     __unchecked_claims__: set[str] = set()
 
+    # Whether this publisher type supports custom (non-canonical) issuer URLs.
+    # When True, lookup_by_claims MUST filter by the JWT's "iss" claim to
+    # prevent cross-issuer publisher confusion. Defaults to False, meaning the
+    # service-level issuer URL mismatch check is enforced.
+    __supports_custom_issuer__: bool = False
+
     # Individual publishers can have complex unique constraints on their
     # required and optional attributes, and thus can't be naively looked
     # up from a raw claim set.

--- a/warehouse/oidc/models/gitlab.py
+++ b/warehouse/oidc/models/gitlab.py
@@ -179,6 +179,12 @@ class GitLabPublisherMixin:
 
     __required_unverifiable_claims__: set[str] = {"ref_path", "sha"}
 
+    # GitLab supports custom issuers (self-managed instances).
+    # lookup_by_claims filters by cls.issuer_url == signed_claims["iss"],
+    # ensuring a self-managed instance can only match publishers registered
+    # with that specific issuer URL.
+    __supports_custom_issuer__: bool = True
+
     __optional_verifiable_claims__: dict[str, CheckClaimCallable[Any]] = {
         "environment": _check_environment,
     }

--- a/warehouse/oidc/services.py
+++ b/warehouse/oidc/services.py
@@ -17,7 +17,7 @@ from warehouse.metrics.interfaces import IMetricsService
 from warehouse.oidc.errors import InvalidPublisherError
 from warehouse.oidc.interfaces import IOIDCPublisherService, SignedClaims
 from warehouse.oidc.models import OIDCPublisher, PendingOIDCPublisher
-from warehouse.oidc.utils import find_publisher_by_issuer
+from warehouse.oidc.utils import OIDC_PUBLISHER_CLASSES, find_publisher_by_issuer
 from warehouse.utils.exceptions import InsecureOIDCPublisherWarning
 
 # Maximum clock-skew tolerance (in seconds) applied when verifying JWT expiration.
@@ -364,11 +364,16 @@ class OIDCPublisherService:
             tags=metrics_tags,
         )
 
-        # Verify that the JWT's issuer matches this service's canonical issuer URL.
-        # Without this check, a custom issuer (e.g. GHES) registered with a
-        # provider type like "github" could forge JWTs that match publishers
-        # registered under the canonical GitHub issuer.
-        if signed_claims["iss"] != self.issuer_url:
+        # Verify that the JWT's issuer matches this service's canonical issuer URL,
+        # unless the publisher type supports custom issuers. Providers like GitLab
+        # filter by issuer_url in lookup_by_claims, so a self-managed instance can
+        # only match publishers explicitly registered with that custom issuer URL.
+        # Providers like GitHub do NOT filter by issuer URL in lookup_by_claims,
+        # so without this check a compromised custom issuer (e.g. GHES) could forge
+        # JWTs matching any canonical publisher.
+        if signed_claims["iss"] != self.issuer_url and not (
+            OIDC_PUBLISHER_CLASSES[self.issuer_url][pending].__supports_custom_issuer__
+        ):
             self.metrics.increment(
                 "warehouse.oidc.find_publisher.issuer_url_mismatch",
                 tags=metrics_tags,


### PR DESCRIPTION
The fix in #19661 prevented misconfigurations by an Admin exposing unexpected behavior for a GitHub issuer, but broke the existing GitLab Self-Managed instances due to the lack of knowing which services support custom issuers and which don't.

Instead of relying on implementing column changes to add `issuer_url` everywhere, and updating each implementation's `lookup_by_claims` to support `issuer_url`, provide a boolean property on issuers that _do_ support custom issuers and use that for lookup.