### PR TITLE
fix(style): definition terms and diff syntax

### DIFF
--- a/warehouse/static/sass/blocks/_project-description.scss
+++ b/warehouse/static/sass/blocks/_project-description.scss
@@ -154,6 +154,15 @@
 
     dt {
       font-weight: fonts.$bold-font-weight;
+
+      .classifier {
+        font-weight: normal;
+
+        &::before {
+          content: ":";
+          margin: 0 0.5em;
+        }
+      }
     }
 
     dd {
@@ -310,7 +319,8 @@ $pygments-black:         #000;
   }
 
   .gd { /* Generic.Deleted */
-    color: $pygments-black;
+    color: $dark-red;
+    background-color: color.adjust($red, $lightness: 45%);
   }
 
   .ge { /* Generic.Emph */
@@ -326,7 +336,8 @@ $pygments-black:         #000;
   }
 
   .gi { /* Generic.Inserted */
-    color: $pygments-black;
+    color: $green;
+    background-color: color.adjust($light-green, $lightness: 45%);
   }
 
   .go { /* Generic.Output */


### PR DESCRIPTION
Add styling for definition terms (docutils: 'classifier') and diff syntax from Pygments.

## Before

<img width="802" height="484" alt="image" src="https://github.com/user-attachments/assets/79675fef-244b-4ffe-8359-b3559b80f441" />


## After

<img width="796" height="487" alt="Screenshot 2026-06-16 at 12 27 07" src="https://github.com/user-attachments/assets/7175d3b8-465a-4993-827f-23d81a5cf712" />
