### PR TITLE
Add `uploaded_via` and `trusted_publishing` to the JSON API

### DIFF
--- a/docs/user/api/json.md
+++ b/docs/user/api/json.md
@@ -144,7 +144,9 @@ Accept: application/json
                     "upload_time_iso_8601": "2015-06-14T14:38:05.875222Z",
                     "url": "https://files.pythonhosted.org/packages/30/52/547eb3719d0e872bdd6fe3ab60cef92596f95262e925e1943f68f840df88/sampleproject-1.2.0-py2.py3-none-any.whl",
                     "yanked": false,
-                    "yanked_reason": null
+                    "yanked_reason": null,
+                    "uploaded_via": null,
+                    "trusted_publishing": false
                 },
                 {
                     "comment_text": "",
@@ -165,7 +167,9 @@ Accept: application/json
                     "upload_time_iso_8601": "2015-06-14T14:37:56.383366Z",
                     "url": "https://files.pythonhosted.org/packages/eb/45/79be82bdeafcecb9dca474cad4003e32ef8e4a0dec6abbd4145ccb02abe1/sampleproject-1.2.0.tar.gz",
                     "yanked": false,
-                    "yanked_reason": null
+                    "yanked_reason": null,
+                    "uploaded_via": null,
+                    "trusted_publishing": false
                 }
             ],
             "1.3.0": [
@@ -200,7 +204,9 @@ Accept: application/json
                 "upload_time_iso_8601": "2024-11-06T22:37:09.220617Z",
                 "url": "https://files.pythonhosted.org/packages/d7/73/c16e5f3f0d37c60947e70865c255a58dc408780a6474de0523afd0ec553a/sampleproject-4.0.0-py3-none-any.whl",
                 "yanked": false,
-                "yanked_reason": null
+                "yanked_reason": null,
+                "uploaded_via": "twine/5.1.1 CPython/3.12.7",
+                "trusted_publishing": true
               },
               {
                 "comment_text": "",
@@ -221,7 +227,9 @@ Accept: application/json
                 "upload_time_iso_8601": "2024-11-06T22:37:10.868088Z",
                 "url": "https://files.pythonhosted.org/packages/48/8c/c18d25735962870ccb6d1cd2ac7bde40008a332211055e260cb7ec4c6bab/sampleproject-4.0.0.tar.gz",
                 "yanked": false,
-                "yanked_reason": null
+                "yanked_reason": null,
+                "uploaded_via": "twine/5.1.1 CPython/3.12.7",
+                "trusted_publishing": true
               }
             ]
         },
@@ -245,7 +253,9 @@ Accept: application/json
               "upload_time_iso_8601": "2024-11-06T22:37:09.220617Z",
               "url": "https://files.pythonhosted.org/packages/d7/73/c16e5f3f0d37c60947e70865c255a58dc408780a6474de0523afd0ec553a/sampleproject-4.0.0-py3-none-any.whl",
               "yanked": false,
-              "yanked_reason": null
+              "yanked_reason": null,
+              "uploaded_via": "twine/5.1.1 CPython/3.12.7",
+              "trusted_publishing": true
             },
             {
               "comment_text": "",
@@ -266,7 +276,9 @@ Accept: application/json
               "upload_time_iso_8601": "2024-11-06T22:37:10.868088Z",
               "url": "https://files.pythonhosted.org/packages/48/8c/c18d25735962870ccb6d1cd2ac7bde40008a332211055e260cb7ec4c6bab/sampleproject-4.0.0.tar.gz",
               "yanked": false,
-              "yanked_reason": null
+              "yanked_reason": null,
+              "uploaded_via": "twine/5.1.1 CPython/3.12.7",
+              "trusted_publishing": true
             }
         ],
         "vulnerabilities": [],
@@ -413,7 +425,9 @@ Accept: application/json
             "upload_time_iso_8601": "2024-11-06T22:37:09.220617Z",
             "url": "https://files.pythonhosted.org/packages/d7/73/c16e5f3f0d37c60947e70865c255a58dc408780a6474de0523afd0ec553a/sampleproject-4.0.0-py3-none-any.whl",
             "yanked": false,
