### PR TITLE
feat(admin): enable releasing project name to org

### DIFF
--- a/tests/functional/admin/__init__.py
+++ b/tests/functional/admin/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/functional/admin/test_prohibited_project_names.py
+++ b/tests/functional/admin/test_prohibited_project_names.py
@@ -1,0 +1,120 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import time
+
+from http import HTTPStatus
+
+from tests.common.constants import REMOTE_ADDR
+from tests.common.db.accounts import UserFactory, UserUniqueLoginFactory
+from tests.common.db.ip_addresses import IpAddressFactory
+from tests.common.db.organizations import OrganizationFactory, OrganizationRoleFactory
+from tests.common.db.packaging import ProhibitedProjectFactory
+from warehouse.accounts.models import UniqueLoginStatus
+from warehouse.organizations.models import OrganizationProject
+from warehouse.packaging.models import Project
+from warehouse.utils.otp import _get_totp
+
+
+class TestReleaseProhibitedProjectName:
+    def _login_admin(self, webtest, user):
+        """Log in a superuser with 2FA and a pre-confirmed IP."""
+        ip_address = IpAddressFactory.create(ip_address=REMOTE_ADDR)
+        UserUniqueLoginFactory.create(
+            user=user,
+            ip_address=ip_address,
+            status=UniqueLoginStatus.CONFIRMED,
+        )
+
+        login_page = webtest.get("/account/login/", status=HTTPStatus.OK)
+        login_form = login_page.forms["login-form"]
+        login_form["username"] = user.username
+        login_form["password"] = "password"
+
+        two_factor_page = login_form.submit().follow(status=HTTPStatus.OK)
+        two_factor_form = two_factor_page.forms["totp-auth-form"]
+        two_factor_form["totp_value"] = (
+            _get_totp(user.totp_secret).generate(time.time()).decode()
+        )
+        two_factor_form.submit().follow(status=HTTPStatus.OK)
+
+    def test_release_to_organization_redirects_to_project_detail(self, webtest):
+        """
+        Releasing a prohibited name to an organization returns a 303 to the new
+        project's admin detail page, and following that redirect resolves (the
+        project is committed before the browser follows it, so it is not a 404).
+        """
+        admin = UserFactory.create(
+            is_superuser=True,
+            with_verified_primary_email=True,
+            clear_pwd="password",
+        )
+        self._login_admin(webtest, admin)
+
+        organization = OrganizationFactory.create(name="release-org")
+        OrganizationRoleFactory.create(organization=organization, user=admin)
+        ProhibitedProjectFactory.create(name="releasable")
+
+        list_page = webtest.get(
+            "/admin/prohibited_project_names/", status=HTTPStatus.OK
+        )
+        csrf_token = list_page.html.find("input", {"name": "csrf_token"})["value"]
+
+        response = webtest.post(
+            "/admin/prohibited_project_names/release/",
+            {
+                "csrf_token": csrf_token,
+                "project_name": "releasable",
+                "organization_name": "release-org",
+            },
+            status=HTTPStatus.SEE_OTHER,
+        )
+        assert response.headers["Location"].endswith("/admin/projects/releasable/")
+
+        detail_page = response.follow(status=HTTPStatus.OK)
+        assert "releasable" in detail_page.text
+
+        db_sess = webtest.extra_environ["warehouse.db_session"]
+        project = db_sess.query(Project).filter(Project.name == "releasable").one()
+        assert (
+            db_sess.query(OrganizationProject)
+            .filter(
+                OrganizationProject.organization == organization,
+                OrganizationProject.project == project,
+            )
+            .count()
+            == 1
+        )
+
+    def test_release_error_redirects_to_list(self, webtest):
+        """
+        An error path (here, an unknown organization) returns a 303 whose target
+        is the list page, not the POST-only release route. Following it resolves
+        (200) rather than 404, and the flashed error is shown.
+        """
+        admin = UserFactory.create(
+            is_superuser=True,
+            with_verified_primary_email=True,
+            clear_pwd="password",
+        )
+        self._login_admin(webtest, admin)
+
+        ProhibitedProjectFactory.create(name="releasable")
+
+        list_page = webtest.get(
+            "/admin/prohibited_project_names/", status=HTTPStatus.OK
+        )
+        csrf_token = list_page.html.find("input", {"name": "csrf_token"})["value"]
+
+        response = webtest.post(
+            "/admin/prohibited_project_names/release/",
+            {
+                "csrf_token": csrf_token,
+                "project_name": "releasable",
+                "organization_name": "does-not-exist",
+            },
+            status=HTTPStatus.SEE_OTHER,
+        )
+        assert response.headers["Location"].endswith("/admin/prohibited_project_names/")
+
+        followed = response.follow(status=HTTPStatus.OK)
+        assert "Unknown organization 'does-not-exist'" in followed.html.get_text()

