### PR TITLE
feat: add source commit to html

### DIFF
--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -1105,14 +1105,14 @@ msgstr ""
 
 #: warehouse/templates/404.html:33 warehouse/templates/500.html:18
 #: warehouse/templates/accounts/two-factor.html:35
-#: warehouse/templates/base.html:340 warehouse/templates/base.html:346
-#: warehouse/templates/base.html:352 warehouse/templates/base.html:358
-#: warehouse/templates/base.html:374 warehouse/templates/base.html:380
-#: warehouse/templates/base.html:405 warehouse/templates/base.html:411
-#: warehouse/templates/base.html:420 warehouse/templates/base.html:433
-#: warehouse/templates/base.html:442 warehouse/templates/base.html:448
-#: warehouse/templates/base.html:454 warehouse/templates/base.html:467
-#: warehouse/templates/base.html:484
+#: warehouse/templates/base.html:342 warehouse/templates/base.html:348
+#: warehouse/templates/base.html:354 warehouse/templates/base.html:360
+#: warehouse/templates/base.html:376 warehouse/templates/base.html:382
+#: warehouse/templates/base.html:407 warehouse/templates/base.html:413
+#: warehouse/templates/base.html:422 warehouse/templates/base.html:435
+#: warehouse/templates/base.html:444 warehouse/templates/base.html:450
+#: warehouse/templates/base.html:456 warehouse/templates/base.html:469
+#: warehouse/templates/base.html:486 warehouse/templates/base.html:494
 #: warehouse/templates/includes/accounts/profile-callout.html:17
 #: warehouse/templates/includes/file-details.html:129
 #: warehouse/templates/index.html:98 warehouse/templates/index.html:105
@@ -1266,7 +1266,7 @@ msgid "Main navigation"
 msgstr ""
 
 #: warehouse/templates/base.html:34 warehouse/templates/base.html:68
-#: warehouse/templates/base.html:335
+#: warehouse/templates/base.html:337
 #: warehouse/templates/includes/current-user-indicator.html:77
 #: warehouse/templates/pages/help.html:209
 #: warehouse/templates/pages/sitemap.html:19
@@ -1342,16 +1342,16 @@ msgstr ""
 msgid "RSS: 40 newest packages"
 msgstr ""
 
-#: warehouse/templates/base.html:206
+#: warehouse/templates/base.html:208
 msgid "Skip to main content"
 msgstr ""
 
-#: warehouse/templates/base.html:210
+#: warehouse/templates/base.html:212
 msgid "Switch to mobile version"
 msgstr ""
 
-#: warehouse/templates/base.html:217 warehouse/templates/base.html:226
-#: warehouse/templates/base.html:236
+#: warehouse/templates/base.html:219 warehouse/templates/base.html:228
+#: warehouse/templates/base.html:238
 #: warehouse/templates/includes/flash-messages.html:41
 #: warehouse/templates/includes/session-notifications.html:19
 #: warehouse/templates/manage/account.html:1011
@@ -1368,177 +1368,184 @@ msgstr ""
 msgid "Warning"
 msgstr ""
 
-#: warehouse/templates/base.html:219
+#: warehouse/templates/base.html:221
 msgid "You are using an unsupported browser, upgrade to a newer version."
 msgstr ""
 
-#: warehouse/templates/base.html:228
+#: warehouse/templates/base.html:230
 msgid ""
 "You are using TestPyPI – a separate instance of the Python Package Index "
 "that allows you to try distribution tools and processes without affecting"
 " the real index."
 msgstr ""
 
-#: warehouse/templates/base.html:238
+#: warehouse/templates/base.html:240
 msgid ""
 "Some features may not work without JavaScript. Please try enabling it if "
 "you encounter problems."
 msgstr ""
 
-#: warehouse/templates/base.html:273 warehouse/templates/base.html:305
+#: warehouse/templates/base.html:275 warehouse/templates/base.html:307
 #: warehouse/templates/error-base-with-search.html:8
 #: warehouse/templates/index.html:29
 msgid "Search PyPI"
 msgstr ""
 
