### PR TITLE
feat: enable per-Release quarantine

### DIFF
--- a/tests/unit/admin/test_routes.py
+++ b/tests/unit/admin/test_routes.py
@@ -317,6 +317,20 @@ def test_includeme():
             domain=warehouse,
         ),
         pretend.call(
+            "admin.project.release.quarantine",
+            "/admin/projects/{project_name}/release/{version}/quarantine/",
+            factory="warehouse.packaging.models:ProjectFactory",
+            traverse="/{project_name}/{version}",
+            domain=warehouse,
+        ),
+        pretend.call(
+            "admin.project.release.remove_from_quarantine",
+            "/admin/projects/{project_name}/release/{version}/remove_from_quarantine/",
+            factory="warehouse.packaging.models:ProjectFactory",
+            traverse="/{project_name}/{version}",
+            domain=warehouse,
+        ),
+        pretend.call(
             "admin.project.remove_from_quarantine",
             "/admin/projects/{project_name}/remove_from_quarantine/",
             factory="warehouse.packaging.models:ProjectFactory",

--- a/tests/unit/admin/views/test_projects.py
+++ b/tests/unit/admin/views/test_projects.py
@@ -365,6 +365,49 @@ class TestProjectQuarantine:
             )
         ]
 
+    def test_release_quarantine(self, db_request):
+        project = ProjectFactory.create()
+        release = ReleaseFactory.create(project=project, version="1.0")
+        db_request.route_path = pretend.call_recorder(
+            lambda *a, **kw: "/admin/projects/release/"
+        )
+        db_request.session = pretend.stub(
+            flash=pretend.call_recorder(lambda *a, **kw: None)
+        )
+        db_request.user = UserFactory.create()
+
+        result = views.release_quarantine(release, db_request)
+
+        assert result.status_code == 303
+        assert release.lifecycle_status == LifecycleStatus.QuarantineEnter
+        assert db_request.route_path.calls == [
+            pretend.call(
+                "admin.project.release",
+                project_name=project.normalized_name,
+                version=release.version,
+            )
+        ]
+
+    def test_release_remove_from_quarantine(self, db_request):
+        project = ProjectFactory.create()
+        release = ReleaseFactory.create(
+            project=project,
+            version="1.0",
+            lifecycle_status=LifecycleStatus.QuarantineEnter,
+        )
+        db_request.route_path = pretend.call_recorder(
+            lambda *a, **kw: "/admin/projects/release/"
+        )
+        db_request.session = pretend.stub(
+            flash=pretend.call_recorder(lambda *a, **kw: None)
+        )
+        db_request.user = UserFactory.create()
+
+        result = views.release_remove_from_quarantine(release, db_request)
+
+        assert result.status_code == 303
+        assert release.lifecycle_status == LifecycleStatus.QuarantineExit
+
 
 class TestProjectReleasesList:
     def test_no_query(self, db_request):

--- a/tests/unit/admin/views/test_quarantine.py
+++ b/tests/unit/admin/views/test_quarantine.py
@@ -5,14 +5,17 @@ from datetime import UTC
 from warehouse.admin.views import quarantine
 from warehouse.packaging.models import LifecycleStatus
 
-from ....common.db.packaging import ProjectFactory
+from ....common.db.packaging import ProjectFactory, ReleaseFactory
 
 
 class TestQuarantineList:
     def test_quarantine_list_no_projects(self, db_request):
         """Test quarantine list view when no projects are quarantined"""
         result = quarantine.quarantine_list(db_request)
-        assert result == {"quarantined_projects": []}
+        assert result == {
+            "quarantined_projects": [],
+            "quarantined_releases": [],
+        }
 
     def test_quarantine_list_with_projects(self, db_request):
         """Test quarantine list view with quarantined projects"""
@@ -97,3 +100,41 @@ class TestQuarantineList:
         # Should only return projects entering quarantine
         assert len(result["quarantined_projects"]) == 1
         assert result["quarantined_projects"][0].name == entering_quarantine.name
+
+    def test_quarantine_list_includes_releases(self, db_request):
+        """Quarantined releases appear separately from quarantined projects."""
+        project = ProjectFactory.create()
+        quarantined_release = ReleaseFactory.create(
+            project=project,
+            version="1.0",
+            lifecycle_status=LifecycleStatus.QuarantineEnter,
+            lifecycle_status_note="Quarantined release",
+        )
+        # A release that has been cleared should not appear.
+        ReleaseFactory.create(
+            project=project,
+            version="2.0",
+            lifecycle_status=LifecycleStatus.QuarantineExit,
+        )
+
+        result = quarantine.quarantine_list(db_request)
+
+        assert result["quarantined_projects"] == []
+        assert len(result["quarantined_releases"]) == 1
+        assert result["quarantined_releases"][0].id == quarantined_release.id
+
+    def test_quarantine_list_skips_releases_of_quarantined_projects(self, db_request):
+        """Releases of a quarantined project are not double-listed."""
+        project = ProjectFactory.create(
+            lifecycle_status=LifecycleStatus.QuarantineEnter
+        )
+        ReleaseFactory.create(
+            project=project,
+            version="1.0",
+            lifecycle_status=LifecycleStatus.QuarantineEnter,
+        )
+
+        result = quarantine.quarantine_list(db_request)
+
+        assert len(result["quarantined_projects"]) == 1
+        assert result["quarantined_releases"] == []

--- a/tests/unit/api/test_simple.py
+++ b/tests/unit/api/test_simple.py
@@ -526,6 +526,40 @@ class TestSimpleDetail:
         ("content_type", "renderer_override"),
         CONTENT_TYPE_PARAMS,
     )
+    def test_with_quarantined_release_omitted(
+        self, db_request, content_type, renderer_override
+    ):
+        """A release with lifecycle_status=quarantine-enter is excluded from
+        the simple detail, but other releases of the same project remain."""
+        db_request.accept = content_type
+        project = ProjectFactory.create()
+        good_release = ReleaseFactory.create(project=project, version="1.0")
+        quarantined_release = ReleaseFactory.create(
+            project=project,
+            version="2.0",
+            lifecycle_status="quarantine-enter",
+        )
+        good_file = FileFactory.create(
+            release=good_release, filename=f"{project.name}-1.0.tar.gz"
+        )
+        FileFactory.create(
+            release=quarantined_release,
+            filename=f"{project.name}-2.0.tar.gz",
+        )
+
+        db_request.matchdict["name"] = project.normalized_name
+        db_request.route_url = lambda *a, **kw: f"/file/{good_file.filename}"
+
+        result = simple.simple_detail(project, db_request)
+
+        assert result["versions"] == ["1.0"]
+        assert len(result["files"]) == 1
+        assert result["files"][0]["filename"] == good_file.filename
+
+    @pytest.mark.parametrize(
+        ("content_type", "renderer_override"),
+        CONTENT_TYPE_PARAMS,
+    )
     def test_with_quarantine_exit_project(
         self, db_request, content_type, renderer_override
     ):

--- a/tests/unit/manage/test_views.py
+++ b/tests/unit/manage/test_views.py
@@ -4353,12 +4353,57 @@ class TestManageProjectRelease:
             "files": files,
         }
 
+    @pytest.mark.parametrize(
+        "method",
+        [
+            "yank_project_release",
+            "unyank_project_release",
+            "delete_project_release",
+            "delete_project_release_file",
+        ],
+    )
+    def test_release_mutations_blocked_when_quarantined(self, pyramid_request, method):
+        release = pretend.stub(
+            version="1.2.3",
+            lifecycle_status=LifecycleStatus.QuarantineEnter,
+            yanked=False,
+            project=pretend.stub(name="foobar"),
+        )
+        pyramid_request.route_path = pretend.call_recorder(
+            lambda *a, **kw: "/the-redirect"
+        )
+        pyramid_request.session = pretend.stub(
+            flash=pretend.call_recorder(lambda *a, **kw: None)
+        )
+
+        view = views.ManageProjectRelease(release, pyramid_request)
+        result = getattr(view, method)()
+
+        assert isinstance(result, HTTPSeeOther)
+        assert result.headers["Location"] == "/the-redirect"
+        assert pyramid_request.session.flash.calls == [
+            pretend.call(
+                "This release is in quarantine and cannot be modified.",
+                queue="error",
+            )
+        ]
+        assert pyramid_request.route_path.calls == [
+            pretend.call(
+                "manage.project.release",
+                project_name=release.project.name,
+                version=release.version,
+            )
+        ]
+        # Yank state is untouched
+        assert release.yanked is False
+
     def test_delete_project_release_disallow_deletion(
         self, monkeypatch, pyramid_request
     ):
         release = pretend.stub(
             version="1.2.3",
             canonical_version="1.2.3",
+            lifecycle_status=None,
             project=pretend.stub(
                 name="foobar", record_event=pretend.call_recorder(lambda *a, **kw: None)
             ),
@@ -4482,6 +4527,7 @@ class TestManageProjectRelease:
             project=pretend.stub(name="foobar"),
             yanked=False,
             yanked_reason="",
+            lifecycle_status=None,
         )
         pyramid_request.POST = {"confirm_yank_version": ""}
         pyramid_request.method = "POST"
@@ -4521,6 +4567,7 @@ class TestManageProjectRelease:
             project=pretend.stub(name="foobar"),
             yanked=False,
             yanked_reason="",
+            lifecycle_status=None,
         )
         pyramid_request.POST = {"confirm_yank_version": "invalid"}
         pyramid_request.method = "POST"
@@ -4636,6 +4683,7 @@ class TestManageProjectRelease:
             project=pretend.stub(name="foobar"),
             yanked=True,
             yanked_reason="",
+            lifecycle_status=None,
         )
         pyramid_request.POST = {
             "confirm_unyank_version": "",
@@ -4678,6 +4726,7 @@ class TestManageProjectRelease:
             project=pretend.stub(name="foobar"),
             yanked=True,
             yanked_reason="Old reason",
+            lifecycle_status=None,
         )
         pyramid_request.POST = {
             "confirm_unyank_version": "invalid",
@@ -4789,7 +4838,11 @@ class TestManageProjectRelease:
         ]
 
     def test_delete_project_release_no_confirm(self, pyramid_request):
-        release = pretend.stub(version="1.2.3", project=pretend.stub(name="foobar"))
+        release = pretend.stub(
+            version="1.2.3",
+            project=pretend.stub(name="foobar"),
+            lifecycle_status=None,
+        )
         pyramid_request.POST = {"confirm_delete_version": ""}
         pyramid_request.method = "POST"
         pyramid_request.db = pretend.stub(delete=pretend.call_recorder(lambda a: None))
@@ -4825,7 +4878,11 @@ class TestManageProjectRelease:
         ]
 
     def test_delete_project_release_bad_confirm(self, pyramid_request):
-        release = pretend.stub(version="1.2.3", project=pretend.stub(name="foobar"))
+        release = pretend.stub(
+            version="1.2.3",
+            project=pretend.stub(name="foobar"),
+            lifecycle_status=None,
+        )
         pyramid_request.POST = {"confirm_delete_version": "invalid"}
         pyramid_request.method = "POST"
         pyramid_request.db = pretend.stub(delete=pretend.call_recorder(lambda a: None))
@@ -4862,7 +4919,11 @@ class TestManageProjectRelease:
         ]
 
     def test_delete_project_release_file_disallow_deletion(self, pyramid_request):
