### PR TITLE
fix: handle recovery codes that are too long

### DIFF
--- a/tests/unit/accounts/test_forms.py
+++ b/tests/unit/accounts/test_forms.py
@@ -135,6 +135,29 @@ class TestLoginForm:
         assert not form.validate()
         assert user_service.find_userid.calls == [pretend.call(expected_username)]
 
+    def test_validate_password_skips_when_field_has_errors(self):
+        user_service = pretend.stub(
+            find_userid=pretend.call_recorder(lambda userid: None),
+        )
+        form = forms.LoginForm(
+            formdata=MultiDict({"username": "my_username"}),
+            request=pretend.stub(
+                remote_addr=REMOTE_ADDR,
+                banned=pretend.stub(by_ip=lambda ip_address: False),
+            ),
+            user_service=user_service,
+            breach_service=pretend.stub(),
+        )
+        field = pretend.stub(data="pw", errors=["Password too long."])
+
+        form.validate_password(field)
+
+        # find_userid is called once by LoginForm.validate_password (after super()),
+        # but not by PasswordMixin.validate_password (which returned early).
+        assert user_service.find_userid.calls == [pretend.call("my_username")]
+        # check_password is never called — the early return skipped it.
+        assert not hasattr(user_service, "check_password")
+
     def test_validate_password_no_user(self):
         request = pretend.stub(
             remote_addr=REMOTE_ADDR,

--- a/tests/unit/accounts/test_forms.py
+++ b/tests/unit/accounts/test_forms.py
@@ -152,7 +152,7 @@ class TestLoginForm:
             user_service=user_service,
             breach_service=breach_service,
         )
-        field = pretend.stub(data="password")
+        field = pretend.stub(data="password", errors=[])
 
         form.validate_password(field)
 
@@ -181,7 +181,7 @@ class TestLoginForm:
             user_service=user_service,
             breach_service=breach_service,
         )
-        field = pretend.stub(data="pw")
+        field = pretend.stub(data="pw", errors=[])
 
         with pytest.raises(wtforms.validators.ValidationError, match=r"Bad Password\!"):
             form.validate_password(field)
@@ -216,7 +216,7 @@ class TestLoginForm:
             breach_service=breach_service,
             check_password_metrics_tags=["bar"],
         )
-        field = pretend.stub(data="pw")
+        field = pretend.stub(data="pw", errors=[])
 
         form.validate_password(field)
 
@@ -257,7 +257,7 @@ class TestLoginForm:
             user_service=user_service,
             breach_service=breach_service,
         )
-        field = pretend.stub(data="pw")
+        field = pretend.stub(data="pw", errors=[])
 
         with pytest.raises(wtforms.validators.ValidationError):
             form.validate_password(field)
@@ -298,7 +298,7 @@ class TestLoginForm:
             user_service=user_service,
             breach_service=breach_service,
         )
-        field = pretend.stub(data="pw")
+        field = pretend.stub(data="pw", errors=[])
 
         with pytest.raises(wtforms.validators.ValidationError):
             form.validate_password(field)
@@ -1301,6 +1301,8 @@ class TestRecoveryCodeForm:
             ("deadbeef00001111 deadbeef11110000", False),
             # Invalid: too short
             ("deadbeef", False),
