### PR TITLE
Fix re-auth allowing other user's credentials

### DIFF
--- a/tests/unit/accounts/test_forms.py
+++ b/tests/unit/accounts/test_forms.py
@@ -1183,15 +1183,15 @@ class TestWebAuthnAuthenticationForm:
 class TestReAuthenticateForm:
     def test_validate(self):
         user_service = pretend.stub(
-            find_userid=lambda userid: 1,
-            check_password=lambda userid, password, tags=None: True,
+            check_password=pretend.call_recorder(
+                lambda userid, password, tags=None: True
+            ),
         )
         request = pretend.stub()
 
         form = forms.ReAuthenticateForm(
             formdata=MultiDict(
                 {
-                    "username": "username",
                     "password": "mysupersecurepassword1!",
                     "next_route": pretend.stub(),
                     "next_route_matchdict": pretend.stub(),
@@ -1199,21 +1199,53 @@ class TestReAuthenticateForm:
                 }
             ),
             request=request,
+            user_id=1,
             user_service=user_service,
         )
 
+        assert form.user_id == 1
         assert form.user_service is user_service
         assert form.__params__ == [
-            "username",
             "password",
             "next_route",
             "next_route_matchdict",
             "next_route_query",
         ]
-        assert isinstance(form.username, wtforms.StringField)
         assert isinstance(form.next_route, wtforms.StringField)
         assert isinstance(form.next_route_matchdict, wtforms.StringField)
         assert form.validate(), str(form.errors)
+        assert user_service.check_password.calls == [
+            pretend.call(1, "mysupersecurepassword1!", tags=None)
+        ]
+
+    def test_validate_ignores_posted_username(self):
+        user_service = pretend.stub(
+            find_userid=pretend.call_recorder(lambda username: 2),
+            check_password=pretend.call_recorder(
+                lambda userid, password, tags=None: True
+            ),
+        )
+
+        form = forms.ReAuthenticateForm(
+            formdata=MultiDict(
+                {
+                    "username": "attacker-controlled",
+                    "password": "mysupersecurepassword1!",
+                    "next_route": pretend.stub(),
+                    "next_route_matchdict": pretend.stub(),
+                    "next_route_query": pretend.stub(),
+                }
+            ),
+            request=pretend.stub(),
+            user_id=1,
+            user_service=user_service,
+        )
+
+        assert form.validate(), str(form.errors)
+        assert user_service.check_password.calls == [
+            pretend.call(1, "mysupersecurepassword1!", tags=None)
+        ]
+        assert user_service.find_userid.calls == []
 
 
 class TestRecoveryCodeForm:

--- a/tests/unit/accounts/test_forms.py
+++ b/tests/unit/accounts/test_forms.py
@@ -1247,6 +1247,43 @@ class TestReAuthenticateForm:
         ]
         assert user_service.find_userid.calls == []
 
+    def test_validate_password_with_field_errors(self):
+        user_service = pretend.stub(
+            check_password=pretend.call_recorder(
+                lambda userid, password, tags=None: True
+            ),
+        )
+        form = forms.ReAuthenticateForm(
+            request=pretend.stub(),
+            user_id=1,
+            user_service=user_service,
+        )
+        field = pretend.stub(data="pw", errors=["This field is required."])
+
+        form.validate_password(field)
+
+        assert user_service.check_password.calls == []
+
+    def test_validate_password_too_many_failed(self):
+        user_service = pretend.stub(
+            check_password=pretend.call_recorder(
+                pretend.raiser(
+                    TooManyFailedLogins(resets_in=datetime.timedelta(seconds=600))
+                )
+            ),
+        )
+        form = forms.ReAuthenticateForm(
+            request=pretend.stub(),
+            user_id=1,
+            user_service=user_service,
+        )
+        field = pretend.stub(data="pw", errors=[])
+
+        with pytest.raises(wtforms.validators.ValidationError):
+            form.validate_password(field)
+
+        assert user_service.check_password.calls == [pretend.call(1, "pw", tags=None)]
+
 
 class TestRecoveryCodeForm:
     def test_validate(self, monkeypatch):