-            "yanked_reason": null
+            "yanked_reason": null,
+            "uploaded_via": "twine/5.1.1 CPython/3.12.7",
+            "trusted_publishing": true
           },
           {
             "comment_text": "",
@@ -434,7 +448,9 @@ Accept: application/json
             "upload_time_iso_8601": "2024-11-06T22:37:10.868088Z",
             "url": "https://files.pythonhosted.org/packages/48/8c/c18d25735962870ccb6d1cd2ac7bde40008a332211055e260cb7ec4c6bab/sampleproject-4.0.0.tar.gz",
             "yanked": false,
-            "yanked_reason": null
+            "yanked_reason": null,
+            "uploaded_via": "twine/5.1.1 CPython/3.12.7",
+            "trusted_publishing": true
           }
         ],
         "vulnerabilities": [],
@@ -527,3 +543,5 @@ For example, here is what a withdrawn vulnerability might look like:
 [Index API]: ./index-api.md
 [`package_roles`]: https://docs.pypi.org/api/xml-rpc/#package_rolespackage_name
 [known vulnerabilities]: https://github.com/pypa/advisory-database
+[User-Agent]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent
+[Trusted Publisher]: https://docs.pypi.org/trusted-publishers/

--- a/tests/unit/legacy/api/test_json.py
+++ b/tests/unit/legacy/api/test_json.py
@@ -13,6 +13,7 @@ from ....common.db.integrations import VulnerabilityRecordFactory
 from ....common.db.organizations import OrganizationProjectFactory
 from ....common.db.packaging import (
     DescriptionFactory,
+    FileEventFactory,
     FileFactory,
     JournalEntryFactory,
     ProjectFactory,
@@ -279,6 +280,8 @@ class TestJSONProject:
                         "requires_python": None,
                         "yanked": False,
                         "yanked_reason": None,
+                        "uploaded_via": None,
+                        "trusted_publishing": False,
                     }
                 ],
                 "2.0": [
@@ -304,6 +307,8 @@ class TestJSONProject:
                         "requires_python": None,
                         "yanked": False,
                         "yanked_reason": None,
+                        "uploaded_via": None,
+                        "trusted_publishing": False,
                     }
                 ],
                 "3.0": [
@@ -329,6 +334,8 @@ class TestJSONProject:
                         "requires_python": None,
                         "yanked": False,
                         "yanked_reason": None,
+                        "uploaded_via": None,
+                        "trusted_publishing": False,
                     }
                 ],
             },
@@ -353,6 +360,8 @@ class TestJSONProject:
                     "requires_python": None,
                     "yanked": False,
                     "yanked_reason": None,
+                    "uploaded_via": None,
+                    "trusted_publishing": False,
                 }
             ],
             "last_serial": je.id,
@@ -362,6 +371,42 @@ class TestJSONProject:
                 "organization": None,
             },
         }
+
+    def test_renders_trusted_publishing(self, pyramid_config, db_request):
+        project = ProjectFactory.create(has_docs=False)
+        trusted_release = ReleaseFactory.create(project=project, version="1.0")
+        trusted_file = FileFactory.create(
+            release=trusted_release,
+            filename=f"{project.name}-1.0.tar.gz",
+            python_version="source",
+            size=200,
+        )
+        FileEventFactory.create(
+            source=trusted_file,
+            tag="fake:event",
+            additional={"uploaded_via_trusted_publisher": True},
+        )
+        plain_release = ReleaseFactory.create(project=project, version="2.0")
+        FileFactory.create(
+            release=plain_release,
+            filename=f"{project.name}-2.0.tar.gz",
+            python_version="source",
+            size=200,
+            uploaded_via="twine/4.0",
+        )
+
+        url = "/the/fake/url/"
+        db_request.route_url = pretend.call_recorder(lambda *args, **kw: url)
+        db_request.matchdict = {"name": project.normalized_name}
+
+        result = json.json_project(plain_release, db_request)
+
+        # all_releases=True must propagate each file's flags to the correct
+        # release entry.
+        assert result["releases"]["1.0"][0]["trusted_publishing"] is True
+        assert result["releases"]["1.0"][0]["uploaded_via"] is None
+        assert result["releases"]["2.0"][0]["trusted_publishing"] is False
+        assert result["releases"]["2.0"][0]["uploaded_via"] == "twine/4.0"
 
 
 class TestJSONProjectSlash:
