### PR TITLE
Fix: Use RFC-5735 TEST-NET addresses in unit tests

### DIFF
--- a/tests/unit/accounts/test_views.py
+++ b/tests/unit/accounts/test_views.py
@@ -2946,7 +2946,7 @@ class TestVerifyOrganizationRole:
         db_request.method = "POST"
         db_request.GET.update({"token": "RANDOM_KEY"})
         db_request.route_path = pretend.call_recorder(lambda *a, **kw: "/")
-        db_request.remote_addr = "192.168.1.1"
+        db_request.remote_addr = "192.0.2.1"
         db_request.session.flash = pretend.call_recorder(lambda *a, **kw: None)
         token_service.loads = pretend.call_recorder(
             lambda token: {
@@ -3085,7 +3085,7 @@ class TestVerifyOrganizationRole:
         db_request.method = "POST"
         db_request.GET.update({"token": "RANDOM_KEY"})
         db_request.route_path = pretend.call_recorder(lambda name: "/")
-        db_request.remote_addr = "192.168.1.1"
+        db_request.remote_addr = "192.0.2.1"
         db_request.session.flash = pretend.call_recorder(lambda *a, **kw: None)
         token_service.loads = pretend.call_recorder(
             lambda token: {
@@ -3132,7 +3132,7 @@ class TestVerifyOrganizationRole:
             {"token": "RANDOM_KEY", "decline": "Decline", "message": message}
         )
         db_request.route_path = pretend.call_recorder(lambda name: "/")
-        db_request.remote_addr = "192.168.1.1"
+        db_request.remote_addr = "192.0.2.1"
         db_request.session.flash = pretend.call_recorder(lambda *a, **kw: None)
         token_service.loads = pretend.call_recorder(
             lambda token: {
@@ -3204,7 +3204,7 @@ class TestVerifyOrganizationRole:
         db_request.method = "POST"
         db_request.GET.update({"token": "RANDOM_KEY"})
         db_request.route_path = pretend.call_recorder(lambda name: "/")
-        db_request.remote_addr = "192.168.1.1"
+        db_request.remote_addr = "192.0.2.1"
         db_request.session.flash = pretend.call_recorder(lambda *a, **kw: None)
         token_service.loads = pretend.call_recorder(
             lambda token: {
@@ -3244,7 +3244,7 @@ class TestVerifyOrganizationRole:
         db_request.method = "POST"
         db_request.GET.update({"token": "RANDOM_KEY"})
         db_request.route_path = pretend.call_recorder(lambda name: "/")
-        db_request.remote_addr = "192.168.1.1"
+        db_request.remote_addr = "192.0.2.1"
         db_request.session.flash = pretend.call_recorder(lambda *a, **kw: None)
         token_service.loads = pretend.call_recorder(
             lambda token: {
@@ -3283,7 +3283,7 @@ class TestVerifyOrganizationRole:
         db_request.method = "GET"
         db_request.GET.update({"token": "RANDOM_KEY"})
         db_request.route_path = pretend.call_recorder(lambda name: "/")
-        db_request.remote_addr = "192.168.1.1"
+        db_request.remote_addr = "192.0.2.1"
         db_request.session.flash = pretend.call_recorder(lambda *a, **kw: None)
         token_service.loads = pretend.call_recorder(
             lambda token: {
@@ -3318,7 +3318,7 @@ class TestVerifyProjectRole:
         db_request.method = "POST"
         db_request.GET.update({"token": "RANDOM_KEY"})
         db_request.route_path = pretend.call_recorder(lambda *a, **kw: "/")
-        db_request.remote_addr = "192.168.1.1"
+        db_request.remote_addr = "192.0.2.1"
         token_service.loads = pretend.call_recorder(
             lambda token: {
                 "action": "email-project-role-verify",
@@ -3464,7 +3464,7 @@ class TestVerifyProjectRole:
         db_request.method = "POST"
         db_request.GET.update({"token": "RANDOM_KEY"})
         db_request.route_path = pretend.call_recorder(lambda name: "/")
-        db_request.remote_addr = "192.168.1.1"
+        db_request.remote_addr = "192.0.2.1"
         token_service.loads = pretend.call_recorder(
             lambda token: {
                 "action": "email-project-role-verify",
@@ -3504,7 +3504,7 @@ class TestVerifyProjectRole:
         db_request.method = "POST"
         db_request.POST.update({"token": "RANDOM_KEY", "decline": "Decline"})
         db_request.route_path = pretend.call_recorder(lambda name: "/")
-        db_request.remote_addr = "192.168.1.1"
+        db_request.remote_addr = "192.0.2.1"
         token_service.loads = pretend.call_recorder(
             lambda token: {
                 "action": "email-project-role-verify",
@@ -3545,7 +3545,7 @@ class TestVerifyProjectRole:
         db_request.method = "POST"
         db_request.GET.update({"token": "RANDOM_KEY"})
         db_request.route_path = pretend.call_recorder(lambda name: "/")
-        db_request.remote_addr = "192.168.1.1"
+        db_request.remote_addr = "192.0.2.1"
         token_service.loads = pretend.call_recorder(
             lambda token: {
                 "action": "email-project-role-verify",
@@ -3583,7 +3583,7 @@ class TestVerifyProjectRole:
         db_request.method = "POST"
         db_request.GET.update({"token": "RANDOM_KEY"})
         db_request.route_path = pretend.call_recorder(lambda name: "/")
-        db_request.remote_addr = "192.168.1.1"
+        db_request.remote_addr = "192.0.2.1"
         token_service.loads = pretend.call_recorder(
             lambda token: {
                 "action": "email-project-role-verify",
@@ -3619,7 +3619,7 @@ class TestVerifyProjectRole:
         db_request.method = "POST"
         db_request.GET.update({"token": "RANDOM_KEY"})
         db_request.route_path = pretend.call_recorder(lambda name: "/")
-        db_request.remote_addr = "192.168.1.1"
+        db_request.remote_addr = "192.0.2.1"
         token_service.loads = pretend.call_recorder(
             lambda token: {
                 "action": "email-project-role-verify",
@@ -3658,7 +3658,7 @@ class TestVerifyProjectRole:
         db_request.method = "GET"
         db_request.GET.update({"token": "RANDOM_KEY"})
         db_request.route_path = pretend.call_recorder(lambda name: "/")
-        db_request.remote_addr = "192.168.1.1"
+        db_request.remote_addr = "192.0.2.1"
         token_service.loads = pretend.call_recorder(
             lambda token: {
                 "action": "email-project-role-verify",

--- a/tests/unit/cache/origin/test_fastly.py
+++ b/tests/unit/cache/origin/test_fastly.py
@@ -144,7 +144,7 @@ class TestFastlyCache:
         request = pretend.stub(
             registry=pretend.stub(
                 settings={
-                    "origin_cache.api_connect_via": "172.16.0.1",
+                    "origin_cache.api_connect_via": "198.51.100.1",
                     "origin_cache.api_key": "the api key",
                     "origin_cache.service_id": "the service id",
                 }
@@ -154,7 +154,7 @@ class TestFastlyCache:
         cacher = fastly.FastlyCache.create_service(None, request)
         assert isinstance(cacher, fastly.FastlyCache)
         assert cacher.api_endpoint == "https://api.fastly.com"
-        assert cacher.api_connect_via == "172.16.0.1"
+        assert cacher.api_connect_via == "198.51.100.1"
         assert cacher.api_key == "the api key"
         assert cacher.service_id == "the service id"
         assert cacher._purger is purge_key.delay
@@ -279,7 +279,7 @@ class TestFastlyCache:
 
     @pytest.mark.parametrize(
         ("connect_via", "forced_ip_https_adapter_calls"),
-        [(None, []), ("172.16.0.1", [pretend.call(dest_ip="172.16.0.1")])],
+        [(None, []), ("198.51.100.1", [pretend.call(dest_ip="198.51.100.1")])],
     )
     def test__purge_key_ok(
         self, monkeypatch, connect_via, forced_ip_https_adapter_calls
@@ -339,8 +339,8 @@ class TestFastlyCache:
         [
             (None, [], {"status": "fail"}),
             (None, [], {}),
-            ("172.16.0.1", [pretend.call(dest_ip="172.16.0.1")], {"status": "fail"}),
-            ("172.16.0.1", [pretend.call(dest_ip="172.16.0.1")], {}),
+            ("198.51.100.1", [pretend.call(dest_ip="198.51.100.1")], {"status": "fail"}),
+            ("198.51.100.1", [pretend.call(dest_ip="198.51.100.1")], {}),
         ],
     )
     def test__purge_key_unsuccessful(
@@ -407,10 +407,10 @@ class TestFastlyCache:
                 ],
             ),
             (
-                "172.16.0.1",
+                "198.51.100.1",
                 [
-                    pretend.call("one", connect_via="172.16.0.1"),
-                    pretend.call("one", connect_via="172.16.0.1"),
+                    pretend.call("one", connect_via="198.51.100.1"),
+                    pretend.call("one", connect_via="198.51.100.1"),
                 ],
             ),
         ],
@@ -441,9 +441,9 @@ class TestFastlyCache:
                 ],
             ),
             (
-                "172.16.0.1",
+                "198.51.100.1",
                 [
-                    pretend.call("one", connect_via="172.16.0.1"),
+                    pretend.call("one", connect_via="198.51.100.1"),
                 ],
             ),
         ],
@@ -480,10 +480,10 @@ class TestFastlyCache:
                 ],
             ),
             (
-                "172.16.0.1",
+                "198.51.100.1",
                 [
-                    pretend.call("one", connect_via="172.16.0.1"),
-                    pretend.call("one", connect_via="172.16.0.1"),
+                    pretend.call("one", connect_via="198.51.100.1"),
+                    pretend.call("one", connect_via="198.51.100.1"),
                 ],
             ),
         ],
@@ -513,32 +513,32 @@ class TestFastlyCache:
         ("connect_via", "purge_key_mock_effects", "purge_key_calls", "metrics_calls"),
         [
             (
-                "172.16.0.1",
+                "198.51.100.1",
                 [requests.ConnectionError, None, None],
                 [
-                    pretend.call("one", connect_via="172.16.0.1"),
+                    pretend.call("one", connect_via="198.51.100.1"),
                     pretend.call("one", connect_via=None),
                     pretend.call("one", connect_via=None),
                 ],
                 [
                     pretend.call(
                         "warehouse.cache.origin.fastly.connect_via.failed",
-                        tags=["ip_address:172.16.0.1"],
+                        tags=["ip_address:198.51.100.1"],
                     )
                 ],
             ),
             (
-                "172.16.0.1",
+                "198.51.100.1",
                 [requests.exceptions.SSLError, None, None],
                 [
-                    pretend.call("one", connect_via="172.16.0.1"),
+                    pretend.call("one", connect_via="198.51.100.1"),
                     pretend.call("one", connect_via=None),
                     pretend.call("one", connect_via=None),
                 ],
                 [
                     pretend.call(
                         "warehouse.cache.origin.fastly.connect_via.failed",
-                        tags=["ip_address:172.16.0.1"],
+                        tags=["ip_address:198.51.100.1"],
                     )
                 ],
             ),
@@ -598,10 +598,10 @@ class TestFastlyCache:
                 [pretend.call("one", connect_via=None)],
             ),
             (
-                "172.16.0.1",
+                "198.51.100.1",
                 [fastly.UnsuccessfulPurgeError, None, None],
                 fastly.UnsuccessfulPurgeError,
-                [pretend.call("one", connect_via="172.16.0.1")],
+                [pretend.call("one", connect_via="198.51.100.1")],
             ),
         ],
     )


### PR DESCRIPTION
## Summary

Replace non-RFC-5735 compliant private IP addresses with properly reserved TEST-NET addresses in unit tests:

-  →  (TEST-NET-1, 192.0.2.0/24) — in tests/unit/accounts/test_views.py (13 occurrences)
-  →  (TEST-NET-2, 198.51.100.0/24) — in tests/unit/cache/origin/test_fastly.py (24 occurrences)

Per [RFC-5735](https://www.rfc-editor.org/rfc/rfc5735), the TEST-NET blocks are:
- 192.0.2.0/24 (TEST-NET-1)
- 198.51.100.0/24 (TEST-NET-2)  
- 203.0.113.0/24 (TEST-NET-3)

## Motivation

As noted in [#13164 (comment)](https://github.com/pypi/warehouse/pull/13164#discussion_r1131763629), using RFC-5735 TEST-NET addresses in tests is preferred over private addressing space (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16).

Closes #13186