### PR TITLE
fix(ci): migrate before bringing the app stack up in dev-env-test

### DIFF
--- a/.github/workflows/dev-env-test.yml
+++ b/.github/workflows/dev-env-test.yml
@@ -16,7 +16,12 @@ jobs:
         with:
           persist-credentials: false
       - run: make build
+      # Run migrations against a db-only stack first, mirroring `make serve`.
+      # Bringing the full app stack up before migrating lets live web/worker
+      # connections contend with migrations that intentionally use short
+      # lock/statement timeouts for production deploys, causing flaky
+      # statement-timeout and deadlock failures.
+      - run: make initdb
       - run: docker compose up -d
       - run: docker compose ps
-      - run: make initdb
       - run: make tests


### PR DESCRIPTION
The nightly Development Environment run kept dying in `make initdb` with either a statement timeout or a deadlock, depending on the night.

Cause: the workflow ran `docker compose up -d` before `make initdb`, so the web and worker containers were already connected and querying the DB while migrations ran. Two migrations are tuned for safe production deploys and can't tolerate that:

- ed4cc2ef6b0f builds an index CONCURRENTLY under a 5s statement_timeout. It has to wait for the app's open transactions, so it gets cancelled.
- 8eee7a6fa93a runs ALTER COLUMN on admin_flags and banners, which are read on nearly every request, and deadlocks against those reads.

On a quiet database both finish in milliseconds, which is why this only showed up as a flake.

Run `make initdb` first against the db-only stack, the way `make serve` already does, then bring the full stack up to confirm it still starts.