### PR TITLE
chore(deps): upgrade base image to trixie

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # Set variables reused in Dockerfile
-ARG PYTHON_IMAGE_VERSION=3.14.5-slim-bookworm
+ARG PYTHON_IMAGE_VERSION=3.14.5-slim-trixie
 
 # First things first, we build an image which is where we're going to compile
 # our static assets with. We use this stage in development.
-FROM node:25.8.1-bookworm AS static-deps
+FROM node:25.8.1-trixie AS static-deps
 
 WORKDIR /opt/warehouse/src/
 


### PR DESCRIPTION
Debian trixie was released in late 2025, and is up to 13.5 as of May 2026 and should be supported for 5 years following initial release.

Refs: https://www.debian.org/releases/trixie/
Refs: https://www.debian.org/News/2026/20260516