@@ -600,6 +645,8 @@ class TestJSONRelease:
                     "requires_python": None,
                     "yanked": False,
                     "yanked_reason": None,
+                    "uploaded_via": None,
+                    "trusted_publishing": False,
                 }
             ],
             "last_serial": je.id,
@@ -698,6 +745,8 @@ class TestJSONRelease:
                     "requires_python": None,
                     "yanked": False,
                     "yanked_reason": None,
+                    "uploaded_via": None,
+                    "trusted_publishing": False,
                 }
             ],
             "last_serial": je.id,
@@ -707,6 +756,196 @@ class TestJSONRelease:
                 "organization": None,
             },
         }
+
+    @pytest.mark.parametrize(
+        ("uploaded_via", "expected"),
+        [
+            ("twine/4.0.0 CPython/3.11.0", "twine/4.0.0 CPython/3.11.0"),
+            # An empty user agent is coerced to null by `f.uploaded_via or None`.
+            ("", None),
+        ],
+    )
+    def test_uploaded_via_renders(
+        self, pyramid_config, db_request, uploaded_via, expected
+    ):
+        project = ProjectFactory.create(has_docs=False)
+        release = ReleaseFactory.create(project=project, version="0.1")
+        FileFactory.create(
+            release=release,
+            filename=f"{project.name}-{release.version}.tar.gz",
+            python_version="source",
+            size=200,
+            uploaded_via=uploaded_via,
+        )
+
+        url = "/the/fake/url/"
+        db_request.route_url = pretend.call_recorder(lambda *args, **kw: url)
+        db_request.matchdict = {
+            "name": project.normalized_name,
+            "version": release.canonical_version,
+        }
+
+        result = json.json_release(release, db_request)
+
+        assert result["urls"][0]["uploaded_via"] == expected
+        assert result["urls"][0]["trusted_publishing"] is False
+
+    def test_trusted_publishing_via_flag_renders(self, pyramid_config, db_request):
+        project = ProjectFactory.create(has_docs=False)
+        release = ReleaseFactory.create(project=project, version="0.1")
+        file = FileFactory.create(
+            release=release,
+            filename=f"{project.name}-{release.version}.tar.gz",
+            python_version="source",
+            size=200,
+        )
+        FileEventFactory.create(
+            source=file,
+            tag="fake:event",
+            additional={"uploaded_via_trusted_publisher": True},
+        )
+
+        url = "/the/fake/url/"
+        db_request.route_url = pretend.call_recorder(lambda *args, **kw: url)
+        db_request.matchdict = {
+            "name": project.normalized_name,
+            "version": release.canonical_version,
+        }
+
+        result = json.json_release(release, db_request)
+
+        assert result["urls"][0]["trusted_publishing"] is True
+
+    def test_trusted_publishing_via_publisher_url_renders(
+        self, pyramid_config, db_request
+    ):
+        project = ProjectFactory.create(has_docs=False)
+        release = ReleaseFactory.create(project=project, version="0.1")
+        file = FileFactory.create(
+            release=release,
+            filename=f"{project.name}-{release.version}.tar.gz",
+            python_version="source",
+            size=200,
+        )
+        FileEventFactory.create(
+            source=file,
+            tag="fake:event",
+            additional={"publisher_url": "https://github.com/foo/bar"},
+        )
+
+        url = "/the/fake/url/"
+        db_request.route_url = pretend.call_recorder(lambda *args, **kw: url)
+        db_request.matchdict = {
+            "name": project.normalized_name,
+            "version": release.canonical_version,
+        }
+
+        result = json.json_release(release, db_request)
+
+        assert result["urls"][0]["trusted_publishing"] is True
+
+    def test_trusted_publishing_non_qualifying_event_renders_false(
+        self, pyramid_config, db_request
+    ):
+        project = ProjectFactory.create(has_docs=False)
+        release = ReleaseFactory.create(project=project, version="0.1")
+        file = FileFactory.create(
+            release=release,
+            filename=f"{project.name}-{release.version}.tar.gz",
+            python_version="source",
+            size=200,
+        )
+        # An event exists but is not a trusted-publisher upload (no flag, no
+        # publisher_url), so the column must still resolve to False.
+        FileEventFactory.create(source=file, tag="fake:event")
+
+        url = "/the/fake/url/"
+        db_request.route_url = pretend.call_recorder(lambda *args, **kw: url)
+        db_request.matchdict = {
+            "name": project.normalized_name,
+            "version": release.canonical_version,
+        }
+
+        result = json.json_release(release, db_request)
+
+        assert result["urls"][0]["trusted_publishing"] is False
+
+    def test_trusted_publishing_multiple_events_no_duplicate(
+        self, pyramid_config, db_request
+    ):
+        project = ProjectFactory.create(has_docs=False)
+        release = ReleaseFactory.create(project=project, version="0.1")
+        file = FileFactory.create(
+            release=release,
+            filename=f"{project.name}-{release.version}.tar.gz",
+            python_version="source",
+            size=200,
+        )
+        # Multiple qualifying events for the same file must not duplicate the
+        # file in the output (regression guard for the EXISTS column).
+        FileEventFactory.create(
+            source=file,
+            tag="fake:event",
+            additional={"uploaded_via_trusted_publisher": True},
+        )
+        FileEventFactory.create(
+            source=file,
+            tag="fake:event",
+            additional={"publisher_url": "https://github.com/foo/bar"},
+        )
+
+        url = "/the/fake/url/"
+        db_request.route_url = pretend.call_recorder(lambda *args, **kw: url)
+        db_request.matchdict = {
+            "name": project.normalized_name,
+            "version": release.canonical_version,
+        }
+
+        result = json.json_release(release, db_request)
+
+        assert len(result["urls"]) == 1
+        assert result["urls"][0]["trusted_publishing"] is True
+
+    def test_multiple_files_pairing_renders(self, pyramid_config, db_request):
+        project = ProjectFactory.create(has_docs=False)
+        release = ReleaseFactory.create(project=project, version="0.1")
+        trusted_file = FileFactory.create(
+            release=release,
+            filename=f"{project.name}-{release.version}.tar.gz",
+            python_version="source",
+            packagetype="sdist",
+            size=200,
+        )
+        FileEventFactory.create(
+            source=trusted_file,
+            tag="fake:event",
+            additional={"publisher_url": "https://github.com/foo/bar"},
+        )
+        plain_file = FileFactory.create(
+            release=release,
+            filename=f"{project.name}-{release.version}-py3-none-any.whl",
+            python_version="py3",
+            packagetype="bdist_wheel",
+            size=200,
+            uploaded_via="twine/5.0",
+        )
+
+        url = "/the/fake/url/"
+        db_request.route_url = pretend.call_recorder(lambda *args, **kw: url)
+        db_request.matchdict = {
+            "name": project.normalized_name,
+            "version": release.canonical_version,
+        }
+
+        result = json.json_release(release, db_request)
+
+        # Index by filename so a mis-paired flag fails rather than passing by
+        # positional luck.
+        urls = {u["filename"]: u for u in result["urls"]}
+        assert urls[trusted_file.filename]["trusted_publishing"] is True
+        assert urls[trusted_file.filename]["uploaded_via"] is None
+        assert urls[plain_file.filename]["trusted_publishing"] is False
+        assert urls[plain_file.filename]["uploaded_via"] == "twine/5.0"
 
     @pytest.mark.parametrize("withdrawn", [None, "2022-06-28T16:39:06Z"])
     def test_vulnerabilities_renders(self, pyramid_config, db_request, withdrawn):