-        release = pretend.stub(version="1.2.3", project=pretend.stub(name="foobar"))
+        release = pretend.stub(
+            version="1.2.3",
+            project=pretend.stub(name="foobar"),
+            lifecycle_status=None,
+        )
         pyramid_request.method = "POST"
         pyramid_request.flags = pretend.stub(
             enabled=pretend.call_recorder(lambda *a: True)
@@ -4987,6 +5048,7 @@ class TestManageProjectRelease:
         release = pretend.stub(
             version="1.2.3",
             project=pretend.stub(name="foobar", normalized_name="foobar"),
+            lifecycle_status=None,
         )
         pyramid_request.POST = {"confirm_project_name": ""}
         pyramid_request.method = "POST"

--- a/tests/unit/utils/test_project.py
+++ b/tests/unit/utils/test_project.py
@@ -18,9 +18,11 @@ from warehouse.packaging.models import (
 from warehouse.utils.project import (
     PROJECT_NAME_RE,
     clear_project_quarantine,
+    clear_release_quarantine,
     confirm_project,
     destroy_docs,
     quarantine_project,
+    quarantine_release,
     remove_documentation,
     remove_project,
 )
@@ -142,6 +144,63 @@ def test_clear_project_quarantine(db_request, flash):
         .filter(Project.name == project.name)
         .filter(Project.lifecycle_status == LifecycleStatus.QuarantineExit)
         .first()
+    )
+    assert bool(db_request.session.flash.calls) == flash
+
+
+@pytest.mark.parametrize("flash", [True, False])
+def test_quarantine_release(db_request, flash):
+    user = UserFactory.create()
+    project = ProjectFactory.create(name="foo")
+    release = ReleaseFactory.create(project=project, version="1.0")
+
+    db_request.user = user
+    db_request.session = stub(flash=call_recorder(lambda *a, **kw: stub()))
+
+    quarantine_release(release, db_request, flash=flash)
+
+    refreshed = db_request.db.query(Release).filter(Release.id == release.id).one()
+    assert refreshed.lifecycle_status == LifecycleStatus.QuarantineEnter
+    assert refreshed.lifecycle_status_note == f"Quarantined by {user.username}."
+
+    # A journal entry should be recorded for the release-level action.
+    assert (
+        db_request.db.query(JournalEntry)
+        .filter(JournalEntry.name == project.name)
+        .filter(JournalEntry.version == release.version)
+        .filter(JournalEntry.action == "release quarantined")
+        .count()
+        == 1
+    )
+    # The project itself is not affected.
+    assert refreshed.project.lifecycle_status is None
+    assert bool(db_request.session.flash.calls) == flash
+
+
+@pytest.mark.parametrize("flash", [True, False])
+def test_clear_release_quarantine(db_request, flash):
+    user = UserFactory.create()
+    project = ProjectFactory.create(name="foo")
+    release = ReleaseFactory.create(
+        project=project,
+        version="1.0",
+        lifecycle_status=LifecycleStatus.QuarantineEnter,
+    )
+
+    db_request.user = user
+    db_request.session = stub(flash=call_recorder(lambda *a, **kw: stub()))
+
+    clear_release_quarantine(release, db_request, flash=flash)
+
+    refreshed = db_request.db.query(Release).filter(Release.id == release.id).one()
+    assert refreshed.lifecycle_status == LifecycleStatus.QuarantineExit
+    assert (
+        db_request.db.query(JournalEntry)
+        .filter(JournalEntry.name == project.name)
+        .filter(JournalEntry.version == release.version)
+        .filter(JournalEntry.action == "release quarantine cleared")
+        .count()
+        == 1
     )
     assert bool(db_request.session.flash.calls) == flash
 

--- a/warehouse/admin/routes.py
+++ b/warehouse/admin/routes.py
@@ -322,6 +322,20 @@ def includeme(config):
         domain=warehouse,
     )
     config.add_route(
+        "admin.project.release.quarantine",
+        "/admin/projects/{project_name}/release/{version}/quarantine/",
+        factory="warehouse.packaging.models:ProjectFactory",
+        traverse="/{project_name}/{version}",
+        domain=warehouse,
+    )
+    config.add_route(
+        "admin.project.release.remove_from_quarantine",
+        "/admin/projects/{project_name}/release/{version}/remove_from_quarantine/",
+        factory="warehouse.packaging.models:ProjectFactory",
+        traverse="/{project_name}/{version}",
+        domain=warehouse,
+    )
+    config.add_route(
         "admin.project.remove_from_quarantine",
         "/admin/projects/{project_name}/remove_from_quarantine/",
         factory="warehouse.packaging.models:ProjectFactory",

--- a/warehouse/admin/templates/admin/projects/release_detail.html
+++ b/warehouse/admin/templates/admin/projects/release_detail.html
@@ -13,6 +13,40 @@
 {% endblock %}
 
 {% block content %}
+  {% if release.lifecycle_status == 'quarantine-enter' %}
+    <div class="card card-danger">
+      <div class="card-header">
+        <h3 class="card-title">
+          <i class="fa fa-lock"></i> Release Quarantined
+        </h3>
+      </div>
+      <div class="card-body">
+        <p>
+          This release is currently in quarantine and will not be served from the
+          index APIs. The rest of the project's releases are unaffected.
+        </p>
+        {% if release.lifecycle_status_changed %}
+          <p>
+            <strong>Since:</strong>
+            {{ release.lifecycle_status_changed.strftime('%Y-%m-%d %H:%M:%S UTC') }}
+          </p>
+        {% endif %}
+        {% if release.lifecycle_status_note %}
+          <p><strong>Note:</strong> {{ release.lifecycle_status_note }}</p>
+        {% endif %}
+        {% if request.has_permission(Permissions.AdminProjectsWrite) %}
+          <form method="post"
+                action="{{ request.route_path('admin.project.release.remove_from_quarantine', project_name=release.project.normalized_name, version=release.version) }}">
+            <input name="csrf_token" type="hidden" value="{{ request.session.get_csrf_token() }}">
+            <button type="submit" class="btn btn-outline-success">
+              <i class="fa fa-unlock"></i> Clear Release from Quarantine
+            </button>
+          </form>
+        {% endif %}
+      </div>
+    </div>
+  {% endif %}
+
   <div class="card">
     <div class="card-header">
       <h3>Details</h3>
@@ -469,6 +503,30 @@
       </div>
     </div>
   </div>
+  {% if request.has_permission(Permissions.AdminProjectsWrite) %}
+    <div class="card card-warning collapsed-card">
+      <div class="card-header">
+        <h3 class="card-title">Quarantine Release</h3>
+        <div class="card-tools">
+          <button type="button" class="btn btn-tool" data-card-widget="collapse"><i class="fas fa-plus"></i></button>
+        </div>
+      </div>
+      <div class="card-body">
+        <p>
+          Quarantining a release is a reversible action. The release will be
+          hidden from index APIs but no files are deleted. Other releases of
+          <strong>{{ release.project.name }}</strong> remain available.
+        </p>
+        <form method="post"
+              action="{{ request.route_path('admin.project.release.quarantine', project_name=release.project.normalized_name, version=release.version) }}">
+          <input name="csrf_token" type="hidden" value="{{ request.session.get_csrf_token() }}">
+          <button type="submit" class="btn btn-warning">
+            <i class="fa fa-lock"></i> Quarantine Release {{ release.version }}
+          </button>
+        </form>
+      </div>
+    </div>
+  {% endif %}
   {% if request.has_permission(Permissions.AdminProjectsDelete) %}
   <div class="card card-danger collapsed-card">
     <div class="card-header">

--- a/warehouse/admin/templates/admin/quarantine/list.html
+++ b/warehouse/admin/templates/admin/quarantine/list.html
@@ -164,4 +164,93 @@
       {% endif %}
     </div>
   </div>
+
+  <div class="card mt-3">
+    <div class="card-header">
+      <h3 class="card-title">Releases in Quarantine</h3>
+    </div>
+    <div class="card-body">
+      {% if quarantined_releases %}
+        <div class="table-responsive">
+          <table class="table table-striped">
+            <thead>
+              <tr>
+                <th>Project</th>
+                <th>Version</th>
+                <th class="d-none d-md-table-cell">Days in Quarantine</th>
+                <th class="d-none d-lg-table-cell">Quarantined Date</th>
+                <th class="d-none d-xl-table-cell">Note</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for release in quarantined_releases %}
+                <tr>
+                  <td>
+                    <a href="{{ request.route_path('admin.project.detail', project_name=release.project.name) }}">
+                      <strong>{{ release.project.name }}</strong>
+                    </a>
+                  </td>
+                  <td><code>{{ release.version }}</code></td>
+                  <td class="d-none d-md-table-cell">
+                    {% if release.lifecycle_status_changed %}
+                      {% set days_quarantined = (now() - release.lifecycle_status_changed).days %}
+                      <span class="badge badge-{{ 'warning' if days_quarantined > 30 else ('info' if days_quarantined > 7 else 'secondary') }}">
+                        {{ days_quarantined }} days
+                      </span>
+                    {% else %}
+                      <em>Unknown</em>
+                    {% endif %}
+                  </td>
+                  <td class="d-none d-lg-table-cell">
+                    {% if release.lifecycle_status_changed %}
+                      {{ release.lifecycle_status_changed.strftime('%Y-%m-%d %H:%M:%S UTC') }}
+                    {% else %}
+                      <em>Unknown</em>
+                    {% endif %}
+                  </td>
+                  <td class="d-none d-xl-table-cell">
+                    {% if release.lifecycle_status_note %}
+                      {{ release.lifecycle_status_note }}
+                    {% else %}
+                      <em>No note</em>
+                    {% endif %}
+                  </td>
+                  <td>
+                    <div class="btn-group" role="group">
+                      <a href="{{ request.route_path('admin.project.release', project_name=release.project.normalized_name, version=release.version) }}"
+                         class="btn btn-sm btn-info" title="View Release">
+                        <i class="fa fa-eye"></i> View
+                      </a>
+                      <form method="post"
+                            action="{{ request.route_path('admin.project.release.remove_from_quarantine', project_name=release.project.normalized_name, version=release.version) }}"
+                            class="d-inline">
+                        <input name="csrf_token" type="hidden" value="{{ request.session.get_csrf_token() }}">
+                        <button type="submit" class="btn btn-sm btn-success" title="Clear from Quarantine">
+                          <i class="fa fa-unlock"></i> Release
+                        </button>
+                      </form>
+                    </div>
+                  </td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+
+        <div class="mt-3">
+          <div class="alert alert-info">
+            <i class="fa fa-info-circle"></i>
+            <strong>{{ quarantined_releases|length }}</strong> release{{ 's' if quarantined_releases|length != 1 else '' }} currently in quarantine.
+            Excludes releases whose parent project is already quarantined.
+          </div>
+        </div>
+      {% else %}
+        <div class="alert alert-success">
+          <i class="fa fa-check-circle"></i>
+          No individual releases are currently in quarantine.
+        </div>
+      {% endif %}
+    </div>
+  </div>
 {% endblock %}

--- a/warehouse/admin/views/projects.py
+++ b/warehouse/admin/views/projects.py
@@ -37,7 +37,9 @@ from warehouse.utils.paginate import paginate_url_factory
 from warehouse.utils.project import (
     archive_project,
     clear_project_quarantine,
+    clear_release_quarantine,
     confirm_project,
+    quarantine_release,
     remove_project,
     unarchive_project,
 )
@@ -461,6 +463,44 @@ def remove_from_quarantine(project, request):
 
     return HTTPSeeOther(
         request.route_path("admin.project.detail", project_name=project.normalized_name)
+    )
+
+
+@view_config(
+    route_name="admin.project.release.quarantine",
+    permission=Permissions.AdminProjectsWrite,
+    request_method="POST",
+    uses_session=True,
+    require_methods=False,
+)
+def release_quarantine(release, request):
+    quarantine_release(release, request)
+
+    return HTTPSeeOther(
+        request.route_path(
+            "admin.project.release",
+            project_name=release.project.normalized_name,
+            version=release.version,
+        )
+    )
+
+
+@view_config(
+    route_name="admin.project.release.remove_from_quarantine",
+    permission=Permissions.AdminProjectsWrite,
+    request_method="POST",
+    uses_session=True,
+    require_methods=False,
+)
+def release_remove_from_quarantine(release, request):
+    clear_release_quarantine(release, request)
+
+    return HTTPSeeOther(
+        request.route_path(
+            "admin.project.release",
+            project_name=release.project.normalized_name,
+            version=release.version,
+        )
     )
 
 

--- a/warehouse/admin/views/quarantine.py
+++ b/warehouse/admin/views/quarantine.py
@@ -10,7 +10,7 @@ from pyramid.view import view_config
 from sqlalchemy import select
 
 from warehouse.authnz import Permissions
-from warehouse.packaging.models import LifecycleStatus, Project
+from warehouse.packaging.models import LifecycleStatus, Project, Release
 
 if typing.TYPE_CHECKING:
     from pyramid.request import Request
@@ -24,19 +24,34 @@ if typing.TYPE_CHECKING:
     uses_session=True,
     require_methods=False,
 )
-def quarantine_list(request: Request) -> dict[str, list[Project]]:
+def quarantine_list(request: Request) -> dict[str, list]:
     """
-    List all projects currently in quarantine.
+    List all projects and releases currently in quarantine.
 
     Shows projects with lifecycle_status == 'quarantine-enter',
-    ordered by lifecycle_status_changed (oldest first).
+    ordered by lifecycle_status_changed (oldest first), alongside releases
+    with the same status (excluding releases whose parent project is itself
+    quarantined, to avoid double-listing).
     """
-    stmt = (
+    project_stmt = (
         select(Project)
         .where(Project.lifecycle_status == LifecycleStatus.QuarantineEnter)
         .order_by(Project.lifecycle_status_changed.asc())
     )
+    quarantined_projects = request.db.scalars(project_stmt).all()
 
-    quarantined_projects = request.db.scalars(stmt).all()
+    release_stmt = (
+        select(Release)
+        .join(Release.project)
+        .where(Release.lifecycle_status == LifecycleStatus.QuarantineEnter)
+        .where(
+            Project.lifecycle_status.is_distinct_from(LifecycleStatus.QuarantineEnter)
+        )
+        .order_by(Release.lifecycle_status_changed.asc())
+    )
+    quarantined_releases = request.db.scalars(release_stmt).all()
 
-    return {"quarantined_projects": quarantined_projects}
+    return {
+        "quarantined_projects": quarantined_projects,
+        "quarantined_releases": quarantined_releases,
+    }

--- a/warehouse/events/tags.py
+++ b/warehouse/events/tags.py
@@ -123,6 +123,8 @@ class EventTag:
         ProjectQuarantineEnter = "project:quarantine:enter"
         ProjectQuarantineExit = "project:quarantine:exit"
         ReleaseAdd = "project:release:add"
+        ReleaseQuarantineEnter = "project:release:quarantine:enter"
+        ReleaseQuarantineExit = "project:release:quarantine:exit"
         ReleaseRemove = "project:release:remove"
         ReleaseUnyank = "project:release:unyank"
         ReleaseYank = "project:release:yank"

--- a/warehouse/legacy/api/json.py
+++ b/warehouse/legacy/api/json.py
@@ -53,6 +53,10 @@ def _json_data(request, project, release, *, all_releases):
         )
         .outerjoin(File)
         .filter(Release.project == project)
+        # Exclude releases in quarantine.
+        .filter(
+            Release.lifecycle_status.is_distinct_from(LifecycleStatus.QuarantineEnter)
+        )
     )
 
     # If we're not looking for all_releases, then we'll filter this further
@@ -213,6 +217,12 @@ def latest_release_factory(request):
                     LifecycleStatus.QuarantineEnter
                 )
             )
+            # Exclude releases in quarantine.
+            .filter(
+                Release.lifecycle_status.is_distinct_from(
+                    LifecycleStatus.QuarantineEnter
+                )
+            )
             .order_by(
                 Release.yanked.asc(),
                 Release.is_prerelease.nullslast(),
@@ -297,6 +307,10 @@ def release_factory(request):
         # Exclude projects in quarantine.
         .filter(
             Project.lifecycle_status.is_distinct_from(LifecycleStatus.QuarantineEnter)
+        )
+        # Exclude releases in quarantine.
+        .filter(
+            Release.lifecycle_status.is_distinct_from(LifecycleStatus.QuarantineEnter)
         )
     )
 

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -163,7 +163,7 @@ msgstr ""
 msgid "Successful WebAuthn assertion"
 msgstr ""
 
-#: warehouse/accounts/views.py:622 warehouse/manage/views/__init__.py:944
+#: warehouse/accounts/views.py:622 warehouse/manage/views/__init__.py:945
 msgid "Recovery code accepted. The supplied code cannot be used again."
 msgstr ""
 
