### PR TITLE
switch codeowners to warehouse-reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @pypi/warehouse-committers
+* @pypi/warehouse-reviewers


### PR DESCRIPTION
The ``warehouse-reviewers`` team is a sub-team of ``warehouse-team`` that adds write permissions to the warehouse repo, and this PR will adjust the codeowners file so that the ``warehouse-reviewers`` team gets reviews requested of them instead of the ``warehouse-committers`` team.

The existing ``warehouse-committers`` team has been made a sub-team of the new ``warehouse-reviewers``, so that all committers are implicitly reviewers (but reviewers are not committers), and the branch protection rules for ``main`` have been updated so that:

- Instead of just "a review" being required, it has to be a codeowners review (so it has to be someone from ``warehouse-reviewers``).
- Only the ``warehouse-committers`` team has push access to ``main``, so only they can actually merge a pull request.

So with this, ``warehouse-reviewers`` can review, but not merge (and thus, cannot trigger a deploy) but ``warehouse-committers`` can both review (by nature of being a sub team of the ``warehouse-reviewers``) and merge.