### PR TITLE
perf(oidc): batch-load project.users in mint_token to fix N+1

### DIFF
--- a/tests/unit/oidc/test_mint_token_queries.py
+++ b/tests/unit/oidc/test_mint_token_queries.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression test: mint_token should not lazy-load `project.users` per project."""
+
+from tests.common.db.accounts import EmailFactory, UserFactory
+from tests.common.db.ip_addresses import IpAddressFactory
+from tests.common.db.oidc import GitHubPublisherFactory
+from tests.common.db.packaging import ProjectFactory, RoleFactory
+from warehouse.ip_addresses.models import IpAddress
+from warehouse.oidc import views
+from warehouse.oidc.models import GitHubPublisher
+
+DUMMY_GITHUB_OIDC_JWT = "eyJ.fakeheader.fakebody.fakesig"
+
+
+def test_mint_token_avoids_per_project_users_n_plus_one(
+    mocker, db_request, query_recorder
+):
+    publisher = GitHubPublisherFactory(environment="prod")
+    projects = []
+    for _ in range(5):
+        p = ProjectFactory.create()
+        for j in range(3):
+            u = UserFactory.create()
+            EmailFactory.create(user=u, primary=True, verified=True)
+            RoleFactory.create(
+                user=u,
+                project=p,
+                role_name="Owner" if j < 2 else "Maintainer",
+            )
+        projects.append(p)
+    publisher.projects = projects
+    ip = IpAddressFactory.create()
+    db_request.db.flush()
+    publisher_id = publisher.id
+    ip_id = ip.id
+    # Detach so a subsequent load mirrors a fresh request — production loads
+    # publisher fresh per request, and that load is what back-populates
+    # `Project.oidc_publishers` and marks each project dirty.
+    db_request.db.expunge_all()
+    publisher = db_request.db.get(GitHubPublisher, publisher_id)
+    # `record_event` reads `request.ip_address`; rebind it after expunge_all.
+    db_request.ip_address = db_request.db.get(IpAddress, ip_id)
+
+    claims = {
+        "iss": "https://token.actions.githubusercontent.com",
+        "ref": "r",
+        "sha": "s",
+        "environment": "prod",
+    }
+    oidc_service = mocker.Mock()
+    oidc_service.verify_jwt_signature.return_value = claims
+    oidc_service.find_publisher.side_effect = lambda c, pending=False: (
+        None if pending else publisher
+    )
+    oidc_service.store_jwt_identifier.return_value = True
+
+    with query_recorder:
+        views.mint_token(oidc_service, DUMMY_GITHUB_OIDC_JWT, claims["iss"], db_request)
+        db_request.db.flush()
+
+    # The N+1 manifests as `Project.users` loaded per dirty project: a SELECT
+    # joining roles, users, and user_emails. The selectinload pre-load should
+    # mean it never appears here.
+    queries = "\n".join(" ".join(q.lower().split()) for q in query_recorder.queries)
+    assert "from roles, users left outer join user_emails" not in queries, (
+        "Expected no per-project Project.users lazy-load during mint_token"
+    )

--- a/tests/unit/oidc/test_views.py
+++ b/tests/unit/oidc/test_views.py
@@ -16,7 +16,11 @@ from tests.common.db.oidc import (
     PendingGitHubPublisherFactory,
 )
 from tests.common.db.organizations import OrganizationFactory
-from tests.common.db.packaging import ProhibitedProjectFactory, ProjectFactory
+from tests.common.db.packaging import (
+    ProhibitedProjectFactory,
+    ProjectFactory,
+    RoleFactory,
+)
 from warehouse.events.tags import EventTag
 from warehouse.macaroons import caveats
 from warehouse.macaroons.interfaces import IMacaroonService
@@ -710,16 +714,10 @@ def test_mint_token_no_pending_publisher_ok(
     time = pretend.stub(time=pretend.call_recorder(lambda: 0))
     monkeypatch.setattr(views, "time", time)
 
-    project = pretend.stub(
-        id="fakeprojectid",
-        record_event=pretend.call_recorder(lambda **kw: None),
-    )
-
+    project = ProjectFactory.create()
     publisher = GitHubPublisherFactory()
-    monkeypatch.setattr(publisher.__class__, "projects", [project])
-    publisher.publisher_url = pretend.call_recorder(lambda **kw: "https://fake/url")
-    # NOTE: Can't set __str__ using pretend.stub()
-    monkeypatch.setattr(publisher.__class__, "__str__", lambda s: "fakespecifier")
+    publisher.projects = [project]
+    db_request.db.flush()
 
     def _find_publisher(claims, pending=False):
         if pending:
@@ -773,30 +771,27 @@ def test_mint_token_no_pending_publisher_ok(
     assert macaroon_service.create_macaroon.calls == [
         pretend.call(
             "fakedomain",
-            f"OpenID token: fakespecifier ({datetime.fromtimestamp(0).isoformat()})",
+            f"OpenID token: {publisher} ({datetime.fromtimestamp(0).isoformat()})",
             [
                 caveats.OIDCPublisher(
                     oidc_publisher_id=str(publisher.id),
                 ),
-                caveats.ProjectID(project_ids=["fakeprojectid"]),
+                caveats.ProjectID(project_ids=[str(project.id)]),
                 caveats.Expiration(expires_at=900, not_before=0),
             ],
             oidc_publisher_id=str(publisher.id),
             additional={"oidc": claims_input},
         )
     ]
-    assert project.record_event.calls == [
-        pretend.call(
-            tag=EventTag.Project.ShortLivedAPITokenAdded,
-            request=db_request,
-            additional={
-                "expires": 900,
-                "publisher_name": "GitHub",
-                "publisher_url": "https://fake/url",
-                "reusable_workflow_used": False,
-            },
-        )
-    ]
+    events = list(project.events)
+    assert len(events) == 1
+    assert events[0].tag == EventTag.Project.ShortLivedAPITokenAdded.value
+    assert events[0].additional == {
+        "expires": 900,
+        "publisher_name": "GitHub",
+        "publisher_url": publisher.publisher_url(),
+        "reusable_workflow_used": False,
+    }
 
 
 def test_mint_token_warn_constrain_environment(monkeypatch, db_request):
@@ -809,20 +804,13 @@ def test_mint_token_warn_constrain_environment(monkeypatch, db_request):
     claims_input = {"ref": "someref", "sha": "somesha"}
     time = pretend.stub(time=pretend.call_recorder(lambda: 0))
     monkeypatch.setattr(views, "time", time)
+
     owner = UserFactory.create()
-
-    project = pretend.stub(
-        id="fakeprojectid",
-        name="fakeproject",
-        record_event=pretend.call_recorder(lambda **kw: None),
-        owners=[owner],
-    )
-
+    project = ProjectFactory.create()
+    RoleFactory.create(user=owner, project=project, role_name="Owner")
     publisher = GitHubPublisherFactory(environment="")
-    monkeypatch.setattr(publisher.__class__, "projects", [project])
-    publisher.publisher_url = pretend.call_recorder(lambda **kw: "https://fake/url")
-    # NOTE: Can't set __str__ using pretend.stub()
-    monkeypatch.setattr(publisher.__class__, "__str__", lambda s: "fakespecifier")
+    publisher.projects = [project]
+    db_request.db.flush()
 
     send_environment_ignored_in_trusted_publisher_email = pretend.call_recorder(
         lambda *a, **kw: None
@@ -883,7 +871,7 @@ def test_mint_token_warn_constrain_environment(monkeypatch, db_request):
         pretend.call(
             db_request,
             {owner},
-            project_name="fakeproject",
+            project_name=project.name,
             publisher=publisher,
             environment_name="fakeenv",
         ),
@@ -892,30 +880,27 @@ def test_mint_token_warn_constrain_environment(monkeypatch, db_request):
     assert macaroon_service.create_macaroon.calls == [
         pretend.call(
             "fakedomain",
-            f"OpenID token: fakespecifier ({datetime.fromtimestamp(0).isoformat()})",
+            f"OpenID token: {publisher} ({datetime.fromtimestamp(0).isoformat()})",
             [
                 caveats.OIDCPublisher(
                     oidc_publisher_id=str(publisher.id),
                 ),
-                caveats.ProjectID(project_ids=["fakeprojectid"]),
+                caveats.ProjectID(project_ids=[str(project.id)]),
                 caveats.Expiration(expires_at=900, not_before=0),
             ],
             oidc_publisher_id=str(publisher.id),
             additional={"oidc": claims_input},
         )
     ]
-    assert project.record_event.calls == [
-        pretend.call(
-            tag=EventTag.Project.ShortLivedAPITokenAdded,
-            request=db_request,
-            additional={
-                "expires": 900,
-                "publisher_name": "GitHub",
-                "publisher_url": "https://fake/url",
-                "reusable_workflow_used": False,
-            },
-        )
-    ]
+    events = list(project.events)
+    assert len(events) == 1
+    assert events[0].tag == EventTag.Project.ShortLivedAPITokenAdded.value
+    assert events[0].additional == {
+        "expires": 900,
+        "publisher_name": "GitHub",
+        "publisher_url": publisher.publisher_url(),
+        "reusable_workflow_used": False,
+    }
 
 
 def test_mint_token_with_prohibited_name_fails(monkeypatch, db_request):
@@ -1004,15 +989,10 @@ def test_mint_token_github_reusable_workflow_metrics(
     time = pretend.stub(time=pretend.call_recorder(lambda: 0))
     monkeypatch.setattr(views, "time", time)
 
-    project = pretend.stub(
-        id="fakeprojectid",
-        record_event=pretend.call_recorder(lambda **kw: None),
-    )
-
+    project = ProjectFactory.create()
     publisher = GitHubPublisherFactory() if is_github else GitLabPublisherFactory()
-    monkeypatch.setattr(publisher.__class__, "projects", [project])
-    # NOTE: Can't set __str__ using pretend.stub()
-    monkeypatch.setattr(publisher.__class__, "__str__", lambda s: "fakespecifier")
+    publisher.projects = [project]
+    db_request.db.flush()
 
     def _find_publisher(claims, pending=False):
         if pending:
@@ -1150,14 +1130,10 @@ def test_mint_token_jti_stored_before_macaroon_creation(monkeypatch, db_request)
     time_mod = pretend.stub(time=pretend.call_recorder(lambda: 0))
     monkeypatch.setattr(views, "time", time_mod)
 
-    project = pretend.stub(
-        id="fakeprojectid",
-        record_event=pretend.call_recorder(lambda **kw: None),
-    )
-
+    project = ProjectFactory.create()
     publisher = GitHubPublisherFactory()
-    monkeypatch.setattr(publisher.__class__, "projects", [project])
-    monkeypatch.setattr(publisher.__class__, "__str__", lambda s: "fakespecifier")
+    publisher.projects = [project]
+    db_request.db.flush()
 
     # Track the order of operations to verify JTI is stored before macaroon
     # creation. Each call appends to this list so we can assert ordering.

--- a/warehouse/oidc/views.py
+++ b/warehouse/oidc/views.py
@@ -12,6 +12,8 @@ from pydantic import BaseModel, StrictStr, ValidationError
 from pyramid.httpexceptions import HTTPException, HTTPForbidden
 from pyramid.request import Request
 from pyramid.view import view_config
+from sqlalchemy import select
+from sqlalchemy.orm import selectinload
 
 from warehouse.email import (
     send_environment_ignored_in_trusted_publisher_email,
@@ -33,7 +35,7 @@ from warehouse.oidc.utils import (
     lookup_custom_issuer_type,
 )
 from warehouse.packaging.interfaces import IProjectService
-from warehouse.packaging.models import ProjectFactory
+from warehouse.packaging.models import Project, ProjectFactory
 from warehouse.rate_limiting.interfaces import IRateLimiter
 
 
@@ -342,6 +344,18 @@ def mint_token(
         oidc_publisher_id=str(publisher.id),
         additional={"oidc": publisher.stored_claims(claims)},
     )
+
+    # Loading `publisher.projects` back-populates `Project.oidc_publishers`,
+    # which marks each project as dirty. At flush time, the cache-purge
+    # bookkeeping in `warehouse.cache.origin` then accesses `project.users`
+    # per dirty project (via the `iterate_on="users"` purge-key factory),
+    # producing an N+1. Pre-load every project's users in a single batched
+    # query so those later accesses hit the relationship cache.
+    request.db.execute(
+        select(Project)
+        .where(Project.id.in_([p.id for p in publisher.projects]))
+        .options(selectinload(Project.users))
+    ).all()
 
     for project in publisher.projects:
         project.record_event(


### PR DESCRIPTION
Datadog flagged sequential `project.users` queries on `POST oidc.mint_token`, one per project on the publisher.

Reading `publisher.projects` back-populates `Project.oidc_publishers` and marks each project dirty. At flush, the cache-purge hook in `warehouse.cache.origin` walks `project.users` per dirty project (the `iterate_on="users"` purge key), so N projects cost N queries.

Preload the users in one `selectinload` query; the later per-project accesses hit the relationship cache instead.

Kept local rather than making `Project.users` eager: Project loads on nearly every read and `User.emails` is already eager, so a global eager load would tax hot read paths to fix a write-only purge. The same N+1 lurks in any txn that dirties several projects at once; if it recurs, the general fix belongs in the cache-purge layer, not here.

Tests move from pretend stubs to factory data and add a query-counting regression test.