--- a/warehouse/legacy/api/json.py
+++ b/warehouse/legacy/api/json.py
@@ -40,9 +40,14 @@ _PROJECT_CACHE_DECORATOR = [
 
 
 def _json_data(request, project, release, *, all_releases):
+    # Use the SQL expression (a correlated EXISTS), not the per-file property,
+    # so trusted-publishing resolves as a column here instead of a COUNT per
+    # file in the loop below (an N+1).
+    trusted_publishing = File.uploaded_via_trusted_publisher.label("trusted_publishing")
+
     # Get all of the releases and files for this project.
     release_files = (
-        request.db.query(Release, File)
+        request.db.query(Release, File, trusted_publishing)
         .options(
             Load(Release).load_only(
                 Release.version,
@@ -78,12 +83,12 @@ def _json_data(request, project, release, *, all_releases):
     ).all()
 
     # Map our releases + files into a dictionary that maps each release to a
-    # list of all its files.
-    releases_and_files: dict[Release, list[File]] = {}
-    for r, file_ in release_files:
+    # list of all its files, pairing each file with its trusted-publishing flag.
+    releases_and_files: dict[Release, list[tuple[File, bool]]] = {}
+    for r, file_, is_trusted_publisher in release_files:
         files = releases_and_files.setdefault(r, [])
         if file_ is not None:
-            files.append(file_)
+            files.append((file_, is_trusted_publisher))
 
     # Serialize our database objects to match the way that PyPI legacy
     # presented this data.
@@ -113,8 +118,10 @@ def _json_data(request, project, release, *, all_releases):
                 "requires_python": r.requires_python or None,
                 "yanked": r.yanked,
                 "yanked_reason": r.yanked_reason or None,
+                "uploaded_via": f.uploaded_via or None,
+                "trusted_publishing": is_trusted_publisher,
             }
-            for f in fs
+            for f, is_trusted_publisher in fs
         ]
         for r, fs in releases_and_files.items()
     }

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -26,6 +26,7 @@ from sqlalchemy import (
     UniqueConstraint,
     cast,
     event,
+    exists,
     func,
     or_,
     orm,
@@ -1027,19 +1028,26 @@ class File(HasEvents, db.Model):
         passive_deletes=True,
     )
 
