### PR TITLE
perf: remove an n+1 pattern from account publishing page

### DIFF
--- a/tests/functional/manage/test_account_publishing.py
+++ b/tests/functional/manage/test_account_publishing.py
@@ -10,6 +10,8 @@ import responses
 from tests.common.constants import REMOTE_ADDR
 from tests.common.db.accounts import UserFactory, UserUniqueLoginFactory
 from tests.common.db.ip_addresses import IpAddressFactory
+from tests.common.db.oidc import GitHubPublisherFactory
+from tests.common.db.packaging import ProjectFactory, RoleFactory
 from warehouse.accounts.models import UniqueLoginStatus
 from warehouse.utils.otp import _get_totp
 
@@ -162,3 +164,48 @@ class TestManageAccountPublishing:
         assert success_message is not None
         assert "Registered a new pending publisher" in success_message.text
         assert "gitlab-project" in success_message.text
+
+    def test_get_publishing_page(self, webtest):
+        """
+        Visit the account publishing page for a user who owns several projects
+        with active OIDC publishers, and ensure the database query count stays
+        bounded — no N+1 over the user's projects or their publishers.
+        """
+        # Arrange: create a user with several projects, each carrying an OIDC
+        # publisher.
+        user = UserFactory.create(
+            with_verified_primary_email=True,
+            with_terms_of_service_agreement=True,
+            clear_pwd="password",
+        )
+        ip_address = IpAddressFactory.create(ip_address=REMOTE_ADDR)
+        UserUniqueLoginFactory.create(
+            user=user, ip_address=ip_address, status=UniqueLoginStatus.CONFIRMED
+        )
+
+        for _ in range(5):
+            project = ProjectFactory.create()
+            RoleFactory.create(user=user, project=project, role_name="Owner")
+            GitHubPublisherFactory.create(projects=[project])
+
+        # Log in with 2FA.
+        login_page = webtest.get("/account/login/", status=HTTPStatus.OK)
+        login_form = login_page.forms["login-form"]
+        login_form["username"] = user.username
+        login_form["password"] = "password"
+        two_factor_page = login_form.submit().follow(status=HTTPStatus.OK)
+        two_factor_form = two_factor_page.forms["totp-auth-form"]
+        two_factor_form["totp_value"] = (
+            _get_totp(user.totp_secret).generate(time.time()).decode()
+        )
+        two_factor_form.submit().follow(status=HTTPStatus.OK)
+
+        # Act: render the publishing page.
+        webtest.get("/manage/account/publishing/", status=HTTPStatus.OK)
+
+        # Assert: total query count is fixed regardless of the number of
+        # projects or publishers attached to them. The 7 queries are:
+        # ip-ban check, session user load, admin flags, projects with
+        # publishers (this view), user's organizations, pending publishers,
+        # active sponsors.
+        assert len(webtest.query_recorder.queries) == 7

--- a/tests/unit/accounts/test_views.py
+++ b/tests/unit/accounts/test_views.py
@@ -4208,10 +4208,6 @@ class TestManageAccountPublishingViews:
             pretend.call(AdminFlagValue.DISALLOW_GOOGLE_OIDC),
             pretend.call(AdminFlagValue.DISALLOW_ACTIVESTATE_OIDC),
             pretend.call(flag),
