### PR TITLE
Validate entry points in wheels

### DIFF
--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -4024,6 +4024,69 @@ class TestFileUpload:
         ]
         assert resp.status_code == 200
 
+    def test_upload_fails_with_invalid_entrypoints_wheel(
+        self, monkeypatch, pyramid_config, db_request
+    ):
+        """
+        Uploading a wheel fails if the entry_points.txt file is invalid.
+        """
+
+        user = UserFactory.create()
+        pyramid_config.testing_securitypolicy(identity=user)
+        db_request.user = user
+        db_request.user_agent = "warehouse-tests/6.6.6"
+        EmailFactory.create(user=user)
+        project = ProjectFactory.create()
+        release = ReleaseFactory.create(project=project, version="1.0")
+        RoleFactory.create(user=user, project=project)
+
+        temp_f = io.BytesIO()
+        project_name = project.normalized_name.replace("-", "_")
+        with zipfile.ZipFile(file=temp_f, mode="w") as zfp:
+            zfp.writestr("some_file", "some_data")
+            zfp.writestr(f"{project_name}-{release.version}.dist-info/METADATA", "")
+            zfp.writestr(
+                f"{project_name}-{release.version}.dist-info/entry_points.txt",
+                "[console_scripts]\n/bin/evil = evil:main\n",
+            )
+            zfp.writestr(
+                f"{project_name}-{release.version}.dist-info/RECORD",
+                dedent(
+                    f"""\
+                    some_file,
+                    {project_name}-{release.version}.dist-info/METADATA,
+                    {project_name}-{release.version}.dist-info/entry_points.txt,
+                    {project_name}-{release.version}.dist-info/RECORD,
+                    """,
+                ),
+            )
+
+        filename = f"{project_name}-{release.version}-cp34-none-any.whl"
+        filebody = temp_f.getvalue()
+
+        db_request.POST = MultiDict(
+            {
+                "metadata_version": "1.2",
+                "name": project.name,
+                "version": release.version,
+                "filetype": "bdist_wheel",
+                "pyversion": "cp34",
+                "md5_digest": hashlib.md5(filebody).hexdigest(),
+                "content": pretend.stub(
+                    filename=filename,
+                    file=io.BytesIO(filebody),
+                    type="application/zip",
+                ),
+            }
+        )
+
+        monkeypatch.setattr(
+            legacy, "_is_valid_dist_file", lambda *a, **kw: (True, None)
+        )
+
+        with pytest.raises(HTTPBadRequest, match="has invalid entry points"):
+            legacy.file_upload(db_request)
+
     def test_upload_fails_with_missing_metadata_wheel(
         self, monkeypatch, pyramid_config, db_request
     ):

--- a/tests/unit/utils/test_wheel.py
+++ b/tests/unit/utils/test_wheel.py
@@ -168,6 +168,7 @@ def _synthesize_entrypoints_wheel(ini_contents: bytes, tmp_path: Path) -> Path:
     return wheel_path
 
 
+@pytest.mark.parametrize("section_name", ["console_scripts", "gui_scripts"])
 @pytest.mark.parametrize(
     ("entrypoint_name", "valid"),
     [
@@ -202,8 +203,8 @@ def _synthesize_entrypoints_wheel(ini_contents: bytes, tmp_path: Path) -> Path:
         ("../../../../foo", False),
     ],
 )
-def test_validate_entrypoints_names(entrypoint_name, valid, tmp_path):
-    int_contents = f"[console_scripts]\n{entrypoint_name}=foo:main\n"
+def test_validate_entrypoints_names(section_name, entrypoint_name, valid, tmp_path):
+    int_contents = f"[{section_name}]\n{entrypoint_name}=foo:main\n"
     wheel_path = _synthesize_entrypoints_wheel(int_contents.encode(), tmp_path)
 
     if valid:

--- a/tests/unit/utils/test_wheel.py
+++ b/tests/unit/utils/test_wheel.py
@@ -1,8 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import zipfile
+
+from pathlib import Path
+
 import pytest
 
 from warehouse.utils import wheel
+from warehouse.utils.wheel import InvalidWheelEntryPointsError
 
 
 @pytest.mark.parametrize(
@@ -144,3 +149,112 @@ from warehouse.utils import wheel
 )
 def test_wheel_to_pretty_tags(filename, expected_tags):
     assert wheel.filename_to_pretty_tags(filename) == expected_tags
