### PR TITLE
make the base locale file unowned

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -22,13 +22,17 @@ package.json                             @pypi/warehouse-reviewers @pypi/warehou
 webpack.config.js                        @pypi/warehouse-reviewers @pypi/warehouse-frontend
 webpack.plugin.localize.js               @pypi/warehouse-reviewers @pypi/warehouse-frontend
 
-# This is not *technically* a frontend file, but editing the frontend will likely
-# mean that these need to be regenerated, so we treat it like it's a frontend file.
-warehouse/locale @pypi/warehouse-reviewers @pypi/warehouse-frontend
-
-# Likewise, not *technically* frontend files, but when you're working on the
+# There are, not *technically* frontend files, but when you're working on the
 # frontend you may end up needing to update the user facing documentation and/or
 # the developer documentation around changes to how the frontend is developed,
 # so we'll allow frontend and reviewers both to own these as well.
 docs/dev/*  @pypi/warehouse-reviewers @pypi/warehouse-frontend
 docs/user/* @pypi/warehouse-reviewers @pypi/warehouse-frontend
+
+# We don't need to have a codeowner for this file, because it is effectively a
+# checked in build artifact that is determinstically generated from the rest
+# of the code base. Thus if you edit this without a corresponding edit somewhere
+# else, tests will fail, and we can rely on the codeowner from whatever file was
+# edited that caused this file to get regenerated to trigger a codeowner
+# review.
+warehouse/locale/messages.pot


### PR DESCRIPTION
In https://github.com/pypi/warehouse/pull/19938 we made a frontend team so that the frontend permissions could be more finely grained scoped to just what the frontend actually needed, with a secondary goal of reducing the amount of noise that someone working only on the frontend would actually get.

That secondary goal ended up not working very well due to the fact that we wanted to allow the frontend team to update the translations without needing a *second* review from the general reviewers team, which meant that they get pulled into any PR that updates `warehouse/locale/messages.pot`.

Unfortunately *most* PRs end up updating `warehouse/locale/messages.pot` because it embeds line numbers from where it pulled the translatable strings from, which meant that most PRs still ended up tagging the front end team.

However, `warehouse/locale/messages.pot` is deterministically generated from the contents of the repository and our test suite ensures that it matches what is expected, so we don't actually need a codeowner for this file at all. The files that we extract translations from will have a codeowner to enforce review, and then our test suite will enforce that this file matches what is expected.