### PR TITLE
refactor: convert admin SCSS to CSS

### DIFF
--- a/warehouse/admin/static/css/admin.css
+++ b/warehouse/admin/static/css/admin.css
@@ -40,11 +40,11 @@
   }
 
   @media (width <= 768px) {
-    td {
+    & td {
       padding: 0.75rem 0.5rem;
     }
 
-    .btn .btn-group-vertical {
+    .btn-group-vertical .btn {
       font-size: 0.875rem;
     }
   }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -331,7 +331,7 @@ module.exports = [
         filename: "js/admin.[contenthash].js",
       },
       all: {
-        import: "./warehouse/admin/static/css/admin.scss",
+        import: "./warehouse/admin/static/css/admin.css",
       },
     },
     devtool: "source-map",
@@ -344,11 +344,10 @@ module.exports = [
     module: {
       rules: [
         {
-          test: /\.(sa|sc|c)ss$/,
+          test: /\.css$/,
           use: [
             MiniCssExtractPlugin.loader,
             "css-loader",
-            "sass-loader",
           ],
         },
         {


### PR DESCRIPTION
Modern CSS syntax supports what we need in the admin site, so remove one layer of abstraction and use native CSS.
Fix selector order for buttons - mobile font-size was never being applied. Update webpack config.