### PR TITLE
fix: provide more granular permissions for POSTs

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,16 @@
+paths-ignore:
+  - .venv
+  - node_modules
+  - "**/*.min.js"
+  - "**/*.bundle.js"
+  - "**/generated/**"
+  - "**/dist/**"
+  - .github/codeql
+  - coverage
+  - dev
+  - docs
+  - tests
+  - warehouse/migrations
+
+queries:
+  - uses: ./.github/codeql/custom-queries/python/warehouse-suite.qls

--- a/.github/codeql/custom-queries/python/ReadPermissionPostEscalation.ql
+++ b/.github/codeql/custom-queries/python/ReadPermissionPostEscalation.ql
@@ -1,0 +1,173 @@
+/**
+ * @name Read permission on POST-capable Pyramid view
+ * @description A @view_config decorator guards a view with a read-only
+ *              permission while the view handles POST requests that may
+ *              perform write/mutation operations. Users with read-only
+ *              access can escalate to perform writes.
+ * @kind problem
+ * @problem.severity warning
+ * @precision high
+ * @id py/pyramid-read-permission-post-escalation
+ * @tags security
+ *       authorization
+ *       pyramid
+ */
+
+import python
+
+/**
+ * Holds when `kwValue` is the value expression for keyword argument
+ * `kwName` in `call`.
+ */
+predicate hasKeywordArg(Call call, string kwName, Expr kwValue) {
+  exists(Keyword kw |
+    kw = call.getAKeyword() and
+    kw.getArg() = kwName and
+    kw.getValue() = kwValue
+  )
+}
+
+/**
+ * Holds when `attr` is a `Permissions.*` attribute access where the
+ * attribute name contains "Read", indicating a read-only permission.
+ */
+predicate isReadPermission(Attribute attr) {
+  attr.getObject().(Name).getId() = "Permissions" and
+  attr.getName().matches("%Read%")
+}
+
+/**
+ * Gets the inner `view_config(...)` call from the outer decorator
+ * application `view_config(...)(func)`.
+ *
+ * Pyramid decorators are parameterized: `@view_config(kwargs)` produces
+ * an outer call `view_config(kwargs)(func)` where `getADecoratorCall()`
+ * returns the outer call and `.getFunc()` yields the inner call that
+ * holds the keyword arguments.
+ */
+Call getInnerDecoratorCall(Function func) {
+  exists(Call outerCall |
+    outerCall = func.getDefinition().(FunctionExpr).getADecoratorCall() and
+    result = outerCall.getFunc()
+  )
+}
+
+/**
+ * Holds when `innerCall` is a `view_config(...)` decorator on `func`.
+ */
+predicate isViewConfigDecorator(Call innerCall, Function func) {
+  innerCall = getInnerDecoratorCall(func) and
+  (
+    innerCall.getFunc().(Name).getId() = "view_config"
+    or
+    innerCall.getFunc().(Attribute).getName() = "view_config"
+  )
+}
+
+/**
+ * Holds when the decorator call explicitly sets `request_method="GET"`,
+ * meaning it only handles GET requests.
+ */
+predicate hasExplicitGetMethod(Call innerCall) {
+  exists(Expr v |
+    hasKeywordArg(innerCall, "request_method", v) and
+    v.(StringLiteral).getText() = "GET"
+  )
+}
+
+/**
+ * Holds when the decorator call sets `require_methods=["POST"]`,
+ * making it a POST-only view.
+ */
+predicate hasRequireMethodsPost(Call innerCall) {
+  exists(List lst |
+    hasKeywordArg(innerCall, "require_methods", lst) and
+    lst.getAnElt().(StringLiteral).getText() = "POST"
+  )
+}
+
+/**
+ * Holds when the decorator call sets `request_method="POST"`.
+ */
+predicate hasRequestMethodPost(Call innerCall) {
+  exists(Expr v |
+    hasKeywordArg(innerCall, "request_method", v) and
+    v.(StringLiteral).getText() = "POST"
+  )
+}
+
+/**
+ * Holds when the decorator call sets `require_methods=False`,
+ * allowing all HTTP methods (GET + POST).
+ */
+predicate hasRequireMethodsFalse(Call innerCall) {
+  exists(Expr v |
+    hasKeywordArg(innerCall, "require_methods", v) and
+    v instanceof False
+  )
+}
+
+/**
+ * Holds when the function body contains a comparison
+ * `request.method == "POST"`, indicating it handles POST internally.
+ */
+predicate bodyChecksPostMethod(Function func) {
+  exists(Compare cmp, Attribute left, StringLiteral right |
+    cmp.getScope() = func and
+    cmp.getLeft() = left and
+    left.getName() = "method" and
+    cmp.getComparator(0) = right and
+    right.getText() = "POST" and
+    cmp.getOp(0) instanceof Eq
+  )
+}
+
+/**
+ * Sub-pattern A: @view_config with require_methods=False, a read-only
+ * permission, and the function body checks request.method == "POST".
+ */
+predicate subpatternA(Call innerCall, Function func, Attribute permAttr) {
+  isViewConfigDecorator(innerCall, func) and
+  hasKeywordArg(innerCall, "permission", permAttr) and
+  isReadPermission(permAttr) and
+  hasRequireMethodsFalse(innerCall) and
+  bodyChecksPostMethod(func) and
+  not hasExplicitGetMethod(innerCall)
+}
+
+/**
+ * Sub-pattern B: @view_config that is POST-only
+ * (require_methods=["POST"] or request_method="POST") but uses a
+ * read-only permission.
+ */
+predicate subpatternB(Call innerCall, Function func, Attribute permAttr) {
+  isViewConfigDecorator(innerCall, func) and
+  hasKeywordArg(innerCall, "permission", permAttr) and
+  isReadPermission(permAttr) and
+  (
+    hasRequireMethodsPost(innerCall) or
+    hasRequestMethodPost(innerCall)
+  ) and
+  not hasExplicitGetMethod(innerCall)
+}
+
+from Call innerCall, Function func, Attribute permAttr, string msg
+where
+  (
+    subpatternA(innerCall, func, permAttr) and
+    msg =
+      "View '" + func.getName() +
+      "' uses read-only permission " + permAttr.getName() +
+      " with require_methods=False but handles POST requests." +
+      " POST operations may need a write permission."
+  )
+  or
+  (
+    subpatternB(innerCall, func, permAttr) and
+    msg =
+      "View '" + func.getName() +
+      "' is POST-only but uses read-only permission " +
+      permAttr.getName() +
+      ". POST-only views should use a write/manage permission."
+  )
+select innerCall, msg

