### PR TITLE
fix: surface project permission errors before email/2FA checks on upload

### DIFF
--- a/tests/unit/forklift/test_decorators.py
+++ b/tests/unit/forklift/test_decorators.py
@@ -65,11 +65,7 @@ class TestEnsureUploadsAllowed:
         req = pretend.stub(
             flags=pretend.stub(enabled=lambda f: False),
             identity=pretend.stub(),
-            user=pretend.stub(
-                username="some-user",
-                primary_email=pretend.stub(email="foo@example.com", verified=True),
-                has_two_factor=True,
-            ),
+            user=pretend.stub(),
         )
         resp = pretend.stub()
 
@@ -148,72 +144,4 @@ class TestEnsureUploadsAllowed:
         assert resp.status == (
             "403 Invalid or non-existent authentication information. "
             "See /path/to/help/ for more information."
-        )
-
-    @pytest.mark.parametrize(
-        ("email", "verified"),
-        [
-            ("foo@example.com", False),
-            (None, None),
-        ],
-    )
-    def test_requires_verified_email(self, email, verified):
-        req = pretend.stub(
-            flags=pretend.stub(enabled=lambda f: False),
-            help_url=lambda *a, **k: "/path/to/help/",
-            identity=pretend.stub(),
-            user=pretend.stub(
-                username="some-user",
-                primary_email=(
-                    pretend.stub(email=email, verified=verified)
-                    if email is not None
-                    else None
-                ),
-            ),
-            metrics=pretend.stub(increment=lambda key, tags: None),
-        )
-
-        @decorators.ensure_uploads_allowed
-        def wrapped(context, request):
-            pytest.fail("wrapped view should not have been called")
-
-        with pytest.raises(HTTPForbidden) as excinfo:
-            wrapped(pretend.stub(), req)
-
-        resp = excinfo.value
-
-        assert resp.status_code == 403
-        assert resp.status == (
-            "403 User 'some-user' does not have a verified primary email address. "
-            "Please add a verified primary email before attempting to "
-            "upload to PyPI. See /path/to/help/ for more information."
-        )
-
-    def test_requires_two_factor(self):
-        req = pretend.stub(
-            flags=pretend.stub(enabled=lambda f: False),
-            help_url=lambda *a, **k: "/path/to/help/",
-            identity=pretend.stub(),
-            user=pretend.stub(
-                username="some-user",
-                primary_email=pretend.stub(email="foo@example.com", verified=True),
-                has_two_factor=False,
-            ),
-            metrics=pretend.stub(increment=lambda key, tags: None),
-        )
-
-        @decorators.ensure_uploads_allowed
-        def wrapped(context, request):
-            pytest.fail("wrapped view should not have been called")
-
-        with pytest.raises(HTTPForbidden) as excinfo:
-            wrapped(pretend.stub(), req)
-
-        resp = excinfo.value
-
-        assert resp.status_code == 403
-        assert resp.status == (
-            "403 User 'some-user' does not have two-factor authentication enabled. "
-            "Please enable two-factor authentication before attempting to "
-            "upload to PyPI. See /path/to/help/ for more information."
         )

