### PR TITLE
fix: close files once done

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,7 +123,7 @@ addopts = [
 ]
 cache_dir = ".cache/pytest"
 filterwarnings = [
-  "error:SELECT statement has a cartesian product:sqlalchemy.exc.SAWarning",
+  "error",
   "ignore::warehouse.utils.exceptions.DevelopmentModeWarning",
 
   # https://github.com/pypi/warehouse/issues/15454#issuecomment-2599321232

--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -168,6 +168,41 @@ def test_sort_releases(db_request, versions, expected):
     ] == expected
 
 
+class TestCloseUploadTempfiles:
+    def test_closes_content_file_and_body_file(self):
+        content_file = pretend.stub(close=pretend.call_recorder(lambda: None))
+        body_file = pretend.stub(
+            closed=False, close=pretend.call_recorder(lambda: None)
+        )
+        request = pretend.stub(
+            POST={"content": pretend.stub(file=content_file)},
+            body_file_raw=body_file,
+        )
+
+        legacy._close_upload_tempfiles(request)
+
+        assert content_file.close.calls == [pretend.call()]
+        assert body_file.close.calls == [pretend.call()]
+
+    def test_no_content_field(self):
+        body_file = pretend.stub(
+            closed=False, close=pretend.call_recorder(lambda: None)
+        )
+        request = pretend.stub(POST={}, body_file_raw=body_file)
+
+        legacy._close_upload_tempfiles(request)
+
+        assert body_file.close.calls == [pretend.call()]
+
+    def test_skips_already_closed_body_file(self):
+        body_file = pretend.stub(closed=True, close=pretend.call_recorder(lambda: None))
+        request = pretend.stub(POST={}, body_file_raw=body_file)
+
+        legacy._close_upload_tempfiles(request)
+
+        assert body_file.close.calls == []
+
+
 class TestFileValidation:
     def test_defaults_to_true(self):
         assert legacy._is_valid_dist_file("", "", NullMetrics()) == (True, None)

--- a/tests/unit/packaging/test_services.py
+++ b/tests/unit/packaging/test_services.py
@@ -69,6 +69,7 @@ class TestLocalFileStorage:
         storage = LocalFileStorage(str(tmpdir))
         file_object = storage.get("file.txt")
         assert file_object.read() == b"my test file contents"
+        file_object.close()
 
     def test_raises_when_file_non_existent(self, tmpdir):
         storage = LocalFileStorage(str(tmpdir))
@@ -216,6 +217,7 @@ class TestLocalSimpleStorage:
         storage = LocalSimpleStorage(str(tmpdir))
         file_object = storage.get("file.txt")
         assert file_object.read() == b"my test file contents"
+        file_object.close()
 
     def test_raises_when_file_non_existent(self, tmpdir):
         storage = LocalSimpleStorage(str(tmpdir))

--- a/tests/unit/test_views.py
+++ b/tests/unit/test_views.py
@@ -371,6 +371,7 @@ def test_favicon(pyramid_request):
 
     assert isinstance(response, FileResponse)
     assert pyramid_request.response.content_type == "image/x-icon"
+    response.app_iter.close()
 
 
 def test_robotstxt(pyramid_request):

--- a/warehouse/cli/db/dbml.py
+++ b/warehouse/cli/db/dbml.py
@@ -87,53 +87,52 @@ class TableInfo(TypedDict):
 
 
 def generate_dbml_file(tables: Iterable[Table], _output: str | None) -> None:
-    file = click.open_file(_output, "w") if _output else click.open_file("-", "w")
+    with click.open_file(_output or "-", "w") as file:
+        tables_info = {}
+        for table in tables:
+            try:
+                tables_info[table.name] = extract_table_info(table)
+            except TypeError as exc:
+                click.echo(
+                    (
+                        f"{exc.args[0]} is not supported."
+                        "Please fill an issue on https://github.com/Kludex/dbml."
+                    ),
+                    file=file,
+                )
+                raise SystemExit(1)
 
-    tables_info = {}
-    for table in tables:
-        try:
-            tables_info[table.name] = extract_table_info(table)
-        except TypeError as exc:
+        for num, (table_name, info) in enumerate(tables_info.items()):
             click.echo(
-                (
-                    f"{exc.args[0]} is not supported."
-                    "Please fill an issue on https://github.com/Kludex/dbml."
-                ),
+                click.style("Table", fg="blue")
+                + f" {table_name} "
+                + click.style("{", fg="white", bold=True),
                 file=file,
             )