--- a/tests/unit/admin/views/test_prohibited_project_names.py
+++ b/tests/unit/admin/views/test_prohibited_project_names.py
@@ -11,9 +11,11 @@ from packaging.utils import canonicalize_name
 from pyramid.httpexceptions import HTTPBadRequest, HTTPNotFound, HTTPSeeOther
 
 from warehouse.admin.views import prohibited_project_names as views
+from warehouse.organizations.models import OrganizationProject
 from warehouse.packaging.models import ProhibitedProjectName, Project, Role
 
 from ....common.db.accounts import UserFactory
+from ....common.db.organizations import OrganizationFactory, OrganizationRoleFactory
 from ....common.db.packaging import (
     FileFactory,
     ProhibitedProjectFactory,
@@ -429,40 +431,34 @@ class TestRemoveProhibitedProjectName:
 
 
 class TestReleaseProhibitedProjectName:
-    def test_no_prohibited_project_name(self, db_request):
-        db_request.session = pretend.stub(
-            flash=pretend.call_recorder(lambda *a, **kw: None)
+    @pytest.fixture
+    def db_request(self, db_request):
+        """Inline test helper with common paths for these tests"""
+        db_request.route_path = lambda route_name, **kw: (
+            f"/admin/projects/{kw['project_name']}/"
+            if "project_name" in kw
+            else "/admin/prohibited_project_names/"
         )
         db_request.current_route_path = lambda: "/admin/prohibited_project_names/"
+        return db_request
 
+    def test_no_prohibited_project_name(self, db_request):
         result = views.release_prohibited_project_name(db_request)
+
         assert isinstance(result, HTTPSeeOther)
-        assert db_request.session.flash.calls == [
-            pretend.call("Provide a project name", queue="error")
-        ]
+        assert db_request.session.pop_flash("error") == ["Provide a project name"]
 
     def test_prohibited_project_name_does_not_exist(self, db_request):
-        db_request.session = pretend.stub(
-            flash=pretend.call_recorder(lambda *a, **kw: None)
-        )
-        db_request.current_route_path = lambda: "/admin/prohibited_project_names/"
-
         db_request.POST["project_name"] = "wu"
 
         result = views.release_prohibited_project_name(db_request)
+
         assert isinstance(result, HTTPSeeOther)
-        assert db_request.session.flash.calls == [
-            pretend.call(
-                "'wu' does not exist on prohibited project name list.", queue="error"
-            )
+        assert db_request.session.pop_flash("error") == [
+            "'wu' does not exist on prohibited project name list."
         ]
 
     def test_project_exists(self, db_request):
-        db_request.session = pretend.stub(
-            flash=pretend.call_recorder(lambda *a, **kw: None)
-        )
-        db_request.current_route_path = lambda: "/admin/prohibited_project_names/"
-
         ProhibitedProjectFactory.create(name="tang")
         ProjectFactory.create(name="tang")
 
@@ -470,55 +466,36 @@ class TestReleaseProhibitedProjectName:
         db_request.POST["username"] = "rza"
 
         result = views.release_prohibited_project_name(db_request)
+
         assert isinstance(result, HTTPSeeOther)
-        assert db_request.session.flash.calls == [
-            pretend.call(
-                "'tang' exists and is not on the prohibited project name list.",
-                queue="error",
-            )
+        assert db_request.session.pop_flash("error") == [
+            "'tang' exists and is not on the prohibited project name list."
         ]
 
     def test_no_username(self, db_request):
-        db_request.session = pretend.stub(
-            flash=pretend.call_recorder(lambda *a, **kw: None)
-        )
-        db_request.current_route_path = lambda: "/admin/prohibited_project_names/"
-
         ProhibitedProjectFactory.create(name="wutang")
 
         db_request.POST["project_name"] = "wutang"
 
         result = views.release_prohibited_project_name(db_request)
+
         assert isinstance(result, HTTPSeeOther)
-        assert db_request.session.flash.calls == [
-            pretend.call("Provide a username", queue="error")
+        assert db_request.session.pop_flash("error") == [
+            "Provide a username or an organization name"
         ]
 
     def test_user_does_not_exist(self, db_request):
-        db_request.session = pretend.stub(
-            flash=pretend.call_recorder(lambda *a, **kw: None)
-        )
-        db_request.current_route_path = lambda: "/admin/prohibited_project_names/"
-
         ProhibitedProjectFactory.create(name="wutang")
 
         db_request.POST["project_name"] = "wutang"
         db_request.POST["username"] = "methodman"
 
         result = views.release_prohibited_project_name(db_request)
+
         assert isinstance(result, HTTPSeeOther)
-        assert db_request.session.flash.calls == [
-            pretend.call("Unknown username 'methodman'", queue="error")
-        ]
+        assert db_request.session.pop_flash("error") == ["Unknown username 'methodman'"]
 
     def test_creates_project_and_assigns_role(self, db_request):
-        db_request.session = pretend.stub(
-            flash=pretend.call_recorder(lambda *a, **kw: None)
-        )
-        db_request.route_path = lambda *a, **kw: (
-            f"/admin/projects/{kw['project_name']}/"
-        )
-
         user = UserFactory.create(username="methodman")
         ProhibitedProjectFactory.create(name="wutangclan")
 
@@ -526,10 +503,11 @@ class TestReleaseProhibitedProjectName:
         db_request.POST["username"] = "methodman"
 
         result = views.release_prohibited_project_name(db_request)
+
         assert isinstance(result, HTTPSeeOther)
         assert result.headers["Location"] == "/admin/projects/wutangclan/"
-        assert db_request.session.flash.calls == [
-            pretend.call("'wutangclan' released to 'methodman'.", queue="success")
+        assert db_request.session.pop_flash("success") == [
+            "'wutangclan' released to 'methodman'."
         ]
 
         assert not (
@@ -540,17 +518,106 @@ class TestReleaseProhibitedProjectName:
         project = (
             db_request.db.query(Project).filter(Project.name == "wutangclan").one()
         )
-        assert project is not None
         role = (
             db_request.db.query(Role)
             .filter(
                 Role.user == user, Role.project == project, Role.role_name == "Owner"
             )
-            .first()
+            .one()
         )
         assert role is not None
-        all_roles = db_request.db.query(Role).filter(Role.project == project).count()
-        assert all_roles == 1
+        assert db_request.db.query(Role).filter(Role.project == project).count() == 1
+
+    def test_username_and_organization(self, db_request):
+        ProhibitedProjectFactory.create(name="wutang")
+
+        db_request.POST["project_name"] = "wutang"
+        db_request.POST["username"] = "rza"
+        db_request.POST["organization_name"] = "wu-tang-corp"
+
+        result = views.release_prohibited_project_name(db_request)
+
+        assert isinstance(result, HTTPSeeOther)
+        assert db_request.session.pop_flash("error") == [
+            "Provide a username or an organization name, not both."
+        ]
+
+    def test_organization_does_not_exist(self, db_request):
+        ProhibitedProjectFactory.create(name="wutang")
+
+        db_request.POST["project_name"] = "wutang"
+        db_request.POST["organization_name"] = "wu-tang-corp"
+
+        result = views.release_prohibited_project_name(db_request)
+
+        assert isinstance(result, HTTPSeeOther)
+        assert db_request.session.pop_flash("error") == [
+            "Unknown organization 'wu-tang-corp'"
+        ]
+
+    def test_organization_not_active(self, db_request):
+        OrganizationFactory.create(name="wu-tang-corp", is_active=False)
+        ProhibitedProjectFactory.create(name="wutang")
+
+        db_request.POST["project_name"] = "wutang"
+        db_request.POST["organization_name"] = "wu-tang-corp"
+
+        result = views.release_prohibited_project_name(db_request)
+
+        assert isinstance(result, HTTPSeeOther)
+        assert db_request.session.pop_flash("error") == [
+            "Organization 'wu-tang-corp' is not active"
+        ]
+
+    def test_creates_project_for_organization(self, db_request, mocker):
+        db_request.user = UserFactory.create()
+        send_email = mocker.patch(
+            "warehouse.manage.views.view_helpers.send_organization_project_added_email",
+            autospec=True,
+        )
+
+        organization = OrganizationFactory.create(name="wu-tang-corp")
+        owner = UserFactory.create()
+        OrganizationRoleFactory.create(organization=organization, user=owner)
+        ProhibitedProjectFactory.create(name="wutangclan")
+
+        db_request.POST["project_name"] = "wutangclan"
+        db_request.POST["organization_name"] = "wu-tang-corp"
+
+        result = views.release_prohibited_project_name(db_request)
+
+        assert isinstance(result, HTTPSeeOther)
+        assert result.headers["Location"] == "/admin/projects/wutangclan/"
+        assert db_request.session.pop_flash("success") == [
+            "'wutangclan' released to organization 'wu-tang-corp'."
+        ]
+
+        assert not (
+            db_request.db.query(ProhibitedProjectName)
+            .filter(ProhibitedProjectName.name == "wutangclan")
+            .count()
+        )
+        project = (
+            db_request.db.query(Project).filter(Project.name == "wutangclan").one()
+        )
+        # The organization owns the project; no individual Owner role is created.
+        assert db_request.db.query(Role).filter(Role.project == project).count() == 0
+        assert (
+            db_request.db.query(OrganizationProject)
+            .filter(
+                OrganizationProject.organization == organization,
+                OrganizationProject.project == project,
+            )
+            .count()
+            == 1
+        )
+        # The organization's owners are notified of the new project.
+        send_email.assert_called_once_with(
+            db_request,
+            {owner},
+            organization_name="wu-tang-corp",
+            project_name="wutangclan",
+        )
 
 
 class TestUltranormReleaseProjectName:

--- a/tests/unit/manage/test_views.py
+++ b/tests/unit/manage/test_views.py
@@ -33,6 +33,7 @@ from warehouse.macaroons.interfaces import IMacaroonService
 from warehouse.manage import views
 from warehouse.manage.views import (
     organizations as org_views,
+    view_helpers,
 )
 from warehouse.organizations.interfaces import IOrganizationService
 from warehouse.organizations.models import (
@@ -3605,7 +3606,7 @@ class TestManageProjectSettings:
             lambda req, user, **k: None
         )
         monkeypatch.setattr(
-            org_views,
+            view_helpers,
             "send_organization_project_added_email",
             send_organization_project_added_email,
         )
@@ -3701,7 +3702,7 @@ class TestManageProjectSettings:
             lambda req, user, **k: None
         )
         monkeypatch.setattr(
-            org_views,
+            view_helpers,
             "send_organization_project_added_email",
             send_organization_project_added_email,
         )
@@ -3831,7 +3832,7 @@ class TestManageProjectSettings:
             lambda req, user, **k: None
         )
         monkeypatch.setattr(
-            org_views,
+            view_helpers,
             "send_organization_project_added_email",
             send_organization_project_added_email,
         )
@@ -3931,7 +3932,7 @@ class TestManageProjectSettings:
             lambda req, user, **k: None
         )
         monkeypatch.setattr(
-            org_views,
+            view_helpers,
             "send_organization_project_added_email",
             send_organization_project_added_email,
         )

--- a/tests/unit/manage/views/test_organizations.py
+++ b/tests/unit/manage/views/test_organizations.py
@@ -38,7 +38,7 @@ from warehouse.accounts.interfaces import TokenExpired
 from warehouse.admin.flags import AdminFlagValue
 from warehouse.authnz import Permissions
 from warehouse.manage import views
-from warehouse.manage.views import organizations as org_views
+from warehouse.manage.views import organizations as org_views, view_helpers
 from warehouse.oidc.models import PendingGitHubPublisher
 from warehouse.organizations import IOrganizationService
 from warehouse.organizations.models import (
@@ -1829,7 +1829,7 @@ class TestManageOrganizationProjects:
             lambda req, user, **k: None
         )
         monkeypatch.setattr(
-            org_views,
+            view_helpers,
             "send_organization_project_added_email",
             send_organization_project_added_email,
         )
@@ -1894,7 +1894,7 @@ class TestManageOrganizationProjects:
             lambda req, user, **k: None
         )
         monkeypatch.setattr(
-            org_views,
+            view_helpers,
             "send_organization_project_added_email",
             send_organization_project_added_email,
         )
@@ -1990,7 +1990,7 @@ class TestManageOrganizationProjects:
             lambda req, user, **k: None
         )
         monkeypatch.setattr(
-            org_views,
+            view_helpers,
             "send_organization_project_added_email",
             send_organization_project_added_email,
         )

--- a/warehouse/admin/templates/admin/prohibited_project_names/list.html
+++ b/warehouse/admin/templates/admin/prohibited_project_names/list.html
@@ -104,12 +104,16 @@
                   </div>
                   <div class="modal-body">
                     <p>
-                      This will remove <strong>{{ prohibited_project_name.name }}</strong> from the prohibited list and create a new project owned by the specified user.
+                      This will remove <strong>{{ prohibited_project_name.name }}</strong> from the prohibited list and create a new project owned by the specified user or organization. Provide exactly one.
                     </p>
                     <hr>
                     <div class="form-group">
                       <label for="releaseUsername-{{ prohibited_project_name.id }}">New owner username</label>
-                      <input type="text" id="releaseUsername-{{ prohibited_project_name.id }}" name="username" class="form-control" placeholder="Enter PyPI username"  autocapitalize="off" autocomplete="off" data-1p-ignore required>
+                      <input type="text" id="releaseUsername-{{ prohibited_project_name.id }}" name="username" class="form-control" placeholder="Enter PyPI username" autocapitalize="off" autocomplete="off" data-1p-ignore>
+                    </div>
+                    <div class="form-group">
+                      <label for="releaseOrganization-{{ prohibited_project_name.id }}">Owner organization name</label>
+                      <input type="text" id="releaseOrganization-{{ prohibited_project_name.id }}" name="organization_name" class="form-control" placeholder="Enter organization name" autocapitalize="off" autocomplete="off" data-1p-ignore>
                     </div>
                   </div>
                   <div class="modal-footer justify-content-between">

--- a/warehouse/admin/views/prohibited_project_names.py
+++ b/warehouse/admin/views/prohibited_project_names.py
@@ -1,6 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 import shlex
+import typing
 
 from collections import defaultdict
 
@@ -13,6 +16,8 @@ from sqlalchemy.exc import NoResultFound
 
 from warehouse.accounts.models import User
 from warehouse.authnz import Permissions
+from warehouse.manage.views.view_helpers import add_organization_project_and_notify
+from warehouse.organizations.interfaces import IOrganizationService
 from warehouse.packaging.models import (
     File,
     ProhibitedProjectName,
@@ -23,6 +28,9 @@ from warehouse.packaging.models import (
 from warehouse.utils.http import is_safe_url
 from warehouse.utils.paginate import paginate_url_factory
 from warehouse.utils.project import prohibit_and_remove_project
+
+if typing.TYPE_CHECKING:
+    from pyramid.request import Request
 
 
 @view_config(
@@ -140,12 +148,17 @@ def confirm_prohibited_project_names(request):
     request_method="POST",
     uses_session=True,
     require_methods=False,
+    has_translations=True,
 )
 def release_prohibited_project_name(request):
+    # Error paths redirect back to the list page, which (unlike this POST-only
+    # release route) has a GET handler to render the flashed message.
+    list_url = request.route_path("admin.prohibited_project_names.list")
+
     project_name = request.POST.get("project_name")
     if project_name is None:
         request.session.flash("Provide a project name", queue="error")
-        return HTTPSeeOther(request.current_route_path())
+        return HTTPSeeOther(list_url)
 
     prohibited_project_name = (
         request.db.query(ProhibitedProjectName)
@@ -157,7 +170,7 @@ def release_prohibited_project_name(request):
             f"{project_name!r} does not exist on prohibited project name list.",
             queue="error",
         )
-        return HTTPSeeOther(request.current_route_path())
+        return HTTPSeeOther(list_url)
 
     project = (
         request.db.query(Project)
@@ -169,17 +182,32 @@ def release_prohibited_project_name(request):
             f"{project_name!r} exists and is not on the prohibited project name list.",
             queue="error",
         )
-        return HTTPSeeOther(request.current_route_path())
+        return HTTPSeeOther(list_url)
 
     username = request.POST.get("username")
+    organization_name = request.POST.get("organization_name")
+
+    if username and organization_name:
+        request.session.flash(
+            "Provide a username or an organization name, not both.", queue="error"
+        )
+        return HTTPSeeOther(list_url)
+
+    if organization_name:
+        return _release_to_organization(
+            request, project_name, prohibited_project_name, organization_name
+        )
+
     if not username:
-        request.session.flash("Provide a username", queue="error")
-        return HTTPSeeOther(request.current_route_path())
+        request.session.flash(
+            "Provide a username or an organization name", queue="error"
+        )
+        return HTTPSeeOther(list_url)
 
     user = request.db.query(User).filter(User.username == username).first()
     if user is None:
         request.session.flash(f"Unknown username '{username}'", queue="error")
-        return HTTPSeeOther(request.current_route_path())
+        return HTTPSeeOther(list_url)
 
     project = Project(name=project_name)
     request.db.add(project)
@@ -191,6 +219,48 @@ def release_prohibited_project_name(request):
     )
 
     request.db.flush()  # generate project.normalized_name  # ast-grep-ignore: db-flush
+
+    return HTTPSeeOther(
+        request.route_path("admin.project.detail", project_name=project.normalized_name)
+    )
+
+
+def _release_to_organization(
+    request: Request,
+    project_name: str,
+    prohibited_project_name: ProhibitedProjectName,
+    organization_name: str,
+) -> HTTPSeeOther:
+    """Release a prohibited project name as a new organization-owned project."""
+    list_url = request.route_path("admin.prohibited_project_names.list")
+
+    organization_service = request.find_service(IOrganizationService, context=None)
+    organization = organization_service.get_organization_by_name(organization_name)
+    if organization is None:
+        request.session.flash(
+            f"Unknown organization '{organization_name}'", queue="error"
+        )
+        return HTTPSeeOther(list_url)
+
+    if not organization.is_active:
+        request.session.flash(
+            f"Organization '{organization_name}' is not active", queue="error"
+        )
+        return HTTPSeeOther(list_url)
+
+    # The project is owned by the organization, so no individual Owner role is
+    # created (mirroring project creation with `creator_is_owner=False`).
+    project = Project(name=project_name)
+    request.db.add(project)
+    request.db.delete(prohibited_project_name)
+    request.db.flush()  # generate project.id  # ast-grep-ignore: db-flush
+
+    add_organization_project_and_notify(request, organization, project)
+
+    request.session.flash(
+        f"{project.name!r} released to organization {organization.name!r}.",
+        queue="success",
+    )
 
     return HTTPSeeOther(
         request.route_path("admin.project.detail", project_name=project.normalized_name)

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -339,14 +339,14 @@ msgstr ""
 
 #: warehouse/accounts/views.py:1793 warehouse/accounts/views.py:2056
 #: warehouse/manage/views/oidc_publishers.py:126
-#: warehouse/manage/views/organizations.py:1820
+#: warehouse/manage/views/organizations.py:1744
 msgid ""
 "Trusted publishing is temporarily disabled. See https://pypi.org/help"
 "#admin-intervention for details."
 msgstr ""
 
 #: warehouse/accounts/views.py:1814
-#: warehouse/manage/views/organizations.py:1843
+#: warehouse/manage/views/organizations.py:1767
 msgid "disabled. See https://pypi.org/help#admin-intervention for details."
 msgstr ""
 
@@ -375,7 +375,7 @@ msgstr ""
 #: warehouse/manage/views/oidc_publishers.py:436
 #: warehouse/manage/views/oidc_publishers.py:552
 #: warehouse/manage/views/oidc_publishers.py:664
-#: warehouse/manage/views/organizations.py:1859
+#: warehouse/manage/views/organizations.py:1783
 msgid "The trusted publisher could not be registered"
 msgstr ""
 
@@ -393,7 +393,7 @@ msgid ""
 msgstr ""
 
 #: warehouse/accounts/views.py:1926
-#: warehouse/manage/views/organizations.py:1908
+#: warehouse/manage/views/organizations.py:1832
 msgid "Registered a new pending publisher to create "
 msgstr ""
 
@@ -665,13 +665,13 @@ msgid ""
 msgstr ""
 
 #: warehouse/manage/views/__init__.py:2281
-#: warehouse/manage/views/organizations.py:980
+#: warehouse/manage/views/organizations.py:934
 #, python-brace-format
 msgid "User '${username}' already has an active invite. Please try again later."
 msgstr ""
 
 #: warehouse/manage/views/__init__.py:2346
-#: warehouse/manage/views/organizations.py:1055
+#: warehouse/manage/views/organizations.py:1009
 #, python-brace-format
 msgid "Invitation sent to '${username}'"
 msgstr ""
@@ -685,7 +685,7 @@ msgid "Invitation already expired."
 msgstr ""
 
 #: warehouse/manage/views/__init__.py:2422
-#: warehouse/manage/views/organizations.py:1255
+#: warehouse/manage/views/organizations.py:1209
 #, python-brace-format
 msgid "Invitation revoked from '${username}'."
 msgstr ""
@@ -778,37 +778,37 @@ msgid ""
 "https://pypi.org/help#admin-intervention for details."
 msgstr ""
 
-#: warehouse/manage/views/organizations.py:956
+#: warehouse/manage/views/organizations.py:910
 #, python-brace-format
 msgid "User '${username}' already has ${role_name} role for organization"
 msgstr ""
 
-#: warehouse/manage/views/organizations.py:967
+#: warehouse/manage/views/organizations.py:921
 #, python-brace-format
 msgid ""
 "User '${username}' does not have a verified primary email address and "
 "cannot be added as a ${role_name} for organization"
 msgstr ""
 
-#: warehouse/manage/views/organizations.py:991
+#: warehouse/manage/views/organizations.py:945
 msgid "Cannot invite new member. Organization is not in good standing."
 msgstr ""
 
-#: warehouse/manage/views/organizations.py:1150
-#: warehouse/manage/views/organizations.py:1192
+#: warehouse/manage/views/organizations.py:1104
+#: warehouse/manage/views/organizations.py:1146
 msgid "Could not find organization invitation."
 msgstr ""
 
-#: warehouse/manage/views/organizations.py:1160
+#: warehouse/manage/views/organizations.py:1114
 msgid "Organization invitation could not be re-sent."
 msgstr ""
 
-#: warehouse/manage/views/organizations.py:1208
+#: warehouse/manage/views/organizations.py:1162
 #, python-brace-format
 msgid "Expired invitation for '${username}' deleted."
 msgstr ""
 
-#: warehouse/manage/views/organizations.py:1875
+#: warehouse/manage/views/organizations.py:1799
 msgid ""
 "This publisher has already been registered in your organization. See your"
 " existing pending publishers below."

--- a/warehouse/manage/views/organizations.py
+++ b/warehouse/manage/views/organizations.py
@@ -28,7 +28,6 @@ from warehouse.email import (
     send_organization_member_invited_email,
     send_organization_member_removed_email,
     send_organization_member_role_changed_email,
-    send_organization_project_added_email,
     send_organization_project_removed_email,
     send_organization_role_verification_email,
     send_organization_updated_email,
@@ -50,6 +49,8 @@ from warehouse.manage.forms import (
     TransferOrganizationProjectForm,
 )
 from warehouse.manage.views.view_helpers import (
+    add_organization_project_and_notify,
+    organization_owners,
     project_owners,
     user_organizations,
     user_projects,
@@ -87,20 +88,6 @@ from warehouse.utils.http import is_safe_url
 from warehouse.utils.organization import confirm_organization
 from warehouse.utils.paginate import paginate_url_factory
 from warehouse.utils.project import confirm_project
-
-
-def organization_owners(request, organization):
-    """Return all users who are owners of the organization."""
-    owner_roles = (
-        request.db.query(User.id)
-        .join(OrganizationRole.user)
-        .filter(
-            OrganizationRole.role_name == OrganizationRoleType.Owner,
-            OrganizationRole.organization == organization,
-        )
-        .subquery()
-    )
-    return request.db.query(User).join(owner_roles, User.id == owner_roles.c.id).all()
 
 
 def organization_managers(request, organization):
@@ -887,41 +874,8 @@ class ManageOrganizationProjectsViews:
                 form.new_project_name.errors.append(exc.detail)
                 return default_response
 
-        # Add project to organization.
-        self.organization_service.add_organization_project(
-            organization_id=self.organization.id,
-            project_id=project.id,
-        )
-
-        # Record events.
-        self.organization.record_event(
-            tag=EventTag.Organization.OrganizationProjectAdd,
-            request=self.request,
-            additional={
-                "submitted_by_user_id": str(self.request.user.id),
-                "project_name": project.name,
-            },
-        )
-        project.record_event(
-            tag=EventTag.Project.OrganizationProjectAdd,
-            request=self.request,
-            additional={
-                "submitted_by_user_id": str(self.request.user.id),
-                "organization_name": self.organization.name,
-            },
-        )
-
-        # Send notification emails.
-        owner_users = set(
-            organization_owners(self.request, self.organization)
-            + project_owners(self.request, project)
-        )
-        send_organization_project_added_email(
-            self.request,
-            owner_users,
-            organization_name=self.organization.name,
-            project_name=project.name,
-        )
+        # Add project to organization, record events, and notify owners.
+        add_organization_project_and_notify(self.request, self.organization, project)
 
         # Display notification message.
         self.request.session.flash(
@@ -1693,39 +1647,9 @@ def transfer_organization_project(project, request):
         # Mark Organization as dirty, so purges will happen
         orm.attributes.flag_dirty(organization)
 
-    # Add project to selected organization.
+    # Add project to selected organization, record events, and notify owners.
     organization = organization_service.get_organization(form.organization.data)
-    organization_service.add_organization_project(organization.id, project.id)
-    organization.record_event(
-        tag=EventTag.Organization.OrganizationProjectAdd,
-        request=request,
-        additional={
-            "submitted_by_user_id": str(request.user.id),
-            "project_name": project.name,
-        },
-    )
-    project.record_event(
-        tag=EventTag.Project.OrganizationProjectAdd,
-        request=request,
-        additional={
-            "submitted_by_user_id": str(request.user.id),
-            "organization_name": organization.name,
-        },
-    )
-
-    # Mark Organization as dirty, so purges will happen
-    orm.attributes.flag_dirty(organization)
-
-    # Send notification emails.
-    owner_users = set(
-        organization_owners(request, organization) + project_owners(request, project)
-    )
-    send_organization_project_added_email(
-        request,
-        owner_users,
-        organization_name=organization.name,
-        project_name=project.name,
-    )
+    add_organization_project_and_notify(request, organization, project)
 
     request.session.flash(
         f"Transferred the project {project.name!r} to {organization.name!r}",

--- a/warehouse/manage/views/view_helpers.py
+++ b/warehouse/manage/views/view_helpers.py
@@ -1,11 +1,22 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Helper functions for `manage/views`, preventing circular imports.
+Shared view-layer helpers, preventing circular imports.
+
+Originally scoped to `manage/views`, some helpers here (e.g.
+`add_organization_project_and_notify`) are also used by `admin/views`.
 """
+
+from __future__ import annotations
+
+import typing
 
 from sqlalchemy import func
 
+from warehouse.accounts.models import User
+from warehouse.email import send_organization_project_added_email
+from warehouse.events.tags import EventTag
+from warehouse.organizations.interfaces import IOrganizationService
 from warehouse.organizations.models import (
     Organization,
     OrganizationRole,
@@ -17,10 +28,68 @@ from warehouse.organizations.models import (
 )
 from warehouse.packaging import Project, Role
 
+if typing.TYPE_CHECKING:
+    from pyramid.request import Request
+
 
 def project_owners(request, project):
     """Return all users who are owners of the project."""
     return project.owners
+
+
+def organization_owners(request: Request, organization: Organization) -> list[User]:
+    """Return all users who are owners of the organization."""
+    owner_roles = (
+        request.db.query(User.id)
+        .join(OrganizationRole.user)
+        .filter(
+            OrganizationRole.role_name == OrganizationRoleType.Owner,
+            OrganizationRole.organization == organization,
+        )
+        .subquery()
+    )
+    return request.db.query(User).join(owner_roles, User.id == owner_roles.c.id).all()
+
+
+def add_organization_project_and_notify(
+    request: Request, organization: Organization, project: Project
+) -> None:
+    """Associate ``project`` with ``organization``, record events, and notify owners.
+
+    Shared by the manage-side "add project to organization" and "transfer
+    project to organization" flows and the admin prohibited-name release flow.
+    """
+    organization_service = request.find_service(IOrganizationService, context=None)
+    organization_service.add_organization_project(
+        organization_id=organization.id, project_id=project.id
+    )
+
+    organization.record_event(
+        tag=EventTag.Organization.OrganizationProjectAdd,
+        request=request,
+        additional={
+            "submitted_by_user_id": str(request.user.id),
+            "project_name": project.name,
+        },
+    )
+    project.record_event(
+        tag=EventTag.Project.OrganizationProjectAdd,
+        request=request,
+        additional={
+            "submitted_by_user_id": str(request.user.id),
+            "organization_name": organization.name,
+        },
+    )
+
+    owner_users = set(
+        organization_owners(request, organization) + project_owners(request, project)
+    )
+    send_organization_project_added_email(
+        request,
+        owner_users,
+        organization_name=organization.name,
+        project_name=project.name,
+    )
 
 
 def user_organizations(request):


### PR DESCRIPTION
Currently prohibited project names can only be released to a user account, and then they would have to transfer it to an organization, which is a little messier than it needs to be.

Extract common functionality to a shared view helper, and wire up the ability to release a project directly to an organization.

Corrects some redirect-on-failure behaviors.