### PR TITLE
feat: enable CORS headers on RSS feeds

### DIFF
--- a/tests/unit/rss/test_views.py
+++ b/tests/unit/rss/test_views.py
@@ -10,6 +10,16 @@ from warehouse.rss import views as rss
 from ...common.db.packaging import ProjectFactory, ReleaseFactory
 
 
+def _assert_has_cors_headers(headers):
+    assert headers["Access-Control-Allow-Origin"] == "*"
+    assert headers["Access-Control-Allow-Headers"] == (
+        "Content-Type, If-Match, If-Modified-Since, If-None-Match, If-Unmodified-Since"
+    )
+    assert headers["Access-Control-Allow-Methods"] == "GET"
+    assert headers["Access-Control-Max-Age"] == "86400"
+    assert headers["Access-Control-Expose-Headers"] == "X-PyPI-Last-Serial"
+
+
 def test_rss_updates(db_request):
     db_request.find_service = pretend.call_recorder(
         lambda *args, **kwargs: pretend.stub(
@@ -36,6 +46,7 @@ def test_rss_updates(db_request):
         )
     }
     assert db_request.response.content_type == "text/xml"
+    _assert_has_cors_headers(db_request.response.headers)
 
 
 def test_rss_packages(db_request):
@@ -62,6 +73,7 @@ def test_rss_packages(db_request):
         "newest_projects": tuple(zip((project3, project1), (None, None)))
     }
     assert db_request.response.content_type == "text/xml"
+    _assert_has_cors_headers(db_request.response.headers)
 
 
 def test_rss_project_releases(db_request):
@@ -91,6 +103,7 @@ def test_rss_project_releases(db_request):
         ),
     }
     assert db_request.response.content_type == "text/xml"
+    _assert_has_cors_headers(db_request.response.headers)
 
 
 @pytest.mark.parametrize(

--- a/warehouse/rss/views.py
+++ b/warehouse/rss/views.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import joinedload
 
 from warehouse.cache.origin import origin_cache
 from warehouse.packaging.models import Project, Release
+from warehouse.utils.cors import _CORS_HEADERS
 
 
 def _format_author(release):
@@ -47,6 +48,7 @@ def _format_author(release):
 )
 def rss_updates(request):
     request.response.content_type = "text/xml"
+    request.response.headers.update(_CORS_HEADERS)
 
     latest_releases = (
         request.db.query(Release)
@@ -74,6 +76,7 @@ def rss_updates(request):
 )
 def rss_packages(request):
     request.response.content_type = "text/xml"
+    request.response.headers.update(_CORS_HEADERS)
 
     newest_projects = (
         request.db.query(Project)
@@ -101,6 +104,7 @@ def rss_packages(request):
 )
 def rss_project_releases(project, request):
     request.response.content_type = "text/xml"
+    request.response.headers.update(_CORS_HEADERS)
 
     latest_releases = (
         request.db.query(Release)


### PR DESCRIPTION
Browser-based feed utilities balk at accessing this already-public, well-cached data via JavaScript.

Relax the browser `same-origin` policy - no affect to server-side or non-browser access.
As these are read-only GET endpoints with no authentication, `CORS *` doesn't enable any new attack surface.
The added `X-PyPI-Last-Serial` header is useless to readers, but keeps the settings consistent across all usages.