### PR TITLE
chore: apply codeql config to base scan as well

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -14,3 +14,19 @@ paths-ignore:
 
 queries:
   - uses: ./.github/codeql/custom-queries/python/warehouse-suite.qls
+
+# Top-level filters apply to every loaded query, including ones from the
+# default `code-scanning` suite that `codeql-action` runs alongside our custom
+# suite. Suite-local `exclude:` blocks only filter queries loaded by that
+# suite, so rules from the default suite slip through without this.
+query-filters:
+  # pyramid_jinja2 auto-escapes all .html templates; CodeQL's Pyramid model
+  # does not account for this and flags every search view that returns `q` to
+  # a template context.
+  - exclude:
+      id: py/reflective-xss
+  - exclude:
+      id: py/jinja2/autoescape-false
+  # All call sites validate via is_safe_url() before redirecting.
+  - exclude:
+      id: py/url-redirection


### PR DESCRIPTION
The config added previously applies to the custom scan suite, not the "base" level scanning. Add the same config there to apply.