### PR TITLE
feat(ui): update behavior for quarantined releases

### DIFF
--- a/tests/unit/packaging/test_models.py
+++ b/tests/unit/packaging/test_models.py
@@ -16,6 +16,7 @@ from warehouse.oidc.models import GitHubPublisher
 from warehouse.organizations.models import OrganizationType, TeamProjectRoleType
 from warehouse.packaging.models import (
     File,
+    LifecycleStatus,
     Project,
     ProjectFactory,
     ProjectMacaroonWarningAssociation,
@@ -528,6 +529,29 @@ class TestProject:
         assert len(project.releases) == len(
             [active_release0, active_release1, yanked_release0]
         )
+
+    def test_latest_version_excludes_quarantined(self, db_session):
+        """Quarantined releases are skipped when computing latest_version."""
+        project = DBProjectFactory.create()
+        DBReleaseFactory.create(
+            project=project,
+            version="2.0",
+            lifecycle_status=LifecycleStatus.QuarantineEnter,
+        )
+        DBReleaseFactory.create(project=project, version="1.0")
+
+        assert project.latest_version.version == "1.0"
+
+    def test_latest_version_none_when_all_quarantined(self, db_session):
+        """latest_version is None when every release is quarantined."""
+        project = DBProjectFactory.create()
+        DBReleaseFactory.create(
+            project=project,
+            version="1.0",
+            lifecycle_status=LifecycleStatus.QuarantineEnter,
+        )
+
+        assert project.latest_version is None
 
 
 class TestDependency:

--- a/tests/unit/packaging/test_views.py
+++ b/tests/unit/packaging/test_views.py
@@ -7,6 +7,7 @@ from natsort import natsorted
 from pyramid.httpexceptions import HTTPMovedPermanently, HTTPNotFound
 
 from warehouse.packaging import views
+from warehouse.packaging.models import LifecycleStatus
 
 from ...common.db.accounts import UserFactory
 from ...common.db.classifiers import ClassifierFactory
@@ -111,6 +112,43 @@ class TestProjectDetail:
         project = ProjectFactory.create()
 
         release = ReleaseFactory.create(project=project, version="1.0", yanked=True)
+
+        response = pretend.stub()
+        release_detail = pretend.call_recorder(lambda ctx, request: response)
+        monkeypatch.setattr(views, "release_detail", release_detail)
+
+        resp = views.project_detail(project, db_request)
+
+        assert resp is response
+        assert release_detail.calls == [pretend.call(release, db_request)]
+
+    def test_prefers_non_quarantined_release(self, monkeypatch, db_request):
+        project = ProjectFactory.create()
+
+        ReleaseFactory.create(
+            project=project,
+            version="2.0",
+            lifecycle_status=LifecycleStatus.QuarantineEnter,
+        )
+        release = ReleaseFactory.create(project=project, version="1.0")
+
+        response = pretend.stub()
+        release_detail = pretend.call_recorder(lambda ctx, request: response)
+        monkeypatch.setattr(views, "release_detail", release_detail)
+
+        resp = views.project_detail(project, db_request)
+
+        assert resp is response
+        assert release_detail.calls == [pretend.call(release, db_request)]
+
+    def test_only_quarantined_release(self, monkeypatch, db_request):
+        project = ProjectFactory.create()
+
+        release = ReleaseFactory.create(
+            project=project,
+            version="1.0",
+            lifecycle_status=LifecycleStatus.QuarantineEnter,
+        )
 
         response = pretend.stub()
         release_detail = pretend.call_recorder(lambda ctx, request: response)

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -997,7 +997,7 @@ msgstr ""
 msgid "Provide an Inspector link to specific lines of code."
 msgstr ""
 
-#: warehouse/packaging/views.py:347
+#: warehouse/packaging/views.py:357
 msgid "Your report has been recorded. Thank you for your help."
 msgstr ""
 

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -484,7 +484,13 @@ class Project(SitemapMixin, HasEvents, HasObservations, db.Model):
             session.query(
                 Release.version, Release.created, Release.is_prerelease, Release.summary
             )
-            .filter(Release.project == self, Release.yanked.is_(False))
+            .filter(
+                Release.project == self,
+                Release.yanked.is_(False),
+                Release.lifecycle_status.is_distinct_from(
+                    LifecycleStatus.QuarantineEnter
+                ),
+            )
             .order_by(Release.is_prerelease.nullslast(), Release._pypi_ordering.desc())
             .first()
         )

--- a/warehouse/packaging/views.py
+++ b/warehouse/packaging/views.py
@@ -19,7 +19,14 @@ from warehouse.authnz import Permissions
 from warehouse.cache.origin import origin_cache
 from warehouse.observations.models import ObservationKind
 from warehouse.packaging.forms import SubmitMalwareObservationForm
-from warehouse.packaging.models import Description, File, Project, Release, Role
+from warehouse.packaging.models import (
+    Description,
+    File,
+    LifecycleStatus,
+    Project,
+    Release,
+    Role,
+)
 from warehouse.utils import wheel
 
 
@@ -172,6 +179,9 @@ def project_detail(project, request):
             request.db.query(Release)
             .filter(Release.project == project)
             .order_by(
+                Release.lifecycle_status.is_not_distinct_from(
+                    LifecycleStatus.QuarantineEnter
+                ),
                 Release.yanked,
                 Release.is_prerelease.nullslast(),
                 Release._pypi_ordering.desc(),


### PR DESCRIPTION
If the release is quarantined, don't offer it as the latest version, similar to yanked. It's still there, and will advertise the state, but it doesn't come up as the most recent available release.

Refs: #20062