### PR TITLE
Use direct SQL UPDATE for macaroon `last_used` to avoid deadlocks

### DIFF
--- a/warehouse/macaroons/services.py
+++ b/warehouse/macaroons/services.py
@@ -144,15 +144,15 @@ class DatabaseMacaroonService:
             # skipping is okay as last_used value is imprecise (python dt, not DB clock)
             # and informational in the ui
             self.db.execute(
-              update(Macaroon)
-              .where(
-                  Macaroon.id.in_(
-                      select(Macaroon.id)
-                      .where(Macaroon.id == dm.id)
-                      .with_for_update(skip_locked=True)
-                  )
-              )
-              .values(last_used=datetime.datetime.now())
+                update(Macaroon)
+                .where(
+                    Macaroon.id.in_(
+                        select(Macaroon.id)
+                        .where(Macaroon.id == dm.id)
+                        .with_for_update(skip_locked=True)
+                    )
+                )
+                .values(last_used=datetime.datetime.now())
             )
 
             return True


### PR DESCRIPTION
Remove macroon dirty state from play to see if we fix deadlocking from https://python-software-foundation.sentry.io/issues/6960944491/?project=51408&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=24h