@@ -544,143 +544,147 @@ msgid ""
 "less."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:404
+#: warehouse/manage/views/__init__.py:405
 msgid "Account details updated"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:435
+#: warehouse/manage/views/__init__.py:436
 #, python-brace-format
 msgid "Email ${email_address} added - check your email for a verification link"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:891
+#: warehouse/manage/views/__init__.py:892
 msgid "Recovery codes already generated"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:893
+#: warehouse/manage/views/__init__.py:894
 msgid "Generating new recovery codes will invalidate your existing codes."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1001
+#: warehouse/manage/views/__init__.py:1002
 msgid "Verify your email to create an API token."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1103
+#: warehouse/manage/views/__init__.py:1104
 msgid "API Token does not exist."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1135
+#: warehouse/manage/views/__init__.py:1136
 msgid "Invalid credentials. Try again"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1256
+#: warehouse/manage/views/__init__.py:1257
 msgid "Invalid alternate repository location details"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1294
+#: warehouse/manage/views/__init__.py:1295
 #, python-brace-format
 msgid "Added alternate repository '${name}'"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1327
-#: warehouse/manage/views/__init__.py:1588
-#: warehouse/manage/views/__init__.py:1673
-#: warehouse/manage/views/__init__.py:1774
-#: warehouse/manage/views/__init__.py:1874
+#: warehouse/manage/views/__init__.py:1328
+#: warehouse/manage/views/__init__.py:1604
+#: warehouse/manage/views/__init__.py:1691
+#: warehouse/manage/views/__init__.py:1794
+#: warehouse/manage/views/__init__.py:1897
 msgid "Confirm the request"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1339
+#: warehouse/manage/views/__init__.py:1340
 msgid "Invalid alternate repository id"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1350
+#: warehouse/manage/views/__init__.py:1351
 msgid "Invalid alternate repository for project"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1359
+#: warehouse/manage/views/__init__.py:1360
 #, python-brace-format
 msgid ""
 "Could not delete alternate repository - ${confirm} is not the same as "
 "${alt_repo_name}"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1389
+#: warehouse/manage/views/__init__.py:1390
 #, python-brace-format
 msgid "Deleted alternate repository '${name}'"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1457
-#: warehouse/manage/views/__init__.py:1758
-#: warehouse/manage/views/__init__.py:1866
+#: warehouse/manage/views/__init__.py:1458
+#: warehouse/manage/views/__init__.py:1778
+#: warehouse/manage/views/__init__.py:1889
 msgid ""
 "Project deletion temporarily disabled. See https://pypi.org/help#admin-"
 "intervention for details."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1601
+#: warehouse/manage/views/__init__.py:1580
+msgid "This release is in quarantine and cannot be modified."
+msgstr ""
+
+#: warehouse/manage/views/__init__.py:1617
 msgid "Could not yank release - "
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1686
+#: warehouse/manage/views/__init__.py:1704
 msgid "Could not un-yank release - "
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1787
+#: warehouse/manage/views/__init__.py:1807
 msgid "Could not delete release - "
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1886
+#: warehouse/manage/views/__init__.py:1909
 msgid "Could not find file"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:1891
+#: warehouse/manage/views/__init__.py:1914
 msgid "Could not delete file - "
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2041
+#: warehouse/manage/views/__init__.py:2064
 #, python-brace-format
 msgid "Team '${team_name}' already has ${role_name} role for project"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2148
+#: warehouse/manage/views/__init__.py:2171
 #, python-brace-format
 msgid "User '${username}' already has ${role_name} role for project"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2215
+#: warehouse/manage/views/__init__.py:2238
 #, python-brace-format
 msgid "${username} is now ${role} of the '${project_name}' project."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2246
+#: warehouse/manage/views/__init__.py:2269
 #, python-brace-format
 msgid ""
 "User '${username}' does not have a verified primary email address and "
 "cannot be added as a ${role_name} for project"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2259
+#: warehouse/manage/views/__init__.py:2282
 #: warehouse/manage/views/organizations.py:980
 #, python-brace-format
 msgid "User '${username}' already has an active invite. Please try again later."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2324
+#: warehouse/manage/views/__init__.py:2347
 #: warehouse/manage/views/organizations.py:1055
 #, python-brace-format
 msgid "Invitation sent to '${username}'"
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2356
+#: warehouse/manage/views/__init__.py:2379
 msgid "Could not find role invitation."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2367
+#: warehouse/manage/views/__init__.py:2390
 msgid "Invitation already expired."
 msgstr ""
 
-#: warehouse/manage/views/__init__.py:2400
+#: warehouse/manage/views/__init__.py:2423
 #: warehouse/manage/views/organizations.py:1255
 #, python-brace-format
 msgid "Invitation revoked from '${username}'."
@@ -1124,13 +1128,13 @@ msgstr ""
 #: warehouse/templates/manage/account/webauthn-provision.html:51
 #: warehouse/templates/manage/account/webauthn-provision.html:68
 #: warehouse/templates/manage/manage_base.html:210
-#: warehouse/templates/manage/project/release.html:162
-#: warehouse/templates/manage/project/release.html:226
-#: warehouse/templates/manage/project/releases.html:137
-#: warehouse/templates/manage/project/releases.html:190
-#: warehouse/templates/packaging/detail.html:447
-#: warehouse/templates/packaging/detail.html:465
-#: warehouse/templates/packaging/detail.html:481
+#: warehouse/templates/manage/project/release.html:184
+#: warehouse/templates/manage/project/release.html:253
+#: warehouse/templates/manage/project/releases.html:157
+#: warehouse/templates/manage/project/releases.html:210
+#: warehouse/templates/packaging/detail.html:469
+#: warehouse/templates/packaging/detail.html:487
+#: warehouse/templates/packaging/detail.html:503
 #: warehouse/templates/pages/classifiers.html:17
 #: warehouse/templates/pages/help.html:7
 #: warehouse/templates/pages/help.html:441
@@ -1176,23 +1180,23 @@ msgstr ""
 #: warehouse/templates/pages/help.html:1213
 #: warehouse/templates/pages/help.html:1256
 #: warehouse/templates/pages/help.html:1263
-#: warehouse/templates/pages/help.html:1309
-#: warehouse/templates/pages/help.html:1314
-#: warehouse/templates/pages/help.html:1319
-#: warehouse/templates/pages/help.html:1334
-#: warehouse/templates/pages/help.html:1347
-#: warehouse/templates/pages/help.html:1366
-#: warehouse/templates/pages/help.html:1378
-#: warehouse/templates/pages/help.html:1395
-#: warehouse/templates/pages/help.html:1403
-#: warehouse/templates/pages/help.html:1414
-#: warehouse/templates/pages/help.html:1444
-#: warehouse/templates/pages/help.html:1459
-#: warehouse/templates/pages/help.html:1465
-#: warehouse/templates/pages/help.html:1471
-#: warehouse/templates/pages/help.html:1477
-#: warehouse/templates/pages/help.html:1483
-#: warehouse/templates/pages/help.html:1490
+#: warehouse/templates/pages/help.html:1310
+#: warehouse/templates/pages/help.html:1315
+#: warehouse/templates/pages/help.html:1320
+#: warehouse/templates/pages/help.html:1335
+#: warehouse/templates/pages/help.html:1348
+#: warehouse/templates/pages/help.html:1367
+#: warehouse/templates/pages/help.html:1379
+#: warehouse/templates/pages/help.html:1396
+#: warehouse/templates/pages/help.html:1404
+#: warehouse/templates/pages/help.html:1415
+#: warehouse/templates/pages/help.html:1445
+#: warehouse/templates/pages/help.html:1460
+#: warehouse/templates/pages/help.html:1466
+#: warehouse/templates/pages/help.html:1472
+#: warehouse/templates/pages/help.html:1478
+#: warehouse/templates/pages/help.html:1484
+#: warehouse/templates/pages/help.html:1491
 #: warehouse/templates/pages/sponsors.html:23
 #: warehouse/templates/pages/sponsors.html:34
 #: warehouse/templates/pages/sponsors.html:42
@@ -1360,7 +1364,7 @@ msgstr ""
 #: warehouse/templates/manage/organization/settings.html:291
 #: warehouse/templates/manage/organization/settings.html:297
 #: warehouse/templates/manage/project/documentation.html:13
-#: warehouse/templates/manage/project/release.html:209
+#: warehouse/templates/manage/project/release.html:236
 #: warehouse/templates/manage/project/settings.html:78
 #: warehouse/templates/manage/project/settings.html:124
 #: warehouse/templates/manage/project/settings.html:365
@@ -3078,8 +3082,8 @@ msgstr ""
 #: warehouse/templates/manage/account.html:546
 #: warehouse/templates/manage/manage_base.html:344
 #: warehouse/templates/manage/manage_base.html:347
-#: warehouse/templates/manage/project/release.html:158
-#: warehouse/templates/manage/project/releases.html:186
+#: warehouse/templates/manage/project/release.html:180
+#: warehouse/templates/manage/project/releases.html:206
 #: warehouse/templates/manage/project/settings.html:63
 #: warehouse/templates/manage/unverified-account.html:186
 #: warehouse/templates/manage/unverified-account.html:189
@@ -3170,7 +3174,7 @@ msgstr ""
 #: warehouse/templates/manage/account/totp-provision.html:46
 #: warehouse/templates/manage/unverified-account.html:200
 #: warehouse/templates/packaging/detail.html:150
-#: warehouse/templates/packaging/detail.html:501
+#: warehouse/templates/packaging/detail.html:523
 #: warehouse/templates/pages/classifiers.html:42
 msgid "Copy to clipboard"
 msgstr ""
@@ -3182,7 +3186,7 @@ msgstr ""
 #: warehouse/templates/manage/account/recovery_codes-provision.html:54
 #: warehouse/templates/manage/account/totp-provision.html:47
 #: warehouse/templates/manage/unverified-account.html:201
-#: warehouse/templates/packaging/detail.html:502
+#: warehouse/templates/packaging/detail.html:524
 #: warehouse/templates/pages/classifiers.html:43
 msgid "Copy"
 msgstr ""
@@ -3320,7 +3324,7 @@ msgstr ""
 
 #: warehouse/templates/includes/manage/manage-project-menu.html:9
 #: warehouse/templates/manage/project/release.html:21
-#: warehouse/templates/manage/project/releases.html:161
+#: warehouse/templates/manage/project/releases.html:181
 msgid "Releases"
 msgstr ""
 
@@ -3521,8 +3525,8 @@ msgstr ""
 
 #: warehouse/templates/manage/account.html:84
 #: warehouse/templates/manage/account.html:177
-#: warehouse/templates/manage/project/release.html:74
-#: warehouse/templates/manage/project/releases.html:53
+#: warehouse/templates/manage/project/release.html:92
+#: warehouse/templates/manage/project/releases.html:56
 #: warehouse/templates/manage/unverified-account.html:69
 #: warehouse/templates/manage/unverified-account.html:147
 msgid "Options"
@@ -3917,7 +3921,7 @@ msgid "Two factor method:"
 msgstr ""
 
 #: warehouse/templates/manage/account.html:692
-#: warehouse/templates/manage/project/release.html:61
+#: warehouse/templates/manage/project/release.html:79
 #: warehouse/templates/manage/unverified-account.html:330
 msgid "None"
 msgstr ""
@@ -4377,7 +4381,8 @@ msgstr ""
 #: warehouse/templates/manage/organizations.html:128
 #: warehouse/templates/manage/organizations.html:134
 #: warehouse/templates/manage/organizations.html:183
-#: warehouse/templates/manage/project/releases.html:76
+#: warehouse/templates/manage/project/releases.html:69
+#: warehouse/templates/manage/project/releases.html:94
 #: warehouse/templates/manage/projects.html:99
 #: warehouse/templates/manage/projects.html:105
 #: warehouse/templates/manage/team/projects.html:49
@@ -4770,7 +4775,8 @@ msgstr ""
 #: warehouse/templates/manage/organization/projects.html:67
 #: warehouse/templates/manage/organization/teams.html:44
 #: warehouse/templates/manage/organizations.html:106
-#: warehouse/templates/manage/project/releases.html:83
+#: warehouse/templates/manage/project/releases.html:76
+#: warehouse/templates/manage/project/releases.html:101
 #: warehouse/templates/manage/projects.html:111
 #: warehouse/templates/manage/projects.html:116
 #: warehouse/templates/manage/team/projects.html:61
@@ -5227,7 +5233,7 @@ msgstr ""
 #: warehouse/templates/manage/organization/publishing.html:156
 #: warehouse/templates/manage/project/documentation.html:21
 #: warehouse/templates/manage/project/publishing.html:153
-#: warehouse/templates/manage/project/release.html:139
+#: warehouse/templates/manage/project/release.html:160
 #: warehouse/templates/pages/stats.html:65
 msgid "Project name"
 msgstr ""
@@ -6422,8 +6428,8 @@ msgid "Delete expired invitation for %(user)s"
 msgstr ""
 
 #: warehouse/templates/manage/organization/roles.html:352
-#: warehouse/templates/manage/project/release.html:96
-#: warehouse/templates/manage/project/releases.html:98
+#: warehouse/templates/manage/project/release.html:115
+#: warehouse/templates/manage/project/releases.html:116
 #: warehouse/templates/manage/project/settings.html:239
 msgid "Delete"
 msgstr ""
@@ -6756,7 +6762,7 @@ msgstr ""
 
 #: warehouse/templates/manage/project/history.html:77
 #: warehouse/templates/manage/project/history.html:108
-#: warehouse/templates/manage/project/release.html:103
+#: warehouse/templates/manage/project/release.html:122
 msgid "Filename:"
 msgstr ""
 
@@ -6941,12 +6947,12 @@ msgid "Back to projects"
 msgstr ""
 
 #: warehouse/templates/manage/project/manage_project_base.html:51
-#: warehouse/templates/packaging/detail.html:330
+#: warehouse/templates/packaging/detail.html:335
 msgid "This project has been quarantined."
 msgstr ""
 
 #: warehouse/templates/manage/project/manage_project_base.html:53
