### PR TITLE
fix(packaging): Rename latest version badge

### DIFF
--- a/tests/functional/test_package_detail.py
+++ b/tests/functional/test_package_detail.py
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from http import HTTPStatus
+
+from ..common.db.packaging import ProjectFactory, ReleaseFactory
+
+
+def test_project_detail_uses_latest_release_badge_copy(webtest):
+    project = ProjectFactory.create()
+    ReleaseFactory.create(project=project, version="1.0")
+
+    resp = webtest.get(f"/project/{project.name}/", status=HTTPStatus.OK)
+
+    latest_badge = resp.html.find("a", class_="status-badge--good")
+    assert latest_badge is not None
+    assert latest_badge.get_text(strip=True) == "Latest release"
+    assert "Latest version" not in resp.text

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -7946,7 +7946,7 @@ msgid "Newer version available (%(version)s)"
 msgstr ""
 
 #: warehouse/templates/packaging/detail.html:191
-msgid "Latest version"
+msgid "Latest release"
 msgstr ""
 
 #: warehouse/templates/packaging/detail.html:196

--- a/warehouse/templates/packaging/detail.html
+++ b/warehouse/templates/packaging/detail.html
@@ -188,7 +188,7 @@
           {% else %}
             <a class="status-badge status-badge--good"
                href="{{ request.route_path('packaging.project', name=release.project.name) }}">
-              <span>{% trans %}Latest version{% endtrans %}</span>
+              <span>{% trans %}Latest release{% endtrans %}</span>
             </a>
           {% endif %}
         {% endif %}


### PR DESCRIPTION
Update the project detail status badge for the current release from "Latest version" to "Latest release", matching current PyPI release terminology.

The gettext template is regenerated so the updated translatable source string is included in `messages.pot`.

Screenshot:

![Package detail badge showing Latest release](https://gist.githubusercontent.com/an8kk/d2ebcb3e97f3119bbcbaa3b9a5c5eb7b/raw/5690f70c0f23af60944f61218e3a1e6cd0eabaa0/warehouse-latest-release-badge.svg)

Verified with the focused package detail functional test, translation extraction, targeted Python/template linting, formatting checks, and whitespace checks.

Fixes #19956
