### PR TITLE
fix: ratelimits on project create and emit headers

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -235,6 +235,10 @@ def pyramid_services(
     services.register_service(ratelimit_service, IRateLimiter, name="email.add")
     services.register_service(ratelimit_service, IRateLimiter, name="email.verify")
     services.register_service(
+        ratelimit_service, IRateLimiter, name="project.create.user"
+    )
+    services.register_service(ratelimit_service, IRateLimiter, name="project.create.ip")
+    services.register_service(
         github_oauth_provider_service, IOAuthProviderService, name="github"
     )
 
@@ -602,7 +606,10 @@ def domain_status_service(mocker):
 @pytest.fixture
 def ratelimit_service(mocker):
     service = DummyRateLimiter()
+    mocker.spy(service, "test")
+    mocker.spy(service, "hit")
     mocker.spy(service, "clear")
+    mocker.spy(service, "resets_in")
     return service
 
 

--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -5300,6 +5300,7 @@ class TestFileUpload:
         project_service.ratelimiters[failing_limiter] = pretend.stub(
             test=lambda *a, **kw: False,
             resets_in=lambda *a, **kw: 60,
+            get_window_stats=lambda *a, **kw: [],
         )
         storage_service = pretend.stub(store=lambda path, filepath, meta: None)
         db_request.find_service = lambda svc, name=None, context=None: {

--- a/tests/unit/packaging/test_services.py
+++ b/tests/unit/packaging/test_services.py
@@ -44,6 +44,7 @@ from warehouse.packaging.services import (
     S3FileStorage,
     project_service_factory,
 )
+from warehouse.rate_limiting.interfaces import WindowStats
 
 from ...common.db.accounts import UserFactory
 from ...common.db.packaging import ProhibitedProjectFactory, ProjectFactory
@@ -1113,6 +1114,35 @@ class TestProjectService:
 
         with pytest.raises(TooManyProjectsCreated):
             project_service.create_project("some-new-project", creator, db_request)
+
+    def test_check_ratelimits_records_rate_limit_headers(
+        self, project_service, db_request, ratelimit_service, mocker
+    ):
+        """`_check_ratelimits` records a snapshot per limiter so the egress
+        tween can emit RateLimit / RateLimit-Policy headers on the response.
+        """
+        creator = UserFactory.create()
+        stats = [
+            WindowStats(
+                amount=4, window_seconds=86400, remaining=3, resets_in_seconds=0
+            )
+        ]
+        mocker.patch.object(ratelimit_service, "get_window_stats", return_value=stats)
+        project_service.ratelimiters["project.create.user"] = ratelimit_service
+        project_service.ratelimiters["project.create.ip"] = ratelimit_service
+
+        project_service._check_ratelimits(db_request, creator)
+
+        # Keyed on the request IP and the creator's id, in that order.
+        assert ratelimit_service.get_window_stats.call_args_list == [
+            mocker.call(db_request.remote_addr),
+            mocker.call(creator.id),
+        ]
+        snapshots = db_request._rate_limit_snapshots
+        assert [(s.name, s.partition_key, s.stats) for s in snapshots] == [
+            ("project.create.ip", "ip", stats),
+            ("project.create.user", "user", stats),
+        ]
 
     def test_check_project_name_already_exists(self, db_session):
         service = ProjectService(session=db_session)

--- a/tests/unit/packaging/test_services.py
+++ b/tests/unit/packaging/test_services.py
@@ -27,6 +27,7 @@ from warehouse.packaging.interfaces import (
     ProjectNameUnavailableSimilarError,
     ProjectNameUnavailableStdlibError,
     ProjectNameUnavailableTypoSquattingError,
+    TooManyProjectsCreated,
 )
 from warehouse.packaging.services import (
     B2FileStorage,
@@ -44,6 +45,7 @@ from warehouse.packaging.services import (
     project_service_factory,
 )
 
+from ...common.db.accounts import UserFactory
 from ...common.db.packaging import ProhibitedProjectFactory, ProjectFactory
 
 
@@ -1041,6 +1043,77 @@ class TestProjectService:
             "/the/help/url/ for more information."
         )
 
+    @pytest.mark.parametrize(
+        ("enforce", "limiter_method", "limiter_name", "keyed_on_creator"),
+        [
+            (ProjectService._check_ratelimits, "test", "project.create.ip", False),
+            (ProjectService._check_ratelimits, "test", "project.create.user", True),
+            (ProjectService._hit_ratelimits, "hit", "project.create.user", True),
+            (ProjectService._hit_ratelimits, "hit", "project.create.ip", False),
+        ],
+        ids=["check-ip", "check-user", "hit-user", "hit-ip"],
+    )
+    def test_ratelimit_exceeded_raises_with_correct_reset_hint(
+        self,
+        project_service,
+        db_request,
+        ratelimit_service,
+        mocker,
+        enforce,
+        limiter_method,
+        limiter_name,
+        keyed_on_creator,
+    ):
+        """A limiter reporting its threshold is reached refuses the creation.
+
+        Both the optimistic ``_check_ratelimits`` gate (via ``test``) and the
+        enforcing ``_hit_ratelimits`` gate (via ``hit``) raise, and the reset
+        hint is keyed on the identifier that tripped the limit: the creator's id
+        for the user limit, the request IP for the IP limit.
+        """
+        creator = UserFactory.create()
+        # Trip just the limiter under test; the other auto-creates and passes.
+        project_service.ratelimiters[limiter_name] = ratelimit_service
+        mocker.patch.object(ratelimit_service, limiter_method, return_value=False)
+
+        with pytest.raises(TooManyProjectsCreated):
+            enforce(project_service, db_request, creator)
+
+        expected = creator.id if keyed_on_creator else db_request.remote_addr
+        ratelimit_service.resets_in.assert_called_once_with(expected)
+
+    def test_hit_ratelimits_skips_ip_limiter_without_remote_addr(
+        self, project_service, db_request, ratelimit_service
+    ):
+        """With no resolvable client IP the IP limiter is left untouched.
+
+        This mirrors the guard already present in ``_check_ratelimits``.
+        """
+        creator = UserFactory.create()
+        db_request.remote_addr = None
+        project_service.ratelimiters["project.create.ip"] = ratelimit_service
+
+        project_service._hit_ratelimits(db_request, creator)
+
+        ratelimit_service.hit.assert_not_called()
+
+    def test_create_project_rejects_when_hit_exceeds_limit(
+        self, project_service, db_request, ratelimit_service, mocker
+    ):
+        """The atomic ``hit`` enforces the limit even when ``test`` passed.
+
+        A burst of concurrent uploads can each clear the optimistic ``test``
+        check before any of them records a hit, so the per-request ``hit`` is
+        what actually caps creation: a request that pushes the counter past the
+        limit is rejected, rolling back the project just created.
+        """
+        creator = UserFactory.create()
+        project_service.ratelimiters["project.create.user"] = ratelimit_service
+        mocker.patch.object(ratelimit_service, "hit", return_value=False)
+
+        with pytest.raises(TooManyProjectsCreated):
+            project_service.create_project("some-new-project", creator, db_request)
+
     def test_check_project_name_already_exists(self, db_session):
         service = ProjectService(session=db_session)
         project = ProjectFactory.create(name="foo")
@@ -1093,12 +1166,10 @@ class TestProjectService:
         service.check_project_name("foo")
 
 
-def test_project_service_factory():
-    db = pretend.stub()
-    request = pretend.stub(
-        db=db,
-        find_service=lambda iface, name=None, context=None: None,
-    )
+def test_project_service_factory(db_request, ratelimit_service):
+    service = project_service_factory(pretend.stub(), db_request)
 
-    service = project_service_factory(pretend.stub(), request)
-    assert service.db == db
+    assert service.db is db_request.db
+    # The factory resolves both rate limiters from the registry by name.
+    assert service.ratelimiters["project.create.user"] is ratelimit_service
+    assert service.ratelimiters["project.create.ip"] is ratelimit_service

--- a/warehouse/packaging/services.py
+++ b/warehouse/packaging/services.py
@@ -53,6 +53,7 @@ from warehouse.packaging.models import (
 )
 from warehouse.packaging.typosnyper import typo_check_name
 from warehouse.rate_limiting import DummyRateLimiter, IRateLimiter
+from warehouse.rate_limiting.headers import record_rate_limit
 from warehouse.utils.exceptions import DevelopmentModeWarning
 from warehouse.utils.project import PROJECT_NAME_RE
 
@@ -417,6 +418,24 @@ class ProjectService:
         self._query_results_cache = query_results_cache
 
     def _check_ratelimits(self, request, creator):
+        # Record the current limiter state so the egress tween can emit
+        # RateLimit / RateLimit-Policy headers, whether or not we reject below.
+        if request.remote_addr is not None:
+            record_rate_limit(
+                request,
+                "project.create.ip",
+                self.ratelimiters["project.create.ip"],
+                identifiers=(request.remote_addr,),
+                partition_key="ip",
+            )
+        record_rate_limit(
+            request,
+            "project.create.user",
+            self.ratelimiters["project.create.user"],
+            identifiers=(creator.id,),
+            partition_key="user",
+        )
+
         # First we want to check if a single IP is exceeding our rate limiter.
         if request.remote_addr is not None and not self.ratelimiters[
             "project.create.ip"

--- a/warehouse/packaging/services.py
+++ b/warehouse/packaging/services.py
@@ -439,14 +439,39 @@ class ProjectService:
                 tags=["ratelimiter:user"],
             )
             raise TooManyProjectsCreated(
-                resets_in=self.ratelimiters["project.create.user"].resets_in(
+                resets_in=self.ratelimiters["project.create.user"].resets_in(creator.id)
+            )
+
+    def _hit_ratelimits(self, request, creator):
+        # `.hit()` atomically increments and returns False when the limit is
+        # exceeded. Concurrent requests can each pass the optimistic `.test()`
+        # in `_check_ratelimits` before any records a hit, so this atomic check
+        # is what actually enforces the limit: a request that pushes a counter
+        # past its limit is rejected here, rolling back the new project. The
+        # limiters are consulted in the same order as `_check_ratelimits`.
+        if request.remote_addr is not None and not self.ratelimiters[
+            "project.create.ip"
+        ].hit(request.remote_addr):
+            logger.warning("IP failed project create threshold reached.")
+            self._metrics.increment(
+                "warehouse.project.create.ratelimited",
+                tags=["ratelimiter:ip"],
+            )
+            raise TooManyProjectsCreated(
+                resets_in=self.ratelimiters["project.create.ip"].resets_in(
                     request.remote_addr
                 )
             )
 
-    def _hit_ratelimits(self, request, creator):
-        self.ratelimiters["project.create.user"].hit(creator.id)
-        self.ratelimiters["project.create.ip"].hit(request.remote_addr)
+        if not self.ratelimiters["project.create.user"].hit(creator.id):
+            logger.warning("User failed project create threshold reached.")
+            self._metrics.increment(
+                "warehouse.project.create.ratelimited",
+                tags=["ratelimiter:user"],
+            )
+            raise TooManyProjectsCreated(
+                resets_in=self.ratelimiters["project.create.user"].resets_in(creator.id)
+            )
 
     def check_project_name(self, name: str) -> None:
         """


### PR DESCRIPTION
The per-user and per-IP limits on new projects were checked with `test()`
at the start of `create_project` and then recorded with `hit()` at the end,
but the return value of `hit()` was discarded. `test()` doesn't reserve a
slot, so concurrent uploads could all clear the check before any of them
recorded a hit, letting one user create well past the configured 4/day.

`_hit_ratelimits` now honors what `hit()` returns. `hit()` atomically
increments and returns False once the limit is reached, so a request that
pushes a counter over its limit raises `TooManyProjectsCreated`, and the
project it just created rolls back with the transaction.

Two smaller fixes while here:
* The user-limit reset hint was computed from the request IP instead of the
  creator's id.
* `_hit_ratelimits` now consults the limiters in the same order as
  `_check_ratelimits` (IP, then user), so both report the same limit when
  both are over.

See separate commit for RateLimit headers addition.

Signed-off-by: Mike Fiedler <miketheman@gmail.com>