-#: warehouse/templates/base.html:278 warehouse/templates/index.html:35
+#: warehouse/templates/base.html:280 warehouse/templates/index.html:35
 msgid "Type '/' to search projects"
 msgstr ""
 
-#: warehouse/templates/base.html:289 warehouse/templates/base.html:318
+#: warehouse/templates/base.html:291 warehouse/templates/base.html:320
 #: warehouse/templates/error-base-with-search.html:19
 #: warehouse/templates/index.html:44
 msgid "Search"
 msgstr ""
 
-#: warehouse/templates/base.html:310
+#: warehouse/templates/base.html:312
 #: warehouse/templates/error-base-with-search.html:13
 msgid "Search projects"
 msgstr ""
 
-#: warehouse/templates/base.html:336
+#: warehouse/templates/base.html:338
 msgid "Help navigation"
 msgstr ""
 
-#: warehouse/templates/base.html:342
+#: warehouse/templates/base.html:344
 msgid "Installing packages"
 msgstr ""
 
-#: warehouse/templates/base.html:348
+#: warehouse/templates/base.html:350
 msgid "Uploading packages"
 msgstr ""
 
-#: warehouse/templates/base.html:354
+#: warehouse/templates/base.html:356
 msgid "User guide"
 msgstr ""
 
-#: warehouse/templates/base.html:360
+#: warehouse/templates/base.html:362
 msgid "Project name retention"
 msgstr ""
 
-#: warehouse/templates/base.html:363
+#: warehouse/templates/base.html:365
 msgid "FAQs"
 msgstr ""
 
-#: warehouse/templates/base.html:369 warehouse/templates/pages/sitemap.html:34
+#: warehouse/templates/base.html:371 warehouse/templates/pages/sitemap.html:34
 msgid "About PyPI"
 msgstr ""
 
-#: warehouse/templates/base.html:370
+#: warehouse/templates/base.html:372
 msgid "About PyPI navigation"
 msgstr ""
 
-#: warehouse/templates/base.html:376
+#: warehouse/templates/base.html:378
 msgid "PyPI Blog"
 msgstr ""
 
-#: warehouse/templates/base.html:382
+#: warehouse/templates/base.html:384
 msgid "Infrastructure dashboard"
 msgstr ""
 
-#: warehouse/templates/base.html:385 warehouse/templates/pages/sitemap.html:40
+#: warehouse/templates/base.html:387 warehouse/templates/pages/sitemap.html:40
 #: warehouse/templates/pages/stats.html:4
 msgid "Statistics"
 msgstr ""
 
-#: warehouse/templates/base.html:388
+#: warehouse/templates/base.html:390
 msgid "Logos & trademarks"
 msgstr ""
 
-#: warehouse/templates/base.html:391
+#: warehouse/templates/base.html:393
 msgid "Our sponsors"
 msgstr ""
 
-#: warehouse/templates/base.html:397
+#: warehouse/templates/base.html:399
 msgid "Contributing to PyPI"
 msgstr ""
 
-#: warehouse/templates/base.html:398
+#: warehouse/templates/base.html:400
 msgid "How to contribute navigation"
 msgstr ""
 
-#: warehouse/templates/base.html:401
+#: warehouse/templates/base.html:403
 msgid "Bugs and feedback"
 msgstr ""
 
-#: warehouse/templates/base.html:407
+#: warehouse/templates/base.html:409
 msgid "Contribute on GitHub"
 msgstr ""
 
-#: warehouse/templates/base.html:413
+#: warehouse/templates/base.html:415
 msgid "Translate PyPI"
 msgstr ""
 
-#: warehouse/templates/base.html:416
+#: warehouse/templates/base.html:418
 msgid "Sponsor PyPI"
 msgstr ""
 
-#: warehouse/templates/base.html:422
+#: warehouse/templates/base.html:424
 msgid "Development credits"
 msgstr ""
 
