### PR TITLE
chore(deps): upgrade pip to 26.1 (latest)

### DIFF
--- a/bin/deps-upgrade
+++ b/bin/deps-upgrade
@@ -57,6 +57,7 @@ pip-compile --allow-unsafe --generate-hashes $pip_compile_args --output-file=req
 pip-compile --allow-unsafe --generate-hashes $pip_compile_args --output-file=requirements/main.txt requirements/main.in
 pip-compile --allow-unsafe --generate-hashes $pip_compile_args --output-file=requirements/lint.txt requirements/lint.in
 pip-compile --allow-unsafe --generate-hashes $pip_compile_args --output-file=requirements/tests.txt requirements/tests.in
+pip-compile --allow-unsafe --generate-hashes $pip_compile_args --output-file=requirements/dev.txt requirements/dev.in
 pip-compile --allow-unsafe --generate-hashes $pip_compile_args --output-file=requirements/docs-dev.txt requirements/docs-dev.in
 pip-compile --allow-unsafe --generate-hashes $pip_compile_args --output-file=requirements/docs-user.txt requirements/docs-user.in
 pip-compile --allow-unsafe --generate-hashes $pip_compile_args --output-file=requirements/docs-blog.txt requirements/docs-blog.in

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -260,9 +260,9 @@ zope-interface==8.3 \
     # via pyramid
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==26.0.1 \
-    --hash=sha256:bdb1b08f4274833d62c1aa29e20907365a2ceb950410df15fc9521bad440122b \
-    --hash=sha256:c4037d8a277c89b320abe636d59f91e6d0922d08a05b60e85e53b296613346d8
+pip==26.1 \
+    --hash=sha256:4e8486d821d814b77319acb7b9e8bf5a4ee7590a643e7cb21029f209be8573c1 \
+    --hash=sha256:81e13ebcca3ffa8cc85e4deff5c27e1ee26dea0aa7fc2f294a073ac208806ff3
     # via
     #   pip-api
     #   pip-tools


### PR DESCRIPTION
Includes fix to include `dev.in` during `deps-upgrade` invocations

Signed-off-by: Mike Fiedler <miketheman@gmail.com>