### PR TITLE
Revert "set a TLDEXTRACT_CACHE environment variable"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -182,10 +182,9 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 FROM python:${PYTHON_IMAGE_VERSION}
 
 # Setup some basic environment variables that are ~never going to change.
-ENV PYTHONUNBUFFERED=1
-ENV PYTHONPATH=/opt/warehouse/src/
+ENV PYTHONUNBUFFERED 1
+ENV PYTHONPATH /opt/warehouse/src/
 ENV PATH="/opt/warehouse/bin:${PATH}"
-ENV TLDEXTRACT_CACHE="/var/cache/tldextract"
 
 WORKDIR /opt/warehouse/src/
 


### PR DESCRIPTION
Reverts pypi/warehouse#20003

Failed in production with https://python-software-foundation.sentry.io/issues/7465813661/events/64e6113b59854715bd89a00de5aeba69/