### PR TITLE
test: replace pretend in the organizations, subscriptions, and api tests

### DIFF
--- a/tests/unit/api/test_billing.py
+++ b/tests/unit/api/test_billing.py
@@ -2,7 +2,6 @@
 
 import json
 
-import pretend
 import pytest
 import stripe
 
@@ -21,7 +20,7 @@ from ...common.db.subscriptions import StripeCustomerFactory, StripeSubscription
 class TestHandleBillingWebhookEvent:
     # checkout.session.completed
     def test_handle_billing_webhook_event_checkout_complete_not_us(
-        self, db_request, subscription_service, monkeypatch, billing_service
+        self, db_request, subscription_service, mocker, billing_service
     ):
         organization = OrganizationFactory.create()
         stripe_customer = StripeCustomerFactory.create()
@@ -47,34 +46,17 @@ class TestHandleBillingWebhookEvent:
             },
         }
 
-        checkout_session = {
-            "id": "cs_test_12345",
-            "customer": {
-                "id": stripe_customer.customer_id,
-                "email": "good@day.com",
-            },
-            "status": "complete",
-            "subscription": {
-                "id": subscription.subscription_id,
-                "items": {
-                    "data": [{"id": "si_12345"}],
-                },
-            },
-        }
-
-        get_checkout_session = pretend.call_recorder(lambda *a, **kw: checkout_session)
-        monkeypatch.setattr(
-            billing_service, "get_checkout_session", get_checkout_session
+        get_checkout_session = mocker.patch.object(
+            billing_service, "get_checkout_session"
         )
 
         billing.handle_billing_webhook_event(db_request, event)
 
-        assert (
-            get_checkout_session.calls == []
-        )  # Should have stopped immediately before this call
+        # Should have stopped immediately before this call
+        get_checkout_session.assert_not_called()
 
     def test_handle_billing_webhook_event_checkout_complete_update(
-        self, db_request, subscription_service, monkeypatch, billing_service
+        self, db_request, subscription_service, mocker, billing_service
     ):
         organization = OrganizationFactory.create()
         stripe_customer = StripeCustomerFactory.create()
@@ -117,15 +99,14 @@ class TestHandleBillingWebhookEvent:
             },
         }
 
-        get_checkout_session = pretend.call_recorder(lambda *a, **kw: checkout_session)
-        monkeypatch.setattr(
-            billing_service, "get_checkout_session", get_checkout_session
+        mocker.patch.object(
+            billing_service, "get_checkout_session", return_value=checkout_session
         )
 
         billing.handle_billing_webhook_event(db_request, event)
 
     def test_handle_billing_webhook_event_checkout_complete_add(
-        self, db_request, subscription_service, monkeypatch, billing_service
+        self, db_request, subscription_service, mocker, billing_service
     ):
         organization = OrganizationFactory.create()
         stripe_customer = StripeCustomerFactory.create()
@@ -164,9 +145,8 @@ class TestHandleBillingWebhookEvent:
             },
         }
 
-        get_checkout_session = pretend.call_recorder(lambda *a, **kw: checkout_session)
-        monkeypatch.setattr(
-            billing_service, "get_checkout_session", get_checkout_session
+        mocker.patch.object(
+            billing_service, "get_checkout_session", return_value=checkout_session
         )
 
         billing.handle_billing_webhook_event(db_request, event)
@@ -194,7 +174,7 @@ class TestHandleBillingWebhookEvent:
             billing.handle_billing_webhook_event(db_request, event)
 
     def test_handle_billing_webhook_event_checkout_complete_invalid_customer(
-        self, db_request, monkeypatch, billing_service
+        self, db_request, mocker, billing_service
     ):
         event = {
             "type": "checkout.session.completed",
@@ -227,16 +207,15 @@ class TestHandleBillingWebhookEvent:
             },
         }
 
-        get_checkout_session = pretend.call_recorder(lambda *a, **kw: checkout_session)
-        monkeypatch.setattr(
-            billing_service, "get_checkout_session", get_checkout_session
+        mocker.patch.object(
+            billing_service, "get_checkout_session", return_value=checkout_session
         )
 
         with pytest.raises(HTTPBadRequest):
             billing.handle_billing_webhook_event(db_request, event)
 
     def test_handle_billing_webhook_event_checkout_complete_invalid_subscription(
-        self, db_request, monkeypatch, billing_service
+        self, db_request, mocker, billing_service
     ):
         event = {
             "type": "checkout.session.completed",
@@ -266,9 +245,8 @@ class TestHandleBillingWebhookEvent:
             },
         }
 
