### PR TITLE
fix: `subject_type` for `"foo:bar"` event tags

### DIFF
--- a/warehouse/events/tags.py
+++ b/warehouse/events/tags.py
@@ -38,11 +38,11 @@ class EventTagEnum(enum.StrEnum):
 
     # Name = "source_type:subject_type:action"
     def __new__(cls, value: str):
-        values = value.split(":")
+        values: list[str] = value.split(":")
         obj = str.__new__(cls, value)
         obj._value_ = value
         obj.source_type = values[0]
-        obj.subject_type = ":".join(values[1:-1]) or value[0]
+        obj.subject_type = ":".join(values[1:-1]) or values[0]
         obj.action = values[-1]
         return obj
 


### PR DESCRIPTION
The `EventTagEnum` docstring indicates that omitted `subject_type` should fallback to `source_type`:

https://github.com/pypi/warehouse/blob/53babdb2bc7a52445fb60c562e8d5a8f49581752/warehouse/events/tags.py#L26

However, a typo resulted in `EventTagEnum("foo:bar")` to have `"f"` instead of `"foo"` for `subject_type`.