-            raise SystemExit(1)
+            for name, field in info["fields"].items():
+                attrs = get_attrs_from_field(field)
+                output = f"  {name} " + click.style(field["type"], fg="yellow")
+                if attrs:
+                    output += attrs
+                click.echo(output, file=file)
+            if info.get("comment"):
+                click.echo(f"  Note: {json.dumps(info['comment'])}", file=file)
+            click.echo(click.style("}", fg="white", bold=True), file=file)
 
-    for num, (table_name, info) in enumerate(tables_info.items()):
-        click.echo(
-            click.style("Table", fg="blue")
-            + f" {table_name} "
-            + click.style("{", fg="white", bold=True),
-            file=file,
-        )
-        for name, field in info["fields"].items():
-            attrs = get_attrs_from_field(field)
-            output = f"  {name} " + click.style(field["type"], fg="yellow")
-            if attrs:
-                output += attrs
-            click.echo(output, file=file)
-        if info.get("comment"):
-            click.echo(f"  Note: {json.dumps(info['comment'])}", file=file)
-        click.echo(click.style("}", fg="white", bold=True), file=file)
+            if info["relationships"]:
+                click.echo(file=file)
 
-        if info["relationships"]:
-            click.echo(file=file)
-
-        for relation in info["relationships"]:
-            # One to Many
-            click.echo(
-                click.style("Ref:", fg="blue")
-                + f" {relation['table_from']}.{relation['table_from_field']} "
-                + click.style(">", fg="green")
-                + f" {relation['table_to']}.{relation['table_to_field']}",
-                file=file,
-            )
-        if num < len(tables_info) - 1:
-            click.echo(file=file)
+            for relation in info["relationships"]:
+                # One to Many
+                click.echo(
+                    click.style("Ref:", fg="blue")
+                    + f" {relation['table_from']}.{relation['table_from_field']} "
+                    + click.style(">", fg="green")
+                    + f" {relation['table_to']}.{relation['table_to_field']}",
+                    file=file,
+                )
+            if num < len(tables_info) - 1:
+                click.echo(file=file)
 
 
 def extract_table_info(table: Table) -> TableInfo:

--- a/warehouse/forklift/legacy.py
+++ b/warehouse/forklift/legacy.py
@@ -556,6 +556,21 @@ def _ensure_user_can_upload(request: Request) -> None:
         ) from None
 
 
+def _close_upload_tempfiles(request):
+    # WebOb's multipart parsing creates two tempfiles when the body is large
+    # enough to exceed ``request_body_tempfile_limit``: one buffering the raw
+    # request body (``body_file_raw``) and one per file field on the parsed
+    # FieldStorage. Neither is closed by WebOb on its own — without explicit
+    # cleanup the OS file descriptors are only reclaimed when the request is
+    # garbage collected, triggering ResourceWarning under -W error.
+    content = request.POST.get("content")
+    if content is not None and hasattr(content, "file"):
+        content.file.close()
+    body_file = request.body_file_raw
+    if hasattr(body_file, "close") and not getattr(body_file, "closed", True):
+        body_file.close()
+
+
 @view_config(
     route_name="forklift.legacy.file_upload",
     uses_session=True,
@@ -568,6 +583,12 @@ def _ensure_user_can_upload(request: Request) -> None:
 def file_upload(request):
     # Log an attempt to upload
     request.metrics.increment("warehouse.upload.attempt")
+
+    # WebOb's multipart parser backs the request body and uploaded "content"
+    # field with tempfiles; ensure they're closed at request teardown
+    # regardless of which exit path this view takes, so the fds aren't
+    # reclaimed by GC later (which would surface as a ResourceWarning).
+    request.add_finished_callback(_close_upload_tempfiles)
 
     # This is a list of warnings that we'll emit *IF* the request is successful.
     warnings: list[str] = []

--- a/warehouse/packaging/services.py
+++ b/warehouse/packaging/services.py
@@ -103,12 +103,12 @@ class GenericLocalBlobStorage:
         return open(os.path.join(self.base, path), "rb")
 
     def get_metadata(self, path):
-        return json.loads(open(os.path.join(self.base, path + ".meta")).read())
+        with open(os.path.join(self.base, path + ".meta")) as f:
+            return json.loads(f.read())
 
     def get_checksum(self, path):
-        return hashlib.md5(
-            open(os.path.join(self.base, path), "rb").read(), usedforsecurity=False
-        ).hexdigest()
+        with open(os.path.join(self.base, path), "rb") as f:
+            return hashlib.md5(f.read(), usedforsecurity=False).hexdigest()
 
     def store(self, path, file_path, *, meta=None):
         destination = os.path.join(self.base, path)


### PR DESCRIPTION
Without a context manager, file handles remains open and become resource leaks.

Surfaced by turning all test-time warnings into errors, and handling each case.