### PR TITLE
Change "Latest version" badge to "Latest release"

### DIFF
--- a/warehouse/templates/packaging/detail.html
+++ b/warehouse/templates/packaging/detail.html
@@ -183,7 +183,7 @@
           {% else %}
             <a class="status-badge status-badge--good"
                href="{{ request.route_path('packaging.project', name=release.project.name) }}">
-              <span>{% trans %}Latest version{% endtrans %}</span>
+              <span>{% trans %}Latest release{% endtrans %}</span>
             </a>
           {% endif %}
         {% endif %}


### PR DESCRIPTION
## Summary

Updates the status badge text from "Latest version" to "Latest release" to match the documentation guidelines at [warehouse.pypa.io/ui-principles/#4-write-clearly-with-consistent-style-and-terminology](https://warehouse.pypa.io/ui-principles/#4-write-clearly-with-consistent-style-and-terminology).

Fixes #19956

## Changes
- `warehouse/templates/packaging/detail.html`: Changed `{% trans %}Latest version{% endtrans %}` to `{% trans %}Latest release{% endtrans %}` in the status badge