### PR TITLE
fix(packaging): rename 'Latest version' badge to 'Latest release' (#19956)

### DIFF
--- a/warehouse/templates/packaging/detail.html
+++ b/warehouse/templates/packaging/detail.html
@@ -183,7 +183,7 @@
           {% else %}
             <a class="status-badge status-badge--good"
                href="{{ request.route_path('packaging.project', name=release.project.name) }}">
-              <span>{% trans %}Latest version{% endtrans %}</span>
+              <span>{% trans %}Latest release{% endtrans %}</span>
             </a>
           {% endif %}
         {% endif %}


### PR DESCRIPTION
Closes #19956.

## What

Change the badge on the project-detail page from "Latest version" to
"Latest release" so the terminology matches the rest of warehouse
(release_date, project releases, etc.).

## File changed

`warehouse/templates/packaging/detail.html`, single `{% trans %}`
string update on the `status-badge--good` element.

## Why

Per warehouse's [UI principles, "Write clearly with consistent style
and terminology"](https://warehouse.pypa.io/ui-principles/#4-write-clearly-with-consistent-style-and-terminology),
which is what the issue cites.

## Note on the admin panel

There's also a "Latest version" string in
`warehouse/admin/templates/admin/projects/list.html:132`, but that's a
column header on the internal admin projects table, a different
surface than the project-detail badge the issue is about, so it's
left alone here.

## Screenshot

The "Latest version" → "Latest release" change is purely textual; the
badge component (`status-badge--good`) keeps its existing colour, icon,
and link target. No CSS / template structure changes. Happy to attach
a before/after screenshot if helpful.