### PR TITLE
feat(admin): optionally notify on token deletion

### DIFF
--- a/tests/unit/admin/views/test_macaroons.py
+++ b/tests/unit/admin/views/test_macaroons.py
@@ -2,13 +2,13 @@
 
 import uuid
 
-import pretend
 import pytest
 
 from warehouse.admin.views import macaroons as views
 from warehouse.macaroons import caveats
 
 from ....common.db.accounts import UserFactory
+from ....common.db.macaroons import MacaroonFactory
 
 
 @pytest.fixture
@@ -88,12 +88,7 @@ class TestMacaroonDetail:
 
     def test_macaroon_exists(self, db_request, macaroon_service):
         user = UserFactory.create()
-        _, macaroon = macaroon_service.create_macaroon(
-            location="test",
-            description="test",
-            scopes=[caveats.RequestUser(user_id=str(user.id))],
-            user_id=user.id,
-        )
+        macaroon = MacaroonFactory.create(user_id=user.id)
         db_request.matchdict["macaroon_id"] = macaroon.id
 
         result = views.macaroon_detail(db_request)
@@ -111,20 +106,58 @@ class TestMacaroonDelete:
     def test_delete_succeeds_and_redirects(self, db_request, macaroon_service):
         user = UserFactory.create()
         db_request.user = user
-        _, macaroon = macaroon_service.create_macaroon(
-            location="test",
-            description="test",
-            scopes=[caveats.RequestUser(user_id=str(user.id))],
-            user_id=user.id,
-        )
+        macaroon = MacaroonFactory.create(user_id=user.id)
         macaroon_id = str(macaroon.id)
         db_request.matchdict["macaroon_id"] = macaroon_id
-        db_request.route_url = pretend.call_recorder(
-            lambda *a, **kw: "/admin/macaroons/decode"
-        )
+        db_request.route_url = lambda *a, **kw: "/admin/macaroons/decode"
 
         result = views.macaroon_delete(db_request)
 
         assert result.status_code == views.HTTPSeeOther.code
         assert result.location == "/admin/macaroons/decode"
         assert macaroon_service.find_macaroon(macaroon_id) is None
+
+    @pytest.mark.parametrize(
+        ("post", "notified", "expected_reason"),
+        [
+            (
+                {"notify": "true", "reason": "Found in a public CI log"},
+                True,
+                "Found in a public CI log",
+            ),
+            ({"notify": "true", "reason": "   "}, True, None),
+            ({}, False, None),
+        ],
+    )
+    def test_delete_optionally_notifies_user(
+        self, db_request, macaroon_service, mocker, post, notified, expected_reason
+    ):
+        user = UserFactory.create()
+        db_request.user = user
+        macaroon = MacaroonFactory.create(user_id=user.id)
+        macaroon_id = str(macaroon.id)
+        db_request.matchdict["macaroon_id"] = macaroon_id
+        db_request.POST = post
+        db_request.route_url = lambda *a, **kw: "/admin/macaroons/decode"
+        send_email = mocker.patch.object(
+            views, "send_token_compromised_email_leak", autospec=True
+        )
+        record_event = mocker.spy(user, "record_event")
+
+        result = views.macaroon_delete(db_request)
+
+        assert result.status_code == views.HTTPSeeOther.code
+        assert macaroon_service.find_macaroon(macaroon_id) is None
+
+        recorded = record_event.call_args.kwargs["additional"]
+        if expected_reason:
+            assert recorded["reason"] == expected_reason
+        else:
+            assert "reason" not in recorded
+
+        if notified:
+            send_email.assert_called_once_with(
+                db_request, user, admin_initiated=True, reason=expected_reason
+            )
+        else:
+            send_email.assert_not_called()

--- a/tests/unit/email/test_init.py
+++ b/tests/unit/email/test_init.py
@@ -1003,8 +1003,37 @@ class TestPasswordCompromisedHIBPEmail:
 
 class TestTokenLeakEmail:
     @pytest.mark.parametrize("verified", [True, False])