+
+
+def _synthesize_entrypoints_wheel(ini_contents: bytes, tmp_path: Path) -> Path:
+    """
+    Synthesize a temporary (partial) wheel file containing the given
+    entry point contents.
+    """
+
+    wheel_path = tmp_path / "test-0.0.1-py3-none-any.whl"
+
+    with zipfile.ZipFile(wheel_path, "w") as zf:
+        zf.writestr(
+            "test-0.0.1.dist-info/entry_points.txt",
+            ini_contents,
+        )
+
+    return wheel_path
+
+
+@pytest.mark.parametrize(
+    ("entrypoint_name", "valid"),
+    [
+        # Valid names.
+        ("foo", True),
+        ("foo.bar", True),
+        ("foo_bar", True),
+        ("foo-bar", True),
+        ("foo123", True),
+        ("123foo", True),
+        ("_foo", True),
+        ("foo_", True),
+        ("foo.", True),
+        (".foo", True),
+        ("foo..bar", True),
+        ("_", True),
+        ("-_-", True),
+        # Invalid names.
+        ("' '", False),
+        ("''", False),
+        ("foo bar", False),
+        ("foo\tbar", False),
+        ("foo\rbar", False),
+        ("foo/bar", False),
+        ("foo\\bar", False),
+        ("foo:bar", False),
+        ("'foo:bar'", False),
+        ("C:\\foo", False),
+        ("'C:\\foo'", False),
+        ("..\\..\\foo", False),
+        ("/foo", False),
+        ("../../../../foo", False),
+    ],
+)
+def test_validate_entrypoints_names(entrypoint_name, valid, tmp_path):
+    int_contents = f"[console_scripts]\n{entrypoint_name}=foo:main\n"
+    wheel_path = _synthesize_entrypoints_wheel(int_contents.encode(), tmp_path)
+
+    if valid:
+        # Should not raise an exception.
+        wheel.validate_entrypoints(str(wheel_path))
+    else:
+        with pytest.raises(
+            InvalidWheelEntryPointsError,
+            match="Invalid entry point name",
+        ):
+            wheel.validate_entrypoints(str(wheel_path))
+
+
+@pytest.mark.parametrize(
+    ("contents", "error"),
+    [
+        # Not valid UTF-8.
+        (b"\xff\xfe\xfd", "not decodable as UTF-8"),
+        # Uses : instead of = as the delimiter.
+        (b"[console_scripts]\nfoo:main\n", "is not a valid INI file"),
+    ],
+)
+def test_validate_entrypoints_invalid_syntax(contents, error, tmp_path):
+    wheel_path = _synthesize_entrypoints_wheel(contents, tmp_path)
+    with pytest.raises(
+        InvalidWheelEntryPointsError,
+        match=error,
+    ):
+        wheel.validate_entrypoints(str(wheel_path))
+
+
+def test_validate_entrypoints_no_console_scripts(tmp_path):
+    int_contents = b"[not_console_scripts]\n/foo/ = bar:main\n"
+    wheel_path = _synthesize_entrypoints_wheel(int_contents, tmp_path)
+
+    # Should not raise an exception since there are no console scripts to validate.
+    assert wheel.validate_entrypoints(str(wheel_path)) is True
+
+
+def test_validate_entrypoints_ok(tmp_path):
+    # Example taken directly from the Entry Points specification.
+    ini_contents = """
+[console_scripts]
+foo = foomod:main
+# One which depends on extras:
+foobar = foomod:main_bar [bar,baz]
+
+# pytest plugins refer to a module, so there is no ':obj'
+[pytest11]
+nbval = nbval.plugin
+"""
+
+    wheel_path = _synthesize_entrypoints_wheel(ini_contents.encode(), tmp_path)
+    assert wheel.validate_entrypoints(str(wheel_path)) is True

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -65,8 +65,10 @@ from warehouse.rate_limiting.interfaces import RateLimiterException
 from warehouse.utils import readme, scanner, zipfiles
 from warehouse.utils.release import strip_keywords
 from warehouse.utils.wheel import (
+    InvalidWheelEntryPointsError,
     InvalidWheelRecordError,
     MissingWheelRecordError,
+    validate_entrypoints,
     validate_record,
 )
 
@@ -1448,6 +1450,15 @@ def file_upload(request):
                     set(project.users),
                     project_name=project.name,
                     filename=filename,
