### PR TITLE
Stabilize email form tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@ from unittest import mock
 
 import alembic.command
 import click.testing
+import email_validator
 import pretend
 import pyramid.testing
 import pytest
@@ -119,6 +120,25 @@ def metrics():
                 metric=metric, tags=tags, sample_rate=sample_rate, use_ms=use_ms
             )
         ),
+    )
+
+
+@pytest.fixture
+def no_email_deliverability_check(monkeypatch):
+    """
+    Prevents unit tests from depending on live email deliverability DNS lookups.
+    """
+    original_validate_email = email_validator.validate_email
+
+    def validate_email_without_deliverability(
+        email, check_deliverability=True, *args, **kwargs
+    ):
+        return original_validate_email(
+            email, check_deliverability=False, *args, **kwargs
+        )
+
+    monkeypatch.setattr(
+        email_validator, "validate_email", validate_email_without_deliverability
     )
 
 

--- a/tests/unit/accounts/test_forms.py
+++ b/tests/unit/accounts/test_forms.py
@@ -3,7 +3,6 @@
 import datetime
 import json
 
-import email_validator
 import pretend
 import pytest
 import wtforms
@@ -439,22 +438,8 @@ class TestLoginForm:
         assert user_service.check_password.calls == []
 
 
-@pytest.fixture
-def _no_deliverability_check(monkeypatch):
-    """
-    Prevents the email_validator library from checking deliverability of email
-    """
-    original_validate_email = email_validator.validate_email  # recursion prevention
-
-    def mock_validate_email(email, check_deliverability=True, *args, **kwargs):
-        return original_validate_email(
-            email, check_deliverability=False, *args, **kwargs
-        )
-
-    monkeypatch.setattr("email_validator.validate_email", mock_validate_email)
-
-
 class TestRegistrationForm:
+    @pytest.mark.usefixtures("no_email_deliverability_check")
     def test_validate(self, metrics):
         captcha_service = pretend.stub(
             enabled=False,
@@ -580,6 +565,7 @@ class TestRegistrationForm:
             str(form.email.errors.pop()) == "The email address isn't valid. Try again."
         )
 
+    @pytest.mark.usefixtures("no_email_deliverability_check")
     def test_exotic_email_success(self, metrics):
         form = forms.RegistrationForm(
             request=pretend.stub(
@@ -597,6 +583,7 @@ class TestRegistrationForm:
         form.validate()
         assert len(form.email.errors) == 0
 
+    @pytest.mark.usefixtures("no_email_deliverability_check")
     def test_email_exists_error(self, pyramid_request):
         pyramid_request.db = pretend.stub(
             query=lambda *a: pretend.stub(scalar=lambda: False)
@@ -618,6 +605,7 @@ class TestRegistrationForm:
             "Use a different email."
         )
 
+    @pytest.mark.usefixtures("no_email_deliverability_check")
     def test_disposable_email_error(self, pyramid_request):
         form = forms.RegistrationForm(
             request=pyramid_request,
@@ -636,7 +624,7 @@ class TestRegistrationForm:
             "different email."
         )
 
-    @pytest.mark.usefixtures("_no_deliverability_check")
+    @pytest.mark.usefixtures("no_email_deliverability_check")
     @pytest.mark.parametrize(
         ("email", "prohibited_domain"),
         [

--- a/tests/unit/accounts/test_views.py
+++ b/tests/unit/accounts/test_views.py
@@ -1901,6 +1901,7 @@ class TestRegister:
         assert add_email.calls == []
         assert send_email.calls == []
 
+    @pytest.mark.usefixtures("no_email_deliverability_check")
     def test_register_redirect(self, db_request, monkeypatch):
         db_request.method = "POST"
 

--- a/tests/unit/manage/test_forms.py
+++ b/tests/unit/manage/test_forms.py
@@ -163,6 +163,7 @@ class TestSaveAccountForm:
 
 
 class TestAddEmailForm:
+    @pytest.mark.usefixtures("no_email_deliverability_check")
     def test_validate(self, metrics):
         user_id = pretend.stub()
         user_service = pretend.stub(find_userid_by_email=lambda _: None)
@@ -180,6 +181,7 @@ class TestAddEmailForm:
         assert form.user_service is user_service
         assert form.validate(), str(form.errors)
 
+    @pytest.mark.usefixtures("no_email_deliverability_check")
     def test_email_exists_error(self, pyramid_request):
         pyramid_request.db = pretend.stub(
             query=lambda *a: pretend.stub(scalar=lambda: False)
@@ -199,6 +201,7 @@ class TestAddEmailForm:
             "Use a different email."
         )
 
+    @pytest.mark.usefixtures("no_email_deliverability_check")
     def test_email_exists_other_account_error(self, pyramid_request):
         pyramid_request.db = pretend.stub(
             query=lambda *a: pretend.stub(scalar=lambda: False)
@@ -217,6 +220,7 @@ class TestAddEmailForm:
             "Use a different email."
         )
 
+    @pytest.mark.usefixtures("no_email_deliverability_check")
     def test_prohibited_email_error(self, pyramid_request):
         pyramid_request.db = pretend.stub(
             query=lambda *a: pretend.stub(scalar=lambda: False)
@@ -354,6 +358,7 @@ class TestAddEmailForm:
 
 
 class TestChangeUnverifiedPrimaryEmailForm:
+    @pytest.mark.usefixtures("no_email_deliverability_check")
     def test_validate(self, metrics):
         user_id = pretend.stub()
         user_service = pretend.stub(find_userid_by_email=lambda _: None)


### PR DESCRIPTION
Avoid live deliverability DNS lookups in tests that only need syntactically valid addresses, while keeping MX-specific coverage explicitly mocked.