### PR TITLE
perf: purge even less

### DIFF
--- a/tests/unit/cache/origin/test_init.py
+++ b/tests/unit/cache/origin/test_init.py
@@ -4,11 +4,18 @@ import pretend
 import pytest
 
 from tests.common.db.accounts import UserFactory
-from tests.common.db.packaging import ProjectFactory
+from tests.common.db.packaging import (
+    FileFactory,
+    ProjectFactory,
+    ReleaseFactory,
+    RoleFactory,
+    RoleInvitationFactory,
+)
 from warehouse.accounts.models import User
 from warehouse.cache import origin
 from warehouse.cache.origin.derivers import html_cache_deriver
 from warehouse.cache.origin.interfaces import IOriginCache
+from warehouse.observations.models import ObservationKind
 
 
 def test_store_purge_keys():
@@ -67,18 +74,101 @@ def test_store_purge_keys_dirty_with_changed_attrs(app_config, db_session):
     assert f"project/{project.normalized_name}" in purges
 
 
-def test_store_purge_keys_skips_events_only_changes(app_config, db_request):
+def _trigger_event(project, request):
+    project.record_event(tag="test:event", request=request, additional={})
+
+
+def _trigger_observation(project, request):
+    project.record_observation(
+        request=request,
+        kind=ObservationKind.IsMalware,
+        actor=UserFactory.create(),
+        summary="test",
+        payload={},
+    )
+
+
+def _trigger_invitation(project, request):
+    RoleInvitationFactory.create(project=project)
+
+
+@pytest.mark.parametrize(
+    "trigger",
+    [_trigger_event, _trigger_observation, _trigger_invitation],
+    ids=["events", "observations", "invitations"],
+)
+def test_store_purge_keys_skips_audit_only_collection_changes(
+    trigger, app_config, db_request
+):
+    # Audit/admin-only collection mutations (events, observations, invitations)
+    # never affect publicly-cached content and should not trigger a Project purge.
     project = ProjectFactory.create()
     db_request.db.flush()
-    # Clear purges from project creation
     db_request.db.info.pop("warehouse.cache.origin.purges", None)
 
-    # Recording an event mutates project.events but no publicly-cached content
-    project.record_event(tag="test:event", request=db_request, additional={})
+    trigger(project, db_request)
     db_request.db.flush()
 
     purges = db_request.db.info.get("warehouse.cache.origin.purges", set())
     assert f"project/{project.normalized_name}" not in purges
+
+
+def test_store_purge_keys_skips_project_dirty_on_roles_change(app_config, db_request):
+    # Role has its own cache_keys; the Project-dirty purge would only add
+    # all-projects and org/{name}, which aren't affected by role membership.
+    project = ProjectFactory.create()
+    db_request.db.flush()
+    db_request.db.info.pop("warehouse.cache.origin.purges", None)
+
+    role = RoleFactory.create(project=project)
+    db_request.db.flush()
+
+    purges = db_request.db.info.get("warehouse.cache.origin.purges", set())
+    assert f"project/{project.normalized_name}" in purges
+    assert f"user/{role.user.username}" in purges
+    assert "all-projects" not in purges
+
+
+def test_store_purge_keys_skips_release_dirty_on_files_change(app_config, db_request):
+    # File has its own cache_keys (project/{name}); Release-dirty would only
+    # add user/*, all-projects, org/{name}, none of which are affected by a
+    # file change to an existing release.
+    release = ReleaseFactory.create()
+    db_request.db.flush()
+    db_request.db.info.pop("warehouse.cache.origin.purges", None)
+
+    FileFactory.create(release=release)
+    db_request.db.flush()
+
+    purges = db_request.db.info.get("warehouse.cache.origin.purges", set())
+    assert f"project/{release.project.normalized_name}" in purges
+    assert "all-projects" not in purges
+
+
+def test_store_purge_keys_skips_project_dirty_on_releases_change(
+    app_config, db_request, mocker
+):
+    # Release's cache_keys emit the SAME 4 keys as Project's would, so the
+    # purge set can't distinguish; assert via log emissions instead.
+    log_info = mocker.spy(origin.logger, "info")
+
+    project = ProjectFactory.create()
+    db_request.db.flush()
+    log_info.reset_mock()
+
+    ReleaseFactory.create(project=project)
+    db_request.db.flush()
+
+    purge_logs = [
+        call
+        for call in log_info.call_args_list
+        if call.args and call.args[0] == "cache_purge_keys_generated"
+    ]
+    logged_classes = {
+        (call.kwargs.get("obj_class"), call.kwargs.get("state")) for call in purge_logs
+    }
+    assert ("Release", "new") in logged_classes
+    assert ("Project", "dirty") not in logged_classes
 
 
 def test_execute_purge_success(app_config, monkeypatch):

--- a/warehouse/cache/origin/__init__.py
+++ b/warehouse/cache/origin/__init__.py
@@ -18,10 +18,30 @@ from warehouse.utils.db import orm_session_from_obj
 
 logger = structlog.get_logger(__name__)
 
-# Attribute mutations that should NOT trigger CDN purges.
-# `events` is an append-only audit log via HasEvents; writing to it (e.g. login,
-# upload) doesn't change any publicly-cached content for the source object.
-_NON_CACHE_RELEVANT_ATTRS = frozenset({"events"})
+# Collection-attribute mutations that should NOT trigger a CDN purge for the
+# parent object. Each falls into one of two buckets:
+#
+#   - Audit/admin-only collections whose contents never appear on a cached
+#     response: `events` (HasEvents), `observations` (HasObservations),
+#     `invitations` (project/org role invitations — only rendered on the
+#     private manage UI and admin pages).
+#
+#   - Collections whose child model has its own `cache_keys` registration
+#     that already covers the affected content: `roles`, `releases`, `files`.
+#     When the child is added/removed its own purge fires, so the parent-dirty
+#     purge is either redundant (same keys) or strictly broader (extra keys
+#     like `all-projects` / `org/*` that aren't actually affected by the
+#     child-scoped change).
+_NON_CACHE_RELEVANT_ATTRS = frozenset(
+    {
+        "events",
+        "observations",
+        "invitations",
+        "roles",
+        "releases",
+        "files",
+    }
+)
 
 
 @db.listens_for(db.Session, "after_flush")


### PR DESCRIPTION
After auditing more purge logs, we can skip even more purges that are not relevant.