-#: warehouse/templates/packaging/detail.html:332
+#: warehouse/templates/packaging/detail.html:337
 msgid ""
 "PyPI Admins need to review this project before it can be restored. While "
 "in quarantine, the project is not installable by clients, and cannot be "
@@ -6954,7 +6960,9 @@ msgid ""
 msgstr ""
 
 #: warehouse/templates/manage/project/manage_project_base.html:60
-#: warehouse/templates/packaging/detail.html:339
+#: warehouse/templates/manage/project/release.html:46
+#: warehouse/templates/packaging/detail.html:344
+#: warehouse/templates/packaging/detail.html:361
 #, python-format
 msgid ""
 "Read more in the <a href=\"%(href)s\">project in quarantine</a> help "
@@ -6962,7 +6970,7 @@ msgid ""
 msgstr ""
 
 #: warehouse/templates/manage/project/manage_project_base.html:67
-#: warehouse/templates/packaging/detail.html:346
+#: warehouse/templates/packaging/detail.html:368
 msgid "This project has been archived."
 msgstr ""
 
@@ -7039,7 +7047,7 @@ msgid "Version %(version)s"
 msgstr ""
 
 #: warehouse/templates/manage/project/release.html:25
-#: warehouse/templates/manage/project/releases.html:169
+#: warehouse/templates/manage/project/releases.html:189
 msgid "Yanked releases"
 msgstr ""
 
@@ -7048,57 +7056,71 @@ msgid "view release"
 msgstr ""
 
 #: warehouse/templates/manage/project/release.html:36
+#: warehouse/templates/packaging/detail.html:351
+msgid "This release has been quarantined."
+msgstr ""
+
+#: warehouse/templates/manage/project/release.html:38
+#: warehouse/templates/packaging/detail.html:353
+msgid ""
+"PyPI Admins need to review this release before it can be restored. While "
+"in quarantine, the release is not installable by clients, and cannot be "
+"modified by its maintainers. Other releases of this project are "
+"unaffected."
+msgstr ""
+
+#: warehouse/templates/manage/project/release.html:54
 #, python-format
 msgid "Files for release %(version)s of %(project_name)s"
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:39
-#: warehouse/templates/manage/project/release.html:50
+#: warehouse/templates/manage/project/release.html:57
+#: warehouse/templates/manage/project/release.html:68
 msgid "Filename, size"
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:40
-#: warehouse/templates/manage/project/release.html:56
+#: warehouse/templates/manage/project/release.html:58
+#: warehouse/templates/manage/project/release.html:74
 msgid "Type"
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:41
-#: warehouse/templates/manage/project/release.html:60
+#: warehouse/templates/manage/project/release.html:59
+#: warehouse/templates/manage/project/release.html:78
 msgid "Python version"
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:42
-#: warehouse/templates/manage/project/release.html:64
+#: warehouse/templates/manage/project/release.html:60
+#: warehouse/templates/manage/project/release.html:82
 msgid "Upload date"
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:73
+#: warehouse/templates/manage/project/release.html:91
 msgid "View file options"
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:81
+#: warehouse/templates/manage/project/release.html:99
 msgid "File options"
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:86
+#: warehouse/templates/manage/project/release.html:104
 msgid "Download"
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:90
+#: warehouse/templates/manage/project/release.html:109
 msgid "Delete file from"
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:92
+#: warehouse/templates/manage/project/release.html:111
 msgid "Delete file"
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:111
+#: warehouse/templates/manage/project/release.html:130
 msgid ""
 "I understand that my users will no longer be able to install this file "
 "for this release of this project."
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:118
+#: warehouse/templates/manage/project/release.html:137
 #, python-format
 msgid ""
 "I understand that I will <a href=%(href)s target=\"_blank\" "
@@ -7106,48 +7128,54 @@ msgid ""
 "name</a> %(filename)s."
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:125
-#: warehouse/templates/manage/project/release.html:257
+#: warehouse/templates/manage/project/release.html:144
+#: warehouse/templates/manage/project/release.html:284
 msgid "I understand that I will not be able to undo this."
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:132
-#: warehouse/templates/manage/project/release.html:263
+#: warehouse/templates/manage/project/release.html:151
+#: warehouse/templates/manage/project/release.html:290
 msgid "I understand that the PyPI administrators will not be able to undo this."
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:150
+#: warehouse/templates/manage/project/release.html:172
 msgid "Uploading new files"
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:152
+#: warehouse/templates/manage/project/release.html:174
 msgid "No files found"
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:155
-#: warehouse/templates/manage/project/releases.html:183
+#: warehouse/templates/manage/project/release.html:177
+#: warehouse/templates/manage/project/releases.html:203
 #: warehouse/templates/manage/project/settings.html:60
 msgid "Dismiss"
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:162
+#: warehouse/templates/manage/project/release.html:184
 #, python-format
 msgid ""
 "Learn how to upload files on the <a href=\"%(href)s\" title=\"%(title)s\""
 " target=\"_blank\" rel=\"noopener\">Python Packaging User Guide</a>"
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:165
+#: warehouse/templates/manage/project/release.html:187
 msgid "Release settings"
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:168
-#: warehouse/templates/manage/project/release.html:202
-#: warehouse/templates/manage/project/releases.html:111
+#: warehouse/templates/manage/project/release.html:190
+msgid ""
+"Yank and delete actions are unavailable while this release is in "
+"quarantine."
+msgstr ""
+
+#: warehouse/templates/manage/project/release.html:195
+#: warehouse/templates/manage/project/release.html:229
+#: warehouse/templates/manage/project/releases.html:131
 msgid "Yank release"
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:171
+#: warehouse/templates/manage/project/release.html:198
 #, python-format
 msgid ""
 "Yanking will mark this release (and %(count)s file within it) to be "
@@ -7158,26 +7186,26 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: warehouse/templates/manage/project/release.html:177
+#: warehouse/templates/manage/project/release.html:204
 msgid ""
 "Yanking will mark this release to be ignored when installing in most "
 "common scenarios."
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:181
+#: warehouse/templates/manage/project/release.html:208
 #, python-format
 msgid ""
 "This release will still be installable for users pinning to this exact "
 "version, e.g. when using <code>%(project_name)s==%(version)s</code>."
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:184
+#: warehouse/templates/manage/project/release.html:211
 #, python-format
 msgid "For more information, see <a href=\"%(href)s\">PEP 592</a>."
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:190
-#: warehouse/templates/manage/project/releases.html:114
+#: warehouse/templates/manage/project/release.html:217
+#: warehouse/templates/manage/project/releases.html:134
 #, python-format
 msgid ""
 "You may provide a reason for yanking this release, which will be "
@@ -7185,54 +7213,54 @@ msgid ""
 "<code>%(project_name)s==%(version)s</code>."
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:194
-#: warehouse/templates/manage/project/releases.html:118
+#: warehouse/templates/manage/project/release.html:221
+#: warehouse/templates/manage/project/releases.html:138
 msgid "Reason (optional)"
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:202
-#: warehouse/templates/manage/project/release.html:267
+#: warehouse/templates/manage/project/release.html:229
+#: warehouse/templates/manage/project/release.html:294
 #: warehouse/templates/manage/project/releases.html:9
-#: warehouse/templates/manage/project/releases.html:108
-#: warehouse/templates/manage/project/releases.html:126
+#: warehouse/templates/manage/project/releases.html:128
 #: warehouse/templates/manage/project/releases.html:146
+#: warehouse/templates/manage/project/releases.html:166
 msgid "Version"
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:207
-#: warehouse/templates/manage/project/release.html:267
-#: warehouse/templates/manage/project/releases.html:128
+#: warehouse/templates/manage/project/release.html:234
+#: warehouse/templates/manage/project/release.html:294
+#: warehouse/templates/manage/project/releases.html:148
 msgid "Delete release"
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:211
+#: warehouse/templates/manage/project/release.html:238
 #, python-format
 msgid "Deleting will irreversibly delete this release along with %(count)s file."
 msgid_plural "Deleting will irreversibly delete this release along with %(count)s files."
 msgstr[0] ""
 msgstr[1] ""
 
-#: warehouse/templates/manage/project/release.html:217
+#: warehouse/templates/manage/project/release.html:244
 msgid "Deleting will irreversibly delete this release."
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:220
-#: warehouse/templates/manage/project/releases.html:131
+#: warehouse/templates/manage/project/release.html:247
+#: warehouse/templates/manage/project/releases.html:151
 msgid ""
 "You will not be able to re-upload a new distribution of the same type "
 "with the same version number."
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:223
-#: warehouse/templates/manage/project/releases.html:134
+#: warehouse/templates/manage/project/release.html:250
+#: warehouse/templates/manage/project/releases.html:154
 msgid ""
 "Deletion will break any downstream projects relying on a pinned version "
 "of this package. It is intended as a last resort to address legal issues "
 "or remove harmful releases."
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:226
-#: warehouse/templates/manage/project/releases.html:137
+#: warehouse/templates/manage/project/release.html:253
+#: warehouse/templates/manage/project/releases.html:157
 #, python-format
 msgid ""
 "Consider <a href=\"%(yank_href)s\" title=\"%(title)s\" target=\"_blank\" "
@@ -7241,20 +7269,20 @@ msgid ""
 "rel=\"noopener\">post release</a> instead."
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:239
+#: warehouse/templates/manage/project/release.html:266
 #, python-format
 msgid ""
 "I understand that I am permanently deleting all files for the "
 "%(release_version)s release of this project."
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:245
+#: warehouse/templates/manage/project/release.html:272
 msgid ""
 "I understand that my users will no longer be able to install this release"
 " of this project."
 msgstr ""
 
-#: warehouse/templates/manage/project/release.html:251
+#: warehouse/templates/manage/project/release.html:278
 #, python-format
 msgid ""
 "I understand that I will <a href=\"%(href)s\" target=\"_blank\" "
@@ -7283,56 +7311,60 @@ msgstr ""
 msgid "Manage version"
 msgstr ""
 
-#: warehouse/templates/manage/project/releases.html:29
+#: warehouse/templates/manage/project/releases.html:25
+msgid "Quarantined"
+msgstr ""
+
+#: warehouse/templates/manage/project/releases.html:32
 #, python-format
 msgid "%(count)s file"
 msgid_plural "%(count)s files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: warehouse/templates/manage/project/releases.html:42
+#: warehouse/templates/manage/project/releases.html:45
 msgid "No files"
 msgstr ""
 
-#: warehouse/templates/manage/project/releases.html:52
+#: warehouse/templates/manage/project/releases.html:55
 msgid "View release options"
 msgstr ""
 
-#: warehouse/templates/manage/project/releases.html:60
+#: warehouse/templates/manage/project/releases.html:63
 #, python-format
 msgid "Options for %(version)s"
 msgstr ""
 
-#: warehouse/templates/manage/project/releases.html:63
+#: warehouse/templates/manage/project/releases.html:81
 msgid "Un-yank Release"
 msgstr ""
 
-#: warehouse/templates/manage/project/releases.html:68
+#: warehouse/templates/manage/project/releases.html:86
 msgid "Un-yank"
 msgstr ""
 
-#: warehouse/templates/manage/project/releases.html:90
+#: warehouse/templates/manage/project/releases.html:108
 msgid "Yank"
 msgstr ""
 
-#: warehouse/templates/manage/project/releases.html:107
+#: warehouse/templates/manage/project/releases.html:127
 msgid "Un-yank release"
 msgstr ""
 
-#: warehouse/templates/manage/project/releases.html:155
+#: warehouse/templates/manage/project/releases.html:175
 #, python-format
 msgid "Manage '%(project_name)s' releases"
 msgstr ""
 
-#: warehouse/templates/manage/project/releases.html:178
+#: warehouse/templates/manage/project/releases.html:198
 msgid "Creating a new release"
 msgstr ""
 
-#: warehouse/templates/manage/project/releases.html:180
+#: warehouse/templates/manage/project/releases.html:200
 msgid "No releases found"
 msgstr ""
 
-#: warehouse/templates/manage/project/releases.html:190
+#: warehouse/templates/manage/project/releases.html:210
 #, python-format
 msgid ""
 "Learn how to create a new release on the <a href=\"%(href)s\" "
@@ -7895,125 +7927,129 @@ msgstr ""
 msgid "This project has been quarantined"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:168
-msgid "This release has been yanked"
+#: warehouse/templates/packaging/detail.html:167
+msgid "This release has been quarantined"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:176
-#, python-format
-msgid "Stable version available (%(version)s)"
+#: warehouse/templates/packaging/detail.html:173
+msgid "This release has been yanked"
 msgstr ""
 
 #: warehouse/templates/packaging/detail.html:181
 #, python-format
-msgid "Newer version available (%(version)s)"
+msgid "Stable version available (%(version)s)"
 msgstr ""
 
 #: warehouse/templates/packaging/detail.html:186
-msgid "Latest version"
+#, python-format
+msgid "Newer version available (%(version)s)"
 msgstr ""
 
 #: warehouse/templates/packaging/detail.html:191
+msgid "Latest version"
+msgstr ""
+
+#: warehouse/templates/packaging/detail.html:196
 #, python-format
 msgid "Released: %(release_date)s"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:204
+#: warehouse/templates/packaging/detail.html:209
 msgid "No project description provided"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:216
+#: warehouse/templates/packaging/detail.html:221
 msgid "Navigation"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:217
-#: warehouse/templates/packaging/detail.html:270
+#: warehouse/templates/packaging/detail.html:222
+#: warehouse/templates/packaging/detail.html:275
 #, python-format
 msgid "Navigation for %(project)s"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:226
-#: warehouse/templates/packaging/detail.html:279
+#: warehouse/templates/packaging/detail.html:231
+#: warehouse/templates/packaging/detail.html:284
 msgid "Project description. Focus will be moved to the description."
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:228
-#: warehouse/templates/packaging/detail.html:281
-#: warehouse/templates/packaging/detail.html:360
+#: warehouse/templates/packaging/detail.html:233
+#: warehouse/templates/packaging/detail.html:286
+#: warehouse/templates/packaging/detail.html:382
 msgid "Project description"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:237