+                )
+
+            try:
+                validate_entrypoints(temporary_filename)
+            except InvalidWheelEntryPointsError:
+                raise _exc_with_message(
+                    HTTPBadRequest,
+                    f"Wheel '{filename}' has invalid entry points defined in "
+                    "the entry_points.txt file",
                 )
 
             """

--- a/warehouse/utils/wheel.py
+++ b/warehouse/utils/wheel.py
@@ -226,14 +226,25 @@ def validate_record(wheel_filepath: str) -> bool:
 _ENTRY_POINT_NAME_RE = re.compile(r"[\w.-]+")
 
 
+def _validate_section(section: configparser.SectionProxy):
+    """
+    Validate the entry point names in a single section.
+    """
+    for ep_name in section:
+        if _ENTRY_POINT_NAME_RE.fullmatch(ep_name) is None:
+            raise InvalidWheelEntryPointsError(
+                f"Invalid entry point name {ep_name!r} in {section.name!r}"
+            )
+
+
 def validate_entrypoints(wheel_filepath: str) -> bool:
     """
     Extract `entry_points.txt` from a wheel and check that it is valid.
 
     Current validity checks include being a well-formed INI file
     (matching the Entry Points specification's constraints) and
-    that all `console_scripts` entry points have names that do
-    not contain absolute or relative path components.
+    that all `console_scripts` and `gui_scripts` entry points have names
+    that do not contain absolute or relative path components.
 
     Validation errors are not currently reported via email.
     """
@@ -265,17 +276,13 @@ def validate_entrypoints(wheel_filepath: str) -> bool:
             f"entry_points.txt is not a valid INI file: {error!r}"
         )
 
-    try:
-        console_scripts = parser["console_scripts"]
-    except KeyError:
-        # `entry_points.txt` might not have a `console_scripts` section.
-        return True
-
-    for ep_name in console_scripts:
-        if _ENTRY_POINT_NAME_RE.fullmatch(ep_name) is None:
-            raise InvalidWheelEntryPointsError(
-                f"Invalid entry point name {ep_name!r} in console_scripts"
-            )
+    for section_name in ("console_scripts", "gui_scripts"):
+        try:
+            section = parser[section_name]
+        except KeyError:
+            # `entry_points.txt` might not have these sections.
+            continue
+        _validate_section(section)
 
         # TODO: We could consider validating the entry point value as well.
         # See: https://packaging.python.org/en/latest/specifications/entry-points/#data-model

--- a/warehouse/utils/wheel.py
+++ b/warehouse/utils/wheel.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import configparser
 import csv
 import os
 import re
@@ -15,6 +16,10 @@ class MissingWheelRecordError(Exception):
 
 
 class InvalidWheelRecordError(Exception):
+    """Internal exception used by this module"""
+
+
+class InvalidWheelEntryPointsError(Exception):
     """Internal exception used by this module"""
 
 
@@ -217,6 +222,67 @@ def validate_record(wheel_filepath: str) -> bool:
     return True
 
 
+# See: https://packaging.python.org/en/latest/specifications/entry-points/#data-model
+_ENTRY_POINT_NAME_RE = re.compile(r"[\w.-]+")
+
+
+def validate_entrypoints(wheel_filepath: str) -> bool:
+    """
+    Extract `entry_points.txt` from a wheel and check that it is valid.
+
+    Current validity checks include being a well-formed INI file
+    (matching the Entry Points specification's constraints) and
+    that all `console_scripts` entry points have names that do
+    not contain absolute or relative path components.
+
+    Validation errors are not currently reported via email.
+    """
+
+    # See: <https://packaging.python.org/en/latest/specifications/entry-points/#file-format>
+    class CaseSensitiveConfigParser(configparser.ConfigParser):
+        optionxform = staticmethod(str)  # type: ignore[assignment]
+
+    filename = os.path.basename(wheel_filepath)
+    name, version, _ = filename.split("-", 2)
+    entry_points_filename = f"{name}-{version}.dist-info/entry_points.txt"
+
+    # A wheel might not have an `entry_points.txt` file.
+    try:
+        with zipfile.ZipFile(wheel_filepath) as zfp:
+            entry_points_contents = zfp.read(entry_points_filename).decode()
+    except KeyError:
+        return True
+    except UnicodeError:
+        # `entry_points.txt` must be decodable as UTF-8.
+        raise InvalidWheelEntryPointsError("entry_points.txt is not decodable as UTF-8")
+
+    # The Entry Points specification requires `=` as the delimiter.
+    parser = CaseSensitiveConfigParser(delimiters=("=",))
+    try:
+        parser.read_string(entry_points_contents)
+    except configparser.Error as error:
+        raise InvalidWheelEntryPointsError(
+            f"entry_points.txt is not a valid INI file: {error!r}"
+        )
+
+    try:
+        console_scripts = parser["console_scripts"]
+    except KeyError:
+        # `entry_points.txt` might not have a `console_scripts` section.
+        return True
+
+    for ep_name in console_scripts:
+        if _ENTRY_POINT_NAME_RE.fullmatch(ep_name) is None:
+            raise InvalidWheelEntryPointsError(
+                f"Invalid entry point name {ep_name!r} in console_scripts"
+            )
+
+        # TODO: We could consider validating the entry point value as well.
+        # See: https://packaging.python.org/en/latest/specifications/entry-points/#data-model
+
+    return True
+
+
 def main(argv) -> int:  # pragma: no cover
     if len(argv) != 1:
         print("Usage: python -m warehouse.utils.wheel <wheel path>")  # noqa: T201
@@ -225,6 +291,7 @@ def main(argv) -> int:  # pragma: no cover
     wheel_filename = os.path.basename(wheel_filepath)
     try:
         validate_record(wheel_filepath)
+        validate_entrypoints(wheel_filepath)
         print(f"{wheel_filename}: OK")  # noqa: T201
         return 0
     except Exception as error:  # noqa: BLE001


### PR DESCRIPTION
When validating wheels on upload, we now additionally validate any entry_points.txt that's present.

This includes checking that the file is well-formed according to the Entry Points specification, and that any `console_scripts` or `gui_scripts` defined have names that match the suggested pattern in the specification. Entry point names outside of those sections are not currently validated, as their semantics are application-defined rather than installer-defined.