-#: warehouse/templates/base.html:428 warehouse/templates/pages/sitemap.html:10
+#: warehouse/templates/base.html:430 warehouse/templates/pages/sitemap.html:10
 msgid "Using PyPI"
 msgstr ""
 
-#: warehouse/templates/base.html:429
+#: warehouse/templates/base.html:431
 msgid "Using PyPI navigation"
 msgstr ""
 
-#: warehouse/templates/base.html:435
+#: warehouse/templates/base.html:437
 #: warehouse/templates/manage/organization/activate_subscription.html:21
 msgid "Terms of Service"
 msgstr ""
 
-#: warehouse/templates/base.html:438
+#: warehouse/templates/base.html:440
 msgid "Report security issue"
 msgstr ""
 
-#: warehouse/templates/base.html:444
+#: warehouse/templates/base.html:446
 msgid "Code of conduct"
 msgstr ""
 
-#: warehouse/templates/base.html:450
+#: warehouse/templates/base.html:452
 msgid "Privacy Notice"
 msgstr ""
 
-#: warehouse/templates/base.html:456
+#: warehouse/templates/base.html:458
 msgid "Acceptable Use Policy"
 msgstr ""
 
-#: warehouse/templates/base.html:466
+#: warehouse/templates/base.html:468
 msgid "Status:"
 msgstr ""
 
-#: warehouse/templates/base.html:470
+#: warehouse/templates/base.html:472
 msgid "all systems operational"
 msgstr ""
 
-#: warehouse/templates/base.html:474
+#: warehouse/templates/base.html:476
 msgid ""
 "Developed and maintained by the Python community, for the Python "
 "community."
 msgstr ""
 
-#: warehouse/templates/base.html:476
+#: warehouse/templates/base.html:478
 msgid "Donate today!"
 msgstr ""
 
-#: warehouse/templates/base.html:488 warehouse/templates/pages/sitemap.html:4
+#: warehouse/templates/base.html:490 warehouse/templates/pages/sitemap.html:4
 msgid "Site map"
 msgstr ""
 
-#: warehouse/templates/base.html:495
+#: warehouse/templates/base.html:494
+#, python-format
+msgid ""
+"Deployed from <a href=\"%(href)s\" title=\"%(title)s\" target=\"_blank\" "
+"rel=\"noopener\"><code>%(sha)s</code></a>"
+msgstr ""
+
+#: warehouse/templates/base.html:502
 msgid "Switch to desktop version"
 msgstr ""
 

--- a/warehouse/templates/base.html
+++ b/warehouse/templates/base.html
@@ -160,6 +160,8 @@
     <meta property="og:title"
           content="{{ self.title() |default('Python Package Index') }}">
     <meta property="og:description" content="{{ self.description() }}">
+    {% set source_commit = request.registry.settings.get("warehouse.commit") %}
+    {% if source_commit and source_commit != "null" %}<meta name="source-commit" content="{{ source_commit }}">{% endif %}
     {% block extra_meta %}{% endblock %}
     <link rel="search"
           type="application/opensearchdescription+xml"
@@ -487,6 +489,11 @@
     <br>
     <a href="{{ request.route_path('sitemap') }}">{% trans %}Site map{% endtrans %}</a>
   </p>
+  {% if source_commit and source_commit != "null" %}
+    <p>
+      {% trans href='https://github.com/pypi/warehouse/commit/' ~ source_commit, sha=source_commit[:7], title=gettext('External link') %}Deployed from <a href="{{ href }}" title="{{ title }}" target="_blank" rel="noopener"><code>{{ sha }}</code></a>{% endtrans %}
+    </p>
+  {% endif %}
 </div>
 <div class="centered hide-on-desktop">
   <button type="button"


### PR DESCRIPTION
It is advantageous to be able to ascertain from the HTML ether one is looking at the version of code deployed to a given page, especially if deployment fails or caches are not expired post-deploy.

By adding the already-available commit ID we gain the ability to inspect that we are "current" or not from the rendered HTML - both in a meta header for anyone scripting, or in the footer for anyone looking.