+            # Invalid: exceeds passlib MAX_PASSWORD_SIZE
+            ("a" * 5000, False),
         ],
     )
     def test_recovery_code_string_validation(

--- a/tests/unit/accounts/test_services.py
+++ b/tests/unit/accounts/test_services.py
@@ -1238,6 +1238,16 @@ class TestDatabaseUserService:
 
         assert user_service.hasher.verify(codes[0], code.code)
 
+    def test_get_recovery_code_oversized_input(self, user_service):
+        user = UserFactory.create()
+        codes = user_service.generate_recovery_codes(user.id)
+        assert len(codes) == 8
+
+        # An oversized input should raise InvalidRecoveryCode,
+        # not passlib's PasswordSizeError.
+        with pytest.raises(InvalidRecoveryCode):
+            user_service.get_recovery_code(user.id, "a" * 5000)
+
     def test_generate_recovery_codes(self, user_service):
         user = UserFactory.create()
 

--- a/warehouse/accounts/forms.py
+++ b/warehouse/accounts/forms.py
@@ -197,6 +197,9 @@ class PasswordMixin:
         super().__init__(*args, **kwargs)
 
     def validate_password(self, field):
+        if field.errors:
+            return
+
         userid = self.user_service.find_userid(self.username.data)
         if userid is not None:
             try:
@@ -589,6 +592,9 @@ class RecoveryCodeAuthenticationForm(
     RecoveryCodeValueMixin, _TwoFactorAuthenticationForm
 ):
     def validate_recovery_code_value(self, field):
+        if field.errors:
+            return
+
         recovery_code_value = field.data.encode("utf-8").strip()
 
         try:

--- a/warehouse/accounts/services.py
+++ b/warehouse/accounts/services.py
@@ -448,8 +448,11 @@ class DatabaseUserService:
         user = self.get_user(user_id)
 
         for stored_recovery_code in self.get_recovery_codes(user.id):
-            if self.hasher.verify(code, stored_recovery_code.code):
-                return stored_recovery_code
+            try:
+                if self.hasher.verify(code, stored_recovery_code.code):
+                    return stored_recovery_code
+            except passlib.exc.PasswordValueError:
+                break
 
         self._metrics.increment(
             "warehouse.authentication.recovery_code.failure",

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -14,7 +14,7 @@ msgstr ""
 msgid "Locale updated"
 msgstr ""
 
-#: warehouse/accounts/forms.py:42 warehouse/accounts/forms.py:304
+#: warehouse/accounts/forms.py:42 warehouse/accounts/forms.py:307
 msgid "The email address isn't valid. Try again."
 msgstr ""
 
@@ -63,68 +63,68 @@ msgid ""
 "different username."
 msgstr ""
 
-#: warehouse/accounts/forms.py:186 warehouse/accounts/forms.py:235
-#: warehouse/accounts/forms.py:248
+#: warehouse/accounts/forms.py:186 warehouse/accounts/forms.py:238
+#: warehouse/accounts/forms.py:251
 msgid "Password too long."
 msgstr ""
 
-#: warehouse/accounts/forms.py:218
+#: warehouse/accounts/forms.py:221
 #, python-brace-format
 msgid ""
 "There have been too many unsuccessful login attempts. You have been "
 "locked out for ${time}. Please try again later."
 msgstr ""
 
-#: warehouse/accounts/forms.py:251
+#: warehouse/accounts/forms.py:254
 msgid "Your passwords don't match. Try again."
 msgstr ""
 
-#: warehouse/accounts/forms.py:285
+#: warehouse/accounts/forms.py:288
 msgid "The email address is too long. Try again."
 msgstr ""
 
-#: warehouse/accounts/forms.py:357
+#: warehouse/accounts/forms.py:360
 msgid "You can't use an email address from this domain. Use a different email."
 msgstr ""
 
-#: warehouse/accounts/forms.py:372
+#: warehouse/accounts/forms.py:375
 msgid ""
 "This email address is already being used by this account. Use a different"
 " email."
 msgstr ""
 
-#: warehouse/accounts/forms.py:383
+#: warehouse/accounts/forms.py:386
 msgid ""
 "This email address is already being used by another account. Use a "
 "different email."
 msgstr ""
 
-#: warehouse/accounts/forms.py:423 warehouse/manage/forms.py:132
+#: warehouse/accounts/forms.py:426 warehouse/manage/forms.py:132
 #: warehouse/manage/forms.py:824
 msgid "The name is too long. Choose a name with 100 characters or less."
 msgstr ""
 
-#: warehouse/accounts/forms.py:429
+#: warehouse/accounts/forms.py:432
 msgid "URLs are not allowed in the name field."
 msgstr ""
 
-#: warehouse/accounts/forms.py:520
+#: warehouse/accounts/forms.py:523
 msgid "Invalid TOTP code."
 msgstr ""
 
-#: warehouse/accounts/forms.py:537
+#: warehouse/accounts/forms.py:540
 msgid "Invalid WebAuthn assertion: Bad payload"
 msgstr ""
 
-#: warehouse/accounts/forms.py:606
+#: warehouse/accounts/forms.py:612
 msgid "Invalid recovery code."
 msgstr ""
 
-#: warehouse/accounts/forms.py:615
+#: warehouse/accounts/forms.py:621
 msgid "Recovery code has been previously used."
 msgstr ""
 
-#: warehouse/accounts/forms.py:645
+#: warehouse/accounts/forms.py:651
 msgid "The username isn't valid. Try again."
 msgstr ""
 


### PR DESCRIPTION
The ValidationError doesn't stop processing, and passes on the issue to
the service.

Fixes WAREHOUSE-PRODUCTION-27A

Signed-off-by: Mike Fiedler <miketheman@gmail.com>