-            pretend.call(AdminFlagValue.DISALLOW_GITHUB_OIDC),
-            pretend.call(AdminFlagValue.DISALLOW_GITLAB_OIDC),
-            pretend.call(AdminFlagValue.DISALLOW_GOOGLE_OIDC),
-            pretend.call(AdminFlagValue.DISALLOW_ACTIVESTATE_OIDC),
         ]
         assert pyramid_request.session.flash.calls == [
             pretend.call(
@@ -4348,10 +4344,6 @@ class TestManageAccountPublishingViews:
             pretend.call(AdminFlagValue.DISALLOW_GOOGLE_OIDC),
             pretend.call(AdminFlagValue.DISALLOW_ACTIVESTATE_OIDC),
             pretend.call(flag),
-            pretend.call(AdminFlagValue.DISALLOW_GITHUB_OIDC),
-            pretend.call(AdminFlagValue.DISALLOW_GITLAB_OIDC),
-            pretend.call(AdminFlagValue.DISALLOW_GOOGLE_OIDC),
-            pretend.call(AdminFlagValue.DISALLOW_ACTIVESTATE_OIDC),
         ]
         assert view.metrics.increment.calls == [
             pretend.call(
@@ -4494,14 +4486,6 @@ class TestManageAccountPublishingViews:
             pretend.call(AdminFlagValue.DISALLOW_GOOGLE_OIDC),
             pretend.call(AdminFlagValue.DISALLOW_ACTIVESTATE_OIDC),
             pretend.call(flag),
-            pretend.call(AdminFlagValue.DISALLOW_GITHUB_OIDC),
-            pretend.call(AdminFlagValue.DISALLOW_GITLAB_OIDC),
-            pretend.call(AdminFlagValue.DISALLOW_GOOGLE_OIDC),
-            pretend.call(AdminFlagValue.DISALLOW_ACTIVESTATE_OIDC),
-            pretend.call(AdminFlagValue.DISALLOW_GITHUB_OIDC),
-            pretend.call(AdminFlagValue.DISALLOW_GITLAB_OIDC),
-            pretend.call(AdminFlagValue.DISALLOW_GOOGLE_OIDC),
-            pretend.call(AdminFlagValue.DISALLOW_ACTIVESTATE_OIDC),
         ]
         assert view.metrics.increment.calls == [
             pretend.call(

--- a/tests/unit/accounts/test_views.py
+++ b/tests/unit/accounts/test_views.py
@@ -3920,7 +3920,7 @@ class TestManageAccountPublishingViews:
     def test_manage_publishing(self, metrics, monkeypatch):
         route_url = pretend.stub()
         request = pretend.stub(
-            user=pretend.stub(),
+            user=pretend.stub(id=pretend.stub()),
             route_url=route_url,
             registry=pretend.stub(
                 settings={
@@ -3934,6 +3934,7 @@ class TestManageAccountPublishingViews:
             flags=pretend.stub(
                 disallow_oidc=pretend.call_recorder(lambda f=None: False)
             ),
+            db=pretend.stub(scalars=lambda *a, **kw: pretend.stub(all=lambda: [])),
             POST=pretend.stub(),
         )
 
@@ -3979,6 +3980,7 @@ class TestManageAccountPublishingViews:
                 "Google": False,
                 "ActiveState": False,
             },
+            "project_names_with_publishers": [],
             "pending_github_publisher_form": pending_github_publisher_form_obj,
             "pending_gitlab_publisher_form": pending_gitlab_publisher_form_obj,
             "pending_google_publisher_form": pending_google_publisher_form_obj,
@@ -4014,7 +4016,10 @@ class TestManageAccountPublishingViews:
         project_service = pretend.stub(check_project_name=lambda name: None)
         pyramid_request.find_service = lambda _, **kw: project_service
 
-        pyramid_request.user = pretend.stub()
+        pyramid_request.user = pretend.stub(id=pretend.stub())
+        pyramid_request.db = pretend.stub(
+            scalars=lambda *a, **kw: pretend.stub(all=lambda: [])
+        )
         pyramid_request.registry = pretend.stub(
             settings={
                 "github.token": "fake-api-token",
@@ -4067,6 +4072,7 @@ class TestManageAccountPublishingViews:
                 "Google": True,
                 "ActiveState": True,
             },
+            "project_names_with_publishers": [],
             "pending_github_publisher_form": pending_github_publisher_form_obj,
             "pending_gitlab_publisher_form": pending_gitlab_publisher_form_obj,
             "pending_google_publisher_form": pending_google_publisher_form_obj,
@@ -4141,7 +4147,10 @@ class TestManageAccountPublishingViews:
             IMetricsService: pretend.stub(),
         }[interface]
 
-        pyramid_request.user = pretend.stub()
+        pyramid_request.user = pretend.stub(id=pretend.stub())
+        pyramid_request.db = pretend.stub(
+            scalars=lambda *a, **kw: pretend.stub(all=lambda: [])
+        )
         pyramid_request.registry = pretend.stub(
             settings={
                 "github.token": "fake-api-token",
@@ -4196,6 +4205,7 @@ class TestManageAccountPublishingViews:
                 "Google": True,
                 "ActiveState": True,
             },
+            "project_names_with_publishers": [],
             "pending_github_publisher_form": pending_github_publisher_form_obj,
             "pending_gitlab_publisher_form": pending_gitlab_publisher_form_obj,
             "pending_google_publisher_form": pending_google_publisher_form_obj,
@@ -4284,6 +4294,10 @@ class TestManageAccountPublishingViews:
         )
         pyramid_request.user = pretend.stub(
             has_primary_verified_email=False,
+            id=pretend.stub(),
+        )
+        pyramid_request.db = pretend.stub(
+            scalars=lambda *a, **kw: pretend.stub(all=lambda: [])
         )
         pyramid_request.flags = pretend.stub(
             disallow_oidc=pretend.call_recorder(lambda f=None: False),
@@ -4332,6 +4346,7 @@ class TestManageAccountPublishingViews:
                 "Google": False,
                 "ActiveState": False,
             },
+            "project_names_with_publishers": [],
             "pending_github_publisher_form": pending_github_publisher_form_obj,
             "pending_gitlab_publisher_form": pending_gitlab_publisher_form_obj,
             "pending_google_publisher_form": pending_google_publisher_form_obj,
@@ -4528,6 +4543,10 @@ class TestManageAccountPublishingViews:
         pyramid_request.user = pretend.stub(
             has_primary_verified_email=True,
             pending_oidc_publishers=[],
+            id=pretend.stub(),
+        )
+        pyramid_request.db = pretend.stub(
+            scalars=lambda *a, **kw: pretend.stub(all=lambda: [])
         )
         pyramid_request.registry = pretend.stub(
             settings={
@@ -4602,6 +4621,7 @@ class TestManageAccountPublishingViews:
         db_request.user = pretend.stub(
             has_primary_verified_email=True,
             pending_oidc_publishers=[],
+            id=uuid.uuid4(),
         )
         db_request.registry = pretend.stub(
             settings={
@@ -5043,7 +5063,10 @@ class TestManageAccountPublishingViews:
             IMetricsService: pretend.stub(),
         }[interface]
 
-        pyramid_request.user = pretend.stub()
+        pyramid_request.user = pretend.stub(id=pretend.stub())
+        pyramid_request.db = pretend.stub(
+            scalars=lambda *a, **kw: pretend.stub(all=lambda: [])
+        )
         pyramid_request.registry = pretend.stub(
             settings={
                 "github.token": "fake-api-token",
@@ -5096,6 +5119,7 @@ class TestManageAccountPublishingViews:
                 "Google": True,
                 "ActiveState": True,
             },
+            "project_names_with_publishers": [],
             "pending_github_publisher_form": pending_github_publisher_form_obj,
             "pending_gitlab_publisher_form": pending_gitlab_publisher_form_obj,
             "pending_google_publisher_form": pending_google_publisher_form_obj,

--- a/warehouse/accounts/views.py
+++ b/warehouse/accounts/views.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import datetime
+import functools
 import hashlib
 import json
 import uuid
@@ -1767,7 +1768,7 @@ class ManageAccountPublishingViews:
                 )
             )
 
-    @property
+    @functools.cached_property
     def default_response(self):
         return {
             "pending_github_publisher_form": self.pending_github_publisher_form,

--- a/warehouse/accounts/views.py
+++ b/warehouse/accounts/views.py
@@ -1770,7 +1770,18 @@ class ManageAccountPublishingViews:
 
     @functools.cached_property
     def default_response(self):
+        project_names_with_publishers = self.request.db.scalars(
+            select(Project.name)
+            .join(Role, Role.project_id == Project.id)
+            .where(
+                Role.user_id == self.request.user.id,
+                Project.oidc_publishers.any(),
+            )
+            .order_by(Project.normalized_name)
+        ).all()
+
         return {
+            "project_names_with_publishers": project_names_with_publishers,
             "pending_github_publisher_form": self.pending_github_publisher_form,
             "pending_gitlab_publisher_form": self.pending_gitlab_publisher_form,
             "pending_google_publisher_form": self.pending_google_publisher_form,

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -128,21 +128,21 @@ msgstr ""
 msgid "The username isn't valid. Try again."
 msgstr ""
 
-#: warehouse/accounts/views.py:119
+#: warehouse/accounts/views.py:120
 #, python-brace-format
 msgid ""
 "There have been too many unsuccessful login attempts. You have been "
 "locked out for {}. Please try again later."
 msgstr ""
 
-#: warehouse/accounts/views.py:140
+#: warehouse/accounts/views.py:141
 #, python-brace-format
 msgid ""
 "Too many emails have been added to this account without verifying them. "
 "Check your inbox and follow the verification links. (IP: ${ip})"
 msgstr ""
 
-#: warehouse/accounts/views.py:152
+#: warehouse/accounts/views.py:153
 #, python-brace-format
 msgid ""
 "Too many password resets have been requested for this account without "
@@ -150,195 +150,195 @@ msgid ""
 " ${ip})"
 msgstr ""
 
-#: warehouse/accounts/views.py:384 warehouse/accounts/views.py:454
-#: warehouse/accounts/views.py:456 warehouse/accounts/views.py:485
-#: warehouse/accounts/views.py:487 warehouse/accounts/views.py:603
+#: warehouse/accounts/views.py:385 warehouse/accounts/views.py:455
+#: warehouse/accounts/views.py:457 warehouse/accounts/views.py:486
+#: warehouse/accounts/views.py:488 warehouse/accounts/views.py:604
 msgid "Invalid or expired two factor login."
 msgstr ""
 
-#: warehouse/accounts/views.py:448
+#: warehouse/accounts/views.py:449
 msgid "Already authenticated"
 msgstr ""
 
-#: warehouse/accounts/views.py:522
+#: warehouse/accounts/views.py:523
 msgid "Successful WebAuthn assertion"
 msgstr ""
 
-#: warehouse/accounts/views.py:633 warehouse/manage/views/__init__.py:948
+#: warehouse/accounts/views.py:634 warehouse/manage/views/__init__.py:948
 msgid "Recovery code accepted. The supplied code cannot be used again."
 msgstr ""
 
-#: warehouse/accounts/views.py:732
+#: warehouse/accounts/views.py:733
 msgid ""
 "New user registration temporarily disabled. See https://pypi.org/help"
 "#admin-intervention for details."
 msgstr ""
 
-#: warehouse/accounts/views.py:895
+#: warehouse/accounts/views.py:896
 msgid "Expired token: request a new password reset link"
 msgstr ""
 
-#: warehouse/accounts/views.py:897
+#: warehouse/accounts/views.py:898
 msgid "Invalid token: request a new password reset link"
 msgstr ""
 
-#: warehouse/accounts/views.py:899 warehouse/accounts/views.py:1008
-#: warehouse/accounts/views.py:1073 warehouse/accounts/views.py:1179
-#: warehouse/accounts/views.py:1350
+#: warehouse/accounts/views.py:900 warehouse/accounts/views.py:1009
+#: warehouse/accounts/views.py:1074 warehouse/accounts/views.py:1180
+#: warehouse/accounts/views.py:1351
 msgid "Invalid token: no token supplied"
 msgstr ""
 
-#: warehouse/accounts/views.py:903
+#: warehouse/accounts/views.py:904
 msgid "Invalid token: not a password reset token"
 msgstr ""
 
-#: warehouse/accounts/views.py:908 warehouse/accounts/views.py:1017
+#: warehouse/accounts/views.py:909 warehouse/accounts/views.py:1018
 msgid "Invalid token: user not found"
 msgstr ""
 
-#: warehouse/accounts/views.py:919
+#: warehouse/accounts/views.py:920
 msgid "Invalid token: user has logged in since this token was requested"
 msgstr ""
 
-#: warehouse/accounts/views.py:937
+#: warehouse/accounts/views.py:938
 msgid ""
 "Invalid token: password has already been changed since this token was "
 "requested"
 msgstr ""
 
-#: warehouse/accounts/views.py:968
+#: warehouse/accounts/views.py:969
 msgid "You have reset your password"
 msgstr ""
 
-#: warehouse/accounts/views.py:1004
+#: warehouse/accounts/views.py:1005
 msgid "Expired token: please try to login again"
 msgstr ""
 
-#: warehouse/accounts/views.py:1006
+#: warehouse/accounts/views.py:1007
 msgid "Invalid token: please try to login again"
 msgstr ""
 
-#: warehouse/accounts/views.py:1012
+#: warehouse/accounts/views.py:1013
 msgid "Invalid token: not a login confirmation token"
 msgstr ""
 
-#: warehouse/accounts/views.py:1027
+#: warehouse/accounts/views.py:1028
 msgid "Invalid login attempt."
 msgstr ""
 
-#: warehouse/accounts/views.py:1032
+#: warehouse/accounts/views.py:1033
 msgid ""
 "Device details didn't match, please try again from the device you "
 "originally used to log in."
 msgstr ""
 
-#: warehouse/accounts/views.py:1043
+#: warehouse/accounts/views.py:1044
 msgid "Your login has been confirmed and this device is now recognized."
 msgstr ""
 
-#: warehouse/accounts/views.py:1069
+#: warehouse/accounts/views.py:1070
 msgid "Expired token: request a new email verification link"
 msgstr ""
 
-#: warehouse/accounts/views.py:1071
+#: warehouse/accounts/views.py:1072
 msgid "Invalid token: request a new email verification link"
 msgstr ""
 
-#: warehouse/accounts/views.py:1077
+#: warehouse/accounts/views.py:1078
 msgid "Invalid token: not an email verification token"
 msgstr ""
 
-#: warehouse/accounts/views.py:1086
+#: warehouse/accounts/views.py:1087
 msgid "Email not found"
 msgstr ""
 
-#: warehouse/accounts/views.py:1089
+#: warehouse/accounts/views.py:1090
 msgid "Email already verified"
 msgstr ""
 
-#: warehouse/accounts/views.py:1109
+#: warehouse/accounts/views.py:1110
 msgid "You can now set this email as your primary address"
 msgstr ""
 
-#: warehouse/accounts/views.py:1112
+#: warehouse/accounts/views.py:1113
 msgid "This is your primary address"
 msgstr ""
 
-#: warehouse/accounts/views.py:1118
+#: warehouse/accounts/views.py:1119
 #, python-brace-format
 msgid "Email address ${email_address} verified. ${confirm_message}."
 msgstr ""
 
-#: warehouse/accounts/views.py:1175
+#: warehouse/accounts/views.py:1176
 msgid "Expired token: request a new organization invitation"
 msgstr ""
 
-#: warehouse/accounts/views.py:1177
+#: warehouse/accounts/views.py:1178
 msgid "Invalid token: request a new organization invitation"
 msgstr ""
 
-#: warehouse/accounts/views.py:1183
+#: warehouse/accounts/views.py:1184
 msgid "Invalid token: not an organization invitation token"
 msgstr ""
 
-#: warehouse/accounts/views.py:1187 warehouse/accounts/views.py:1198
+#: warehouse/accounts/views.py:1188 warehouse/accounts/views.py:1199
 msgid "Organization invitation is not valid."
 msgstr ""
 
-#: warehouse/accounts/views.py:1196
+#: warehouse/accounts/views.py:1197
 msgid "Organization invitation no longer exists."
 msgstr ""
 
-#: warehouse/accounts/views.py:1250
+#: warehouse/accounts/views.py:1251
 #, python-brace-format
 msgid "Invitation for '${organization_name}' is declined."
 msgstr ""
 
-#: warehouse/accounts/views.py:1313
+#: warehouse/accounts/views.py:1314
 #, python-brace-format
 msgid "You are now ${role} of the '${organization_name}' organization."
 msgstr ""
 
-#: warehouse/accounts/views.py:1346
+#: warehouse/accounts/views.py:1347
 msgid "Expired token: request a new project role invitation"
 msgstr ""
 
-#: warehouse/accounts/views.py:1348
+#: warehouse/accounts/views.py:1349
 msgid "Invalid token: request a new project role invitation"
 msgstr ""
 
-#: warehouse/accounts/views.py:1354
+#: warehouse/accounts/views.py:1355
 msgid "Invalid token: not a collaboration invitation token"
 msgstr ""
 
-#: warehouse/accounts/views.py:1358 warehouse/accounts/views.py:1378
+#: warehouse/accounts/views.py:1359 warehouse/accounts/views.py:1379
 msgid "Role invitation is not valid."
 msgstr ""
 
-#: warehouse/accounts/views.py:1365
+#: warehouse/accounts/views.py:1366
 msgid "Invalid token: project does not exist"
 msgstr ""
 
-#: warehouse/accounts/views.py:1376
+#: warehouse/accounts/views.py:1377
 msgid "Role invitation no longer exists."
 msgstr ""
 
-#: warehouse/accounts/views.py:1410
+#: warehouse/accounts/views.py:1411
 #, python-brace-format
 msgid "Invitation for '${project_name}' is declined."
 msgstr ""
 
-#: warehouse/accounts/views.py:1476
+#: warehouse/accounts/views.py:1477
 #, python-brace-format
 msgid "You are now ${role} of the '${project_name}' project."
 msgstr ""
 
-#: warehouse/accounts/views.py:1588
+#: warehouse/accounts/views.py:1589
 #, python-brace-format
 msgid "Please review our updated <a href=\"${tos_url}\">Terms of Service</a>."
 msgstr ""
 
-#: warehouse/accounts/views.py:1798 warehouse/accounts/views.py:2052
+#: warehouse/accounts/views.py:1810 warehouse/accounts/views.py:2064
 #: warehouse/manage/views/oidc_publishers.py:126
 #: warehouse/manage/views/organizations.py:1822
 msgid ""
@@ -346,22 +346,22 @@ msgid ""
 "#admin-intervention for details."
 msgstr ""
 
-#: warehouse/accounts/views.py:1819
+#: warehouse/accounts/views.py:1831
 #: warehouse/manage/views/organizations.py:1845
 msgid "disabled. See https://pypi.org/help#admin-intervention for details."
 msgstr ""
 
-#: warehouse/accounts/views.py:1835
+#: warehouse/accounts/views.py:1847
 msgid ""
 "You must have a verified email in order to register a pending trusted "
 "publisher. See https://pypi.org/help#openid-connect for details."
 msgstr ""
 
-#: warehouse/accounts/views.py:1848
+#: warehouse/accounts/views.py:1860
 msgid "You can't register more than 3 pending trusted publishers at once."
 msgstr ""
 
-#: warehouse/accounts/views.py:1863
+#: warehouse/accounts/views.py:1875
 #: warehouse/manage/views/oidc_publishers.py:308
 #: warehouse/manage/views/oidc_publishers.py:423
 #: warehouse/manage/views/oidc_publishers.py:539
@@ -371,7 +371,7 @@ msgid ""
 "again later."
 msgstr ""
 
-#: warehouse/accounts/views.py:1873
+#: warehouse/accounts/views.py:1885
 #: warehouse/manage/views/oidc_publishers.py:321
 #: warehouse/manage/views/oidc_publishers.py:436
 #: warehouse/manage/views/oidc_publishers.py:552
@@ -380,23 +380,23 @@ msgstr ""
 msgid "The trusted publisher could not be registered"
 msgstr ""
 
-#: warehouse/accounts/views.py:1888
+#: warehouse/accounts/views.py:1900
 msgid ""
 "This trusted publisher has already been registered. Please contact PyPI's"
 " admins if this wasn't intentional."
 msgstr ""
 
-#: warehouse/accounts/views.py:1922
+#: warehouse/accounts/views.py:1934
 #: warehouse/manage/views/organizations.py:1910
 msgid "Registered a new pending publisher to create "
 msgstr ""
 
-#: warehouse/accounts/views.py:2065 warehouse/accounts/views.py:2078
-#: warehouse/accounts/views.py:2085
+#: warehouse/accounts/views.py:2077 warehouse/accounts/views.py:2090
+#: warehouse/accounts/views.py:2097
 msgid "Invalid publisher ID"
 msgstr ""
 
-#: warehouse/accounts/views.py:2092
+#: warehouse/accounts/views.py:2104
 msgid "Removed trusted publisher for project "
 msgstr ""
 
@@ -5380,51 +5380,51 @@ msgstr ""
 msgid "Manage publishers"
 msgstr ""
 
-#: warehouse/templates/manage/account/publishing.html:387
+#: warehouse/templates/manage/account/publishing.html:386
 msgid "Project"
 msgstr ""
 
-#: warehouse/templates/manage/account/publishing.html:407
+#: warehouse/templates/manage/account/publishing.html:404
 msgid ""
 "No publishers are currently configured. Publishers for existing projects "
 "can be added in the publishing configuration for each individual project."
 msgstr ""
 
-#: warehouse/templates/manage/account/publishing.html:417
+#: warehouse/templates/manage/account/publishing.html:414
 #: warehouse/templates/manage/organization/publishing.html:414
 msgid "Pending project name"
 msgstr ""
 
-#: warehouse/templates/manage/account/publishing.html:418
+#: warehouse/templates/manage/account/publishing.html:415
 #: warehouse/templates/manage/organization/publishing.html:415
 #: warehouse/templates/manage/project/publishing.html:375
 msgid "Publisher"
 msgstr ""
 
-#: warehouse/templates/manage/account/publishing.html:419
+#: warehouse/templates/manage/account/publishing.html:416
 #: warehouse/templates/manage/organization/publishing.html:416
 #: warehouse/templates/manage/project/publishing.html:376
 msgid "Details"
 msgstr ""
 
-#: warehouse/templates/manage/account/publishing.html:429
+#: warehouse/templates/manage/account/publishing.html:426
 #: warehouse/templates/manage/organization/publishing.html:426
 msgid ""
 "No pending publishers are currently configured. Publishers for projects "
 "that don't exist yet can be added below."
 msgstr ""
 
-#: warehouse/templates/manage/account/publishing.html:436
+#: warehouse/templates/manage/account/publishing.html:433
 #: warehouse/templates/manage/organization/publishing.html:431
 msgid "Add a new pending publisher"
 msgstr ""
 
-#: warehouse/templates/manage/account/publishing.html:438
+#: warehouse/templates/manage/account/publishing.html:435
 #: warehouse/templates/manage/organization/publishing.html:432
 msgid "You can use this page to register \"pending\" trusted publishers."
 msgstr ""
 
-#: warehouse/templates/manage/account/publishing.html:443
+#: warehouse/templates/manage/account/publishing.html:440
 #: warehouse/templates/manage/organization/publishing.html:434
 #, python-format
 msgid ""
@@ -5436,7 +5436,7 @@ msgid ""
 "trusted publishers <a href=\"%(href)s\">here</a>."
 msgstr ""
 
-#: warehouse/templates/manage/account/publishing.html:453
+#: warehouse/templates/manage/account/publishing.html:450
 #: warehouse/templates/manage/organization/publishing.html:444
 msgid ""
 "Configuring a \"pending\" publisher for a project name does "
@@ -5444,7 +5444,7 @@ msgid ""
 " other user may create it, including via their own \"pending\" publisher."
 msgstr ""
 
-#: warehouse/templates/manage/account/publishing.html:488
+#: warehouse/templates/manage/account/publishing.html:485
 #: warehouse/templates/manage/project/publishing.html:419
 #, python-format
 msgid ""

--- a/warehouse/templates/manage/account/publishing.html
+++ b/warehouse/templates/manage/account/publishing.html
@@ -379,8 +379,7 @@
     {{ oidc_desc() }}
     <h2 class="no-bottom-padding">{% trans %}Manage publishers{% endtrans %}</h2>
     <h3>Projects with active publishers</h3>
-    {% set projects = user.projects | selectattr('oidc_publishers') | list %}
-    {% if projects %}
+    {% if project_names_with_publishers %}
       <table class="table">
         <thead>
           <tr scope="col">
@@ -389,16 +388,14 @@
           </tr>
         </thead>
         <tbody>
-          {% for project in user.projects %}
-            {% if project.oidc_publishers %}
-              <tr>
-                <td scope="row">{{ project.name }}</td>
-                <td scope="row">
-                  <a href="{{ request.route_path('manage.project.settings.publishing', project_name=project.name) }}"
-                     class="button button--primary">Manage</a>
-                </td>
-              </tr>
-            {% endif %}
+          {% for name in project_names_with_publishers %}
+            <tr>
+              <td scope="row">{{ name }}</td>
+              <td scope="row">
+                <a href="{{ request.route_path('manage.project.settings.publishing', project_name=name) }}"
+                   class="button button--primary">Manage</a>
+              </td>
+            </tr>
           {% endfor %}
         </tbody>
       </table>


### PR DESCRIPTION
When loading the /manage/account/publishing/ page, the template loader
pattern iterated on every project for the user, lazy-loading `oidc_publishers`.
The more projects with OIDC enabled, the slower the page.

Instead, load all of the Project's `name` column only, since that's
all what's needed for the template.

----

perf: wrap default_response with a cached_property

When called multiple times in a request, no need to reload the same data
each time.

