### PR TITLE
add recommended extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,12 @@
+{
+	// List of extensions which should be recommended for users of this workspace.
+	"recommendations": [
+		"editorconfig.editorconfig",
+		"charliermarsh.ruff",
+		"ms-python.python",
+		"tombi-toml.tombi"
+	],
+	// List of extensions recommended by VS Code that should not be recommended for
+	// users of this workspace.
+	"unwantedRecommendations": []
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,7 @@
 {
 	// List of extensions which should be recommended for users of this workspace.
 	"recommendations": [
+		"ast-grep.ast-grep-vscode",
 		"editorconfig.editorconfig",
 		"charliermarsh.ruff",
 		"ms-python.python",


### PR DESCRIPTION
Dunno how people feel about adding a VSCode specific file here, but this will make it so when someone opens up warehouse for the first time they get these extensions recommended to them (it does not automatically install them or anything). For people who have opened up warehouse in the past these extensions will still appear in the recommended list, it just won't do the little toast notification in the bottom right.

See VSCode [docs](https://code.visualstudio.com/docs/configure/extensions/extension-marketplace#_workspace-recommended-extensions).