### PR TITLE
Make admin quarantine confirmation clearer

### DIFF
--- a/warehouse/admin/templates/admin/users/detail.html
+++ b/warehouse/admin/templates/admin/users/detail.html
@@ -303,7 +303,7 @@
                       </button>
                     </div>
                     <div class="modal-body">
-                      <p>This will quarantine all projects owned by this user, removing them from public APIs until cleared or removed.</p>
+                      <p>This will quarantine all projects owned or maintained by this user, removing them from public APIs until cleared or removed.</p>
                       <p>This action is reversible.</p>
                       <hr>
                       <p>Enter username '{{ user.username }}' to confirm:</p>


### PR DESCRIPTION
Quarantining all of a user's projects affects both owned and maintained projects. This PR fixes the confirmation message to include the "maintained" part.

cc @miketheman 