-#: warehouse/templates/packaging/detail.html:301
+#: warehouse/templates/packaging/detail.html:242
+#: warehouse/templates/packaging/detail.html:306
 msgid "Release history. Focus will be moved to the history panel."
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:239
-#: warehouse/templates/packaging/detail.html:303
-#: warehouse/templates/packaging/detail.html:388
+#: warehouse/templates/packaging/detail.html:244
+#: warehouse/templates/packaging/detail.html:308
+#: warehouse/templates/packaging/detail.html:410
 msgid "Release history"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:249
-#: warehouse/templates/packaging/detail.html:313
+#: warehouse/templates/packaging/detail.html:254
+#: warehouse/templates/packaging/detail.html:318
 msgid "Download files. Focus will be moved to the project files."
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:251
-#: warehouse/templates/packaging/detail.html:315
-#: warehouse/templates/packaging/detail.html:445
+#: warehouse/templates/packaging/detail.html:256
+#: warehouse/templates/packaging/detail.html:320
+#: warehouse/templates/packaging/detail.html:467
 msgid "Download files"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:265
+#: warehouse/templates/packaging/detail.html:270
 msgid "Report project as malware"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:290
+#: warehouse/templates/packaging/detail.html:295
 msgid "Project details. Focus will be moved to the project details."
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:292
-#: warehouse/templates/packaging/detail.html:376
+#: warehouse/templates/packaging/detail.html:297
+#: warehouse/templates/packaging/detail.html:398
 msgid "Project details"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:348
+#: warehouse/templates/packaging/detail.html:370
 msgid ""
 "The maintainers of this project have marked this project as archived. No "
 "new releases are expected."
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:356
-#: warehouse/templates/packaging/detail.html:427
+#: warehouse/templates/packaging/detail.html:378
+#: warehouse/templates/packaging/detail.html:449
 msgid "Reason this release was yanked:"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:365
+#: warehouse/templates/packaging/detail.html:387
 msgid "The author of this package has not provided a project description"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:390
+#: warehouse/templates/packaging/detail.html:412
 msgid "Release notifications"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:391
+#: warehouse/templates/packaging/detail.html:413
 msgid "RSS feed"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:402
+#: warehouse/templates/packaging/detail.html:424
 msgid "This version"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:418
+#: warehouse/templates/packaging/detail.html:440
 msgid "pre-release"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:421
+#: warehouse/templates/packaging/detail.html:443
 msgid "yanked"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:447
+#: warehouse/templates/packaging/detail.html:469
 #, python-format
 msgid ""
 "Download the file for your platform. If you're not sure which to choose, "
@@ -8021,34 +8057,34 @@ msgid ""
 "target=\"_blank\" rel=\"noopener\">installing packages</a>."
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:450
+#: warehouse/templates/packaging/detail.html:472
 msgid "Source Distribution"
 msgid_plural "Source Distributions"
 msgstr[0] ""
 msgstr[1] ""
 
-#: warehouse/templates/packaging/detail.html:464
+#: warehouse/templates/packaging/detail.html:486
 msgid "No source distribution files available for this release."
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:465
+#: warehouse/templates/packaging/detail.html:487
 #, python-format
 msgid ""
 "See tutorial on <a href=\"%(href)s\" title=\"%(title)s\" "
 "target=\"_blank\" rel=\"noopener\">generating distribution archives</a>."
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:471
+#: warehouse/templates/packaging/detail.html:493
 msgid "Built Distribution"
 msgid_plural "Built Distributions"
 msgstr[0] ""
 msgstr[1] ""
 
-#: warehouse/templates/packaging/detail.html:478
+#: warehouse/templates/packaging/detail.html:500
 msgid "Filter files by name, interpreter, ABI, and platform."
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:481
+#: warehouse/templates/packaging/detail.html:503
 #, python-format
 msgid ""
 "If you're not sure about the file name format, learn more about <a "
@@ -8056,20 +8092,20 @@ msgid ""
 "rel=\"noopener\">wheel file names</a>."
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:485
+#: warehouse/templates/packaging/detail.html:507
 msgid "The dropdown lists show the available interpreters, ABIs, and platforms."
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:488
+#: warehouse/templates/packaging/detail.html:510
 msgid "Enable javascript to be able to filter the list of wheel files."
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:492
+#: warehouse/templates/packaging/detail.html:514
 msgid "Copy a direct link to the current filters"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:510
-#: warehouse/templates/packaging/detail.html:515
+#: warehouse/templates/packaging/detail.html:532
+#: warehouse/templates/packaging/detail.html:537
 msgid "File name"
 msgstr ""
 
@@ -8392,7 +8428,7 @@ msgid ""
 msgstr ""
 
 #: warehouse/templates/pages/help.html:181
-msgid "My project says it's in quarantine. What does that mean?"
+msgid "My project or release says it's in quarantine. What does that mean?"
 msgstr ""
 
 #: warehouse/templates/pages/help.html:185
@@ -8458,7 +8494,7 @@ msgid "Troubleshooting"
 msgstr ""
 
 #: warehouse/templates/pages/help.html:393
-#: warehouse/templates/pages/help.html:1306
+#: warehouse/templates/pages/help.html:1307
 msgid "About"
 msgstr ""
 
@@ -9548,29 +9584,30 @@ msgstr ""
 #: warehouse/templates/pages/help.html:1282
 #, python-format
 msgid ""
-"Projects may get placed in quarantine for any number of reasons, such as "
-"suspicion of malicious activity, spam, or other violations of the <a "
-"href=\"%(tou)s\" target=\"_blank\" rel=\"noopener\">Terms of Service</a> "
-"or <a href=\"%(aup)s\" target=\"_blank\" rel=\"noopener\">Acceptable Use "
-"Policy</a>."
+"Projects or individual releases may get placed in quarantine for any "
+"number of reasons, such as suspicion of malicious activity, spam, or "
+"other violations of the <a href=\"%(tou)s\" target=\"_blank\" "
+"rel=\"noopener\">Terms of Service</a> or <a href=\"%(aup)s\" "
+"target=\"_blank\" rel=\"noopener\">Acceptable Use Policy</a>."
 msgstr ""
 
 #: warehouse/templates/pages/help.html:1291
 msgid ""
-"While in quarantine, the project is not installable by clients, and "
-"cannot be being modified by its maintainers. PyPI Administrators will "
-"need to review this project before it can be restored."
+"While in quarantine, the project or release is not installable by "
+"clients, and cannot be modified by its maintainers. PyPI Administrators "
+"will need to review it before it can be restored. When a single release "
+"is quarantined, other releases of the same project are unaffected."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:1298
+#: warehouse/templates/pages/help.html:1299
 #, python-format
 msgid ""
-"If you believe your project has mistakenly been flagged for quarantine, "
-"contact PyPI via <a href=\"%(mailto)s\">security@pypi.org</a> with any "
-"details."
+"If you believe your project or release has mistakenly been flagged for "
+"quarantine, contact PyPI via <a href=\"%(mailto)s\">security@pypi.org</a>"
+" with any details."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:1309
+#: warehouse/templates/pages/help.html:1310
 #, python-format
 msgid ""
 "PyPI is powered by the Warehouse project; <a href=\"%(href)s\" "
@@ -9580,7 +9617,7 @@ msgid ""
 "Group (PackagingWG)."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:1314
+#: warehouse/templates/pages/help.html:1315
 #, python-format
 msgid ""
 "The <a href=\"%(href)s\" title=\"%(title)s\" target=\"_blank\" "
@@ -9589,7 +9626,7 @@ msgid ""
 "Python packaging."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:1319
+#: warehouse/templates/pages/help.html:1320
 #, python-format
 msgid ""
 "The <a href=\"%(packaging_wg_href)s\" title=\"%(title)s\" "
@@ -9602,7 +9639,7 @@ msgid ""
 "Warehouse's security and accessibility."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:1334
+#: warehouse/templates/pages/help.html:1335
 #, python-format
 msgid ""
 "PyPI is powered by <a href=\"%(warehouse_href)s\" title=\"%(title)s\" "
@@ -9611,14 +9648,14 @@ msgid ""
 " sponsors</a>."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:1344
+#: warehouse/templates/pages/help.html:1345
 msgid ""
 "As of April 16, 2018, PyPI.org is at \"production\" status, meaning that "
 "it has moved out of beta and replaced the old site (pypi.python.org). It "
 "is now robust, tested, and ready for expected browser and API traffic."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:1347
+#: warehouse/templates/pages/help.html:1348
 #, python-format
 msgid ""
 "PyPI is heavily cached and distributed via <abbr title=\"content delivery"
@@ -9635,7 +9672,7 @@ msgid ""
 "href=\"%(private_index_href)s\">private index</a>."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:1366
+#: warehouse/templates/pages/help.html:1367
 #, python-format
 msgid ""
 "We have a huge amount of work to do to continue to maintain and improve "
@@ -9643,22 +9680,22 @@ msgid ""
 "target=\"_blank\" rel=\"noopener\">the Warehouse project</a>)."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:1372
+#: warehouse/templates/pages/help.html:1373
 msgid "Financial:"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:1372
+#: warehouse/templates/pages/help.html:1373
 #, python-format
 msgid ""
 "We would deeply appreciate <a href=\"%(href)s\">your donations to fund "
 "development and maintenance</a>."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:1375
+#: warehouse/templates/pages/help.html:1376
 msgid "Development:"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:1375
+#: warehouse/templates/pages/help.html:1376
 msgid ""
 "Warehouse is open source, and we would love to see some new faces working"
 " on the project. You <strong>do not</strong> need to be an experienced "
@@ -9666,7 +9703,7 @@ msgid ""
 " you make your first open source pull request!"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:1378
+#: warehouse/templates/pages/help.html:1379
 #, python-format
 msgid ""
 "If you have skills in Python, Full-Text Search, HTML, SCSS, JavaScript, "
@@ -9680,7 +9717,7 @@ msgid ""
 "here."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:1395
+#: warehouse/templates/pages/help.html:1396
 #, python-format
 msgid ""
 "Issues are grouped into <a href=\"%(href)s\" title=\"%(title)s\" "
@@ -9690,11 +9727,11 @@ msgid ""
 " we can guide you through the contribution process."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:1402
+#: warehouse/templates/pages/help.html:1403
 msgid "Stay updated:"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:1403
+#: warehouse/templates/pages/help.html:1404
 #, python-format
 msgid ""
 "You can also follow the ongoing development of the project on the <a "
@@ -9702,7 +9739,7 @@ msgid ""
 "rel=\"noopener\">Python packaging forum on Discourse</a>."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:1414
+#: warehouse/templates/pages/help.html:1415
 #, python-format
 msgid ""
 "Changes to PyPI are generally announced on both the <a "
@@ -9714,21 +9751,21 @@ msgid ""
 "rel=\"noopener\">RSS</a> feed."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:1432
+#: warehouse/templates/pages/help.html:1433
 #, python-format
 msgid ""
 "All traffic is routed through our global CDN, which lists their public IP"
 " addresses here: <a href=\"%(href)s\">%(href)s</a>."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:1435
+#: warehouse/templates/pages/help.html:1436
 #, python-format
 msgid ""
 "More information about this list can be found here: <a "
 "href=\"%(href)s\">%(href)s</a>."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:1439
+#: warehouse/templates/pages/help.html:1440
 msgid ""
 "When Warehouse's maintainers are deploying new features, at first we mark"
 " them with a small \"beta feature\" symbol to tell you: this should "
@@ -9736,11 +9773,11 @@ msgid ""
 "functionality."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:1441
+#: warehouse/templates/pages/help.html:1442
 msgid "Currently, no features are in beta."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:1444
+#: warehouse/templates/pages/help.html:1445
 #, python-format
 msgid ""
 "\"PyPI\" should be pronounced like \"pie pea eye\", specifically with the"
@@ -9750,43 +9787,43 @@ msgid ""
 "implementation of the Python language."
 msgstr ""
 
-#: warehouse/templates/pages/help.html:1454
+#: warehouse/templates/pages/help.html:1455
 msgid "Resources"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:1455
+#: warehouse/templates/pages/help.html:1456
 msgid "Looking for something else? Perhaps these links will help:"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:1461
+#: warehouse/templates/pages/help.html:1462
 msgid "PyPI User Documentation"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:1467
+#: warehouse/templates/pages/help.html:1468
 msgid "Python Packaging User Guide"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:1473
+#: warehouse/templates/pages/help.html:1474
 msgid "Python documentation"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:1479
+#: warehouse/templates/pages/help.html:1480
 msgid "(main Python website)"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:1485
+#: warehouse/templates/pages/help.html:1486
 msgid "Python community page"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:1485
+#: warehouse/templates/pages/help.html:1486
 msgid "(lists IRC channels, mailing lists, etc.)"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:1488
+#: warehouse/templates/pages/help.html:1489
 msgid "Contact"
 msgstr ""
 
-#: warehouse/templates/pages/help.html:1490
+#: warehouse/templates/pages/help.html:1491
 #, python-format
 msgid ""
 "The <a href=\"%(pypa_href)s\" title=\"%(title)s\" target=\"_blank\" "

--- a/warehouse/manage/views/__init__.py
+++ b/warehouse/manage/views/__init__.py
@@ -102,6 +102,7 @@ from warehouse.packaging.models import (
     AlternateRepository,
     File,
     JournalEntry,
+    LifecycleStatus,
     Project,
     Release,
     Role,
@@ -1574,12 +1575,27 @@ class ManageProjectRelease:
             "files": self.release.files.all(),
         }
 
+    def _quarantined_redirect(self):
+        self.request.session.flash(
+            self.request._("This release is in quarantine and cannot be modified."),
+            queue="error",
+        )
+        return HTTPSeeOther(
+            self.request.route_path(
+                "manage.project.release",
+                project_name=self.release.project.name,
+                version=self.release.version,
+            )
+        )
+
     @view_config(
         request_method="POST",
         request_param=["confirm_yank_version"],
         require_reauth=True,
     )
     def yank_project_release(self):