--- a/tests/unit/accounts/test_views.py
+++ b/tests/unit/accounts/test_views.py
@@ -3786,7 +3786,7 @@ class TestReAuthentication:
             pretend.call(
                 pyramid_request.POST,
                 request=pyramid_request,
-                username=pyramid_request.user.username,
+                user_id=pyramid_request.user.id,
                 next_route=pyramid_request.matched_route.name,
                 next_route_matchdict=json.dumps(pyramid_request.matchdict),
                 next_route_query=json.dumps(pyramid_request.GET.mixed()),
@@ -3808,6 +3808,75 @@ class TestReAuthentication:
         assert isinstance(result, HTTPSeeOther)
         assert pyramid_request.route_path.calls == [pretend.call("accounts.login")]
         assert result.headers["Location"] == "/the-redirect"
+
+    def test_reauth_rejects_different_users_password(
+        self, monkeypatch, pyramid_request, pyramid_services
+    ):
+        alice = pretend.stub(
+            id=1,
+            username="alice",
+            record_event=pretend.call_recorder(lambda **kwargs: None),
+        )
+        user_service = pretend.stub(
+            check_password=pretend.call_recorder(
+                lambda user_id, password, tags=None: (
+                    user_id == 2 and password == "bob-password"
+                )
+            ),
+            find_userid=pretend.call_recorder(lambda username: 2),
+            get_user=pretend.call_recorder(lambda user_id: alice),
+            get_password_timestamp=pretend.call_recorder(lambda user_id: 0),
+        )
+        response = pretend.stub(headers={"Location": "/target"})
+
+        monkeypatch.setattr(views, "HTTPSeeOther", lambda url: response)
+        pyramid_services.register_service(user_service, IUserService, None)
+
+        pyramid_request.method = "POST"
+        pyramid_request.POST = MultiDict(
+            {
+                "username": "bob",
+                "password": "bob-password",
+                "next_route": "manage.account.publishing",
+                "next_route_matchdict": "{}",
+                "next_route_query": "{}",
+            }
+        )
+        pyramid_request.user = alice
+        pyramid_request.matched_route = pretend.stub(name="manage.account.publishing")
+        pyramid_request.matchdict = {}
+        pyramid_request.GET = pretend.stub(mixed=lambda: {})
+        pyramid_request.route_path = pretend.call_recorder(lambda *a, **kw: "/target")
+        pyramid_request.session.record_auth_timestamp = pretend.call_recorder(
+            lambda: None
+        )
+        pyramid_request.session.record_password_timestamp = pretend.call_recorder(
+            lambda ts: None
+        )
+
+        result = views.reauthenticate(pyramid_request)
+
+        assert result is response
+        assert user_service.check_password.calls == [
+            pretend.call(
+                alice.id,
+                "bob-password",
+                tags=[
+                    "method:reauth",
+                    "auth_method:reauthenticate_form",
+                ],
+            )
+        ]
+        assert user_service.find_userid.calls == []
+        assert alice.record_event.calls == [
+            pretend.call(
+                tag="account:reauthenticate:failure",
+                request=pyramid_request,
+                additional={"reason": "invalid_password"},
+            )
+        ]
+        assert pyramid_request.session.record_auth_timestamp.calls == []
+        assert pyramid_request.session.record_password_timestamp.calls == []
 
 
 class TestManageAccountPublishingViews:

--- a/tests/unit/manage/test_init.py
+++ b/tests/unit/manage/test_init.py
@@ -56,7 +56,7 @@ class TestReAuthView:
             session=pretend.stub(
                 needs_reauthentication=pretend.call_recorder(lambda *args: True)
             ),
-            user=pretend.stub(username=pretend.stub()),
+            user=pretend.stub(id=pretend.stub(), username=pretend.stub()),
             matched_route=pretend.stub(name=pretend.stub()),
             matchdict={"foo": "bar"},
             GET=pretend.stub(mixed=lambda: {"baz": "bar"}),

--- a/warehouse/accounts/forms.py
+++ b/warehouse/accounts/forms.py
@@ -560,16 +560,12 @@ class WebAuthnAuthenticationForm(WebAuthnCredentialMixin, _TwoFactorAuthenticati
 
 class ReAuthenticateForm(PasswordMixin, wtforms.Form):
     __params__ = [
-        "username",
         "password",
         "next_route",
         "next_route_matchdict",
         "next_route_query",
     ]
 
-    username = wtforms.fields.HiddenField(
-        validators=[wtforms.validators.InputRequired()]
-    )
     next_route = wtforms.fields.HiddenField(
         validators=[wtforms.validators.InputRequired()]
     )
@@ -580,9 +576,39 @@ class ReAuthenticateForm(PasswordMixin, wtforms.Form):
         validators=[wtforms.validators.InputRequired()]
     )
 
-    def __init__(self, *args, user_service, **kwargs):
+    def __init__(self, *args, user_id, user_service, **kwargs):
         super().__init__(*args, **kwargs)
+        self.user_id = user_id
         self.user_service = user_service
+
+    def validate_password(self, field):
+        if field.errors:
+            return
+
+        try:
+            if not self.user_service.check_password(
+                self.user_id,
+                field.data,
+                tags=self._check_password_metrics_tags,
+            ):
+                user = self.user_service.get_user(self.user_id)
+                user.record_event(
+                    tag=f"account:{self.action}:failure",
+                    request=self.request,
+                    additional={"reason": "invalid_password"},
+                )
+                raise wtforms.validators.ValidationError(INVALID_PASSWORD_MESSAGE)
+        except TooManyFailedLogins as err:
+            raise wtforms.validators.ValidationError(
+                _(
+                    "There have been too many unsuccessful login attempts. "
+                    "You have been locked out for ${time}. "
+                    "Please try again later.",
+                    mapping={
+                        "time": humanize.naturaldelta(err.resets_in.total_seconds())
+                    },
+                )
+            ) from None
 
 
 class RecoveryCodeAuthenticationForm(

--- a/warehouse/accounts/views.py
+++ b/warehouse/accounts/views.py
@@ -1648,7 +1648,7 @@ def reauthenticate(request, _form_class=ReAuthenticateForm):
     form = _form_class(
         request.POST,
         request=request,
-        username=request.user.username,
+        user_id=request.user.id,
         next_route=request.matched_route.name,
         next_route_matchdict=json.dumps(request.matchdict),
         next_route_query=json.dumps(request.GET.mixed()),

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -68,7 +68,7 @@ msgstr ""
 msgid "Password too long."
 msgstr ""
 
-#: warehouse/accounts/forms.py:219
+#: warehouse/accounts/forms.py:219 warehouse/accounts/forms.py:604
 #, python-brace-format
 msgid ""
 "There have been too many unsuccessful login attempts. You have been "
@@ -115,15 +115,15 @@ msgstr ""
 msgid "Invalid WebAuthn assertion: Bad payload"
 msgstr ""
 
-#: warehouse/accounts/forms.py:609
+#: warehouse/accounts/forms.py:635
 msgid "Invalid recovery code."
 msgstr ""
 
-#: warehouse/accounts/forms.py:618
+#: warehouse/accounts/forms.py:644
 msgid "Recovery code has been previously used."
 msgstr ""
 
-#: warehouse/accounts/forms.py:647
+#: warehouse/accounts/forms.py:673
 msgid "The username isn't valid. Try again."
 msgstr ""
 
@@ -1606,7 +1606,7 @@ msgstr ""
 #: warehouse/templates/accounts/reset-password.html:62
 #: warehouse/templates/accounts/reset-password.html:67
 #: warehouse/templates/manage/account.html:453
-#: warehouse/templates/re-auth.html:19 warehouse/templates/re-auth.html:74
+#: warehouse/templates/re-auth.html:19 warehouse/templates/re-auth.html:73
 msgid "Confirm password"
 msgstr ""
 
@@ -1618,7 +1618,7 @@ msgstr ""
 #: warehouse/templates/accounts/register.html:142
 #: warehouse/templates/accounts/reset-password.html:28
 #: warehouse/templates/manage/manage_base.html:447
-#: warehouse/templates/re-auth.html:49
+#: warehouse/templates/re-auth.html:48
 msgid "Password"
 msgstr ""
 
@@ -1721,27 +1721,27 @@ msgstr ""
 #: warehouse/templates/manage/team/settings.html:22
 #: warehouse/templates/packaging/submit-malware-observation.html:54
 #: warehouse/templates/packaging/submit-malware-observation.html:67
-#: warehouse/templates/re-auth.html:51
+#: warehouse/templates/re-auth.html:50
 msgid "(required)"
 msgstr ""
 
 #: warehouse/templates/accounts/login.html:71
-#: warehouse/templates/re-auth.html:55
+#: warehouse/templates/re-auth.html:54
 msgid "Your password"
 msgstr ""
 
 #: warehouse/templates/accounts/login.html:68
 #: warehouse/templates/manage/manage_base.html:453
-#: warehouse/templates/re-auth.html:82
+#: warehouse/templates/re-auth.html:81
 msgid "Show password"
 msgstr ""
 
 #: warehouse/templates/accounts/login.html:95
-#: warehouse/templates/re-auth.html:86
+#: warehouse/templates/re-auth.html:85
 msgid "Forgot password?"
 msgstr ""
 
-#: warehouse/templates/re-auth.html:90
+#: warehouse/templates/re-auth.html:89
 #, python-format
 msgid ""
 "<b>Tip:</b> you are about to perform a <a href=\"%(href)s\">sensitive "

--- a/warehouse/manage/__init__.py
+++ b/warehouse/manage/__init__.py
@@ -28,7 +28,7 @@ def reauth_view(view, info):
                 form = ReAuthenticateForm(
                     request.POST,
                     request=request,
-                    username=request.user.username,
+                    user_id=request.user.id,
                     next_route=request.matched_route.name,
                     next_route_matchdict=json.dumps(request.matchdict),
                     next_route_query=json.dumps(request.GET.mixed()),

--- a/warehouse/templates/re-auth.html
+++ b/warehouse/templates/re-auth.html
@@ -37,7 +37,6 @@
         {{ form.next_route }}
         {{ form.next_route_matchdict }}
         {{ form.next_route_query }}
-        {{ form.username }}
         {% if form.form_errors %}
           <ul class="form-errors" role="alert">
             {% for error in form.form_errors %}<li>{{ error }}</li>{% endfor %}


### PR DESCRIPTION
Currently, when a user's session is stale and they get the re-auth form, this form has a hidden input field for the username. If one changes this hidden input before submitting the form, one can re-auth the expired session of user `A` using the credentials of user `B`.

Concretely:
1. User Alice is logged in
2. Once Alice's session goes stale after 30 minutes, it requires reauthentication to access certain re-auth protected views
3. On the reauth form, one can change the hidden `username` field from `alice` to another account, e.g. `bob`.
4. Bob's valid password is entered and the form is submitted
5. Alice session is re-authenticated using Bob's credentials, and one is redirected to the protected view of Alice's account

This happens because the password validation during re-auth is not tied to the authenticated session user. This PR fixes that by removing the username hidden field and defining a `validate_password` function that uses the session's user ID instead.

cc @miketheman 