--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -2725,9 +2725,10 @@ class TestFileUpload:
 
         assert resp.status_code == 403
         assert resp.status == (
-            f"403 User {user.username!r} does not have a verified primary email "
-            "address. Please add a verified primary email before attempting to "
-            "upload to PyPI. See /the/help/url/ for more information."
+            f"403 User {user.username!r}, associated with the API token used, "
+            "does not have a verified primary email address. Please add a "
+            "verified primary email before attempting to upload to PyPI. "
+            "See /the/help/url/ for more information."
         )
 
     def test_upload_fails_without_two_factor_after_permission_check(
@@ -2770,9 +2771,10 @@ class TestFileUpload:
 
         assert resp.status_code == 403
         assert resp.status == (
-            f"403 User {user.username!r} does not have two-factor authentication "
-            "enabled. Please enable two-factor authentication before attempting "
-            "to upload to PyPI. See /the/help/url/ for more information."
+            f"403 User {user.username!r}, associated with the API token used, "
+            "does not have two-factor authentication enabled. Please enable "
+            "two-factor authentication before attempting to upload to PyPI. "
+            "See /the/help/url/ for more information."
         )
 
     def test_upload_permission_error_surfaces_before_email_check(
@@ -2860,9 +2862,10 @@ class TestFileUpload:
 
         assert resp.status_code == 403
         assert resp.status == (
-            f"403 User {user.username!r} does not have a verified primary email "
-            "address. Please add a verified primary email before attempting to "
-            "upload to PyPI. See /the/help/url/ for more information."
+            f"403 User {user.username!r}, associated with the API token used, "
+            "does not have a verified primary email address. Please add a "
+            "verified primary email before attempting to upload to PyPI. "
+            "See /the/help/url/ for more information."
         )
         # The project must not have been created.
         assert (

--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -12,6 +12,7 @@ import zipfile
 
 from cgi import FieldStorage
 from textwrap import dedent
+from types import SimpleNamespace
 from unittest import mock
 
 import pretend
@@ -2679,6 +2680,196 @@ class TestFileUpload:
         assert resp.status == (
             f"403 The given token isn't allowed to upload to project '{project.name}'. "
             "See /the/help/url/ for more information."
+        )
+
+    def test_upload_fails_with_unverified_email_after_permission_check(
+        self, pyramid_config, db_request, mocker
+    ):
+        """The email check fires from inside the view, after the permission
+        check passes, so a maintainer without a verified primary email gets
+        the email error.
+
+        See: https://github.com/pypi/warehouse/issues/18575
+        """
+        user = UserFactory.create()
+        project = ProjectFactory.create()
+        release = ReleaseFactory.create(project=project, version="1.0")
+        RoleFactory.create(user=user, project=project)
+
+        filename = "{}-{}.tar.gz".format(
+            project.normalized_name.replace("-", "_"), release.version
+        )
+
+        pyramid_config.testing_securitypolicy(identity=user)
+        db_request.user = user
+        db_request.POST = MultiDict(
+            {
+                "metadata_version": "1.2",
+                "name": project.name,
+                "version": release.version,
+                "filetype": "sdist",
+                "md5_digest": "nope!",
+                "content": SimpleNamespace(
+                    filename=filename,
+                    file=io.BytesIO(b"a" * (warehouse.constants.MAX_FILESIZE + 1)),
+                    type="application/tar",
+                ),
+            }
+        )
+        db_request.help_url = mocker.Mock(return_value="/the/help/url/")
+
+        with pytest.raises(HTTPForbidden) as excinfo:
+            legacy.file_upload(db_request)
+
+        resp = excinfo.value
+
+        assert resp.status_code == 403
+        assert resp.status == (
+            f"403 User {user.username!r} does not have a verified primary email "
+            "address. Please add a verified primary email before attempting to "
+            "upload to PyPI. See /the/help/url/ for more information."
+        )
+
+    def test_upload_fails_without_two_factor_after_permission_check(
+        self, pyramid_config, db_request, mocker
+    ):
+        """A user with permission and a verified email but no 2FA receives
+        the 2FA error from the view, after the permission check."""
+        user = UserFactory.create(with_verified_primary_email=True)
+        user.totp_secret = None  # Drop totp_secret so has_two_factor is False.
+        project = ProjectFactory.create()
+        release = ReleaseFactory.create(project=project, version="1.0")
+        RoleFactory.create(user=user, project=project)
+
+        filename = "{}-{}.tar.gz".format(
+            project.normalized_name.replace("-", "_"), release.version
+        )
+
+        pyramid_config.testing_securitypolicy(identity=user)
+        db_request.user = user
+        db_request.POST = MultiDict(
+            {
+                "metadata_version": "1.2",
+                "name": project.name,
+                "version": release.version,
+                "filetype": "sdist",
+                "md5_digest": "nope!",
+                "content": SimpleNamespace(
+                    filename=filename,
+                    file=io.BytesIO(b"a" * (warehouse.constants.MAX_FILESIZE + 1)),
+                    type="application/tar",
+                ),
+            }
+        )
+        db_request.help_url = mocker.Mock(return_value="/the/help/url/")
+
+        with pytest.raises(HTTPForbidden) as excinfo:
+            legacy.file_upload(db_request)
+
+        resp = excinfo.value
+
+        assert resp.status_code == 403
+        assert resp.status == (
+            f"403 User {user.username!r} does not have two-factor authentication "
+            "enabled. Please enable two-factor authentication before attempting "
+            "to upload to PyPI. See /the/help/url/ for more information."
+        )
+
+    def test_upload_permission_error_surfaces_before_email_check(
+        self, pyramid_config, db_request, mocker
+    ):
+        """When a user lacks both project permission and a verified email,
+        the permission error surfaces first because it is the more useful
+        diagnostic for the misconfigured-token case.
+
+        See: https://github.com/pypi/warehouse/issues/18575
+        """
+        owner = UserFactory.create()
+        EmailFactory.create(user=owner)
+        intruder = UserFactory.create()  # No verified email, no 2FA.
+        project = ProjectFactory.create()
+        release = ReleaseFactory.create(project=project, version="1.0")
+        RoleFactory.create(user=owner, project=project)
+
+        filename = "{}-{}.tar.gz".format(
+            project.normalized_name.replace("-", "_"), release.version
+        )
+
+        pyramid_config.testing_securitypolicy(identity=intruder, permissive=False)
+        db_request.user = intruder
+        db_request.POST = MultiDict(
+            {
+                "metadata_version": "1.2",
+                "name": project.name,
+                "version": release.version,
+                "filetype": "sdist",
+                "md5_digest": "nope!",
+                "content": SimpleNamespace(
+                    filename=filename,
+                    file=io.BytesIO(b"a" * (warehouse.constants.MAX_FILESIZE + 1)),
+                    type="application/tar",
+                ),
+            }
+        )
+        db_request.help_url = mocker.Mock(return_value="/the/help/url/")
+
+        with pytest.raises(HTTPForbidden) as excinfo:
+            legacy.file_upload(db_request)
+
+        resp = excinfo.value
+
+        assert resp.status_code == 403
+        assert resp.status == (
+            f"403 The user {intruder.username!r} "
+            f"isn't allowed to upload to project '{project.name}'. "
+            "See /the/help/url/ for more information."
+        )
+
+    def test_upload_new_project_fails_with_unverified_email(
+        self, pyramid_config, db_request, mocker
+    ):
+        """A user attempting to upload (and thereby create) a brand new
+        project without a verified email is rejected before the project
+        gets created, so we don't leave an empty project record behind."""
+        user = UserFactory.create()  # No verified email.
+
+        filename = "new_project-1.0.tar.gz"
+
+        pyramid_config.testing_securitypolicy(identity=user)
+        db_request.user = user
+        db_request.POST = MultiDict(
+            {
+                "metadata_version": "1.2",
+                "name": "new-project",
+                "version": "1.0",
+                "filetype": "sdist",
+                "md5_digest": "nope!",
+                "content": SimpleNamespace(
+                    filename=filename,
+                    file=io.BytesIO(b"a" * (warehouse.constants.MAX_FILESIZE + 1)),
+                    type="application/tar",
+                ),
+            }
+        )
+        db_request.help_url = mocker.Mock(return_value="/the/help/url/")
+
+        with pytest.raises(HTTPForbidden) as excinfo:
+            legacy.file_upload(db_request)
+
+        resp = excinfo.value
+
+        assert resp.status_code == 403
+        assert resp.status == (
+            f"403 User {user.username!r} does not have a verified primary email "
+            "address. Please add a verified primary email before attempting to "
+            "upload to PyPI. See /the/help/url/ for more information."
+        )
+        # The project must not have been created.
+        assert (
+            db_request.db.query(Project)
+            .filter(Project.normalized_name == "new-project")
+            .first()
+            is None
         )
 
     def test_upload_attestation_fails_without_oidc_publisher(

--- a/warehouse/forklift/decorators.py
+++ b/warehouse/forklift/decorators.py
@@ -101,49 +101,6 @@ def ensure_uploads_allowed(wrapped):
                 ),
             )
 
-        # These checks only make sense when our authenticated identity is a user,
-        # not a project identity (like OIDC-minted tokens.)
-        if request.user:
-            # Ensure that user has a verified, primary email address. This should both
-            # reduce the ease of spam account creation and activity, as well as act as
-            # a forcing function for https://github.com/pypa/warehouse/issues/3632.
-            # TODO: Once https://github.com/pypa/warehouse/issues/3632 has been solved,
-            #       we might consider a different condition, possibly looking at
-            #       User.is_active instead.
-            if not (request.user.primary_email and request.user.primary_email.verified):
-                request.metrics.increment(
-                    "warehouse.upload.failed", tags=["reason:unverified-email"]
-                )
-                raise _exc_with_message(
-                    HTTPForbidden,
-                    (
-                        "User {!r} does not have a verified primary email address. "
-                        "Please add a verified primary email before attempting to "
-                        "upload to PyPI. See {project_help} for more information."
-                    ).format(
-                        request.user.username,
-                        project_help=request.help_url(_anchor="verified-email"),
-                    ),
-                ) from None
-            # Ensure user has enabled 2FA before they can upload a file.
-            if not request.user.has_two_factor:
-                request.metrics.increment(
-                    "warehouse.upload.failed", tags=["reason:no-2fa"]
-                )
-                raise _exc_with_message(
-                    HTTPForbidden,
-                    (
-                        "User {!r} does not have two-factor authentication enabled. "
-                        "Please enable two-factor authentication before attempting to "
-                        "upload to PyPI. See {project_help} for more information."
-                    ).format(
-                        request.user.username,
-                        project_help=request.help_url(
-                            _anchor="two-factor-authentication"
-                        ),
-                    ),
-                ) from None
-
         # Otherwise, we'll just dispatch to our underlying view
         return wrapped(context, request)
 

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -528,9 +528,10 @@ def _ensure_user_can_upload(request: Request) -> None:
         raise _exc_with_message(
             HTTPForbidden,
             (
-                "User {!r} does not have a verified primary email address. "
-                "Please add a verified primary email before attempting to "
-                "upload to PyPI. See {project_help} for more information."
+                "User {!r}, associated with the API token used, does not "
+                "have a verified primary email address. Please add a "
+                "verified primary email before attempting to upload to "
+                "PyPI. See {project_help} for more information."
             ).format(
                 request.user.username,
                 project_help=request.help_url(_anchor="verified-email"),
@@ -542,9 +543,10 @@ def _ensure_user_can_upload(request: Request) -> None:
         raise _exc_with_message(
             HTTPForbidden,
             (
-                "User {!r} does not have two-factor authentication enabled. "
-                "Please enable two-factor authentication before attempting to "
-                "upload to PyPI. See {project_help} for more information."
+                "User {!r}, associated with the API token used, does not "
+                "have two-factor authentication enabled. Please enable "
+                "two-factor authentication before attempting to upload to "
+                "PyPI. See {project_help} for more information."
             ).format(
                 request.user.username,
                 project_help=request.help_url(_anchor="two-factor-authentication"),

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -506,6 +506,52 @@ def _commonpath(values):
     return os.path.commonpath(values)
 
 
+def _ensure_user_can_upload(request: Request) -> None:
+    """Enforce per-user upload prerequisites: a verified primary email and 2FA.
+
+    Called from the upload view after the project permission check (and
+    before new-project creation) so that a user who lacks permission to a
+    project sees the permission error rather than a confusing email or 2FA
+    error.
+
+    See: https://github.com/pypi/warehouse/issues/18575
+    """
+    # These checks only make sense when our authenticated identity is a user,
+    # not a project identity (like OIDC-minted tokens.)
+    if not request.user:
+        return
+
+    if not (request.user.primary_email and request.user.primary_email.verified):
+        request.metrics.increment(
+            "warehouse.upload.failed", tags=["reason:unverified-email"]
+        )
+        raise _exc_with_message(
+            HTTPForbidden,
+            (
+                "User {!r} does not have a verified primary email address. "
+                "Please add a verified primary email before attempting to "
+                "upload to PyPI. See {project_help} for more information."
+            ).format(
+                request.user.username,
+                project_help=request.help_url(_anchor="verified-email"),
+            ),
+        ) from None
+
+    if not request.user.has_two_factor:
+        request.metrics.increment("warehouse.upload.failed", tags=["reason:no-2fa"])
+        raise _exc_with_message(
+            HTTPForbidden,
+            (
+                "User {!r} does not have two-factor authentication enabled. "
+                "Please enable two-factor authentication before attempting to "
+                "upload to PyPI. See {project_help} for more information."
+            ).format(
+                request.user.username,
+                project_help=request.help_url(_anchor="two-factor-authentication"),
+            ),
+        ) from None
+
+
 @view_config(
     route_name="forklift.legacy.file_upload",
     uses_session=True,
@@ -660,6 +706,10 @@ def file_upload(request):
                 ),
             )
 
+        # Enforce email/2FA prerequisites before creating a brand new project,
+        # so we don't leave an empty project record behind on rejection.
+        _ensure_user_can_upload(request)
+
         # We attempt to create the project.
         project_service = request.find_service(IProjectService)
         try:
@@ -713,6 +763,8 @@ def file_upload(request):
             "warehouse.upload.failed", tags=["reason:permission-denied"]
         )
         raise _exc_with_message(HTTPForbidden, msg)
+
+    _ensure_user_can_upload(request)
 
     # If organization owned project, check if the organization is active.
     # Inactive organizations cannot upload new releases to their projects.


### PR DESCRIPTION
The verified-email and 2FA checks previously ran in the `ensure_uploads_allowed` decorator, ahead of the project permission check in the upload view. A user uploading with a token whose owner doesn't have permission to the target project (and who also lacks a verified email or 2FA) would see a confusing "verified email" error instead of the more useful "not allowed to upload to project X".

Move the user-only email and 2FA checks out of the decorator and into the view as `_ensure_user_can_upload`, called after the project permission check. For brand-new projects, the helper is also called before `create_project()` so we don't leave an empty project record behind on rejection.

Closes #18575