+        if self.release.lifecycle_status == LifecycleStatus.QuarantineEnter:
+            return self._quarantined_redirect()
         version = self.request.POST.get("confirm_yank_version")
         yanked_reason = self.request.POST.get("yanked_reason", "")
 
@@ -1667,6 +1683,8 @@ class ManageProjectRelease:
         require_reauth=True,
     )
     def unyank_project_release(self):
+        if self.release.lifecycle_status == LifecycleStatus.QuarantineEnter:
+            return self._quarantined_redirect()
         version = self.request.POST.get("confirm_unyank_version")
         if not version:
             self.request.session.flash(
@@ -1752,6 +1770,8 @@ class ManageProjectRelease:
         require_reauth=True,
     )
     def delete_project_release(self):
+        if self.release.lifecycle_status == LifecycleStatus.QuarantineEnter:
+            return self._quarantined_redirect()
         if self.request.flags.enabled(AdminFlagValue.DISALLOW_DELETION):
             self.request.session.flash(
                 self.request._(
@@ -1851,6 +1871,9 @@ class ManageProjectRelease:
         require_reauth=True,
     )
     def delete_project_release_file(self):
+        if self.release.lifecycle_status == LifecycleStatus.QuarantineEnter:
+            return self._quarantined_redirect()
+
         def _error(message):
             self.request.session.flash(message, queue="error")
             return HTTPSeeOther(

--- a/warehouse/migrations/versions/a3b1c4d5e6f7_add_release_lifecycle_status.py
+++ b/warehouse/migrations/versions/a3b1c4d5e6f7_add_release_lifecycle_status.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Add Release Lifecycle Status
+
+Revision ID: a3b1c4d5e6f7
+Revises: e8a83da04d40
+Create Date: 2026-05-12 00:00:00.000000
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "a3b1c4d5e6f7"
+down_revision = "e8a83da04d40"
+
+
+def upgrade():
+    op.execute("SET statement_timeout = 11000")
+    op.execute("SET lock_timeout = 10000")
+
+    op.add_column(
+        "releases",
+        sa.Column(
+            "lifecycle_status",
+            postgresql.ENUM(
+                "quarantine-enter",
+                "quarantine-exit",
+                "archived",
+                "archived-noindex",
+                name="lifecyclestatus",
+                create_type=False,
+            ),
+            nullable=True,
+            comment="Lifecycle status can change release visibility and access",
+        ),
+    )
+    op.add_column(
+        "releases",
+        sa.Column(
+            "lifecycle_status_changed",
+            sa.DateTime(),
+            server_default=sa.text("now()"),
+            nullable=True,
+            comment="When the lifecycle status was last changed",
+        ),
+    )
+    op.add_column(
+        "releases",
+        sa.Column(
+            "lifecycle_status_note",
+            sa.String(),
+            nullable=True,
+            comment="Note about the lifecycle status",
+        ),
+    )
+    op.create_index(
+        "releases_lifecycle_status_idx",
+        "releases",
+        ["lifecycle_status"],
+        unique=False,
+    )
+
+
+def downgrade():
+    op.drop_index("releases_lifecycle_status_idx", table_name="releases")
+    op.drop_column("releases", "lifecycle_status_note")
+    op.drop_column("releases", "lifecycle_status_changed")
+    op.drop_column("releases", "lifecycle_status")

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -655,6 +655,7 @@ class Release(HasObservations, db.Model):
             Index("release_project_created_idx", cls.project_id, cls.created.desc()),
             Index("release_version_idx", cls.version),
             Index("release_canonical_version_idx", cls.canonical_version),
+            Index("releases_lifecycle_status_idx", cls.lifecycle_status),
             UniqueConstraint("project_id", "version"),
         )
 
@@ -702,6 +703,17 @@ class Release(HasObservations, db.Model):
     requires_python: Mapped[str | None] = mapped_column(Text)
     created: Mapped[datetime_now] = mapped_column()
     published: Mapped[bool_true] = mapped_column()
+
+    lifecycle_status: Mapped[LifecycleStatus | None] = mapped_column(
+        comment="Lifecycle status can change release visibility and access"
+    )
+    lifecycle_status_changed: Mapped[datetime_now | None] = mapped_column(
+        onupdate=func.now(),
+        comment="When the lifecycle status was last changed",
+    )
+    lifecycle_status_note: Mapped[str | None] = mapped_column(
+        comment="Note about the lifecycle status"
+    )
 
     description_id: Mapped[UUID] = mapped_column(
         ForeignKey("release_descriptions.id", onupdate="CASCADE", ondelete="CASCADE"),

--- a/warehouse/packaging/utils.py
+++ b/warehouse/packaging/utils.py
@@ -55,6 +55,11 @@ def _simple_detail(project, request):
         .options(joinedload(File.release))
         .join(Release)
         .filter(Release.project == project)
+        # Exclude releases that are in the `quarantine-enter` lifecycle status.
+        # Use `is_distinct_from` to keep NULL (unset) statuses.
+        .filter(
+            Release.lifecycle_status.is_distinct_from(LifecycleStatus.QuarantineEnter)
+        )
         # Exclude projects that are in the `quarantine-enter` lifecycle status.
         .join(Project)
         .filter(

--- a/warehouse/templates/manage/project/release.html
+++ b/warehouse/templates/manage/project/release.html
@@ -31,61 +31,80 @@
       <a href="{{ request.route_path('packaging.release', name=release.project.name, version=release.version) }}">{% trans %}view release{% endtrans %}</a>
     </h3>
   </div>
-  {% if files %}
-    <table class="table table--files">
-      <caption class="sr-only">{% trans version=release.version, project_name=project.name %}Files for release {{ version }} of {{ project_name }}{% endtrans %}</caption>
-      <thead>
+  {% if release.lifecycle_status == "quarantine-enter" %}
+    <div class="callout-block callout-block--warning">
+      <p>{% trans %}This release has been quarantined.{% endtrans %}</p>
+      <p>
+        {% trans %}
+        PyPI Admins need to review this release before it can be restored.
+        While in quarantine, the release is not installable by clients,
+        and cannot be modified by its maintainers. Other releases of this
+        project are unaffected.
+      {% endtrans %}
+    </p>
+    <p>
+      {% trans href=request.route_path('help') + "#project_in_quarantine" %}
+      Read more in the <a href="{{ href }}">project in quarantine</a> help article.
+    {% endtrans %}
+  </p>
+</div>
+{% endif %}
+{% if files %}
+  <table class="table table--files">
+    <caption class="sr-only">{% trans version=release.version, project_name=project.name %}Files for release {{ version }} of {{ project_name }}{% endtrans %}</caption>
+    <thead>
+      <tr>
+        <th scope="col">{% trans %}Filename, size{% endtrans %}</th>
+        <th scope="col">{% trans %}Type{% endtrans %}</th>
+        <th scope="col">{% trans %}Python version{% endtrans %}</th>
+        <th scope="col">{% trans %}Upload date{% endtrans %}</th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for file in files %}
         <tr>
-          <th scope="col">{% trans %}Filename, size{% endtrans %}</th>
-          <th scope="col">{% trans %}Type{% endtrans %}</th>
-          <th scope="col">{% trans %}Python version{% endtrans %}</th>
-          <th scope="col">{% trans %}Upload date{% endtrans %}</th>
-          <th></th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for file in files %}
-          <tr>
-            <th scope="row">
-              <span class="table__mobile-label">{% trans %}Filename, size{% endtrans %}</span>
-              <a href="{{ request.route_url('packaging.file', path=file.path) }}">{{ file.filename }}</a>
-              {% if file.size %}({{ file.size|filesizeformat() }}){% endif %}
-              <br>
-            </th>
-            <td>
-              <span class="table__mobile-label">{% trans %}Type{% endtrans %}</span>
-              {{ file.packagetype|format_package_type }}
-            </td>
-            <td>
-              <span class="table__mobile-label">{% trans %}Python version{% endtrans %}</span>
-              {{ file.python_version if file.python_version != 'source' else gettext("None") }}
-            </td>
-            <td>
-              <span class="table__mobile-label">{% trans %}Upload date{% endtrans %}</span>
-              {{ humanize(file.upload_time) }}
-            </td>
-            <td class="table__align-right">
-              <nav class="dropdown dropdown--with-icons">
-                <button type="button"
-                        class="button button--primary dropdown__trigger"
-                        aria-haspopup="true"
-                        aria-expanded="false"
-                        aria-label="{% trans %}View file options{% endtrans %}">
-                  {% trans %}Options{% endtrans %}
-                  <span class="dropdown__trigger-caret">
-                    <i class="fa fa-caret-down" aria-hidden="true"></i>
-                  </span>
-                </button>
-                <ul class="dropdown__content"
-                    aria-hidden="true"
-                    aria-label="{% trans %}File options{% endtrans %}">
-                  <li>
-                    <a href="{{ request.route_url('packaging.file', path=file.path) }}"
-                       class="dropdown__link">
-                      <i class="fa fa-download" aria-hidden="true"></i>
-                      {% trans %}Download{% endtrans %}
-                    </a>
-                  </li>
+          <th scope="row">
+            <span class="table__mobile-label">{% trans %}Filename, size{% endtrans %}</span>
+            <a href="{{ request.route_url('packaging.file', path=file.path) }}">{{ file.filename }}</a>
+            {% if file.size %}({{ file.size|filesizeformat() }}){% endif %}
+            <br>
+          </th>
+          <td>
+            <span class="table__mobile-label">{% trans %}Type{% endtrans %}</span>
+            {{ file.packagetype|format_package_type }}
+          </td>
+          <td>
+            <span class="table__mobile-label">{% trans %}Python version{% endtrans %}</span>
+            {{ file.python_version if file.python_version != 'source' else gettext("None") }}
+          </td>
+          <td>
+            <span class="table__mobile-label">{% trans %}Upload date{% endtrans %}</span>
+            {{ humanize(file.upload_time) }}
+          </td>
+          <td class="table__align-right">
+            <nav class="dropdown dropdown--with-icons">
+              <button type="button"
+                      class="button button--primary dropdown__trigger"
+                      aria-haspopup="true"
+                      aria-expanded="false"
+                      aria-label="{% trans %}View file options{% endtrans %}">
+                {% trans %}Options{% endtrans %}
+                <span class="dropdown__trigger-caret">
+                  <i class="fa fa-caret-down" aria-hidden="true"></i>
+                </span>
+              </button>
+              <ul class="dropdown__content"
+                  aria-hidden="true"
+                  aria-label="{% trans %}File options{% endtrans %}">
+                <li>
+                  <a href="{{ request.route_url('packaging.file', path=file.path) }}"
+                     class="dropdown__link">
+                    <i class="fa fa-download" aria-hidden="true"></i>
+                    {% trans %}Download{% endtrans %}
+                  </a>
+                </li>
+                {% if release.lifecycle_status != "quarantine-enter" %}
                   <li>
                     {% set title = gettext("Delete file from") %}
                     {% set confirm_name = "delete_file_from" %}
@@ -134,35 +153,43 @@
                       </ul>
                     {% endset %}
                   </li>
-                </ul>
-              </nav>
+                {% endif %}
+              </ul>
+            </nav>
+            {% if release.lifecycle_status != "quarantine-enter" %}
               {{ confirm_modal(title, gettext("Project name") , "project_name", project.name, slug, confirm_button_label=confirm_button_label, extra_fields=extra_fields, extra_description=extra_description) }}
-            </td>
-          </tr>
-        {% endfor %}
-      </tbody>
-    </table>
+            {% endif %}
+          </td>
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+{% endif %}
+<div class="callout-block"
+     data-controller="dismissable"
+     data-dismissable-identifier="uploading">
+  {% if files %}
+    <h3>{% trans %}Uploading new files{% endtrans %}</h3>
+  {% else %}
+    <h3>{% trans %}No files found{% endtrans %}</h3>
   {% endif %}
-  <div class="callout-block"
-       data-controller="dismissable"
-       data-dismissable-identifier="uploading">
-    {% if files %}
-      <h3>{% trans %}Uploading new files{% endtrans %}</h3>
-    {% else %}
-      <h3>{% trans %}No files found{% endtrans %}</h3>
-    {% endif %}
-    <button type="button"
-            title="{% trans %}Dismiss{% endtrans %}"
-            data-action="click->dismissable#dismiss"
-            class="callout-block__dismiss"
-            aria-label="{% trans %}Close{% endtrans %}">
-      <i class="fa fa-times" aria-hidden="true"></i>
-    </button>
-    <p>
-      {% trans href='https://packaging.python.org/guides/distributing-packages-using-setuptools/#uploading-your-project-to-pypi', title=gettext('External link') %}Learn how to upload files on the <a href="{{ href }}" title="{{ title }}" target="_blank" rel="noopener">Python Packaging User Guide</a>{% endtrans %}
-    </p>
+  <button type="button"
+          title="{% trans %}Dismiss{% endtrans %}"
+          data-action="click->dismissable#dismiss"
+          class="callout-block__dismiss"
+          aria-label="{% trans %}Close{% endtrans %}">
+    <i class="fa fa-times" aria-hidden="true"></i>
+  </button>
+  <p>
+    {% trans href='https://packaging.python.org/guides/distributing-packages-using-setuptools/#uploading-your-project-to-pypi', title=gettext('External link') %}Learn how to upload files on the <a href="{{ href }}" title="{{ title }}" target="_blank" rel="noopener">Python Packaging User Guide</a>{% endtrans %}
+  </p>
+</div>
+<h3>{% trans %}Release settings{% endtrans %}</h3>
+{% if release.lifecycle_status == "quarantine-enter" %}
+  <div class="callout-block">
+    <p>{% trans %}Yank and delete actions are unavailable while this release is in quarantine.{% endtrans %}</p>
   </div>
-  <h3>{% trans %}Release settings{% endtrans %}</h3>
+{% else %}
   {% if not release.yanked %}
     <div class="callout-block callout-block">
       <h3>{% trans %}Yank release{% endtrans %}</h3>
@@ -266,4 +293,5 @@
 </p>
 {{ confirm_button(gettext("Delete release") , gettext("Version"), "delete_version", release.version, additional_attributes="data-delete-confirm-target=button") }}
 </div>
+{% endif %}
 {% endblock %}

--- a/warehouse/templates/manage/project/releases.html
+++ b/warehouse/templates/manage/project/releases.html
@@ -21,6 +21,9 @@
           <th scope="row">
             <a href="{{ request.route_path('manage.project.release', project_name=project.name, version=release.version) }}"
                title="{% trans %}Manage version{% endtrans %}">{{ release.version }}</a>
+            {% if release.lifecycle_status == "quarantine-enter" %}
+              <span class="badge badge--warning">{% trans %}Quarantined{% endtrans %}</span>
+            {% endif %}
           </th>
           <td>{{ humanize(release.created) }}</td>
           <td>
@@ -58,7 +61,22 @@
           <ul class="dropdown__content"
               aria-hidden="true"
               aria-label="{% trans version=release.version %}Options for {{ version }}{% endtrans %}">
-            {% if release.yanked %}
+            {% if release.lifecycle_status == "quarantine-enter" %}
+              <li>
+                <a href="{{ request.route_path('manage.project.release', project_name=project.name, version=release.version) }}"
+                   class="dropdown__link">
+                  <i class="fa fa-pencil-alt" aria-hidden="true"></i>
+                  {% trans %}Manage{% endtrans %}
+                </a>
+              </li>
+              <li>
+                <a href="{{ request.route_path('packaging.release', name=release.project.name, version=release.version) }}"
+                   class="dropdown__link">
+                  <i class="fa fa-eye" aria-hidden="true"></i>
+                  {% trans %}View{% endtrans %}
+                </a>
+              </li>
+            {% elif release.yanked %}
               <li>
                 {% set title = gettext("Un-yank Release") %}
                 {% set confirm_name = "unyank_release" %}
@@ -102,7 +120,9 @@
           </ul>
         </nav>
         {% set action = request.route_path('manage.project.release', project_name=project.name, version=release.version) %}
-        {% if release.yanked %}
+        {% if release.lifecycle_status == "quarantine-enter" %}
+          {# Quarantined: no yank/delete modals #}
+        {% elif release.yanked %}
           {% set slug = 'unyank_release-modal-{}'.format(loop.index) %}
           {% set title = gettext("Un-yank release") %}
           {{ confirm_modal(title, gettext('Version') , 'unyank_version', release.version, slug, custom_warning_text=version_warning_text, action=action, warning=False) }}

--- a/warehouse/templates/packaging/detail.html
+++ b/warehouse/templates/packaging/detail.html
@@ -139,7 +139,7 @@
     <div class="package-header">
       <div class="package-header__left">
         <h1 class="package-header__name">{{ release.project.name }} {{ release.version }}</h1>
-        {% if files and not project.lifecycle_status == "quarantine-enter" %}
+        {% if files and not project.lifecycle_status == "quarantine-enter" and not release.lifecycle_status == "quarantine-enter" %}
           <div data-controller="clipboard">
             <p class="package-header__pip-instructions">
               <span id="pip-command" data-clipboard-target="source">{{ pip_command(release, request.matched_route.name, testPyPI) }}</span>
@@ -160,6 +160,11 @@
           <a class="status-badge status-badge--warn"
              href="{{ request.route_path("help") }}#project_in_quarantine">
             <span>{% trans %}This project has been quarantined{% endtrans %}</span>
+          </a>
+        {% elif release.lifecycle_status == "quarantine-enter" %}
+          <a class="status-badge status-badge--warn"
+             href="{{ request.route_path("help") }}#project_in_quarantine">
+            <span>{% trans %}This release has been quarantined{% endtrans %}</span>
           </a>
         {% elif release.yanked %}
           <a class="status-badge status-badge--bad"
@@ -239,7 +244,7 @@
                   {% trans %}Release history{% endtrans %}
                 </a>
               </li>
-              {% if files %}
+              {% if files and not release.lifecycle_status == "quarantine-enter" %}
                 <li role="tab">
                   <a id="files-tab"
                      href="#files"
@@ -303,7 +308,7 @@
                 {% trans %}Release history{% endtrans %}
               </a>
             </li>
-            {% if files %}
+            {% if files and not release.lifecycle_status == "quarantine-enter" %}
               <li role="tab">
                 <a id="mobile-files-tab"
                    href="#files"
@@ -341,194 +346,211 @@
             {% endtrans %}
           </p>
         </div>
-      {% elif project.lifecycle_status in ["archived", "archived-noindex"] %}
+      {% elif release.lifecycle_status == "quarantine-enter" %}
         <div class="callout-block callout-block--warning">
-          <p>{% trans %}This project has been archived.{% endtrans %}</p>
+          <p>{% trans %}This release has been quarantined.{% endtrans %}</p>
           <p>
             {% trans %}
-            The maintainers of this project have marked this project as archived.
-            No new releases are expected.
+            PyPI Admins need to review this release before it can be restored.
+            While in quarantine, the release is not installable by clients,
+            and cannot be modified by its maintainers. Other releases of this
+            project are unaffected.
           {% endtrans %}
         </p>
-      </div>
-    {% elif release.yanked and release.yanked_reason %}
-      <div class="callout-block callout-block--danger">
-        <p>{% trans %}Reason this release was yanked:{% endtrans %}</p>
-        <p>{{ release.yanked_reason }}</p>
-      </div>
-    {% endif %}
-    <h2 class="page-title">{% trans %}Project description{% endtrans %}</h2>
-    {% if description %}
-      <div class="project-description">{{ description|camoify|safe }}</div>
-    {% else %}
-      <div class="callout-block">
-        <p>{% trans %}The author of this package has not provided a project description{% endtrans %}</p>
-      </div>
-    {% endif %}
-  </div>
-  {# Tab: project details #}
-  <div id="data"
-       data-project-tabs-target="content"
-       class="vertical-tabs__content"
-       role="tabpanel"
-       aria-labelledby="mobile-data-tab"
-       tabindex="-1">
-    <h2 class="page-title">{% trans %}Project details{% endtrans %}</h2>
-    {% include "warehouse:templates/includes/packaging/project-data.html" %}
-    <br>
-  </div>
-  {# Tab: Release history #}
-  <div id="history"
-       data-project-tabs-target="content"
-       class="vertical-tabs__content"
-       role="tabpanel"
-       aria-labelledby="history-tab mobile-history-tab"
-       tabindex="-1">
-    <h2 class="page-title split-layout">
-      <span>{% trans %}Release history{% endtrans %}</span>
-      <span class="reset-text margin-top">
-        <a href="{{ request.route_path("help") }}#project-release-notifications">{% trans %}Release notifications{% endtrans %}</a> |
-        <a href="{{ request.route_path('rss.project.releases', name=release.project.normalized_name) }}">{% trans %}RSS feed{% endtrans %} <i class="fa fa-rss" aria-hidden="true"></i></a>
-      </span>
-    </h2>
-    <div class="release-timeline">
-      {% set blue_cube = request.static_url('warehouse:static/dist/images/blue-cube.svg') %}
-      {% set white_cube = request.static_url('warehouse:static/dist/images/white-cube.svg') %}
-      {% for hversion in all_versions %}
-        {% set is_current = (hversion.version == release.version) %}
-        <div class="release{{ ' release--latest' if loop.first else ' release--oldest' if loop.last }}{{ ' release--current' if is_current }}">
-          <div class="release__meta">
-            {% if is_current %}
-              <span class="badge">{% trans %}This version{% endtrans %}</span>
-            {% endif %}
-          </div>
-          <div class="release__graphic">
-            {% if loop.length > 1 %}<div class="release__line"></div>{% endif %}
-            {% if is_current %}
-              <img class="release__node" alt="" src="{{ blue_cube }}">
-            {% else %}
-              <img class="release__node" alt="" src="{{ white_cube }}">
-            {% endif %}
-          </div>
-          <a class="card release__card"
-             href="{{ request.route_path('packaging.release', name=release.project.name, version=hversion.version) }}">
-            <p class="release__version">
-              {{ hversion.version }}
-              {% if hversion.is_prerelease %}
-                <span class="badge badge--warning">{% trans %}pre-release{% endtrans %}</span>
-              {% endif %}
-              {% if hversion.yanked %}
-                <span class="badge badge--danger">{% trans %}yanked{% endtrans %}</span>
-              {% endif %}
-            </p>
-            <p class="release__version-date">{{ humanize(hversion.created) }}</p>
-            {% if hversion.yanked and hversion.yanked_reason %}
-              <div class="callout-block callout-block--danger release__yanked-reason">
-                <p>{% trans %}Reason this release was yanked:{% endtrans %}</p>
-                <p>{{ hversion.yanked_reason }}</p>
-              </div>
-            {% endif %}
-          </a>
-        </div>
-      {% endfor %}
+        <p>
+          {% trans href=request.route_path('help') + "#project_in_quarantine" %}
+          Read more in the <a href="{{ href }}">project in quarantine</a> help article.
+        {% endtrans %}
+      </p>
     </div>
-  </div>
-  {% if files %}
-    {# Tab: Downloads #}
-    <div id="files"
-         data-project-tabs-target="content"
-         class="vertical-tabs__content"
-         role="tabpanel"
-         aria-labelledby="files-tab mobile-files-tab"
-         tabindex="-1"
-         data-controller="filter-list">
-      <h2 class="page-title">{% trans %}Download files{% endtrans %}</h2>
+  {% elif project.lifecycle_status in ["archived", "archived-noindex"] %}
+    <div class="callout-block callout-block--warning">
+      <p>{% trans %}This project has been archived.{% endtrans %}</p>
       <p>
-        {% trans href='https://packaging.python.org/tutorials/installing-packages/', title=gettext('External link') %}Download the file for your platform. If you're not sure which to choose, learn more about <a href="{{ href }}" title="{{ title }}" target="_blank" rel="noopener">installing packages</a>.{% endtrans %}
-      </p>
-      <h3>
-        {% trans count=sdists|length %}
-        Source Distribution
-      {% pluralize %}
-        Source Distributions
+        {% trans %}
+        The maintainers of this project have marked this project as archived.
+        No new releases are expected.
       {% endtrans %}
-    </h3>
-    {% if sdists %}
-      {{ file_table(sdists) }}
-    {% else %}
-      <div class="file">
-        <div class="file__graphic">
-          <i class="fas fa-exclamation-circle" aria-hidden="true"></i>
-        </div>
-        <div class="card">
-          {% trans %}No source distribution files available for this release.{% endtrans %}
-          {% trans href='https://packaging.python.org/tutorials/packaging-projects/#generating-distribution-archives', title=gettext('External link') %}See tutorial on <a href="{{ href }}" title="{{ title }}" target="_blank" rel="noopener">generating distribution archives</a>.{% endtrans %}
-        </div>
-      </div>
-    {% endif %}
-    {% if bdists %}
-      <h3>
-        {% trans count=bdists|length %}
-        Built Distribution
-      {% pluralize %}
-        Built Distributions
-      {% endtrans %}
-    </h3>
-    <p class="hidden initial-toggle-visibility">
-      {% trans %}Filter files by name, interpreter, ABI, and platform.{% endtrans %}
     </p>
+  </div>
+{% elif release.yanked and release.yanked_reason %}
+  <div class="callout-block callout-block--danger">
+    <p>{% trans %}Reason this release was yanked:{% endtrans %}</p>
+    <p>{{ release.yanked_reason }}</p>
+  </div>
+{% endif %}
+<h2 class="page-title">{% trans %}Project description{% endtrans %}</h2>
+{% if description %}
+  <div class="project-description">{{ description|camoify|safe }}</div>
+{% else %}
+  <div class="callout-block">
+    <p>{% trans %}The author of this package has not provided a project description{% endtrans %}</p>
+  </div>
+{% endif %}
+</div>
+{# Tab: project details #}
+<div id="data"
+     data-project-tabs-target="content"
+     class="vertical-tabs__content"
+     role="tabpanel"
+     aria-labelledby="mobile-data-tab"
+     tabindex="-1">
+  <h2 class="page-title">{% trans %}Project details{% endtrans %}</h2>
+  {% include "warehouse:templates/includes/packaging/project-data.html" %}
+  <br>
+</div>
+{# Tab: Release history #}
+<div id="history"
+     data-project-tabs-target="content"
+     class="vertical-tabs__content"
+     role="tabpanel"
+     aria-labelledby="history-tab mobile-history-tab"
+     tabindex="-1">
+  <h2 class="page-title split-layout">
+    <span>{% trans %}Release history{% endtrans %}</span>
+    <span class="reset-text margin-top">
+      <a href="{{ request.route_path("help") }}#project-release-notifications">{% trans %}Release notifications{% endtrans %}</a> |
+      <a href="{{ request.route_path('rss.project.releases', name=release.project.normalized_name) }}">{% trans %}RSS feed{% endtrans %} <i class="fa fa-rss" aria-hidden="true"></i></a>
+    </span>
+  </h2>
+  <div class="release-timeline">
+    {% set blue_cube = request.static_url('warehouse:static/dist/images/blue-cube.svg') %}
+    {% set white_cube = request.static_url('warehouse:static/dist/images/white-cube.svg') %}
+    {% for hversion in all_versions %}
+      {% set is_current = (hversion.version == release.version) %}
+      <div class="release{{ ' release--latest' if loop.first else ' release--oldest' if loop.last }}{{ ' release--current' if is_current }}">
+        <div class="release__meta">
+          {% if is_current %}
+            <span class="badge">{% trans %}This version{% endtrans %}</span>
+          {% endif %}
+        </div>
+        <div class="release__graphic">
+          {% if loop.length > 1 %}<div class="release__line"></div>{% endif %}
+          {% if is_current %}
+            <img class="release__node" alt="" src="{{ blue_cube }}">
+          {% else %}
+            <img class="release__node" alt="" src="{{ white_cube }}">
+          {% endif %}
+        </div>
+        <a class="card release__card"
+           href="{{ request.route_path('packaging.release', name=release.project.name, version=hversion.version) }}">
+          <p class="release__version">
+            {{ hversion.version }}
+            {% if hversion.is_prerelease %}
+              <span class="badge badge--warning">{% trans %}pre-release{% endtrans %}</span>
+            {% endif %}
+            {% if hversion.yanked %}
+              <span class="badge badge--danger">{% trans %}yanked{% endtrans %}</span>
+            {% endif %}
+          </p>
+          <p class="release__version-date">{{ humanize(hversion.created) }}</p>
+          {% if hversion.yanked and hversion.yanked_reason %}
+            <div class="callout-block callout-block--danger release__yanked-reason">
+              <p>{% trans %}Reason this release was yanked:{% endtrans %}</p>
+              <p>{{ hversion.yanked_reason }}</p>
+            </div>
+          {% endif %}
+        </a>
+      </div>
+    {% endfor %}
+  </div>
+</div>
+{% if files and not release.lifecycle_status == "quarantine-enter" %}
+  {# Tab: Downloads #}
+  <div id="files"
+       data-project-tabs-target="content"
+       class="vertical-tabs__content"
+       role="tabpanel"
+       aria-labelledby="files-tab mobile-files-tab"
+       tabindex="-1"
+       data-controller="filter-list">
+    <h2 class="page-title">{% trans %}Download files{% endtrans %}</h2>
     <p>
-      {% trans href='https://packaging.python.org/en/latest/specifications/binary-distribution-format/', title=gettext('External link') %}If you're not sure about the file name format, learn more about <a href="{{ href }}" title="{{ title }}" target="_blank" rel="noopener">wheel file names</a>.{% endtrans %}
+      {% trans href='https://packaging.python.org/tutorials/installing-packages/', title=gettext('External link') %}Download the file for your platform. If you're not sure which to choose, learn more about <a href="{{ href }}" title="{{ title }}" target="_blank" rel="noopener">installing packages</a>.{% endtrans %}
     </p>
-    <noscript>
-      <p class="initial-toggle-visibility">
-        {% trans %}The dropdown lists show the available interpreters, ABIs, and platforms.{% endtrans %}
-      </p>
-      <p class="initial-toggle-visibility">
-        {% trans %}Enable javascript to be able to filter the list of wheel files.{% endtrans %}
-      </p>
-    </noscript>
-    <p class="hidden initial-toggle-visibility" data-controller="clipboard">
-      {% trans %}Copy a direct link to the current filters {% endtrans %}
-      <a class="hidden"
-         href="{% if request.matched_route %}{{ request.current_route_url() }}{% else %}{{ request.url }}{% endif %}#files"
-         data-clipboard-target="source"
-         data-filter-list-target="url"></a>
-      <button type="button"
-              class="button button--small copy-tooltip copy-tooltip-w"
-              data-action="clipboard#copy"
-              data-clipboard-target="tooltip"
-              data-clipboard-tooltip-value="{% trans %}Copy to clipboard{% endtrans %}">
-        {% trans %}Copy{% endtrans %}
-      </button>
-    </p>
-    <p class="hidden initial-toggle-visibility">
-      <span data-filter-list-target="summary"></span>
-    </p>
-    <div>
-      <div class="form-group hidden initial-toggle-visibility">
-        <label class="form-group__label sr-only" for="bdist-filenames-filter">{% trans %}File name{% endtrans %}</label>
-        <input class="form-group__field"
-               type="text"
-               id="bdist-filenames-filter"
-               name="bdist-filenames-filter"
-               placeholder="{% trans %}File name{% endtrans %}"
-               {% if wheel_filters_params['filename'] %}value="{{ wheel_filters_params['filename'] }}"{% endif %}
-               autocapitalize="none"
-               autocomplete=""
-               spellcheck="false"
-               data-action="filter-list#filter"
-               data-filter-list-target="filter"
-               data-filtered-source="filename">
+    <h3>
+      {% trans count=sdists|length %}
+      Source Distribution
+    {% pluralize %}
+      Source Distributions
+    {% endtrans %}
+  </h3>
+  {% if sdists %}
+    {{ file_table(sdists) }}
+  {% else %}
+    <div class="file">
+      <div class="file__graphic">
+        <i class="fas fa-exclamation-circle" aria-hidden="true"></i>
       </div>
-      <div class="col-grid">
-        <div class="form-group col-third">{{ filter_select('interpreters', 'Interpreter', wheel_filters_params) }}</div>
-        <div class="form-group col-third">{{ filter_select('abis', 'ABI', wheel_filters_params) }}</div>
-        <div class="form-group col-third">{{ filter_select('platforms', 'Platform', wheel_filters_params) }}</div>
+      <div class="card">
+        {% trans %}No source distribution files available for this release.{% endtrans %}
+        {% trans href='https://packaging.python.org/tutorials/packaging-projects/#generating-distribution-archives', title=gettext('External link') %}See tutorial on <a href="{{ href }}" title="{{ title }}" target="_blank" rel="noopener">generating distribution archives</a>.{% endtrans %}
       </div>
     </div>
-    {{ file_table(bdists) }}
   {% endif %}
+  {% if bdists %}
+    <h3>
+      {% trans count=bdists|length %}
+      Built Distribution
+    {% pluralize %}
+      Built Distributions
+    {% endtrans %}
+  </h3>
+  <p class="hidden initial-toggle-visibility">
+    {% trans %}Filter files by name, interpreter, ABI, and platform.{% endtrans %}
+  </p>
+  <p>
+    {% trans href='https://packaging.python.org/en/latest/specifications/binary-distribution-format/', title=gettext('External link') %}If you're not sure about the file name format, learn more about <a href="{{ href }}" title="{{ title }}" target="_blank" rel="noopener">wheel file names</a>.{% endtrans %}
+  </p>
+  <noscript>
+    <p class="initial-toggle-visibility">
+      {% trans %}The dropdown lists show the available interpreters, ABIs, and platforms.{% endtrans %}
+    </p>
+    <p class="initial-toggle-visibility">
+      {% trans %}Enable javascript to be able to filter the list of wheel files.{% endtrans %}
+    </p>
+  </noscript>
+  <p class="hidden initial-toggle-visibility" data-controller="clipboard">
+    {% trans %}Copy a direct link to the current filters {% endtrans %}
+    <a class="hidden"
+       href="{% if request.matched_route %}{{ request.current_route_url() }}{% else %}{{ request.url }}{% endif %}#files"
+       data-clipboard-target="source"
+       data-filter-list-target="url"></a>
+    <button type="button"
+            class="button button--small copy-tooltip copy-tooltip-w"
+            data-action="clipboard#copy"
+            data-clipboard-target="tooltip"
+            data-clipboard-tooltip-value="{% trans %}Copy to clipboard{% endtrans %}">
+      {% trans %}Copy{% endtrans %}
+    </button>
+  </p>
+  <p class="hidden initial-toggle-visibility">
+    <span data-filter-list-target="summary"></span>
+  </p>
+  <div>
+    <div class="form-group hidden initial-toggle-visibility">
+      <label class="form-group__label sr-only" for="bdist-filenames-filter">{% trans %}File name{% endtrans %}</label>
+      <input class="form-group__field"
+             type="text"
+             id="bdist-filenames-filter"
+             name="bdist-filenames-filter"
+             placeholder="{% trans %}File name{% endtrans %}"
+             {% if wheel_filters_params['filename'] %}value="{{ wheel_filters_params['filename'] }}"{% endif %}
+             autocapitalize="none"
+             autocomplete=""
+             spellcheck="false"
+             data-action="filter-list#filter"
+             data-filter-list-target="filter"
+             data-filtered-source="filename">
+    </div>
+    <div class="col-grid">
+      <div class="form-group col-third">{{ filter_select('interpreters', 'Interpreter', wheel_filters_params) }}</div>
+      <div class="form-group col-third">{{ filter_select('abis', 'ABI', wheel_filters_params) }}</div>
+      <div class="form-group col-third">{{ filter_select('platforms', 'Platform', wheel_filters_params) }}</div>
+    </div>
+  </div>
+  {{ file_table(bdists) }}
+{% endif %}
 </div>
 {# Tabs: file details #}
 {% for file in files %}

--- a/warehouse/templates/pages/help.html
+++ b/warehouse/templates/pages/help.html
@@ -178,7 +178,7 @@
   {% trans %}I'm having trouble setting up two factor authentication with an authentication application (<abbr title="time-based one-time password">TOTP</abbr>). Can you help me?{% endtrans %}
 {% endmacro %}
 {% macro project_in_quarantine() %}
-  {% trans %}My project says it's in quarantine. What does that mean?{% endtrans %}
+  {% trans %}My project or release says it's in quarantine. What does that mean?{% endtrans %}
 {% endmacro %}
 {# About #}
 {% macro maintainers() %}
@@ -1280,7 +1280,7 @@ print(f"BLAKE2b-256: {blake2b_hash}\nSHA256: {sha256_hash}")</pre>
 <h3 id="project_in_quarantine">{{ project_in_quarantine() }}</h3>
 <p>
   {% trans tou="https://policies.python.org/pypi.org/Terms-of-Service/", aup="https://policies.python.org/pypi.org/Acceptable-Use-Policy/" %}
-  Projects may get placed in quarantine for any number of reasons,
+  Projects or individual releases may get placed in quarantine for any number of reasons,
   such as suspicion of malicious activity, spam, or other violations of the
   <a href="{{ tou }}" target="_blank" rel="noopener">Terms of Service</a>
   or
@@ -1289,14 +1289,15 @@ print(f"BLAKE2b-256: {blake2b_hash}\nSHA256: {sha256_hash}")</pre>
 </p>
 <p>
   {% trans %}
-  While in quarantine, the project is not installable by clients,
-  and cannot be being modified by its maintainers.
-  PyPI Administrators will need to review this project before it can be restored.
+  While in quarantine, the project or release is not installable by clients,
+  and cannot be modified by its maintainers.
+  PyPI Administrators will need to review it before it can be restored.
+  When a single release is quarantined, other releases of the same project are unaffected.
 {% endtrans %}
 </p>
 <p>
   {% trans mailto="mailto:security@pypi.org" %}
-  If you believe your project has mistakenly been flagged for quarantine,
+  If you believe your project or release has mistakenly been flagged for quarantine,
   contact PyPI via <a href="{{ mailto }}">security@pypi.org</a>
   with any details.
 {% endtrans %}

--- a/warehouse/utils/project.py
+++ b/warehouse/utils/project.py
@@ -13,6 +13,7 @@ from warehouse.packaging.models import (
     LifecycleStatus,
     ProhibitedProjectName,
     Project,
+    Release,
 )
 from warehouse.tasks import task
 
@@ -160,6 +161,78 @@ def clear_project_quarantine(project: Project, request, flash=True) -> None:
         request.session.flash(
             f"Project {project.name} quarantine cleared.\n"
             "Please update related Help Scout conversations.",
+            queue="success",
+        )
+
+
+def quarantine_release(release: Release, request, flash: bool = True) -> None:
+    """
+    Quarantine a single release. Reversible action.
+
+    Mirrors :func:`quarantine_project` but scoped to a specific release. The
+    parent project is unaffected so other releases remain installable.
+    """
+    user_service = request.find_service(IUserService)
+    actor = request.user or user_service.get_admin_user()
+
+    release.lifecycle_status = LifecycleStatus.QuarantineEnter
+    release.lifecycle_status_note = f"Quarantined by {actor.username}."
+
+    release.project.record_event(
+        tag=EventTag.Project.ReleaseQuarantineEnter,
+        request=request,
+        additional={
+            "submitted_by": actor.username,
+            "canonical_version": release.canonical_version,
+            "version": release.version,
+        },
+    )
+
+    request.db.add(
+        JournalEntry(
+            name=release.project.name,
+            version=release.version,
+            action="release quarantined",
+            submitted_by=actor,
+        )
+    )
+
+    if flash:
+        request.session.flash(
+            f"Release {release.version} of {release.project.name} quarantined.",
+            queue="success",
+        )
+
+
+def clear_release_quarantine(release: Release, request, flash: bool = True) -> None:
+    """
+    Remove a release from quarantine.
+    """
+    release.lifecycle_status = LifecycleStatus.QuarantineExit
+    release.lifecycle_status_note = f"Quarantine cleared by {request.user.username}."
+
+    release.project.record_event(
+        tag=EventTag.Project.ReleaseQuarantineExit,
+        request=request,
+        additional={
+            "submitted_by": request.user.username,
+            "canonical_version": release.canonical_version,
+            "version": release.version,
+        },
+    )
+
+    request.db.add(
+        JournalEntry(
+            name=release.project.name,
+            version=release.version,
+            action="release quarantine cleared",
+            submitted_by=request.user,
+        )
+    )
+
+    if flash:
+        request.session.flash(
+            f"Release {release.version} of {release.project.name} quarantine cleared.",
             queue="success",
         )
 


### PR DESCRIPTION
Adds the ability to quarantine a specific release (and its files) instead of an entire project.

Useful when an existing project gets a malicious release, enables clearing the *project* from quarantine, after placing the release in quarantine - their lifecycle statuses are independent right now. If we find some better workflow toggles after using it for a bit, we can add those as needed.

Resolves #19414 

Some screenshots:

<img width="289" height="103" alt="image" src="https://github.com/user-attachments/assets/14aafddf-1b44-4c80-b459-2591df3a71bc" />


<img width="809" height="188" alt="image" src="https://github.com/user-attachments/assets/1b3f9d22-a5e9-45be-9dbf-e4b039ceced2" />


<img width="880" height="240" alt="image" src="https://github.com/user-attachments/assets/600c9aa8-0472-46ea-8b16-4d2c5f636820" />

---
Admin

<img width="798" height="342" alt="image" src="https://github.com/user-attachments/assets/665fbda1-4056-4059-b600-9236aeb4c4eb" />


<img width="733" height="270" alt="image" src="https://github.com/user-attachments/assets/5131a56e-4aa8-49b3-aadf-6d8af828e1bd" />