-        get_checkout_session = pretend.call_recorder(lambda *a, **kw: checkout_session)
-        monkeypatch.setattr(
-            billing_service, "get_checkout_session", get_checkout_session
+        mocker.patch.object(
+            billing_service, "get_checkout_session", return_value=checkout_session
         )
 
         with pytest.raises(HTTPBadRequest):

--- a/tests/unit/api/test_config.py
+++ b/tests/unit/api/test_config.py
@@ -1,76 +1,70 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import types
+
 import orjson
-import pretend
 import pytest
 
 from warehouse.api import config
 
 
-def test_api_set_content_type():
-    response = pretend.stub()
-
-    @pretend.call_recorder
+def test_api_set_content_type(mocker):
     def view(context, request):
-        return response
+        return mocker.sentinel.response
 
-    info = pretend.stub(options={"api_version": "v1"})
+    info = types.SimpleNamespace(options={"api_version": "v1"})
     wrapped_view = config._api_set_content_type(view, info)
 
-    context = pretend.stub()
-    request = pretend.stub(response=pretend.stub(content_type=None))
+    request = types.SimpleNamespace(response=types.SimpleNamespace(content_type=None))
 
-    assert wrapped_view(context, request) is response
+    assert wrapped_view(None, request) is mocker.sentinel.response
     assert request.response.content_type == "application/vnd.pypi.v1+json"
 
 
-def test_api_set_content_type_no_api_version():
-    response = pretend.stub()
-
-    @pretend.call_recorder
+def test_api_set_content_type_no_api_version(mocker):
     def view(context, request):
-        return response
+        return mocker.sentinel.response
 
-    info = pretend.stub(options={})
+    info = types.SimpleNamespace(options={})
     wrapped_view = config._api_set_content_type(view, info)
 
-    context = pretend.stub()
-    request = pretend.stub(response=pretend.stub(content_type=None))
+    request = types.SimpleNamespace(response=types.SimpleNamespace(content_type=None))
 
-    assert wrapped_view(context, request) is response
+    assert wrapped_view(None, request) is mocker.sentinel.response
     assert request.response.content_type is None
 
 
 @pytest.mark.parametrize("env_name", ["development", "production"])
-def test_includeme(monkeypatch, env_name):
+def test_includeme(monkeypatch, env_name, mocker):
     # We use `str(Path(__file__).parent / 'openapi.yaml'` to get the path.
     # In our test, monkeypatch to a known value.
     monkeypatch.setattr(config, "__file__", "/mnt/dummy/config.py")
 
-    conf = pretend.stub(
-        add_view_deriver=pretend.call_recorder(
-            lambda deriver, over=None, under=None: None
-        ),
-        include=pretend.call_recorder(lambda x: None),
-        pyramid_openapi3_spec=pretend.call_recorder(lambda *a, **kw: None),
-        pyramid_openapi3_add_deserializer=pretend.call_recorder(lambda *a, **kw: None),
-        pyramid_openapi3_add_explorer=pretend.call_recorder(lambda *a, **kw: None),
-        registry=pretend.stub(settings={"warehouse.env": env_name}),
+    conf = mocker.Mock(
+        spec=[
+            "add_view_deriver",
+            "include",
+            "pyramid_openapi3_spec",
+            "pyramid_openapi3_add_deserializer",
+            "pyramid_openapi3_add_explorer",
+            "registry",
+        ]
     )
+    conf.registry.settings = {"warehouse.env": env_name}
 
     config.includeme(conf)
 
-    assert conf.add_view_deriver.calls == [pretend.call(config._api_set_content_type)]
-    assert conf.include.calls == [pretend.call("pyramid_openapi3")]
-    assert conf.pyramid_openapi3_spec.calls == [
-        pretend.call("/mnt/dummy/openapi.yaml", route="/api/openapi.yaml")
-    ]
-    assert conf.pyramid_openapi3_add_deserializer.calls == [
-        pretend.call("application/vnd.pypi.api-v0-danger+json", orjson.loads)
-    ]
+    conf.add_view_deriver.assert_called_once_with(config._api_set_content_type)
+    conf.include.assert_called_once_with("pyramid_openapi3")
+    conf.pyramid_openapi3_spec.assert_called_once_with(
+        "/mnt/dummy/openapi.yaml", route="/api/openapi.yaml"
+    )
+    conf.pyramid_openapi3_add_deserializer.assert_called_once_with(
+        "application/vnd.pypi.api-v0-danger+json", orjson.loads
+    )
     if env_name == "development":
-        assert conf.pyramid_openapi3_add_explorer.calls == [
-            pretend.call(route="/api/explorer/")
-        ]
+        conf.pyramid_openapi3_add_explorer.assert_called_once_with(
+            route="/api/explorer/"
+        )
     else:
-        assert not conf.pyramid_openapi3_add_explorer.calls
+        conf.pyramid_openapi3_add_explorer.assert_not_called()

--- a/tests/unit/api/test_integrity.py
+++ b/tests/unit/api/test_integrity.py
@@ -1,9 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
-import pretend
 import pytest
 
 from warehouse.api import integrity
+
+from ...common.db.packaging import FileFactory
 
 
 @pytest.mark.parametrize(
@@ -62,31 +63,31 @@ def test_select_content_type(db_request, accept, expected):
 )
 def test_provenance_for_file_bad_accept(db_request, content_type):
     db_request.accept = content_type
-    response = integrity.provenance_for_file(pretend.stub(), db_request)
+    response = integrity.provenance_for_file(None, db_request)
     assert response.status_code == 406
     assert response.json == {"message": "Request not acceptable"}
 
 
-def test_provenance_for_file_accept_multiple(db_request, monkeypatch):
+def test_provenance_for_file_accept_multiple(db_request):
     db_request.accept = "text/html, application/vnd.pypi.integrity.v1+json; q=0.9"
-    file = pretend.stub(provenance=None, filename="fake-1.2.3.tar.gz")
+    file = FileFactory.build(filename="fake-1.2.3.tar.gz")
 
     response = integrity.provenance_for_file(file, db_request)
     assert response.status_code == 404
     assert response.json == {"message": "No provenance available for fake-1.2.3.tar.gz"}
 
 
-def test_provenance_for_file_not_enabled(db_request, monkeypatch):
-    monkeypatch.setattr(db_request, "flags", pretend.stub(enabled=lambda *a: True))
+def test_provenance_for_file_not_enabled(db_request, mocker):
+    mocker.patch.object(db_request.flags, "enabled", return_value=True)
 
-    response = integrity.provenance_for_file(pretend.stub(), db_request)
+    response = integrity.provenance_for_file(None, db_request)
     assert response.status_code == 403
     assert response.json == {"message": "Attestations temporarily disabled"}
 
 
-def test_provenance_for_file_not_present(db_request, monkeypatch):
-    monkeypatch.setattr(db_request, "flags", pretend.stub(enabled=lambda *a: False))
-    file = pretend.stub(provenance=None, filename="fake-1.2.3.tar.gz")
+def test_provenance_for_file_not_present(db_request, mocker):
+    mocker.patch.object(db_request.flags, "enabled", return_value=False)
+    file = FileFactory.build(filename="fake-1.2.3.tar.gz")
 
     response = integrity.provenance_for_file(file, db_request)
     assert response.status_code == 404

--- a/tests/unit/api/test_simple.py
+++ b/tests/unit/api/test_simple.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-import pretend
 import pytest
 
 from packaging.version import parse
@@ -178,12 +177,12 @@ class TestSimpleIndex:
 
 
 class TestSimpleDetail:
-    def test_redirects(self, pyramid_request):
-        project = pretend.stub(normalized_name="foo")
+    def test_redirects(self, pyramid_request, mocker):
+        project = ProjectFactory.build(name="foo")
 
         pyramid_request.matchdict["name"] = "Foo"
-        pyramid_request.current_route_path = pretend.call_recorder(
-            lambda name: "/foobar/"
+        current_route_path = mocker.patch.object(
+            pyramid_request, "current_route_path", return_value="/foobar/"
         )
 
         resp = simple.simple_detail(project, pyramid_request)
@@ -191,7 +190,7 @@ class TestSimpleDetail:
         assert isinstance(resp, HTTPMovedPermanently)
         assert resp.headers["Location"] == "/foobar/"
         _assert_has_cors_headers(resp.headers)
-        assert pyramid_request.current_route_path.calls == [pretend.call(name="foo")]
+        current_route_path.assert_called_once_with(name="foo")
 
     @pytest.mark.parametrize(
         ("content_type", "renderer_override"),

--- a/tests/unit/organizations/test_init.py
+++ b/tests/unit/organizations/test_init.py
@@ -1,7 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-import pretend
-
 from celery.schedules import crontab
 
 from warehouse import organizations
@@ -14,26 +12,20 @@ from warehouse.organizations.tasks import (
 )
 
 
-def test_includeme():
-    config = pretend.stub(
-        register_service_factory=pretend.call_recorder(
-            lambda factory, iface, name=None: None
-        ),
-        add_periodic_task=pretend.call_recorder(lambda *a, **kw: None),
-    )
+def test_includeme(mocker):
+    config = mocker.Mock(spec=["register_service_factory", "add_periodic_task"])
 
     organizations.includeme(config)
 
-    assert config.register_service_factory.calls == [
-        pretend.call(database_organization_factory, IOrganizationService),
-    ]
-
-    assert config.add_periodic_task.calls == [
-        pretend.call(crontab(minute="*/5"), update_organization_invitation_status),
-        pretend.call(
+    config.register_service_factory.assert_called_once_with(
+        database_organization_factory, IOrganizationService
+    )
+    assert config.add_periodic_task.call_args_list == [
+        mocker.call(crontab(minute="*/5"), update_organization_invitation_status),
+        mocker.call(
             crontab(minute=0, hour=0), delete_declined_organization_applications
         ),
-        pretend.call(
+        mocker.call(
             crontab(minute=0, hour=0), update_organziation_subscription_usage_record
         ),
     ]

--- a/tests/unit/organizations/test_models.py
+++ b/tests/unit/organizations/test_models.py
@@ -1,8 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import datetime
+import types
 
-import pretend
 import psycopg
 import pytest
 
@@ -75,7 +75,9 @@ class TestOrganizationFactory:
         assert root[normalized] == organization
 
     def test_traversal_redirects(self, db_request):
-        db_request.matched_route = pretend.stub(generate=lambda *a, **kw: "route-path")
+        db_request.matched_route = types.SimpleNamespace(
+            generate=lambda *a, **kw: "route-path"
+        )
         organization = DBOrganizationFactory.create()
         DBOrganizationNameCatalogFactory.create(
             normalized_name="oldname",

--- a/tests/unit/organizations/test_services.py
+++ b/tests/unit/organizations/test_services.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
-import pretend
+import types
+
 import pytest
 
 from zope.interface.verify import verifyClass
@@ -45,24 +46,20 @@ from ...common.db.packaging import ProjectFactory
 from ...common.db.subscriptions import StripeCustomerFactory, StripeSubscriptionFactory
 
 
-def test_database_organizations_factory():
-    db = pretend.stub()
-    context = pretend.stub()
-    request = pretend.stub(db=db)
-
-    service = services.database_organization_factory(context, request)
-    assert service.db is db
+def test_database_organizations_factory(mocker):
+    request = types.SimpleNamespace(db=mocker.sentinel.db)
+    service = services.database_organization_factory(None, request)
+    assert service.db is mocker.sentinel.db
 
 
 class TestDatabaseOrganizationService:
     def test_verify_service(self):
         assert verifyClass(IOrganizationService, services.DatabaseOrganizationService)
 
-    def test_service_creation(self):
-        session = pretend.stub()
-        service = services.DatabaseOrganizationService(session)
+    def test_service_creation(self, mocker):
+        service = services.DatabaseOrganizationService(mocker.sentinel.session)
 
-        assert service.db is session
+        assert service.db is mocker.sentinel.session
 
     def test_get_organization(self, organization_service):
         organization = OrganizationFactory.create()
@@ -105,14 +102,13 @@ class TestDatabaseOrganizationService:
         ) == [app]
 
     def test_approve_organization_application(
-        self, db_request, organization_service, monkeypatch
+        self, db_request, organization_service, mocker
     ):
-        send_email = pretend.call_recorder(lambda *a, **kw: None)
-        monkeypatch.setattr(
-            services, "send_new_organization_approved_email", send_email
+        send_approved = mocker.patch.object(
+            services, "send_new_organization_approved_email"
         )
-        monkeypatch.setattr(
-            services, "send_new_organization_declined_email", send_email
+        send_declined = mocker.patch.object(
+            services, "send_new_organization_declined_email"
         )
 
         admin = UserFactory(username="admin", is_superuser=True)
@@ -184,20 +180,18 @@ class TestDatabaseOrganizationService:
         )
         assert competing_organization_application.organization is None
 
-        assert send_email.calls == [
-            pretend.call(
-                db_request,
-                organization_application.submitted_by,
-                organization_name=organization.name,
-                message="",
-            ),
-            pretend.call(
-                db_request,
-                competing_organization_application.submitted_by,
-                organization_name=competing_organization_application.name,
-                message="",
-            ),
-        ]
+        send_approved.assert_called_once_with(
+            db_request,
+            organization_application.submitted_by,
+            organization_name=organization.name,
+            message="",
+        )
+        send_declined.assert_called_once_with(
+            db_request,
+            competing_organization_application.submitted_by,
+            organization_name=competing_organization_application.name,
+            message="",
+        )
 
         catalog_entry = (
             db_request.db.query(OrganizationNameCatalog)
@@ -252,11 +246,10 @@ class TestDatabaseOrganizationService:
         assert organization_application.status == OrganizationApplicationStatus.Deferred
 
     def test_request_more_information_organization_application(
-        self, db_request, organization_service, monkeypatch
+        self, db_request, organization_service, mocker
     ):
-        send_email = pretend.call_recorder(lambda *a, **kw: None)
-        monkeypatch.setattr(
-            services, "send_new_organization_moreinformationneeded_email", send_email
+        send_email = mocker.patch.object(
+            services, "send_new_organization_moreinformationneeded_email"
         )
 
         admin = UserFactory(username="admin", is_superuser=True)
@@ -273,22 +266,19 @@ class TestDatabaseOrganizationService:
             organization_application.status
             == OrganizationApplicationStatus.MoreInformationNeeded
         )
-        assert send_email.calls == [
-            pretend.call(
-                db_request,
-                organization_application.submitted_by,
-                organization_name=organization_application.name,
-                organization_application_id=organization_application.id,
-                message="some message",
-            ),
-        ]
+        send_email.assert_called_once_with(
+            db_request,
+            organization_application.submitted_by,
+            organization_name=organization_application.name,
+            organization_application_id=organization_application.id,
+            message="some message",
+        )
 
     def test_request_more_information_organization_application_no_message(
-        self, db_request, organization_service, monkeypatch
+        self, db_request, organization_service, mocker
     ):
-        send_email = pretend.call_recorder(lambda *a, **kw: None)
-        monkeypatch.setattr(
-            services, "send_new_organization_moreinformationneeded_email", send_email
+        send_email = mocker.patch.object(
+            services, "send_new_organization_moreinformationneeded_email"
         )
 
         admin = UserFactory(username="admin", is_superuser=True)
@@ -301,14 +291,13 @@ class TestDatabaseOrganizationService:
             )
 
         assert len(organization_application.observations) == 0
-        assert send_email.calls == []
+        send_email.assert_not_called()
 
     def test_decline_organization_application(
-        self, db_request, organization_service, monkeypatch
+        self, db_request, organization_service, mocker
     ):
-        send_email = pretend.call_recorder(lambda *a, **kw: None)
-        monkeypatch.setattr(
-            services, "send_new_organization_declined_email", send_email
+        send_email = mocker.patch.object(
+            services, "send_new_organization_declined_email"
         )
 
         admin = UserFactory(username="admin", is_superuser=True)
@@ -320,14 +309,12 @@ class TestDatabaseOrganizationService:
         )
 
         assert organization_application.status == OrganizationApplicationStatus.Declined
-        assert send_email.calls == [
-            pretend.call(
-                db_request,
-                organization_application.submitted_by,
-                organization_name=organization_application.name,
-                message="",
-            ),
-        ]
+        send_email.assert_called_once_with(
+            db_request,
+            organization_application.submitted_by,
+            organization_name=organization_application.name,
+            message="",
+        )
 
     def test_find_organizationid(self, organization_service):
         organization = OrganizationFactory.create()

--- a/tests/unit/organizations/test_tasks.py
+++ b/tests/unit/organizations/test_tasks.py
@@ -2,8 +2,6 @@
 
 import datetime
 
-import pretend
-
 from warehouse.accounts.interfaces import ITokenService, TokenExpired
 from warehouse.events.tags import EventTag
 from warehouse.organizations.models import (
@@ -40,60 +38,54 @@ from ...common.db.subscriptions import (
 
 class TestUpdateInvitationStatus:
     def test_update_invitation_status(
-        self, db_request, user_service, organization_service
+        self, db_request, user_service, organization_service, token_service, mocker
     ):
         organization = OrganizationFactory.create()
-        organization.record_event = pretend.call_recorder(lambda *a, **kw: None)
+        org_event = mocker.patch.object(organization, "record_event", autospec=True)
         user = UserFactory.create()
-        user.record_event = pretend.call_recorder(lambda *a, **kw: None)
+        user_event = mocker.patch.object(user, "record_event", autospec=True)
 
         invite = OrganizationInvitationFactory(user=user, organization=organization)
 
-        token_service = pretend.stub(loads=pretend.raiser(TokenExpired))
-        db_request.find_service = pretend.call_recorder(lambda *a, **kw: token_service)
+        mocker.patch.object(token_service, "loads", side_effect=TokenExpired)
+        find_service = mocker.spy(db_request, "find_service")
 
         update_organization_invitation_status(db_request)
 
-        assert db_request.find_service.calls == [
-            pretend.call(ITokenService, name="email")
-        ]
+        find_service.assert_called_once_with(ITokenService, name="email")
         assert invite.invite_status == OrganizationInvitationStatus.Expired
 
-        assert user.record_event.calls == [
-            pretend.call(
-                tag=EventTag.Account.OrganizationRoleExpireInvite,
-                request=db_request,
-                additional={"organization_name": invite.organization.name},
-            )
-        ]
-        assert organization.record_event.calls == [
-            pretend.call(
-                tag=EventTag.Organization.OrganizationRoleExpireInvite,
-                request=db_request,
-                additional={"target_user_id": str(invite.user.id)},
-            )
-        ]
+        user_event.assert_called_once_with(
+            tag=EventTag.Account.OrganizationRoleExpireInvite,
+            request=db_request,
+            additional={"organization_name": invite.organization.name},
+        )
+        org_event.assert_called_once_with(
+            tag=EventTag.Organization.OrganizationRoleExpireInvite,
+            request=db_request,
+            additional={"target_user_id": str(invite.user.id)},
+        )
 
-    def test_no_updates(self, db_request, user_service, organization_service):
+    def test_no_updates(
+        self, db_request, user_service, organization_service, token_service, mocker
+    ):
         organization = OrganizationFactory.create()
-        organization.record_event = pretend.call_recorder(lambda *a, **kw: None)
+        org_event = mocker.patch.object(organization, "record_event", autospec=True)
         user = UserFactory.create()
-        user.record_event = pretend.call_recorder(lambda *a, **kw: None)
+        user_event = mocker.patch.object(user, "record_event", autospec=True)
 
         invite = OrganizationInvitationFactory(user=user, organization=organization)
 
-        token_service = pretend.stub(loads=lambda token: {})
-        db_request.find_service = pretend.call_recorder(lambda *a, **kw: token_service)
+        mocker.patch.object(token_service, "loads", return_value={})
+        find_service = mocker.spy(db_request, "find_service")
 
         update_organization_invitation_status(db_request)
 
-        assert db_request.find_service.calls == [
-            pretend.call(ITokenService, name="email")
-        ]
+        find_service.assert_called_once_with(ITokenService, name="email")
         assert invite.invite_status == OrganizationInvitationStatus.Pending
 
-        assert user.record_event.calls == []
-        assert organization.record_event.calls == []
+        user_event.assert_not_called()
+        org_event.assert_not_called()
 
 
 class TestDeleteOrganizationApplications:
@@ -146,7 +138,9 @@ class TestDeleteOrganizationApplications:
 
 
 class TestUpdateOrganizationSubscriptionUsage:
-    def test_update_organization_subscription_usage_record(self, db_request):
+    def test_update_organization_subscription_usage_record(
+        self, db_request, billing_service, mocker
+    ):
         # Setup an organization with an active subscription
         organization = OrganizationFactory.create()
         owner_user = UserFactory.create()
@@ -210,22 +204,16 @@ class TestUpdateOrganizationSubscriptionUsage:
         )
         StripeSubscriptionItemFactory.create(subscription=subscription)
 
-        create_or_update_usage_record = pretend.call_recorder(
-            lambda *a, **kw: {
+        mocker.patch.object(
+            billing_service,
+            "create_or_update_usage_record",
+            return_value={
                 "subscription_item_id": "si_1234",
                 "organization_member_count": "5",
-            }
+            },
         )
-        billing_service = pretend.stub(
-            create_or_update_usage_record=create_or_update_usage_record,
-        )
-
-        db_request.find_service = pretend.call_recorder(
-            lambda *a, **kw: billing_service
-        )
+        find_service = mocker.spy(db_request, "find_service")
 
         update_organziation_subscription_usage_record(db_request)
 
-        assert db_request.find_service.calls == [
-            pretend.call(IBillingService, context=None)
-        ]
+        find_service.assert_called_once_with(IBillingService, context=None)

--- a/tests/unit/organizations/test_views.py
+++ b/tests/unit/organizations/test_views.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-import pretend
 import pytest
 
 from pyramid.httpexceptions import HTTPMovedPermanently, HTTPNotFound
@@ -11,11 +10,11 @@ from ...common.db.organizations import OrganizationFactory
 
 
 class TestOrganizationProfile:
-    def test_redirects_name(self, db_request):
+    def test_redirects_name(self, db_request, mocker):
         org = OrganizationFactory.create()
 
-        db_request.current_route_path = pretend.call_recorder(
-            lambda organization: "/user/the-redirect/"
+        current_route_path = mocker.patch.object(
+            db_request, "current_route_path", return_value="/user/the-redirect/"
         )
         db_request.matchdict = {"organization": org.name.swapcase()}
 
@@ -23,9 +22,7 @@ class TestOrganizationProfile:
 
         assert isinstance(result, HTTPMovedPermanently)
         assert result.headers["Location"] == "/user/the-redirect/"
-        assert db_request.current_route_path.calls == [
-            pretend.call(organization=org.name)
-        ]
+        current_route_path.assert_called_once_with(organization=org.name)
 
     def test_returns_organization(self, db_request):
         org = OrganizationFactory.create()

--- a/tests/unit/subscriptions/test_init.py
+++ b/tests/unit/subscriptions/test_init.py
@@ -1,35 +1,22 @@
 # SPDX-License-Identifier: Apache-2.0
 
-import pretend
-
 from warehouse import subscriptions
 from warehouse.subscriptions.interfaces import IBillingService, ISubscriptionService
 from warehouse.subscriptions.services import subscription_factory
 
 
-def test_includeme():
-    billing_class = pretend.stub(
-        create_service=pretend.call_recorder(lambda *a, **kw: pretend.stub())
+def test_includeme(mocker):
+    billing_class = mocker.Mock(spec=["create_service"])
+    config = mocker.Mock(
+        spec=["maybe_dotted", "register_service_factory", "registry", "get_settings"]
     )
-
-    settings = {}
-
-    config = pretend.stub(
-        maybe_dotted=lambda dotted: billing_class,
-        register_service_factory=pretend.call_recorder(
-            lambda factory, iface, name=None: None
-        ),
-        registry=pretend.stub(
-            settings={
-                "billing.backend": "hand.some",
-            }
-        ),
-        get_settings=lambda: settings,
-    )
+    config.maybe_dotted.return_value = billing_class
+    config.registry.settings = {"billing.backend": "hand.some"}
+    config.get_settings.return_value = {}
 
     subscriptions.includeme(config)
 
-    assert config.register_service_factory.calls == [
-        pretend.call(subscription_factory, ISubscriptionService),
-        pretend.call(billing_class.create_service, IBillingService),
+    assert config.register_service_factory.call_args_list == [
+        mocker.call(subscription_factory, ISubscriptionService),
+        mocker.call(billing_class.create_service, IBillingService),
     ]

--- a/tests/unit/subscriptions/test_services.py
+++ b/tests/unit/subscriptions/test_services.py
@@ -1,8 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import importlib
+import types
 
-import pretend
 import pytest
 import stripe
 
@@ -42,38 +42,34 @@ class TestStripeBillingService:
     def test_verify_service(self):
         assert verifyClass(IBillingService, StripeBillingService)
 
-    def test_basic_init(self):
-        api = pretend.stub()
-
+    def test_basic_init(self, mocker):
         billing_service = StripeBillingService(
-            api=api,
+            api=mocker.sentinel.api,
             publishable_key="secret_to_everybody",
             webhook_secret="keep_it_secret_keep_it_safe",
             domain="tests",
         )
 
-        assert billing_service.api is api
+        assert billing_service.api is mocker.sentinel.api
         assert billing_service.publishable_key == "secret_to_everybody"
         assert billing_service.webhook_secret == "keep_it_secret_keep_it_safe"
         assert billing_service.domain == "tests"
 
-    def test_create_service(self):
+    def test_create_service(self, pyramid_request):
         # Reload stripe to reset the global stripe.api_key to default.
         importlib.reload(stripe)
 
-        request = pretend.stub(
-            registry=pretend.stub(
-                settings={
-                    "billing.api_base": "http://localhost:12111",
-                    "billing.api_version": "2020-08-27",
-                    "billing.secret_key": "sk_test_123",
-                    "billing.publishable_key": "pk_test_123",
-                    "billing.webhook_key": "whsec_123",
-                    "billing.domain": "tests",
-                }
-            )
+        pyramid_request.registry.settings.update(
+            {
+                "billing.api_base": "http://localhost:12111",
+                "billing.api_version": "2020-08-27",
+                "billing.secret_key": "sk_test_123",
+                "billing.publishable_key": "pk_test_123",
+                "billing.webhook_key": "whsec_123",
+                "billing.domain": "tests",
+            }
         )
-        billing_service = StripeBillingService.create_service(None, request)
+        billing_service = StripeBillingService.create_service(None, pyramid_request)
         # Assert api_base isn't overwritten with mock service even if we try
         assert billing_service.api.api_base != "http://localhost:12111"
         assert billing_service.api.api_version == "2020-08-27"
@@ -87,34 +83,30 @@ class TestMockStripeBillingService:
     def test_verify_service(self):
         assert verifyClass(IBillingService, MockStripeBillingService)
 
-    def test_basic_init(self):
-        api = pretend.stub()
-
+    def test_basic_init(self, mocker):
         billing_service = MockStripeBillingService(
-            api=api,
+            api=mocker.sentinel.api,
             publishable_key="secret_to_everybody",
             webhook_secret="keep_it_secret_keep_it_safe",
             domain="tests",
         )
 
-        assert billing_service.api is api
+        assert billing_service.api is mocker.sentinel.api
         assert billing_service.publishable_key == "secret_to_everybody"
         assert billing_service.webhook_secret == "keep_it_secret_keep_it_safe"
         assert billing_service.domain == "tests"
 
-    def test_create_service(self):
-        request = pretend.stub(
-            registry=pretend.stub(
-                settings={
-                    "billing.api_base": "http://localhost:12111",
-                    "billing.api_version": "2020-08-27",
-                    "billing.secret_key": "sk_test_123",
-                    "billing.publishable_key": "pk_test_123",
-                    "billing.webhook_key": "whsec_123",
-                }
-            )
+    def test_create_service(self, pyramid_request):
+        pyramid_request.registry.settings.update(
+            {
+                "billing.api_base": "http://localhost:12111",
+                "billing.api_version": "2020-08-27",
+                "billing.secret_key": "sk_test_123",
+                "billing.publishable_key": "pk_test_123",
+                "billing.webhook_key": "whsec_123",
+            }
         )
-        billing_service = MockStripeBillingService.create_service(None, request)
+        billing_service = MockStripeBillingService.create_service(None, pyramid_request)
         assert billing_service.api.api_base == "http://localhost:12111"
         assert billing_service.api.api_version == "2020-08-27"
         assert billing_service.api.api_key == "sk_test_123"
@@ -192,26 +184,28 @@ class TestMockStripeBillingService:
         )
         assert session_url is not None
 
-    def test_webhook_received(self, billing_service, monkeypatch):
-        payload = pretend.stub()
-        sig_header = pretend.stub()
+    def test_webhook_received(self, billing_service, mocker):
+        construct_event = mocker.patch.object(stripe.Webhook, "construct_event")
 
-        construct_event = pretend.call_recorder(lambda *a, **kw: None)
-        monkeypatch.setattr(stripe.Webhook, "construct_event", construct_event)
+        billing_service.webhook_received(
+            mocker.sentinel.payload, mocker.sentinel.sig_header
+        )
 
-        billing_service.webhook_received(payload, sig_header)
-
-        assert construct_event.calls == [
-            pretend.call(payload, sig_header, billing_service.webhook_secret),
-        ]
+        construct_event.assert_called_once_with(
+            mocker.sentinel.payload,
+            mocker.sentinel.sig_header,
+            billing_service.webhook_secret,
+        )
 
     def test_create_or_update_product(
-        self, billing_service, subscription_service, monkeypatch
+        self, billing_service, subscription_service, mocker
     ):
         subscription_product = StripeSubscriptionProductFactory.create()
 
-        search_products = pretend.call_recorder(
-            lambda *a, **kw: {
+        mocker.patch.object(
+            billing_service,
+            "search_products",
+            return_value={
                 "data": [
                     {
                         "id": str(subscription_product.id),
@@ -219,9 +213,8 @@ class TestMockStripeBillingService:
                         "created": 0,
                     },
                 ],
-            }
+            },
         )
-        monkeypatch.setattr(billing_service, "search_products", search_products)
 
         product = billing_service.create_or_update_product(
             name=subscription_product.product_name,
@@ -232,9 +225,10 @@ class TestMockStripeBillingService:
 
         assert product is not None
 
-    def test_create_or_update_product_new_product(self, billing_service, monkeypatch):
-        search_products = pretend.call_recorder(lambda *a, **kw: {"data": []})
-        monkeypatch.setattr(billing_service, "search_products", search_products)
+    def test_create_or_update_product_new_product(self, billing_service, mocker):
+        mocker.patch.object(
+            billing_service, "search_products", return_value={"data": []}
+        )
 
         product = billing_service.create_or_update_product(
             name="Vitamin PyPI",
@@ -341,7 +335,7 @@ class TestMockStripeBillingService:
         assert prices is not None
 
     def test_create_or_update_price(
-        self, billing_service, subscription_service, monkeypatch
+        self, billing_service, subscription_service, mocker
     ):
         subscription_price = StripeSubscriptionPriceFactory.create()
         price = {
@@ -370,8 +364,8 @@ class TestMockStripeBillingService:
             "tax_behavior": subscription_price.tax_behavior,
             "created": 0,
         }
-        monkeypatch.setattr(
-            billing_service, "search_prices", lambda *a, **kw: {"data": [price, other]}
+        mocker.patch.object(
+            billing_service, "search_prices", return_value={"data": [price, other]}
         )
 
         price = billing_service.create_or_update_price(
@@ -409,44 +403,38 @@ class TestMockStripeBillingService:
 
 
 class TestGenericBillingService:
-    def test_basic_init(self):
-        api = pretend.stub()
-
+    def test_basic_init(self, mocker):
         billing_service = GenericBillingService(
-            api=api,
+            api=mocker.sentinel.api,
             publishable_key="secret_to_everybody",
             webhook_secret="keep_it_secret_keep_it_safe",
             domain="tests",
         )
 
-        assert billing_service.api is api
+        assert billing_service.api is mocker.sentinel.api
         assert billing_service.publishable_key == "secret_to_everybody"
         assert billing_service.webhook_secret == "keep_it_secret_keep_it_safe"
         assert billing_service.domain == "tests"
 
     def test_notimplementederror(self):
         with pytest.raises(NotImplementedError):
-            GenericBillingService.create_service(pretend.stub(), pretend.stub())
+            GenericBillingService.create_service(None, None)
 
 
-def test_subscription_factory():
-    db = pretend.stub()
-    context = pretend.stub()
-    request = pretend.stub(db=db)
-
-    service = services.subscription_factory(context, request)
-    assert service.db is db
+def test_subscription_factory(mocker):
+    request = types.SimpleNamespace(db=mocker.sentinel.db)
+    service = services.subscription_factory(None, request)
+    assert service.db is mocker.sentinel.db
 
 
 class TestStripeSubscriptionService:
     def test_verify_service(self):
         assert verifyClass(ISubscriptionService, services.StripeSubscriptionService)
 
-    def test_service_creation(self):
-        session = pretend.stub()
-        service = services.StripeSubscriptionService(session)
+    def test_service_creation(self, mocker):
+        service = services.StripeSubscriptionService(mocker.sentinel.session)
 
-        assert service.db is session
+        assert service.db is mocker.sentinel.session
 
     def test_find_subscriptionid_nonexistent_sub(self, subscription_service):
         assert subscription_service.find_subscriptionid("fake_news") is None


### PR DESCRIPTION
Migrate the test suites under `tests/unit/{organizations,subscriptions,api}` off the `pretend` library, using `pytest-mock` and `factory_boy` instead.

- Stubs that stood in for real objects now use a factory build or an existing `conftest` fixtures. Opaque values use `mocker.sentinel`; the few genuinely classless shapes use `types.SimpleNamespace`.
- `call_recorder` + `monkeypatch.setattr` give way to `mocker.patch.object` and `mocker.spy`, and `x.calls == [pretend.call(...)]` checks become `assert_called_once_with`, `call_args_list`, or `assert_not_called`.
- `includeme` tests pass a `mocker.Mock(spec=[...])` as the config, so an unexpected directive still raises.

Refs: #18880