### PR TITLE
chore(deps): unpin inputs where possible

### DIFF
--- a/requirements/deploy.in
+++ b/requirements/deploy.in
@@ -1,2 +1,2 @@
 gunicorn<24.0.0  # pin to below 24 to avoid a restart error
-ddtrace==4.7.0
+ddtrace

--- a/requirements/lint.in
+++ b/requirements/lint.in
@@ -1,4 +1,4 @@
-ruff==0.15.12
+ruff
 ast-grep-cli
 djlint
 flake8
@@ -18,7 +18,7 @@ types-passlib
 types-python-slugify
 types-pytz
 types-redis
-types-requests==2.33.0.20260408
+types-requests
 types-stripe
 types-WTForms
 types-WebOb

--- a/requirements/main.in
+++ b/requirements/main.in
@@ -24,7 +24,7 @@ html5lib
 humanize
 itsdangerous
 Jinja2>=2.8
-kombu[redis]>=5.6,<5.7  # https://github.com/jazzband/pip-tools/issues/1577
+kombu[redis]  # https://github.com/jazzband/pip-tools/issues/1577
 limits
 linehaul
 lxml
@@ -63,8 +63,8 @@ requests-aws4auth
 redis>=2.8.0,<7.0.0
 rfc3986
 sentry-sdk
-pypi-attestations==0.0.29
-sqlalchemy[asyncio]>=2.0,<3.0
+pypi-attestations
+sqlalchemy[asyncio]
 stdlib-list
 stripe
 structlog
@@ -73,7 +73,7 @@ transaction
 trove-classifiers
 ua-parser
 urllib3
-webauthn>=1.0.0,<3.0.0
+webauthn
 whitenoise
 WTForms[email]>=2.0.0
 yara-x

--- a/requirements/tests.in
+++ b/requirements/tests.in
@@ -2,14 +2,14 @@ coverage
 factory_boy
 freezegun
 pretend
-pytest>=9.0.0
+pytest
 pytest-icdiff
 pytest-mock
-pytest-postgresql>=3.1.3,<9.0.0
+pytest-postgresql
 pytest-randomly
 pytest-socket
 pytest-sugar
 pytest-xdist
 pytz
-responses>=0.5.1
+responses
 webtest


### PR DESCRIPTION
Dependabot will run `pip-compile` for updates, and when it does, it bumps the values in the .in files as well as the rendered .txt files.

Touching the .in files impacts local developers needlessly running the same `pip-compile` steps that have already been done via CI, slowing them down when nothing has effectively changed.

This should minimize the amount of locally-run pip-compile.