--- a/.github/codeql/custom-queries/python/codeql-pack.lock.yml
+++ b/.github/codeql/custom-queries/python/codeql-pack.lock.yml
@@ -1,0 +1,34 @@
+---
+lockVersion: 1.0.0
+dependencies:
+  codeql/concepts:
+    version: 0.0.21
+  codeql/controlflow:
+    version: 2.0.31
+  codeql/dataflow:
+    version: 2.1.3
+  codeql/mad:
+    version: 1.0.47
+  codeql/python-all:
+    version: 7.0.4
+  codeql/python-queries:
+    version: 1.8.0
+  codeql/regex:
+    version: 1.0.47
+  codeql/ssa:
+    version: 2.0.23
+  codeql/suite-helpers:
+    version: 1.0.47
+  codeql/threat-models:
+    version: 1.0.47
+  codeql/tutorial:
+    version: 1.0.47
+  codeql/typetracking:
+    version: 2.0.31
+  codeql/util:
+    version: 2.0.34
+  codeql/xml:
+    version: 1.0.47
+  codeql/yaml:
+    version: 1.0.47
+compiled: false

--- a/.github/codeql/custom-queries/python/qlpack.yml
+++ b/.github/codeql/custom-queries/python/qlpack.yml
@@ -1,0 +1,7 @@
+name: warehouse/python-custom
+version: 0.0.1
+library: false
+extractor: python
+dependencies:
+  codeql/python-all: "*"
+  codeql/python-queries: "*"