-    @property
+    @classmethod
+    def _trusted_publisher_event_filter(cls):
+        return or_(
+            cls.Event.additional["uploaded_via_trusted_publisher"].as_boolean(),
+            cls.Event.additional["publisher_url"].as_string().is_not(None),
+        )
+
+    @hybrid_property
     def uploaded_via_trusted_publisher(self) -> bool:
         """Return True if the file was uploaded via a trusted publisher."""
-        return (
-            self.events.where(
-                or_(
-                    self.Event.additional[
-                        "uploaded_via_trusted_publisher"
-                    ].as_boolean(),
-                    self.Event.additional["publisher_url"].as_string().is_not(None),
-                )
-            ).count()
-            > 0
+        return self.events.where(self._trusted_publisher_event_filter()).count() > 0
+
+    @uploaded_via_trusted_publisher.expression  # type: ignore[no-redef]
+    def uploaded_via_trusted_publisher(cls):
+        """Return an expression evaluating to True if the file was uploaded
+        via a trusted publisher.
+        """
+        return exists().where(
+            cls.Event.source_id == cls.id,
+            cls._trusted_publisher_event_filter(),
         )
 
     @hybrid_property


### PR DESCRIPTION
Exposes two per-file fields on the JSON API (`/pypi/{name}/json` and
  `/pypi/{name}/{version}/json`):
  
  - `uploaded_via`: the upload client's `User-Agent` (e.g. `"twine/5.1.1 CPython/3.12.7"`), or `null`.
  - `trusted_publishing`: `true` if uploaded via a [Trusted Publisher](https://docs.pypi.org/trusted-publishers/),
  else `false`.
  
  JSON-API counterpart to #20065 (Simple API). These were previously only on the
  release HTML page, behind a Fastly challenge, so unreachable by automation.
  
  `trusted_publishing` is computed as a correlated `EXISTS` column in the main
  query (scoped per-file, short-circuits) to avoid an N+1. 