### PR TITLE
fix: use atomic upsert for IpAddress to prevent UniqueViolation

### DIFF
--- a/tests/unit/utils/test_wsgi.py
+++ b/tests/unit/utils/test_wsgi.py
@@ -4,8 +4,6 @@ import pretend
 import pytest
 import sentry_sdk
 
-from sqlalchemy import type_coerce
-from sqlalchemy.dialects.postgresql import INET
 from sqlalchemy.exc import NoResultFound
 
 from warehouse.ip_addresses.models import IpAddress
@@ -210,33 +208,70 @@ class TestVhmRootRemover:
 
 
 def test_ip_address_exists(db_request):
+    """When the IP already exists, upsert returns the existing row."""
     ip_address = DBIpAddressFactory(ip_address="192.0.2.69")
-    db_request.environ["REMOTE_ADDR"] = "192.0.2.69"
     db_request.remote_addr = "192.0.2.69"
+    db_request.remote_addr_hashed = ip_address.hashed_ip_address
 
     assert wsgi._ip_address(db_request) == ip_address
 
 
 def test_ip_address_created(db_request):
+    """When the IP doesn't exist, upsert creates it with metadata."""
     with pytest.raises(NoResultFound):
-        db_request.db.query(IpAddress).filter_by(
-            ip_address=type_coerce("192.0.2.69", INET)
-        ).one()
+        db_request.db.query(IpAddress).filter_by(ip_address="192.0.2.69").one()
 
     db_request.environ["GEOIP_CITY"] = "Anytown, ST"
     db_request.remote_addr = "192.0.2.69"
     db_request.remote_addr_hashed = "deadbeef"
 
-    wsgi._ip_address(db_request)
+    ip_address = wsgi._ip_address(db_request)
 
-    ip_address = (
-        db_request.db.query(IpAddress)
-        .filter_by(ip_address=type_coerce("192.0.2.69", INET))
-        .one()
-    )
     assert str(ip_address.ip_address) == "192.0.2.69"
     assert ip_address.hashed_ip_address == "deadbeef"
     assert ip_address.geoip_info == {"city": "Anytown, ST"}
+
+
+def test_ip_address_concurrent_insert(db_request):
+    """The upsert handles a conflicting row that exists in the DB but not in
+    the ORM identity map — the same scenario as a concurrent INSERT that
+    committed between a hypothetical SELECT (miss) and our INSERT.
+
+    Before the upsert fix, _ip_address used SELECT-then-INSERT which would
+    raise UniqueViolation in this race condition.
+    """
+    ip = "192.0.2.69"
+    db_request.remote_addr = ip
+    db_request.remote_addr_hashed = "deadbeef"
+
+    # Insert the IP directly via Core SQL, bypassing the ORM identity map.
+    # This simulates a row committed by a concurrent request that our
+    # session doesn't know about.
+    db_request.db.execute(IpAddress.__table__.insert().values(ip_address=ip))
+
+    # The upsert should handle the conflict gracefully — no UniqueViolation
+    result = wsgi._ip_address(db_request)
+
+    assert str(result.ip_address) == ip
+    assert result.hashed_ip_address == "deadbeef"
+
+
+def test_ip_address_updates_metadata_on_existing(db_request):
+    """When the IP already exists, metadata (hash, geoip) should be updated."""
+    existing = DBIpAddressFactory(
+        ip_address="192.0.2.69",
+        hashed_ip_address="oldhash",
+        geoip_info={"city": "OldCity"},
+    )
+    db_request.remote_addr = "192.0.2.69"
+    db_request.remote_addr_hashed = "newhash"
+    db_request.environ["GEOIP_CITY"] = "NewCity"
+
+    result = wsgi._ip_address(db_request)
+
+    assert result.id == existing.id
+    assert result.hashed_ip_address == "newhash"
+    assert result.geoip_info == {"city": "NewCity"}
 
 
 def test_remote_addr_hashed():

--- a/warehouse/utils/wsgi.py
+++ b/warehouse/utils/wsgi.py
@@ -9,9 +9,7 @@ from typing import TYPE_CHECKING
 
 import sentry_sdk
 
-from sqlalchemy import type_coerce
-from sqlalchemy.dialects.postgresql import INET
-from sqlalchemy.exc import NoResultFound
+from sqlalchemy.dialects.postgresql import insert
 
 from warehouse.ip_addresses.models import IpAddress
 
@@ -146,23 +144,34 @@ def _remote_addr_hashed(request: Request) -> str:
     return request.environ.get("REMOTE_ADDR_HASHED", "")
 
 
-def _ip_address(request):
+def _ip_address(request: Request) -> IpAddress:
     """Return the IpAddress object for the remote address from the environment."""
-    remote_inet = type_coerce(request.remote_addr, INET)
-    try:
-        ip_address = request.db.query(IpAddress).filter_by(ip_address=remote_inet).one()
-    except NoResultFound:
-        ip_address = IpAddress(ip_address=request.remote_addr)
-        request.db.add(ip_address)
-
-    ip_address.hashed_ip_address = request.remote_addr_hashed
-    ip_address.geoip_info = {
+    geoip_info = {
         k: request.environ[f"GEOIP_{v}"]
         for k, v in GEOIP_FIELDS.items()
         if f"GEOIP_{v}" in request.environ
-    }
+    } or None
 
-    return ip_address
+    # Use an atomic upsert to avoid UniqueViolation from concurrent requests
+    # that race between SELECT (miss) and INSERT for the same IP address.
+    stmt = (
+        insert(IpAddress)
+        .values(
+            ip_address=request.remote_addr,
+            hashed_ip_address=request.remote_addr_hashed,
+            geoip_info=geoip_info,
+        )
+        .on_conflict_do_update(
+            index_elements=["ip_address"],
+            set_={
+                "hashed_ip_address": request.remote_addr_hashed,
+                "geoip_info": geoip_info,
+            },
+        )
+        .returning(IpAddress)
+    )
+
+    return request.db.scalars(stmt).one()
 
 
 def includeme(config):


### PR DESCRIPTION
Replace the SELECT-then-INSERT pattern in `_ip_address()` with a PostgreSQL `INSERT ON CONFLICT DO UPDATE` (upsert). This eliminates a TOCTOU race condition where concurrent requests for the same IP address both miss the SELECT, then both attempt INSERT, causing one to fail with `UniqueViolation` on the `ip_addresses_ip_address_key` unique constraint.

The race manifested in two ways in production:

- At the explicit `flush()` in `_ip_address` itself (before the flush removal in #19816)
- At unrelated autoflush points (after the flush removal), e.g. during `_sort_releases` queries in forklift uploads, `device_is_known` queries during 2FA, or AdminFlag queries during template rendering

The upsert atomically handles both cases (IP exists or not) in a single statement, and also updates `hashed_ip_address` and `geoip_info` metadata on each request, matching the previous behavior.

Refs: https://docs.sqlalchemy.org/en/20/dialects/postgresql.html#insert-on-conflict-upsert
Refs: https://www.postgresql.org/docs/current/sql-insert.html#SQL-ON-CONFLICT