+    @pytest.mark.parametrize(
+        ("kwargs", "expected_context"),
+        [
+            (
+                {"public_url": "http://example.com", "origin": "github"},
+                {
+                    "public_url": "http://example.com",
+                    "origin": "github",
+                    "admin_initiated": False,
+                    "reason": None,
+                },
+            ),
+            (
+                {"admin_initiated": True, "reason": "Found in a public CI log"},
+                {
+                    "public_url": None,
+                    "origin": None,
+                    "admin_initiated": True,
+                    "reason": "Found in a public CI log",
+                },
+            ),
+        ],
+    )
     def test_token_leak_email(
-        self, pyramid_request, pyramid_config, monkeypatch, verified
+        self,
+        pyramid_request,
+        pyramid_config,
+        monkeypatch,
+        verified,
+        kwargs,
+        expected_context,
     ):
         stub_user = pretend.stub(
             id=3,
@@ -1040,14 +1069,10 @@ class TestTokenLeakEmail:
         monkeypatch.setattr(email, "send_email", send_email)
 
         result = email.send_token_compromised_email_leak(
-            pyramid_request, stub_user, public_url="http://example.com", origin="github"
+            pyramid_request, stub_user, **kwargs
         )
 
-        assert result == {
-            "username": "username",
-            "public_url": "http://example.com",
-            "origin": "github",
-        }
+        assert result == {"username": "username", **expected_context}
         assert pyramid_request.task.calls == [pretend.call(send_email)]
         assert send_email.delay.calls == [
             pretend.call(

--- a/warehouse/admin/templates/admin/macaroons/detail.html
+++ b/warehouse/admin/templates/admin/macaroons/detail.html
@@ -87,6 +87,17 @@
             This will permanently destroy the macaroon and cannot be undone.
           </p>
           <hr>
+          <div class="form-check">
+            <input type="checkbox" class="form-check-input" id="notifyUser" name="notify" value="true">
+            <label class="form-check-label" for="notifyUser">
+              Notify the user that this token was compromised
+            </label>
+          </div>
+          <div class="form-group mt-2">
+            <label for="notifyReason">Reason / public URL (optional)</label>
+            <textarea class="form-control" id="notifyReason" name="reason" rows="2"
+              placeholder="Included in the notification email, if sent."></textarea>
+          </div>
           <input type="hidden" name="macaroon" value="{{ macaroon.id }}">
         </div>
         <div class="modal-footer">

--- a/warehouse/admin/views/macaroons.py
+++ b/warehouse/admin/views/macaroons.py
@@ -5,6 +5,7 @@ from pyramid.view import view_config
 from sqlalchemy.orm import joinedload
 
 from warehouse.authnz import Permissions
+from warehouse.email import send_token_compromised_email_leak
 from warehouse.events.tags import EventTag
 from warehouse.macaroons.errors import InvalidMacaroonError
 from warehouse.macaroons.interfaces import IMacaroonService
@@ -95,19 +96,32 @@ def macaroon_delete(request):
     if macaroon is None:
         raise HTTPNotFound
 
-    # TODO: Shows up in user history. Should it? `removed_by` is not shown.
+    user = macaroon.user
+    notify = bool(request.POST.get("notify"))
+    reason = request.POST.get("reason", "").strip() or None
+
+    additional = {
+        "macaroon_id": str(macaroon.id),
+        "description": macaroon.description,
+        "removed_by": request.user.username,  # not displayed to user
+        "redact_ip": True,
+    }
+    if reason:
+        additional["reason"] = reason
+
     # Since we still have a macaroon, record the event to the associated user
-    macaroon.user.record_event(
+    user.record_event(
         tag=EventTag.Account.APITokenRemoved,
         request=request,
-        additional={
-            "macaroon_id": str(macaroon.id),
-            "description": macaroon.description,
-            "removed_by": request.user.username,
-        },
+        additional=additional,
     )
 
     macaroon_service.delete_macaroon(macaroon_id)
+
+    if notify:
+        send_token_compromised_email_leak(
+            request, user, admin_initiated=True, reason=reason
+        )
 
     request.session.flash(
         f"Macaroon with ID {macaroon_id} has been deleted.", queue="success"

--- a/warehouse/email/__init__.py
+++ b/warehouse/email/__init__.py
@@ -296,8 +296,16 @@ def send_password_reset_by_admin_email(request, user):
 
 
 @_email("token-compromised-leak", allow_unverified=True)
-def send_token_compromised_email_leak(request, user, *, public_url, origin):
-    return {"username": user.username, "public_url": public_url, "origin": origin}
+def send_token_compromised_email_leak(
+    request, user, *, public_url=None, origin=None, admin_initiated=False, reason=None
+):
+    return {
+        "username": user.username,
+        "public_url": public_url,
+        "origin": origin,
+        "admin_initiated": admin_initiated,
+        "reason": reason,
+    }
 
 
 @_email(

--- a/warehouse/templates/email/token-compromised-leak/body.html
+++ b/warehouse/templates/email/token-compromised-leak/body.html
@@ -3,44 +3,66 @@
 {% set site_name = request.registry.settings["site.name"] %}
 {% block content %}
   <h3>What?</h3>
-  <p>
-    A third party ({{ origin.name }}) has informed us that a {{ site_name }} API token
-    associated with your account "{{ username }}" was found to be accessible at the
-    following public URL. We have automatically revoked this token.
-  </p>
-  <p>
-    <a href="{{ public_url }}">{{ public_url }}</a>
-  </p>
+  {% if admin_initiated %}
+    <p>
+      A {{ site_name }} administrator has revoked an API token associated with your account
+      "{{ username }}" because it was found to be compromised.
+    </p>
+    {% if reason %}
+      <p>Additional details from the administrator:</p>
+      <p>{{ reason }}</p>
+    {% endif %}
+  {% else %}
+    <p>
+      A third party ({{ origin.name }}) has informed us that a {{ site_name }} API token
+      associated with your account "{{ username }}" was found to be accessible at the
+      following public URL. We have automatically revoked this token.
+    </p>
+    <p>
+      <a href="{{ public_url }}">{{ public_url }}</a>
+    </p>
+  {% endif %}
   <h3>What should I do?</h3>
+  {% if not admin_initiated %}
+    <p>
+      First, we recommend that you inspect the public page where the token
+      appeared. Please investigate whether this is the result of an error on your side or if
+      someone else acquired and published your token.
+    </p>
+    <p>
+      If the token was not published by you, it means it was stolen, either from you or from
+      someone with access to your account on {{ site_name }}. We urge you to take all the
+      necessary steps to secure all your credentials.
+    </p>
+  {% endif %}
   <p>
-    First, we recommend that you inspect the public page where the token
-    appeared. Please investigate whether this is the result of an error on your side or if
-    someone else acquired and published your token.
-  </p>
-  <p>
-    If the token was not published by you, it means it was stolen, either from you or from
-    someone with access to your account on {{ site_name }}. We urge you to take all the
-    necessary steps to secure all your credentials.
-  </p>
-  <p>
-    Once you have taken the applicable steps to ensure the token will not become public
+    Once you have taken the applicable steps to ensure the token will not become compromised
     again, you're welcome to generate a new one. Log into your account and head to your
     profile page to create a new API token. You will need to update your existing
     integrations with the new token.
   </p>
   <p>
+    If you publish from a CI/CD service such as GitHub Actions or GitLab CI, consider
+    adopting
+    <a href="{{ request.user_docs_url('/trusted-publishers/') }}">Trusted Publishing</a>
+    instead of API tokens. It uses short-lived, automatically rotated credentials, so
+    there is no long-lived token that can be leaked.
+  </p>
+  <p>
     Lastly, please review the releases of all your packages. You should make
-    sure a third party did not use your publicly accessible token to impersonate
+    sure a third party did not use your compromised token to impersonate
     you and release a malicious package.
   </p>
-  <h3>How do you know this?</h3>
-  <p>
-    This is an automated message. Our partner {{ origin.name }} analyzes all the data it
-    receives for unintentional {{ site_name }} token publications and warns us every time
-    it finds one. We check every disclosure we receive and take action when the token
-    appears
-    valid.
-  </p>
+  {% if not admin_initiated %}
+    <h3>How do you know this?</h3>
+    <p>
+      This is an automated message. Our partner {{ origin.name }} analyzes all the data it
+      receives for unintentional {{ site_name }} token publications and warns us every time
+      it finds one. We check every disclosure we receive and take action when the token
+      appears
+      valid.
+    </p>
+  {% endif %}
   <p>
     For more information, see our
     <a href="{{ request.help_url(_anchor='compromised-token') }}">FAQ</a>.

--- a/warehouse/templates/email/token-compromised-leak/body.txt
+++ b/warehouse/templates/email/token-compromised-leak/body.txt
@@ -8,14 +8,26 @@ What happened?
 
 {% set site_name=request.registry.settings["site.name"] %}
 
+{% if admin_initiated %}
+A {{ site_name }} administrator has revoked an API token associated with your account
+"{{ username }}" because it was found to be compromised.
+{% if reason %}
+
+Additional details from the administrator:
+
+{{ reason }}
+{% endif %}
+{% else %}
 A third party ({{ origin.name }}) has informed us that a {{ site_name }} API token
 associated with your account "{{ username }}" was found to be accessible at the
 following public URL. We have automatically revoked this token.
 
 {{ public_url }}
+{% endif %}
 
 What should I do?
 
+{% if not admin_initiated %}
 First, we recommend that you inspect the public page where the token
 appeared. Please investigate whether this is the result of an error on your side or if
 someone else acquired and published your token.
@@ -24,21 +36,30 @@ If the token was not published by you, it means it was stolen, either from you o
 someone with access to your account on {{ site_name }}. We urge you to take all the
 necessary steps to secure all your credentials.
 
-Once you have taken the applicable steps to ensure the token will not become public
+{% endif %}
+Once you have taken the applicable steps to ensure the token will not become compromised
 again, you're welcome to generate a new one. Log into your account and head to your
 profile page to create a new API token. You will need to update your existing
 integrations with the new token.
 
+If you publish from a CI/CD service such as GitHub Actions or GitLab CI, consider
+adopting Trusted Publishing instead of API tokens. It uses short-lived, automatically
+rotated credentials, so there is no long-lived token that can be leaked:
+
+{{ request.user_docs_url('/trusted-publishers/') }}
+
 Lastly, please review the releases of all your packages. You should make
-sure a third party did not use your publicly accessible token to impersonate
+sure a third party did not use your compromised token to impersonate
 you and release a malicious package.
 
+{% if not admin_initiated %}
 How do you know this?
 
 This is an automated message. Our partner {{ origin.name }} analyzes all the data it receives
 for unintentional {{ site_name }} token publications and warns us every time it finds
 one. We check every disclosure we receive and take action when the token appears valid.
 
+{% endif %}
 For more information, see our FAQ at {{ request.help_url(_anchor='compromised-token') }}
 
 For help, you can send an email to admin@pypi.org to communicate with the PyPI

--- a/warehouse/templates/email/token-compromised-leak/subject.txt
+++ b/warehouse/templates/email/token-compromised-leak/subject.txt
@@ -2,4 +2,4 @@
 
 {% extends "email/_base/subject.txt" %}
 
-{% block subject %}Your API credentials from {{ request.registry.settings["site.name"] }} were found on a public webpage{% endblock %}
+{% block subject %}{% if admin_initiated %}A {{ request.registry.settings["site.name"] }} administrator revoked one of your API tokens{% else %}Your API credentials from {{ request.registry.settings["site.name"] }} were found on a public webpage{% endif %}{% endblock %}


### PR DESCRIPTION
When an admin deletes a macaroon (token), provide the administrator the facility to also send a notification to the user, and allow them to also set a reason to inform the user of why.