--- a/.github/codeql/custom-queries/python/tests/ReadPermissionPostEscalation/ReadPermissionPostEscalation.expected
+++ b/.github/codeql/custom-queries/python/tests/ReadPermissionPostEscalation/ReadPermissionPostEscalation.expected
@@ -1,0 +1,3 @@
+| test.py:25:2:29:1 | view_config() | View 'positive_a_require_methods_false_with_body_check' uses read-only permission FooRead with require_methods=False but handles POST requests. POST operations may need a write permission. |
+| test.py:38:2:42:1 | view_config() | View 'positive_b1_require_methods_post_only' is POST-only but uses read-only permission FooRead. POST-only views should use a write/manage permission. |
+| test.py:49:2:53:1 | view_config() | View 'positive_b2_request_method_post' is POST-only but uses read-only permission FooRead. POST-only views should use a write/manage permission. |

--- a/.github/codeql/custom-queries/python/tests/ReadPermissionPostEscalation/ReadPermissionPostEscalation.qlref
+++ b/.github/codeql/custom-queries/python/tests/ReadPermissionPostEscalation/ReadPermissionPostEscalation.qlref
@@ -1,0 +1,1 @@
+../../ReadPermissionPostEscalation.ql

--- a/.github/codeql/custom-queries/python/tests/ReadPermissionPostEscalation/test.py
+++ b/.github/codeql/custom-queries/python/tests/ReadPermissionPostEscalation/test.py
@@ -1,0 +1,105 @@
+# Fixtures for ReadPermissionPostEscalation.ql
+# Each labeled block exercises one branch of the query.
+
+
+class Permissions:
+    FooRead = "foo:read"
+    FooWrite = "foo:write"
+    FooManage = "foo:manage"
+
+
+def view_config(**kwargs):
+    def decorator(func):
+        return func
+    return decorator
+
+
+def other_decorator(**kwargs):
+    def decorator(func):
+        return func
+    return decorator
+
+
+# --- POSITIVE: sub-pattern A -------------------------------------------------
+# require_methods=False + read permission + body checks request.method == "POST"
+@view_config(
+    route_name="positive.subpattern_a",
+    require_methods=False,
+    permission=Permissions.FooRead,
+)
+def positive_a_require_methods_false_with_body_check(request):
+    if request.method == "POST":
+        return "handle post"
+    return "show form"
+
+
+# --- POSITIVE: sub-pattern B1 ------------------------------------------------
+# require_methods=["POST"] + read permission
+@view_config(
+    route_name="positive.subpattern_b1",
+    require_methods=["POST"],
+    permission=Permissions.FooRead,
+)
+def positive_b1_require_methods_post_only(request):
+    return "post action"
+
+
+# --- POSITIVE: sub-pattern B2 ------------------------------------------------
+# request_method="POST" + read permission
+@view_config(
+    route_name="positive.subpattern_b2",
+    request_method="POST",
+    permission=Permissions.FooRead,
+)
+def positive_b2_request_method_post(request):
+    return "post action"
+
+
+# --- NEGATIVE: explicit GET --------------------------------------------------
+# request_method="GET" should exclude even if permission is read
+@view_config(
+    route_name="negative.explicit_get",
+    request_method="GET",
+    permission=Permissions.FooRead,
+)
+def negative_explicit_get(request):
+    return "get action"
+
+
+# --- NEGATIVE: POST with write permission -----------------------------------
+@view_config(
+    route_name="negative.post_write_perm",
+    request_method="POST",
+    permission=Permissions.FooWrite,
+)
+def negative_post_with_write_permission(request):
+    return "post action"
+
+
+# --- NEGATIVE: POST with manage permission (not *Read*) ---------------------
+@view_config(
+    route_name="negative.post_manage_perm",
+    require_methods=["POST"],
+    permission=Permissions.FooManage,
+)
+def negative_post_with_manage_permission(request):
+    return "post action"
+
+
+# --- NEGATIVE: sub-pattern A shape but body never checks request.method -----
+@view_config(
+    route_name="negative.no_body_check",
+    require_methods=False,
+    permission=Permissions.FooRead,
+)
+def negative_no_body_post_check(request):
+    return "no post branch"
+
+
+# --- NEGATIVE: not a view_config decorator ----------------------------------
+@other_decorator(
+    require_methods=["POST"],
+    permission=Permissions.FooRead,
+)
+def negative_not_view_config(request):
+    return "post action"

