### PR TITLE
fix: silence gunicorn startup noise

### DIFF
--- a/gunicorn-prod.conf.py
+++ b/gunicorn-prod.conf.py
@@ -19,6 +19,13 @@ access_log_format = (
 
 statsd_host = "localhost:8125"
 
+# Disable remote control of the daemon
+# On startup, tries to write to `/`, and it does not have permission to,
+# raising an exception, but allowing the server to start.
+# Instead of overwriting `XDG_RUNTIME_DIR` to a writable target,
+# which could affect other code, disable the interface as we are unlikely to need it.
+control_socket_disable = True
+
 
 def when_ready(server):
     open("/tmp/app-initialized", "w").close()

--- a/gunicorn-uploads.conf.py
+++ b/gunicorn-uploads.conf.py
@@ -22,6 +22,13 @@ access_log_format = (
 
 statsd_host = "localhost:8125"
 
+# Disable remote control of the daemon
+# On startup, tries to write to `/`, and it does not have permission to,
+# raising an exception, but allowing the server to start.
+# Instead of overwriting `XDG_RUNTIME_DIR` to a writable target,
+# which could affect other code, disable the interface as we are unlikely to need it.
+control_socket_disable = True
+
 
 def when_ready(server):
     open("/tmp/app-initialized", "w").close()


### PR DESCRIPTION
We don't need the new interface that showed up in 25.1.0, and it's noisy.

Fixes WAREHOUSE-PRODUCTION-2GK