### PR TITLE
add a frontend team that is scoped to working on HTML/CSS/etc

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,27 @@
+# By default, everything is owned by our reviewers team.
 * @pypi/warehouse-reviewers
+
+# Frontend files are owned by both our reviewers team AND the frontend team,
+# which allows either team to approve a Pull Request, but it does not require
+# both to approve it.
+#
+# We have to keep @pypi/warehouse-reviewers here, because GitHub will only match
+# a path to a single line in the CODEOWNERS file, whichever line it matches last.
+.github/ISSUE_TEMPLATE/~visual-design.md @pypi/warehouse-reviewers @pypi/warehouse-frontend
+tests/frontend/*                         @pypi/warehouse-reviewers @pypi/warehouse-frontend
+warehouse/admin/static/*                 @pypi/warehouse-reviewers @pypi/warehouse-frontend
+warehouse/admin/templates/*              @pypi/warehouse-reviewers @pypi/warehouse-frontend
+warehouse/static/*                       @pypi/warehouse-reviewers @pypi/warehouse-frontend
+warehouse/templates/*                    @pypi/warehouse-reviewers @pypi/warehouse-frontend
+.stylelintrc.json                        @pypi/warehouse-reviewers @pypi/warehouse-frontend
+babel.cfg                                @pypi/warehouse-reviewers @pypi/warehouse-frontend
+babel.config.js                          @pypi/warehouse-reviewers @pypi/warehouse-frontend
+eslint.config.mjs                        @pypi/warehouse-reviewers @pypi/warehouse-frontend
+package-lock.json                        @pypi/warehouse-reviewers @pypi/warehouse-frontend
+package.json                             @pypi/warehouse-reviewers @pypi/warehouse-frontend
+webpack.config.js                        @pypi/warehouse-reviewers @pypi/warehouse-frontend
+webpack.plugin.localize.js               @pypi/warehouse-reviewers @pypi/warehouse-frontend
+
+# This is not *technically* a frontend file, but editing the frontend will likely
+# mean that these need to be regenerated, so we treat it like it's a frontend file.
+warehouse/locale @pypi/warehouse-reviewers @pypi/warehouse-frontend

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -25,3 +25,10 @@ webpack.plugin.localize.js               @pypi/warehouse-reviewers @pypi/warehou
 # This is not *technically* a frontend file, but editing the frontend will likely
 # mean that these need to be regenerated, so we treat it like it's a frontend file.
 warehouse/locale @pypi/warehouse-reviewers @pypi/warehouse-frontend
+
+# Likewise, not *technically* frontend files, but when you're working on the
+# frontend you may end up needing to update the user facing documentation and/or
+# the developer documentation around changes to how the frontend is developed,
+# so we'll allow frontend and reviewers both to own these as well.
+docs/dev/*  @pypi/warehouse-reviewers @pypi/warehouse-frontend
+docs/user/* @pypi/warehouse-reviewers @pypi/warehouse-frontend


### PR DESCRIPTION
I've added a @pypi/warehouse-frontend team which has the same level of permissions as @pypi/warehouse-committers, so they're allowed to merge PRs to `main`.

However, @pypi/warehouse-frontend is *not* a sub-team of @pypi/warehouse-reviewers, so because we require approval from code owners to merge a PR, that means we can more finely scope the effective permissions that @pypi/warehouse-frontend has, by only giving that team codeowner over a subset of the files.

This PR updates our `CODEOWNERS` file so that files that are relevant to working on the front end has both @pypi/warehouse-frontend and @pypi/warehouse-reviewers as owners, which GitHub will implement as requesting reviews from *both* teams, but will only require a review from *ONE* of the codeowners.

That "OR" handling is implemented per file, so if a PR touches both files that touch the frontend *and* files that are not part of the front end, then the @pypi/warehouse-frontend team will be able to approve for the frontend files, but not for the additional files. However @pypi/warehouse-reviewers would be able to approve for  both (since they are listed as owners for both-- if we ever added a file that @pypi/warehouse-reviewers  isn't an owner on, then they wouldn't be to approve for that).