### PR TITLE
ignore a few missing imports in pyright

### DIFF
--- a/tests/unit/test_db.py
+++ b/tests/unit/test_db.py
@@ -8,7 +8,7 @@ import psycopg
 import pytest
 import sqlalchemy
 import venusian
-import zope.sqlalchemy  # type: ignore
+import zope.sqlalchemy  # pyright: ignore
 
 from sqlalchemy import event
 from sqlalchemy.exc import DBAPIError, OperationalError

--- a/tests/unit/test_db.py
+++ b/tests/unit/test_db.py
@@ -8,7 +8,7 @@ import psycopg
 import pytest
 import sqlalchemy
 import venusian
-import zope.sqlalchemy # type: ignore
+import zope.sqlalchemy  # type: ignore
 
 from sqlalchemy import event
 from sqlalchemy.exc import DBAPIError, OperationalError

--- a/tests/unit/test_db.py
+++ b/tests/unit/test_db.py
@@ -8,7 +8,7 @@ import psycopg
 import pytest
 import sqlalchemy
 import venusian
-import zope.sqlalchemy
+import zope.sqlalchemy # type: ignore
 
 from sqlalchemy import event
 from sqlalchemy.exc import DBAPIError, OperationalError

--- a/warehouse/cli/shell.py
+++ b/warehouse/cli/shell.py
@@ -24,13 +24,13 @@ def autodetect():
 
 
 def bpython(**locals_):
-    import bpython # type: ignore
+    import bpython  # type: ignore
 
     bpython.embed(locals_)
 
 
 def ipython(**locals_):
-    from IPython import start_ipython # type: ignore
+    from IPython import start_ipython  # type: ignore
 
     start_ipython(argv=[], user_ns=locals_)
 

--- a/warehouse/cli/shell.py
+++ b/warehouse/cli/shell.py
@@ -9,12 +9,12 @@ from warehouse.cli import warehouse
 
 def autodetect():
     try:
-        import bpython  # noqa
+        import bpython  # type: ignore # noqa
 
         return "bpython"
     except ImportError:
         try:
-            import IPython  # noqa
+            import IPython  # type: ignore # noqa
 
             return "ipython"
         except ImportError:
@@ -24,13 +24,13 @@ def autodetect():
 
 
 def bpython(**locals_):
-    import bpython
+    import bpython # type: ignore
 
     bpython.embed(locals_)
 
 
 def ipython(**locals_):
-    from IPython import start_ipython
+    from IPython import start_ipython # type: ignore
 
     start_ipython(argv=[], user_ns=locals_)
 

--- a/warehouse/cli/shell.py
+++ b/warehouse/cli/shell.py
@@ -9,12 +9,12 @@ from warehouse.cli import warehouse
 
 def autodetect():
     try:
-        import bpython  # type: ignore # noqa
+        import bpython  # pyright: ignore # noqa
 
         return "bpython"
     except ImportError:
         try:
-            import IPython  # type: ignore # noqa
+            import IPython  # pyright: ignore # noqa
 
             return "ipython"
         except ImportError:
@@ -24,13 +24,13 @@ def autodetect():
 
 
 def bpython(**locals_):
-    import bpython  # type: ignore
+    import bpython  # pyright: ignore
 
     bpython.embed(locals_)
 
 
 def ipython(**locals_):
-    from IPython import start_ipython  # type: ignore
+    from IPython import start_ipython  # pyright: ignore
 
     start_ipython(argv=[], user_ns=locals_)
 

--- a/warehouse/db.py
+++ b/warehouse/db.py
@@ -11,7 +11,7 @@ import psycopg.types.json
 import pyramid_retry
 import sqlalchemy
 import venusian
-import zope.sqlalchemy
+import zope.sqlalchemy # type: ignore
 
 from pyramid.renderers import JSON
 from sqlalchemy import event, func, inspect

--- a/warehouse/db.py
+++ b/warehouse/db.py
@@ -11,7 +11,7 @@ import psycopg.types.json
 import pyramid_retry
 import sqlalchemy
 import venusian
-import zope.sqlalchemy  # type: ignore
+import zope.sqlalchemy  # pyright: ignore
 
 from pyramid.renderers import JSON
 from sqlalchemy import event, func, inspect

--- a/warehouse/db.py
+++ b/warehouse/db.py
@@ -11,7 +11,7 @@ import psycopg.types.json
 import pyramid_retry
 import sqlalchemy
 import venusian
-import zope.sqlalchemy # type: ignore
+import zope.sqlalchemy  # type: ignore
 
 from pyramid.renderers import JSON
 from sqlalchemy import event, func, inspect


### PR DESCRIPTION
We ignore these in the mypy configuration, unfortunately pyright doesn't check that configuration and so it warns on these which has been keeping my editor yelling at me for awhile now.

Adding a handful of "noise" comments seems pretty low cost to me and makes working on warehouse less annoying for me personally 😄, but I'm happy to just keep trying to remember to exclude this "floating patch" that I've had applied to my local environment for awhile now if people feel strongly about not adding them.