### PR TITLE
feat(oidc): expire pending trusted publishers after a TTL

### DIFF
--- a/tests/unit/email/test_init.py
+++ b/tests/unit/email/test_init.py
@@ -5493,6 +5493,114 @@ class TestRecoveryCodeEmails:
 
 
 class TestTrustedPublisherEmails:
+    def test_pending_trusted_publisher_expired_email(
+        self, pyramid_request, pyramid_config, monkeypatch
+    ):
+        stub_user = pretend.stub(
+            id="id",
+            username="username",
+            name="",
+            email="email@example.com",
+            primary_email=pretend.stub(email="email@example.com", verified=True),
+        )
+        subject_renderer = pyramid_config.testing_add_renderer(
+            "email/pending-trusted-publisher-expired/subject.txt"
+        )
+        subject_renderer.string_response = "Email Subject"
+        body_renderer = pyramid_config.testing_add_renderer(
+            "email/pending-trusted-publisher-expired/body.txt"
+        )
+        body_renderer.string_response = "Email Body"
+        html_renderer = pyramid_config.testing_add_renderer(
+            "email/pending-trusted-publisher-expired/body.html"
+        )
+        html_renderer.string_response = "<p>Email HTML Body</p>"
+
+        send_email = pretend.stub(
+            delay=pretend.call_recorder(lambda *args, **kwargs: None)
+        )
+        pyramid_request.task = pretend.call_recorder(lambda *args, **kwargs: send_email)
+        monkeypatch.setattr(email, "send_email", send_email)
+
+        pyramid_request.db = pretend.stub(
+            query=lambda a: pretend.stub(
+                filter=lambda *a: pretend.stub(
+                    one=lambda: pretend.stub(user_id=stub_user.id)
+                )
+            ),
+        )
+        pyramid_request.user = stub_user
+        pyramid_request.registry.settings = {"mail.sender": "noreply@example.com"}
+
+        result = email.send_pending_trusted_publisher_expired_email(
+            pyramid_request,
+            stub_user,
+            project_name="test_project",
+            days=30,
+        )
+
+        assert result == {
+            "project_name": "test_project",
+            "days": 30,
+        }
+        subject_renderer.assert_()
+        body_renderer.assert_(project_name="test_project", days=30)
+        html_renderer.assert_(project_name="test_project", days=30)
+
+    def test_pending_trusted_publisher_expiration_reminder_email(
+        self, pyramid_request, pyramid_config, monkeypatch
+    ):
+        stub_user = pretend.stub(
+            id="id",
+            username="username",
+            name="",
+            email="email@example.com",
+            primary_email=pretend.stub(email="email@example.com", verified=True),
+        )
+        subject_renderer = pyramid_config.testing_add_renderer(
+            "email/pending-trusted-publisher-expiration-reminder/subject.txt"
+        )
+        subject_renderer.string_response = "Email Subject"
+        body_renderer = pyramid_config.testing_add_renderer(
+            "email/pending-trusted-publisher-expiration-reminder/body.txt"
+        )
+        body_renderer.string_response = "Email Body"
+        html_renderer = pyramid_config.testing_add_renderer(
+            "email/pending-trusted-publisher-expiration-reminder/body.html"
+        )
+        html_renderer.string_response = "<p>Email HTML Body</p>"
+
+        send_email = pretend.stub(
+            delay=pretend.call_recorder(lambda *args, **kwargs: None)
+        )
+        pyramid_request.task = pretend.call_recorder(lambda *args, **kwargs: send_email)
+        monkeypatch.setattr(email, "send_email", send_email)
+
+        pyramid_request.db = pretend.stub(
+            query=lambda a: pretend.stub(
+                filter=lambda *a: pretend.stub(
+                    one=lambda: pretend.stub(user_id=stub_user.id)
+                )
+            ),
+        )
+        pyramid_request.user = stub_user
+        pyramid_request.registry.settings = {"mail.sender": "noreply@example.com"}
+
+        result = email.send_pending_trusted_publisher_expiration_reminder_email(
+            pyramid_request,
+            stub_user,
+            project_name="test_project",
+            days_remaining=5,
+        )
+
+        assert result == {
+            "project_name": "test_project",
+            "days_remaining": 5,
+        }
+        subject_renderer.assert_()
+        body_renderer.assert_(project_name="test_project", days_remaining=5)
+        html_renderer.assert_(project_name="test_project", days_remaining=5)
+
     def test_pending_trusted_publisher_reified_email(
         self, pyramid_request, pyramid_config, monkeypatch
     ):