--- a/.github/codeql/custom-queries/python/tests/ReadPermissionPostEscalation/test.py
+++ b/.github/codeql/custom-queries/python/tests/ReadPermissionPostEscalation/test.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 # Fixtures for ReadPermissionPostEscalation.ql
 # Each labeled block exercises one branch of the query.
 

--- a/.github/codeql/custom-queries/python/warehouse-suite.qls
+++ b/.github/codeql/custom-queries/python/warehouse-suite.qls
@@ -1,0 +1,22 @@
+- description: warehouse Python analysis — custom checks only (security-extended staged)
+# TODO: evaluate custom-pack-only results in CI, then re-enable security-extended
+# by uncommenting the `apply:` block below. The exclude filters further down
+# already cover the known false-positive rules from security-extended.
+# - apply: codeql-suites/python-security-extended.qls
+#   from: codeql/python-queries
+- queries: .
+# pyramid_jinja2 auto-escapes all .html templates. CodeQL's Pyramid
+# model does not account for this, producing false positives on every
+# view that returns user input to a template context.
+- exclude:
+    id:
+      - py/reflective-xss
+      - py/jinja2/autoescape-false
+# All call sites validate via is_safe_url() before redirecting.
+- exclude:
+    id:
+      - py/url-redirection
+- exclude:
+    precision:
+      - low
+      - medium

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -57,6 +57,7 @@ jobs:
       uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
       with:
         languages: ${{ matrix.language }}
+        config-file: .github/codeql/codeql-config.yml
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,8 @@ dev/.mypy_cache/
 dev/.pip-cache/
 dev/.pip-tools-cache/
 dev/.pytest_cache/
+dev/codeql/
+.github/codeql/**/*.testproj/
 ./data/
 
 warehouse/.commit

