### PR TITLE
refactor: remove redundant SentryWsgiMiddleware

### DIFF
--- a/tests/unit/test_sentry.py
+++ b/tests/unit/test_sentry.py
@@ -4,8 +4,6 @@ import pretend
 import pytest
 import sentry_sdk
 
-from sentry_sdk.integrations.wsgi import SentryWsgiMiddleware
-
 from warehouse import sentry
 
 
@@ -70,7 +68,6 @@ def test_includeme(monkeypatch):
     config = pretend.stub(
         registry=Registry(),
         add_request_method=pretend.call_recorder(lambda *a, **kw: None),
-        add_wsgi_middleware=pretend.call_recorder(lambda *a, **kw: None),
     )
     config.registry.settings.update(
         {
@@ -100,4 +97,3 @@ def test_includeme(monkeypatch):
     assert config.add_request_method.calls == [
         pretend.call(sentry._sentry, name="sentry", reify=True)
     ]
-    assert config.add_wsgi_middleware.calls == [pretend.call(SentryWsgiMiddleware)]

--- a/warehouse/config.py
+++ b/warehouse/config.py
@@ -941,8 +941,9 @@ def configure(settings=None):
     # Add our extensions to Request
     config.include(".utils.wsgi")
 
-    # We want Sentry to be the last things we add here so that it's the outer
-    # most WSGI middleware.
+    # Initialize Sentry for exception capture. PyramidIntegration wraps
+    # Pyramid's Router with SentryWsgiMiddleware internally, so include
+    # order here no longer affects WSGI middleware nesting.
     config.include(".sentry")
 
     # Register Content-Security-Policy service

--- a/warehouse/sentry.py
+++ b/warehouse/sentry.py
@@ -6,7 +6,6 @@ from sentry_sdk.integrations.celery import CeleryIntegration
 from sentry_sdk.integrations.logging import LoggingIntegration
 from sentry_sdk.integrations.pyramid import PyramidIntegration
 from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
-from sentry_sdk.integrations.wsgi import SentryWsgiMiddleware
 from webob.request import DisconnectionError
 
 
@@ -20,11 +19,10 @@ ignore_exceptions = (
     # then Gunicorn treating that as being told to exit the process. Either way,
     # there isn't anything we can do about them, so they just cause noise.
     SystemExit,
-    # Gunicorn internally raises these errors, and will catch them and handle
-    # them correctly... however they have to first pass through our WSGI
-    # middleware which is catching them and logging them. Instead we
-    # will ignore them. We have to list these as strings, and list all
-    # of them because we don't want to import Gunicorn in our application
+    # Gunicorn raises these errors during request parsing and handles them
+    # itself, but they surface in Sentry via PyramidIntegration when views
+    # read the request body. Ignore them so they don't add noise. Listed as
+    # strings to avoid importing Gunicorn into the application.
     "gunicorn.http.errors.ParseException",
     "gunicorn.http.errors.NoMoreData",
     "gunicorn.http.errors.InvalidRequestLine",
@@ -86,7 +84,3 @@ def includeme(config):
 
     # Create a request method that'll get us the Sentry SDK in each request.
     config.add_request_method(_sentry, name="sentry", reify=True)
-
-    # Wrap the WSGI object with the middle to catch any exceptions we don't
-    # catch elsewhere.
-    config.add_wsgi_middleware(SentryWsgiMiddleware)


### PR DESCRIPTION
PyramidIntegration (sentry-sdk 2.x) already wraps Pyramid's Router.__call__ with SentryWsgiMiddleware internally, so registering it explicitly was double-wrapping for exceptions raised in Pyramid views. The integration also patches Request.invoke_exception_view to capture exceptions surfaced through Pyramid's exception views.

Note: outer WSGI middleware (whitenoise, ProxyFixer, VhmRootRemover) is no longer wrapped by Sentry; those layers are simple and the ignore list in before_send already filtered the relevant gunicorn parse errors.

Also clean up two stale comments that referenced the removed outer middleware.