### PR TITLE
don't execute warehouse just to compile pycs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -96,8 +96,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
             -r /tmp/requirements/docs-dev.txt \
             -r /tmp/requirements/docs-user.txt \
             -r /tmp/requirements/docs-blog.txt \
-    && pip check \
-    && find /opt/warehouse -name '*.pyc' -delete
+    && pip check
 
 WORKDIR /opt/warehouse/src/
 
@@ -171,8 +170,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
                     -r /tmp/requirements/main.txt \
                     $(if [ "$DEVEL" = "yes" ]; then echo '-r /tmp/requirements/tests.txt -r /tmp/requirements/lint.txt'; fi) \
                     $(if [ "$CI" = "yes" ]; then echo '-r /tmp/requirements/docs-dev.txt -r /tmp/requirements/docs-user.txt -r /tmp/requirements/docs-blog.txt'; fi ) \
-    && pip check \
-    && find /opt/warehouse -name '*.pyc' -delete
+    && pip check
 
 
 
@@ -196,6 +194,9 @@ ARG DEVEL=no
 # Define whether we're building a CI image. This will include all the docs stuff
 # as well for the matrix!
 ARG CI=no
+
+# Pre-compile the stdlib bytecode to save time collectively on container boot!
+RUN python -m compileall /usr/local/lib -j 0
 
 # By default, Docker has special steps to avoid keeping APT caches in the layers, which
 # is good, but in our case, we're going to mount a special cache volume (kept between
@@ -232,8 +233,8 @@ COPY --from=static /opt/warehouse/src/warehouse/admin/static/dist/ /opt/warehous
 COPY --from=build /opt/warehouse/ /opt/warehouse/
 COPY . /opt/warehouse/src/
 
+# Pre-compile our module's bytecode to save time collectively on container boot!
+RUN python -m compileall warehouse/ -j 0
+
 # Pre-cache TLD list
 RUN tldextract --update
-# Load our module to pre-compile as much bytecode as we can easily.
-# Saves time collectively on container boot!
-RUN python -m warehouse db -h


### PR DESCRIPTION
Currently the `Dockerfile` runs `python -m warehouse db -h` to trigger compilation of the `.pyc` files so that containers can boot up faster, however that adds ~14s to the container build process on my desktop, the bulk of which has nothing to do with compiling pyc files and mostly has to do with the fact that we're executing warehouse's code (and all of its imports), which has the *side effect* of compiling the pyc files.

Rather than doing that, we can just run `python -m compileall` (with the `-j 0` flag to parallelize it) to compile all of the files in `/opt/warehouse/src/`, which will cover warehouse and the tests (but not warehouse's dependencies).

pip compiles the `*.pyc` files for everything it installs, which we went out of our way to delete, so to get the `*.pyc` files for our dependencies, we just stop deleting those `*.pyc` files that pip already created for us.

The `python -m compileall` command takes about 2s on my desktop, the difference in deleting or not deleting the `*.pyc` files appears to basically be just noise.