### PR TITLE
ignore a .venv directory if one exists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 .state
 .idea
 .envrc
+.venv
 
 docs/dev/_build/
 docs/user/_build/

--- a/bin/lint
+++ b/bin/lint
@@ -2,7 +2,7 @@
 set -ex
 
 # Actually run our tests.
-find . -name '*.py' -exec python -m pyupgrade --py313-plus {} +
+find . -path ./.venv -prune -o -name '*.py' -exec python -m pyupgrade --py313-plus {} +
 python -m flake8 .
 python -m black --check --diff *.py warehouse/ tests/
 python -m isort --check *.py warehouse/ tests/

--- a/bin/lint
+++ b/bin/lint
@@ -2,7 +2,7 @@
 set -ex
 
 # Actually run our tests.
-find . -path ./.venv -prune -o -name '*.py' -exec python -m pyupgrade --py313-plus {} +
+find . -path './.*' -prune -o -name '*.py' -exec python -m pyupgrade --py313-plus {} +
 python -m flake8 .
 python -m black --check --diff *.py warehouse/ tests/
 python -m isort --check *.py warehouse/ tests/

--- a/bin/reformat
+++ b/bin/reformat
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -ex
 
-find . -name '*.py' -exec python -m pyupgrade --py313-plus {} +
+find . -path ./.venv -prune -o -name '*.py' -exec python -m pyupgrade --py313-plus {} +
 python -m isort *.py warehouse/ tests/
 python -m black *.py warehouse/ tests/
 python -m djlint --reformat ./warehouse/templates ./docs/blog

--- a/bin/reformat
+++ b/bin/reformat
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -ex
 
-find . -path ./.venv -prune -o -name '*.py' -exec python -m pyupgrade --py313-plus {} +
+find . -path './.*' -prune -o -name '*.py' -exec python -m pyupgrade --py313-plus {} +
 python -m isort *.py warehouse/ tests/
 python -m black *.py warehouse/ tests/
 python -m djlint --reformat ./warehouse/templates ./docs/blog


### PR DESCRIPTION
This just allows someone to use tools that want to add a `.venv` directory without it causing issues. This should be a no-op otherwise.