### PR TITLE
chore(perf): reduce cache purges for events

### DIFF
--- a/tests/unit/cache/origin/test_init.py
+++ b/tests/unit/cache/origin/test_init.py
@@ -67,6 +67,20 @@ def test_store_purge_keys_dirty_with_changed_attrs(app_config, db_session):
     assert f"project/{project.normalized_name}" in purges
 
 
+def test_store_purge_keys_skips_events_only_changes(app_config, db_request):
+    project = ProjectFactory.create()
+    db_request.db.flush()
+    # Clear purges from project creation
+    db_request.db.info.pop("warehouse.cache.origin.purges", None)
+
+    # Recording an event mutates project.events but no publicly-cached content
+    project.record_event(tag="test:event", request=db_request, additional={})
+    db_request.db.flush()
+
+    purges = db_request.db.info.get("warehouse.cache.origin.purges", set())
+    assert f"project/{project.normalized_name}" not in purges
+
+
 def test_execute_purge_success(app_config, monkeypatch):
     cacher = pretend.stub(purge=pretend.call_recorder(lambda purges: None))
     factory = pretend.call_recorder(lambda ctx, config: cacher)

--- a/warehouse/cache/origin/__init__.py
+++ b/warehouse/cache/origin/__init__.py
@@ -18,6 +18,11 @@ from warehouse.utils.db import orm_session_from_obj
 
 logger = structlog.get_logger(__name__)
 
+# Attribute mutations that should NOT trigger CDN purges.
+# `events` is an append-only audit log via HasEvents; writing to it (e.g. login,
+# upload) doesn't change any publicly-cached content for the source object.
+_NON_CACHE_RELEVANT_ATTRS = frozenset({"events"})
+
 
 @db.listens_for(db.Session, "after_flush")
 def store_purge_keys(config, session, flush_context):
@@ -35,6 +40,16 @@ def store_purge_keys(config, session, flush_context):
         except KeyError:
             continue
 
+        changed = set()
+        if obj in session.dirty:
+            try:
+                changed = set(sa_inspect(obj).committed_state.keys())
+            except NoInspectionAvailable:
+                pass
+            # Skip if only non-cache-relevant attributes changed
+            if changed and changed <= _NON_CACHE_RELEVANT_ATTRS:
+                continue
+
         keys = list(key_maker(obj).purge)
 
         if keys:
@@ -50,13 +65,8 @@ def store_purge_keys(config, session, flush_context):
                 "state": state,
                 "keys": sorted(keys),
             }
-            if state == "dirty":
-                try:
-                    changed = sorted(sa_inspect(obj).committed_state.keys())
-                except NoInspectionAvailable:
-                    changed = []
-                if changed:
-                    log_kw["changed_attrs"] = changed
+            if changed:
+                log_kw["changed_attrs"] = sorted(changed)
             logger.info("cache_purge_keys_generated", **log_kw)
 
         purges.update(keys)


### PR DESCRIPTION
When we record_event for a given Project/Release/File as part of tracking activities, we don't want to issue a purge for changes that have no bearing on the public behavior for the object.

Today, an example timeline of purges:
```mermaid
gantt
    title Cache Purges for sampleproject (user/example-user)
    dateFormat HH:mm:ss.SSS
    axisFormat %M:%S

    section mint_token
    Project/events         :crit,  p01, 00:00:00.000, 1s
    Project/events         :crit,  p02, 00:00:01.399, 1s
    Project/events         :crit,  p03, 00:00:02.697, 1s

    section Release upload
    Project/events         :crit,  p04, 00:03:14.108, 1s
    Project/events         :crit,  p05, 00:03:15.334, 1s
    Project/events         :crit,  p06, 00:03:16.430, 1s
    Release/new            :        r01, 00:03:16.785, 1s
    Project/releases       :        p07, 00:03:16.785, 1s
    Project/events         :crit,  p08, 00:03:16.793, 1s
    Release/_pypi_ordering :        r02, 00:03:16.797, 1s
    File/new               :        f01, 00:03:17.341, 1s
    Release/files          :        r03, 00:03:17.341, 1s
    File/new               :        f02, 00:03:17.578, 1s
    Release/files          :        r04, 00:03:17.580, 1s
    File/events            :crit,  f03, 00:03:17.985, 1s
    Project/events         :crit,  p09, 00:03:19.329, 1s
    Project/events         :crit,  p10, 00:03:20.638, 1s
```
🔴 red = events-only (skippable with the new filter)

This drops the 3 early purges due to `mint_token` recording an event for the Project (from Trusted Publishing), and 7 more from the actual release upload. 7 purges remain for now - over 50% fewer purges.



Sets the stage for the ability to add other model attributes (columns) for exclusion if we find more of them.