### PR TITLE
chore(dependabot): test grouped updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,10 @@ updates:
       # Keep both psycopg and psycopg-c together
       patterns:
         - "psycopg*"
+    python-packages:
+      # Group all remaining packages together
+      patterns:
+        - "*"
   cooldown:
     default-days: 7
 - package-ecosystem: github-actions


### PR DESCRIPTION
Try grouping "everything else" again.
Attempted two years ago in #15920 and reverted in #15932 after unsuccessful runs.

If this works consistently for a couple of days, remove the "Combine PRs" manual action, and remove any other pieces for it.

Refs: #15909