### PR TITLE
fix(dev): switch dev gunicorn to a threaded worker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,7 +94,7 @@ services:
 
   web:
     image: warehouse:docker-compose
-    command: gunicorn --reload --reload-extra-file=warehouse/api/openapi.yaml -b 0.0.0.0:8000 --access-logfile - --error-logfile - warehouse.wsgi:application
+    command: gunicorn --reload --reload-extra-file=warehouse/api/openapi.yaml --threads 4 -b 0.0.0.0:8000 --access-logfile - --error-logfile - warehouse.wsgi:application
     env_file: dev/environment
     pull_policy: never
     volumes: *base_volumes


### PR DESCRIPTION
The dev web service runs one gunicorn sync worker with no buffering proxy in front of it. A sync worker blocks in recv() while reading a request, so a connection that's accepted but never sends any request bytes (a browser preconnect socket, say) ties up the only worker until the 30s timeout kills it. That's why the first request after startup or a reload often errors while the retry, on a fresh worker, succeeds.

The "Perhaps out of memory?" line gunicorn logs is a red herring: it prints that on any SIGKILL, and here gunicorn killed its own worker after the timeout. It was never memory.

Passing --threads 4 promotes gunicorn to the gthread worker, which parks idle connections in a selector and keeps the heartbeat on the main thread, so a silent connection can't monopolize the worker. It stays one process, so pyramid_debugtoolbar's in-process request history keeps working (more workers would break that).

Reproduced by holding a silent TCP connection open and then sending a normal request: the sync worker stalled ~33s and got SIGKILLed, matching the reported log; with --threads 4 the same request came back in ~45ms.