--- a/tests/unit/oidc/test_tasks.py
+++ b/tests/unit/oidc/test_tasks.py
@@ -4,11 +4,21 @@ import datetime
 
 import pretend
 
+from warehouse.events.tags import EventTag
 from warehouse.macaroons import caveats
 from warehouse.macaroons.models import Macaroon
-from warehouse.oidc.tasks import compute_oidc_metrics, delete_expired_oidc_macaroons
+from warehouse.oidc.models import PendingOIDCPublisher
+from warehouse.oidc.tasks import (
+    PENDING_PUBLISHER_EXPIRY_DAYS,
+    PENDING_PUBLISHER_REMINDER_DAYS,
+    compute_oidc_metrics,
+    delete_expired_oidc_macaroons,
+    delete_expired_pending_publishers,
+    pending_publisher_cutoff,
+    send_pending_publisher_expiration_reminders,
+)
 
-from ...common.db.oidc import GitHubPublisherFactory
+from ...common.db.oidc import GitHubPublisherFactory, PendingGitHubPublisherFactory
 from ...common.db.packaging import (
     FileEventFactory,
     FileFactory,
@@ -159,4 +169,148 @@ def test_delete_expired_oidc_macaroons(db_request, macaroon_service, metrics):
 
     assert metrics.gauge.calls == [
         pretend.call("warehouse.oidc.expired_oidc_tokens_deleted", 1),
+    ]
+
+
+def test_delete_expired_pending_publishers(db_request, metrics, monkeypatch):
+    """Expired pending publishers are deleted and their owners notified."""
+    send_email = pretend.call_recorder(lambda *a, **kw: None)
+    monkeypatch.setattr(
+        "warehouse.oidc.tasks.send_pending_trusted_publisher_expired_email",
+        send_email,
+    )
+
+    expired_publisher = PendingGitHubPublisherFactory.create(
+        project_name="expired-project",
+        created=pending_publisher_cutoff(PENDING_PUBLISHER_EXPIRY_DAYS)
+        - datetime.timedelta(seconds=1),
+    )
+    fresh_publisher = PendingGitHubPublisherFactory.create(
+        project_name="fresh-project",
+    )
+    record_event = pretend.call_recorder(lambda **kw: None)
+    expired_publisher.added_by.record_event = record_event
+
+    assert db_request.db.query(PendingOIDCPublisher).count() == 2
+
+    delete_expired_pending_publishers(db_request)
+
+    # Only the fresh publisher should remain
+    assert db_request.db.query(PendingOIDCPublisher).count() == 1
+    remaining = db_request.db.query(PendingOIDCPublisher).one()
+    assert remaining.project_name == fresh_publisher.project_name
+
+    # Email was sent to the expired publisher's owner
+    assert send_email.calls == [
+        pretend.call(
+            db_request,
+            expired_publisher.added_by,
+            project_name="expired-project",
+            days=PENDING_PUBLISHER_EXPIRY_DAYS,
+        ),
+    ]
+
+    # An auto-removal event was recorded against the registrant, with
+    # location redacted (system action, not user-initiated).
+    assert record_event.calls == [
+        pretend.call(
+            tag=EventTag.Account.PendingOIDCPublisherRemoved,
+            request=db_request,
+            additional={
+                "project": "expired-project",
+                "publisher": expired_publisher.publisher_name,
+                "id": str(expired_publisher.id),
+                "specifier": str(expired_publisher),
+                "url": expired_publisher.publisher_url(),
+                "submitted_by": "system:ttl-expired",
+                "redact_ip": True,
+            },
+        )
+    ]
+
+    assert metrics.gauge.calls == [
+        pretend.call("warehouse.oidc.expired_pending_publishers_deleted", 1),
+    ]
+
+
+def test_delete_expired_pending_publishers_none_expired(
+    db_request, metrics, monkeypatch
+):
+    """When no pending publishers are expired, nothing is deleted."""
+    send_email = pretend.call_recorder(lambda *a, **kw: None)
+    monkeypatch.setattr(
+        "warehouse.oidc.tasks.send_pending_trusted_publisher_expired_email",
+        send_email,
+    )
+
+    PendingGitHubPublisherFactory.create(project_name="fresh-project")
+
+    delete_expired_pending_publishers(db_request)
+
+    assert db_request.db.query(PendingOIDCPublisher).count() == 1
+    assert send_email.calls == []
+    assert metrics.gauge.calls == [
+        pretend.call("warehouse.oidc.expired_pending_publishers_deleted", 0),
+    ]
+
+
+def test_send_pending_publisher_expiration_reminders(db_request, metrics, monkeypatch):
+    """Pending publishers in the reminder window get a one-shot reminder email."""
+    send_email = pretend.call_recorder(lambda *a, **kw: None)
+    monkeypatch.setattr(
+        "warehouse.oidc.tasks.send_pending_trusted_publisher_expiration_reminder_email",
+        send_email,
+    )
+
+    reminder_cutoff = pending_publisher_cutoff(
+        PENDING_PUBLISHER_EXPIRY_DAYS - PENDING_PUBLISHER_REMINDER_DAYS
+    )
+    needs_reminder = PendingGitHubPublisherFactory.create(
+        project_name="needs-reminder",
+        created=reminder_cutoff - datetime.timedelta(seconds=1),
+    )
+    already_reminded = PendingGitHubPublisherFactory.create(
+        project_name="already-reminded",
+        created=reminder_cutoff - datetime.timedelta(seconds=1),
+        expiration_reminded=True,
+    )
+    fresh = PendingGitHubPublisherFactory.create(project_name="fresh-project")
+
+    send_pending_publisher_expiration_reminders(db_request)
+
+    assert send_email.calls == [
+        pretend.call(
+            db_request,
+            needs_reminder.added_by,
+            project_name="needs-reminder",
+            days_remaining=PENDING_PUBLISHER_REMINDER_DAYS,
+        ),
+    ]
+
+    assert needs_reminder.expiration_reminded is True
+    assert already_reminded.expiration_reminded is True
+    assert fresh.expiration_reminded is False
+
+    assert metrics.gauge.calls == [
+        pretend.call("warehouse.oidc.pending_publisher_expiration_reminders_sent", 1),
+    ]
+
+
+def test_send_pending_publisher_expiration_reminders_none_due(
+    db_request, metrics, monkeypatch
+):
+    """When no pending publishers are in the reminder window, nothing is sent."""
+    send_email = pretend.call_recorder(lambda *a, **kw: None)
+    monkeypatch.setattr(
+        "warehouse.oidc.tasks.send_pending_trusted_publisher_expiration_reminder_email",
+        send_email,
+    )
+
+    PendingGitHubPublisherFactory.create(project_name="fresh-project")
+
+    send_pending_publisher_expiration_reminders(db_request)
+
+    assert send_email.calls == []
+    assert metrics.gauge.calls == [
+        pretend.call("warehouse.oidc.pending_publisher_expiration_reminders_sent", 0),
     ]

--- a/warehouse/email/__init__.py
+++ b/warehouse/email/__init__.py
@@ -1042,6 +1042,24 @@ def send_pending_trusted_publisher_invalidated_email(request, user, project_name
     }
 
 
+@_email("pending-trusted-publisher-expired")
+def send_pending_trusted_publisher_expired_email(request, user, project_name, days):
+    return {
+        "project_name": project_name,
+        "days": days,
+    }
+
+
+@_email("pending-trusted-publisher-expiration-reminder")
+def send_pending_trusted_publisher_expiration_reminder_email(
+    request, user, project_name, days_remaining
+):
+    return {
+        "project_name": project_name,
+        "days_remaining": days_remaining,
+    }
+
+
 @_email("pending-trusted-publisher-reified")
 def send_pending_trusted_publisher_reified_email(
     request, user, project_name, publisher_specifier

--- a/warehouse/migrations/versions/e8a83da04d40_add_expiry_columns_to_pending_oidc_publishers.py
+++ b/warehouse/migrations/versions/e8a83da04d40_add_expiry_columns_to_pending_oidc_publishers.py
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Add expiry columns to pending_oidc_publishers
+
+Revision ID: e8a83da04d40
+Revises: b8e6e0867168
+Create Date: 2026-04-09 00:00:00.000000
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "e8a83da04d40"
+down_revision = "b8e6e0867168"
+
+
+def upgrade():
+    op.add_column(
+        "pending_oidc_publishers",
+        sa.Column(
+            "created",
+            sa.DateTime(),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+    )
+    op.add_column(
+        "pending_oidc_publishers",
+        sa.Column(
+            "expiration_reminded",
+            sa.Boolean(),
+            server_default=sa.false(),
+            nullable=False,
+        ),
+    )
+
+
+def downgrade():
+    op.drop_column("pending_oidc_publishers", "expiration_reminded")
+    op.drop_column("pending_oidc_publishers", "created")

--- a/warehouse/oidc/__init__.py
+++ b/warehouse/oidc/__init__.py
@@ -7,7 +7,12 @@ from celery.schedules import crontab
 
 from warehouse.oidc.interfaces import IOIDCPublisherService
 from warehouse.oidc.services import OIDCPublisherServiceFactory
-from warehouse.oidc.tasks import compute_oidc_metrics, delete_expired_oidc_macaroons
+from warehouse.oidc.tasks import (
+    compute_oidc_metrics,
+    delete_expired_oidc_macaroons,
+    delete_expired_pending_publishers,
+    send_pending_publisher_expiration_reminders,
+)
 from warehouse.oidc.utils import (
     ACTIVESTATE_OIDC_ISSUER_URL,
     GITHUB_OIDC_ISSUER_URL,
@@ -78,3 +83,13 @@ def includeme(config: Configurator) -> None:
     # Daily purge expired OIDC-minted API tokens. These tokens are temporary in nature
     # and expire after 15 minutes of creation.
     config.add_periodic_task(crontab(minute=0, hour=6), delete_expired_oidc_macaroons)
+
+    # Daily purge expired pending OIDC publishers. Pending publishers that have
+    # not been used within their TTL are deleted and their owners are notified.
+    config.add_periodic_task(
+        crontab(minute=0, hour=2), delete_expired_pending_publishers
+    )
+    # Daily reminder for pending OIDC publishers approaching their TTL.
+    config.add_periodic_task(
+        crontab(minute=0, hour=3), send_pending_publisher_expiration_reminders
+    )

--- a/warehouse/oidc/models/_core.py
+++ b/warehouse/oidc/models/_core.py
@@ -25,6 +25,7 @@ from warehouse.oidc.errors import InvalidPublisherError, ReusedTokenError
 from warehouse.oidc.interfaces import SignedClaims
 from warehouse.oidc.urls import verify_url_from_reference
 from warehouse.packaging.models import PROJECT_NAME_PATTERN
+from warehouse.utils.db.types import bool_false, datetime_now
 
 if TYPE_CHECKING:
     from pypi_attestations import Publisher
@@ -408,6 +409,8 @@ class PendingOIDCPublisher(OIDCPublisherMixin, db.Model):
     pypi_organization: Mapped[Organization | None] = orm.relationship(
         back_populates="pending_oidc_publishers"
     )
+    created: Mapped[datetime_now]
+    expiration_reminded: Mapped[bool_false]
 
     __table_args__ = (
         CheckConstraint(

--- a/warehouse/oidc/tasks.py
+++ b/warehouse/oidc/tasks.py
@@ -1,12 +1,40 @@
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
+import typing
+
 from datetime import UTC, datetime, timedelta
 
+from sqlalchemy import select
+
 from warehouse import tasks
+from warehouse.email import (
+    send_pending_trusted_publisher_expiration_reminder_email,
+    send_pending_trusted_publisher_expired_email,
+)
+from warehouse.events.tags import EventTag
 from warehouse.macaroons.models import Macaroon
 from warehouse.metrics import IMetricsService
-from warehouse.oidc.models import OIDCPublisher
+from warehouse.oidc.models import OIDCPublisher, PendingOIDCPublisher
 from warehouse.packaging.models import File, Project, Release
+
+if typing.TYPE_CHECKING:
+    from pyramid.request import Request
+
+# Pending publishers expire after this many days.
+PENDING_PUBLISHER_EXPIRY_DAYS = 30
+
+# Pending publishers receive a reminder email this many days before expiry.
+PENDING_PUBLISHER_REMINDER_DAYS = 5
+
+
+def pending_publisher_cutoff(days: int) -> datetime:
+    """Return the cutoff before which pending publishers older than `days` created.
+
+    Returned as naive UTC to match the naive `created` column for in-Python comparisons.
+    """
+    return datetime.now(tz=UTC).replace(tzinfo=None) - timedelta(days=days)
 
 
 @tasks.task(ignore_result=True, acks_late=True)
@@ -81,4 +109,74 @@ def delete_expired_oidc_macaroons(request):
     metrics.gauge(
         "warehouse.oidc.expired_oidc_tokens_deleted",
         rows_deleted,
+    )
+
+
+@tasks.task(ignore_result=True, acks_late=True)
+def delete_expired_pending_publishers(request: Request) -> None:
+    """
+    Delete pending OIDC publishers that have exceeded their TTL.
+    Sends a notification email to each publisher's owner before deletion.
+    """
+    cutoff = pending_publisher_cutoff(PENDING_PUBLISHER_EXPIRY_DAYS)
+    expired_publishers = request.db.scalars(
+        select(PendingOIDCPublisher).where(PendingOIDCPublisher.created < cutoff)
+    ).all()
+
+    for publisher in expired_publishers:
+        send_pending_trusted_publisher_expired_email(
+            request,
+            publisher.added_by,
+            project_name=publisher.project_name,
+            days=PENDING_PUBLISHER_EXPIRY_DAYS,
+        )
+        publisher.added_by.record_event(
+            tag=EventTag.Account.PendingOIDCPublisherRemoved,
+            request=request,
+            additional={
+                "project": publisher.project_name,
+                "publisher": publisher.publisher_name,
+                "id": str(publisher.id),
+                "specifier": str(publisher),
+                "url": publisher.publisher_url(),
+                "submitted_by": "system:ttl-expired",
+                "redact_ip": True,
+            },
+        )
+        request.db.delete(publisher)
+
+    request.metrics.gauge(
+        "warehouse.oidc.expired_pending_publishers_deleted",
+        len(expired_publishers),
+    )
+
+
+@tasks.task(ignore_result=True, acks_late=True)
+def send_pending_publisher_expiration_reminders(request: Request) -> None:
+    """
+    Send a one-shot reminder email for pending OIDC publishers approaching
+    their TTL. The `expiration_reminded` flag prevents re-reminding.
+    """
+    cutoff = pending_publisher_cutoff(
+        PENDING_PUBLISHER_EXPIRY_DAYS - PENDING_PUBLISHER_REMINDER_DAYS
+    )
+    publishers = request.db.scalars(
+        select(PendingOIDCPublisher).where(
+            PendingOIDCPublisher.created < cutoff,
+            PendingOIDCPublisher.expiration_reminded.is_(False),
+        )
+    ).all()
+
+    for publisher in publishers:
+        send_pending_trusted_publisher_expiration_reminder_email(
+            request,
+            publisher.added_by,
+            project_name=publisher.project_name,
+            days_remaining=PENDING_PUBLISHER_REMINDER_DAYS,
+        )
+        publisher.expiration_reminded = True
+
+    request.metrics.gauge(
+        "warehouse.oidc.pending_publisher_expiration_reminders_sent",
+        len(publishers),
     )

--- a/warehouse/templates/email/pending-trusted-publisher-expiration-reminder/body.html
+++ b/warehouse/templates/email/pending-trusted-publisher-expiration-reminder/body.html
@@ -1,0 +1,15 @@
+{# SPDX-License-Identifier: Apache-2.0 -#}
+{% extends "email/_base/body.html" %}
+{% block content %}
+  <p>
+    The pending trusted publisher you registered for the project
+    <strong>{{ project_name }}</strong> will expire in
+    <strong>{{ days_remaining }} days</strong> if it has not been used to
+    publish.
+  </p>
+  <p>
+    If you still want to use this trusted publisher, publish a release
+    through it before it expires. Otherwise, you can register it again
+    later.
+  </p>
+{% endblock %}

--- a/warehouse/templates/email/pending-trusted-publisher-expiration-reminder/body.txt
+++ b/warehouse/templates/email/pending-trusted-publisher-expiration-reminder/body.txt
@@ -1,0 +1,13 @@
+{# SPDX-License-Identifier: Apache-2.0 -#}
+
+{% extends "email/_base/body.txt" %}
+
+{% block content %}
+The pending trusted publisher you registered for the project
+{{ project_name }} will expire in {{ days_remaining }} days if it has not
+been used to publish.
+
+If you still want to use this trusted publisher, publish a release
+through it before it expires. Otherwise, you can register it again
+later.
+{% endblock %}

--- a/warehouse/templates/email/pending-trusted-publisher-expiration-reminder/subject.txt
+++ b/warehouse/templates/email/pending-trusted-publisher-expiration-reminder/subject.txt
@@ -1,0 +1,5 @@
+{# SPDX-License-Identifier: Apache-2.0 -#}
+
+{% extends "email/_base/subject.txt" %}
+
+{% block subject %}Pending trusted publisher for {{ project_name }} expiring soon{% endblock %}

--- a/warehouse/templates/email/pending-trusted-publisher-expired/body.html
+++ b/warehouse/templates/email/pending-trusted-publisher-expired/body.html
@@ -1,0 +1,10 @@
+{# SPDX-License-Identifier: Apache-2.0 -#}
+{% extends "email/_base/body.html" %}
+{% block content %}
+  <p>
+    You registered a pending trusted publisher for a project
+    (<strong>{{ project_name }}</strong>), but it has expired because the
+    project was not created within {{ days }} days.
+  </p>
+  <p>If you still want to use this trusted publisher, you can register it again.</p>
+{% endblock %}

--- a/warehouse/templates/email/pending-trusted-publisher-expired/body.txt
+++ b/warehouse/templates/email/pending-trusted-publisher-expired/body.txt
@@ -1,0 +1,11 @@
+{# SPDX-License-Identifier: Apache-2.0 -#}
+
+{% extends "email/_base/body.txt" %}
+
+{% block content %}
+You registered a pending trusted publisher for a project
+({{ project_name }}), but it has expired because the project was not
+created within {{ days }} days.
+
+If you still want to use this trusted publisher, you can register it again.
+{% endblock %}

--- a/warehouse/templates/email/pending-trusted-publisher-expired/subject.txt
+++ b/warehouse/templates/email/pending-trusted-publisher-expired/subject.txt
@@ -1,0 +1,5 @@
+{# SPDX-License-Identifier: Apache-2.0 -#}
+
+{% extends "email/_base/subject.txt" %}
+
+{% block subject %}Pending trusted publisher expired for {{ project_name }}{% endblock %}


### PR DESCRIPTION
Pending OIDC publishers that are never used can accumulate indefinitely. Expire them after `PENDING_PUBLISHER_EXPIRY_DAYS` (30 days) to limit the window during which a stale or speculative pending publisher can be reified into a real project.

- daily task purges expired rows and notifies the registrant by email
- daily task sends a one-shot reminder `PENDING_PUBLISHER_REMINDER_DAYS` (5 days) before expiry, gated by an `expiration_reminded` flag

The cutoff is computed by a single helper, `pending_publisher_cutoff(days)`, returning a naive UTC datetime to match the naive `created` column for in-Python comparisons.