### PR TITLE
mark the translations as a generated file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 * text=auto eol=lf
+
+warehouse/locale/messages.pot linguist-generated


### PR DESCRIPTION
Mark the `warehouse/locale/messages.pot` file as [generated](https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github) so that PR diffs don't try to render it by default.