--- a/Makefile
+++ b/Makefile
@@ -178,6 +178,8 @@ dbshell: .state/docker-build-base
 
 clean:
 	rm -rf dev/*.sql
+	rm -rf docs/blog-site/ docs/dev-site/ docs/user-site/
+	rm -rf warehouse/static/dist/ warehouse/admin/static/dist/
 
 purge: stop clean
 	rm -rf .state dev/.coverage* dev/.mypy_cache dev/.pip-cache dev/.pip-tools-cache dev/.pytest_cache .state/db-populated .state/db-migrated
@@ -187,4 +189,81 @@ purge: stop clean
 stop:
 	docker compose stop
 
-.PHONY: default build serve resetdb initdb shell dbshell tests dev-docs user-docs deps deps_upgrade_all deps_upgrade_project clean purge debug stop compile-pot runmigrations checkdb
+# ============================================================================
+# CodeQL static analysis (runs on host, not in Docker)
+# ============================================================================
+# First-time run:
+#   make codeql                       # install packs, build DB, analyze everything
+#
+# Other useful targets:
+#   make codeql-analyze-python        # analyze one language against existing DB
+#   make codeql-db                    # (re)build just the database
+#   make codeql-rebuild               # force DB rebuild (packs/CLI sentinels kept)
+#   make codeql-test                  # run custom query unit tests
+#   make codeql-clean                 # remove DB, results, and sentinels
+#
+# The DB is automatically rebuilt when any tracked source file under
+# warehouse/ changes (detected at make-invocation time via `find`).
+#
+# Override CODEQL_LANGS to scope to a subset (requires codeql-clean first if
+# the existing DB was built with a different set):
+#   make codeql CODEQL_LANGS=python
+#
+# Artifacts land under dev/codeql/ (gitignored):
+#   dev/codeql/db/        database cluster
+#   dev/codeql/results/   <language>.sarif per analyzed language
+
+CODEQL_LANGS ?= python javascript
+
+_codeql_db        := dev/codeql/db
+_codeql_results   := dev/codeql/results
+
+_codeql_pack_python      = .github/codeql/custom-queries/python
+_codeql_custom_python    = .github/codeql/custom-queries/python/warehouse-suite.qls
+_codeql_sources          := $(shell git ls-files 'warehouse/*.py' 'warehouse/*.js' ':!warehouse/migrations/*' 2>/dev/null)
+
+.state/codeql-cli:
+	@command -v codeql >/dev/null 2>&1 || { \
+		echo "error: 'codeql' not found on PATH."; \
+		echo "       macOS:   brew install --cask codeql"; \
+		echo "       other:   https://github.com/github/codeql-cli-binaries/releases"; \
+		exit 1; \
+	}
+	@mkdir -p .state && touch .state/codeql-cli
+
+.state/codeql-packs: .state/codeql-cli
+	codeql pack install $(_codeql_pack_python)
+	@mkdir -p .state && touch .state/codeql-packs
+
+.state/codeql-db: .state/codeql-packs .github/codeql/codeql-config.yml $(_codeql_sources)
+	rm -rf $(_codeql_db)
+	@mkdir -p $(dir $(_codeql_db))
+	codeql database create $(_codeql_db) --db-cluster --threads=0 \
+		$(addprefix --language=,$(CODEQL_LANGS)) \
+		--codescanning-config=.github/codeql/codeql-config.yml
+	@mkdir -p .state && touch .state/codeql-db
+
+codeql-db: .state/codeql-db
+
+codeql-rebuild:
+	rm -rf $(_codeql_db) .state/codeql-db
+	$(MAKE) codeql-db
+
+codeql-analyze-%: .state/codeql-db
+	@mkdir -p $(_codeql_results)
+	codeql database analyze $(_codeql_db)/$* --threads=0 \
+		--format=sarif-latest \
+		--output=$(_codeql_results)/$*.sarif \
+		$(_codeql_custom_$*)
+
+codeql-analyze: $(addprefix codeql-analyze-,$(CODEQL_LANGS))
+
+codeql: codeql-analyze
+
+codeql-test: .state/codeql-packs
+	codeql test run $(_codeql_pack_python)/tests
+
+codeql-clean:
+	rm -rf dev/codeql .state/codeql-db .state/codeql-packs .state/codeql-cli
+
+.PHONY: default build serve resetdb initdb shell dbshell tests dev-docs user-docs deps deps_upgrade_all deps_upgrade_project clean purge debug stop compile-pot runmigrations checkdb codeql codeql-db codeql-rebuild codeql-analyze codeql-test codeql-clean

--- a/docs/user/organization-accounts/roles-entities.md
+++ b/docs/user/organization-accounts/roles-entities.md
@@ -48,7 +48,7 @@ upload releases for a project
 * **Owner**: A collaborator assigned this role can manage
 the project and collaborators for the project
 
-This table summarizes the roles and perimissions within an organization.
+This table summarizes the roles and permissions within an organization.
 
 | Action | Member | Manager | Owner | Billing Manager |
 | ---------------------------------- | ------ | ------ | ------ | ------ |

--- a/tests/unit/organizations/test_models.py
+++ b/tests/unit/organizations/test_models.py
@@ -185,7 +185,6 @@ class TestOrganization:
                     f"user:{billing_mgr1.user.id}",
                     [
                         Permissions.OrganizationsRead,
-                        Permissions.OrganizationsRoleRemove,
                         Permissions.OrganizationTeamsRead,
                         Permissions.OrganizationsBillingManage,
                     ],
@@ -195,7 +194,6 @@ class TestOrganization:
                     f"user:{billing_mgr2.user.id}",
                     [
                         Permissions.OrganizationsRead,
-                        Permissions.OrganizationsRoleRemove,
                         Permissions.OrganizationTeamsRead,
                         Permissions.OrganizationsBillingManage,
                     ],
@@ -407,7 +405,6 @@ class TestTeam:
                     f"user:{billing_mgr1.user.id}",
                     [
                         Permissions.OrganizationsRead,
-                        Permissions.OrganizationsRoleRemove,
                         Permissions.OrganizationTeamsRead,
                         Permissions.OrganizationsBillingManage,
                     ],
@@ -417,7 +414,6 @@ class TestTeam:
                     f"user:{billing_mgr2.user.id}",
                     [
                         Permissions.OrganizationsRead,
-                        Permissions.OrganizationsRoleRemove,
                         Permissions.OrganizationTeamsRead,
                         Permissions.OrganizationsBillingManage,
                     ],

--- a/tests/unit/organizations/test_models.py
+++ b/tests/unit/organizations/test_models.py
@@ -153,6 +153,7 @@ class TestOrganization:
                     f"user:{owner1.user.id}",
                     [
                         Permissions.OrganizationsRead,
+                        Permissions.OrganizationsRoleRemove,
                         Permissions.OrganizationTeamsRead,
                         Permissions.OrganizationsManage,
                         Permissions.OrganizationTeamsManage,
@@ -166,6 +167,7 @@ class TestOrganization:
                     f"user:{owner2.user.id}",
                     [
                         Permissions.OrganizationsRead,
+                        Permissions.OrganizationsRoleRemove,
                         Permissions.OrganizationTeamsRead,
                         Permissions.OrganizationsManage,
                         Permissions.OrganizationTeamsManage,
@@ -183,6 +185,7 @@ class TestOrganization:
                     f"user:{billing_mgr1.user.id}",
                     [
                         Permissions.OrganizationsRead,
+                        Permissions.OrganizationsRoleRemove,
                         Permissions.OrganizationTeamsRead,
                         Permissions.OrganizationsBillingManage,
                     ],
@@ -192,6 +195,7 @@ class TestOrganization:
                     f"user:{billing_mgr2.user.id}",
                     [
                         Permissions.OrganizationsRead,
+                        Permissions.OrganizationsRoleRemove,
                         Permissions.OrganizationTeamsRead,
                         Permissions.OrganizationsBillingManage,
                     ],
@@ -205,6 +209,7 @@ class TestOrganization:
                     f"user:{account_mgr1.user.id}",
                     [
                         Permissions.OrganizationsRead,
+                        Permissions.OrganizationsRoleRemove,
                         Permissions.OrganizationTeamsRead,
                         Permissions.OrganizationTeamsManage,
                         Permissions.OrganizationProjectsAdd,
@@ -215,6 +220,7 @@ class TestOrganization:
                     f"user:{account_mgr2.user.id}",
                     [
                         Permissions.OrganizationsRead,
+                        Permissions.OrganizationsRoleRemove,
                         Permissions.OrganizationTeamsRead,
                         Permissions.OrganizationTeamsManage,
                         Permissions.OrganizationProjectsAdd,
@@ -227,12 +233,20 @@ class TestOrganization:
                 (
                     Allow,
                     f"user:{member1.user.id}",
-                    [Permissions.OrganizationsRead, Permissions.OrganizationTeamsRead],
+                    [
+                        Permissions.OrganizationsRead,
+                        Permissions.OrganizationsRoleRemove,
+                        Permissions.OrganizationTeamsRead,
+                    ],
                 ),
                 (
                     Allow,
                     f"user:{member2.user.id}",
-                    [Permissions.OrganizationsRead, Permissions.OrganizationTeamsRead],
+                    [
+                        Permissions.OrganizationsRead,
+                        Permissions.OrganizationsRoleRemove,
+                        Permissions.OrganizationTeamsRead,
+                    ],
                 ),
             ],
             key=lambda x: x[1],
@@ -361,6 +375,7 @@ class TestTeam:
                     f"user:{owner1.user.id}",
                     [
                         Permissions.OrganizationsRead,
+                        Permissions.OrganizationsRoleRemove,
                         Permissions.OrganizationTeamsRead,
                         Permissions.OrganizationsManage,
                         Permissions.OrganizationTeamsManage,
@@ -374,6 +389,7 @@ class TestTeam:
                     f"user:{owner2.user.id}",
                     [
                         Permissions.OrganizationsRead,
+                        Permissions.OrganizationsRoleRemove,
                         Permissions.OrganizationTeamsRead,
                         Permissions.OrganizationsManage,
                         Permissions.OrganizationTeamsManage,
@@ -391,6 +407,7 @@ class TestTeam:
                     f"user:{billing_mgr1.user.id}",
                     [
                         Permissions.OrganizationsRead,
+                        Permissions.OrganizationsRoleRemove,
                         Permissions.OrganizationTeamsRead,
                         Permissions.OrganizationsBillingManage,
                     ],
@@ -400,6 +417,7 @@ class TestTeam:
                     f"user:{billing_mgr2.user.id}",
                     [
                         Permissions.OrganizationsRead,
+                        Permissions.OrganizationsRoleRemove,
                         Permissions.OrganizationTeamsRead,
                         Permissions.OrganizationsBillingManage,
                     ],
@@ -413,6 +431,7 @@ class TestTeam:
                     f"user:{account_mgr1.user.id}",
                     [
                         Permissions.OrganizationsRead,
+                        Permissions.OrganizationsRoleRemove,
                         Permissions.OrganizationTeamsRead,
                         Permissions.OrganizationTeamsManage,
                         Permissions.OrganizationProjectsAdd,
@@ -423,6 +442,7 @@ class TestTeam:
                     f"user:{account_mgr2.user.id}",
                     [
                         Permissions.OrganizationsRead,
+                        Permissions.OrganizationsRoleRemove,
                         Permissions.OrganizationTeamsRead,
                         Permissions.OrganizationTeamsManage,
                         Permissions.OrganizationProjectsAdd,
@@ -435,12 +455,20 @@ class TestTeam:
                 (
                     Allow,
                     f"user:{member1.user.id}",
-                    [Permissions.OrganizationsRead, Permissions.OrganizationTeamsRead],
+                    [
+                        Permissions.OrganizationsRead,
+                        Permissions.OrganizationsRoleRemove,
+                        Permissions.OrganizationTeamsRead,
+                    ],
                 ),
                 (
                     Allow,
                     f"user:{member2.user.id}",
-                    [Permissions.OrganizationsRead, Permissions.OrganizationTeamsRead],
+                    [
+                        Permissions.OrganizationsRead,
+                        Permissions.OrganizationsRoleRemove,
+                        Permissions.OrganizationTeamsRead,
+                    ],
                 ),
             ],
             key=lambda x: x[1],

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -559,6 +559,7 @@ def test_root_factory_access_control_list():
                 Permissions.AdminIpAddressesRead,
                 Permissions.AdminIpAddressesWrite,
                 Permissions.AdminJournalRead,
+                Permissions.AdminMacaroonsInspect,
                 Permissions.AdminMacaroonsRead,
                 Permissions.AdminMacaroonsWrite,
                 Permissions.AdminObservationsRead,

--- a/warehouse/admin/views/macaroons.py
+++ b/warehouse/admin/views/macaroons.py
@@ -15,7 +15,7 @@ from warehouse.macaroons.services import deserialize_raw_macaroon
 @view_config(
     route_name="admin.macaroon.decode_token",
     renderer="warehouse.admin:templates/admin/macaroons/decode_token.html",
-    permission=Permissions.AdminMacaroonsRead,
+    permission=Permissions.AdminMacaroonsInspect,
     request_method="GET",
     uses_session=True,
     require_csrf=True,
@@ -24,7 +24,7 @@ from warehouse.macaroons.services import deserialize_raw_macaroon
 @view_config(
     route_name="admin.macaroon.decode_token",
     renderer="warehouse.admin:templates/admin/macaroons/decode_token.html",
-    permission=Permissions.AdminMacaroonsRead,
+    permission=Permissions.AdminMacaroonsInspect,
     request_method="POST",
     uses_session=True,
     require_csrf=True,

--- a/warehouse/authnz/_permissions.py
+++ b/warehouse/authnz/_permissions.py
@@ -42,6 +42,7 @@ class Permissions(StrEnum):
     AdminIpAddressesWrite = "admin:ip-addresses:write"
     AdminJournalRead = "admin:journal:read"
 
+    AdminMacaroonsInspect = "admin:macaroons:inspect"
     AdminMacaroonsRead = "admin:macaroons:read"
     AdminMacaroonsWrite = "admin:macaroons:write"
 
@@ -107,6 +108,7 @@ class Permissions(StrEnum):
     OrganizationsManage = "organizations:manage"
     OrganizationsBillingManage = "organizations:billing:manage"
     OrganizationsRead = "organizations:read"
+    OrganizationsRoleRemove = "organizations:role:remove"
     OrganizationProjectsAdd = "organizations:projects:add"
     OrganizationProjectsRemove = "organizations:projects:remove"  # TODO: unused?
     OrganizationTeamsManage = "organizations:teams:manage"

--- a/warehouse/config.py
+++ b/warehouse/config.py
@@ -71,6 +71,7 @@ class RootFactory:
                 Permissions.AdminIpAddressesRead,
                 Permissions.AdminIpAddressesWrite,
                 Permissions.AdminJournalRead,
+                Permissions.AdminMacaroonsInspect,
                 Permissions.AdminMacaroonsRead,
                 Permissions.AdminMacaroonsWrite,
                 Permissions.AdminObservationsRead,

--- a/warehouse/manage/views/organizations.py
+++ b/warehouse/manage/views/organizations.py
@@ -1348,7 +1348,7 @@ def change_organization_role(
     uses_session=True,
     require_active_organization=True,
     require_methods=["POST"],
-    permission=Permissions.OrganizationsRead,
+    permission=Permissions.OrganizationsRoleRemove,
     has_translations=True,
     require_reauth=True,
 )

--- a/warehouse/manage/views/teams.py
+++ b/warehouse/manage/views/teams.py
@@ -350,7 +350,7 @@ class ManageTeamRolesViews:
     @view_config(
         request_method="POST",
         route_name="manage.team.delete_role",
-        permission=Permissions.OrganizationTeamsRead,
+        permission=Permissions.OrganizationsRoleRemove,
     )
     def delete_team_role(self):
         # Get team role.

--- a/warehouse/organizations/models.py
+++ b/warehouse/organizations/models.py
@@ -520,6 +520,7 @@ class Organization(OrganizationMixin, HasEvents, db.Model):
                         f"user:{role.user.id}",
                         [
                             Permissions.OrganizationsRead,
+                            Permissions.OrganizationsRoleRemove,
                             Permissions.OrganizationTeamsRead,
                             Permissions.OrganizationsManage,
                             Permissions.OrganizationTeamsManage,
@@ -545,6 +546,7 @@ class Organization(OrganizationMixin, HasEvents, db.Model):
                         f"user:{role.user.id}",
                         [
                             Permissions.OrganizationsRead,
+                            Permissions.OrganizationsRoleRemove,
                             Permissions.OrganizationTeamsRead,
                             Permissions.OrganizationsBillingManage,
                         ],
@@ -566,6 +568,7 @@ class Organization(OrganizationMixin, HasEvents, db.Model):
                         f"user:{role.user.id}",
                         [
                             Permissions.OrganizationsRead,
+                            Permissions.OrganizationsRoleRemove,
                             Permissions.OrganizationTeamsRead,
                             Permissions.OrganizationTeamsManage,
                             Permissions.OrganizationProjectsAdd,
@@ -590,6 +593,7 @@ class Organization(OrganizationMixin, HasEvents, db.Model):
                         f"user:{role.user.id}",
                         [
                             Permissions.OrganizationsRead,
+                            Permissions.OrganizationsRoleRemove,
                             Permissions.OrganizationTeamsRead,
                         ],
                     )

--- a/warehouse/organizations/models.py
+++ b/warehouse/organizations/models.py
@@ -537,6 +537,7 @@ class Organization(OrganizationMixin, HasEvents, db.Model):
                 # - Manage billing (Permissions.OrganizationsBillingManage)
                 # Disallowed:
                 # - Invite/remove organization member (Permissions.OrganizationsManage)
+                # - Remove own org/team role (Permissions.OrganizationsRoleRemove)
                 # - Create/delete team and add/remove members (OrganizationTeamsManage)
                 # - Add project (Permissions.OrganizationProjectsAdd)
                 # - Remove project (Permissions.OrganizationProjectsRemove)
@@ -546,7 +547,6 @@ class Organization(OrganizationMixin, HasEvents, db.Model):
                         f"user:{role.user.id}",
                         [
                             Permissions.OrganizationsRead,
-                            Permissions.OrganizationsRoleRemove,
                             Permissions.OrganizationTeamsRead,
                             Permissions.OrganizationsBillingManage,
                         ],


### PR DESCRIPTION
Similar to other permissions-based routes, separate read/write to
prevent unintentional use of a permission named "*Read" on a resource
that isn't read-only (POST et al).

---

chore(ci): introduce codeql custom queries

Based on the learnings from the recent audit, add some custom CodeQL
configurations, `make` targets to make it easier to work with, and a
custom query to prevent accidentally allowing Read permissions on Write
operations.
