### PR TITLE
fix(admin): only select the reported version

### DIFF
--- a/tests/functional/admin/test_malware_reports.py
+++ b/tests/functional/admin/test_malware_reports.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import time
+
+from http import HTTPStatus
+
+from tests.common.constants import REMOTE_ADDR
+from tests.common.db.accounts import UserFactory, UserUniqueLoginFactory
+from tests.common.db.ip_addresses import IpAddressFactory
+from tests.common.db.observations import ObserverFactory
+from tests.common.db.packaging import (
+    ProjectFactory,
+    ProjectObservationFactory,
+    ReleaseFactory,
+)
+from warehouse.accounts.models import UniqueLoginStatus
+from warehouse.utils.otp import _get_totp
+
+
+class TestMalwareReportDetail:
+    def _login_admin(self, webtest, user):
+        """Log in a superuser with 2FA and a pre-confirmed IP."""
+        ip_address = IpAddressFactory.create(ip_address=REMOTE_ADDR)
+        UserUniqueLoginFactory.create(
+            user=user,
+            ip_address=ip_address,
+            status=UniqueLoginStatus.CONFIRMED,
+        )
+
+        login_page = webtest.get("/account/login/", status=HTTPStatus.OK)
+        login_form = login_page.forms["login-form"]
+        login_form["username"] = user.username
+        login_form["password"] = "password"
+
+        two_factor_page = login_form.submit().follow(status=HTTPStatus.OK)
+        two_factor_form = two_factor_page.forms["totp-auth-form"]
+        two_factor_form["totp_value"] = (
+            _get_totp(user.totp_secret).generate(time.time()).decode()
+        )
+        two_factor_form.submit().follow(status=HTTPStatus.OK)
+
+    def test_remove_release_checks_only_reported_version(self, webtest):
+        """
+        The remove-release modal pre-checks the release named in the report's
+        inspector_url. Only the exact version is checked — a shorter version that
+        is a substring of the reported one (e.g. ``0.11.9`` inside ``0.11.97``)
+        must not be checked.
+        """
+        admin = UserFactory.create(
+            is_superuser=True,
+            with_verified_primary_email=True,
+            clear_pwd="password",
+        )
+        self._login_admin(webtest, admin)
+
+        project = ProjectFactory.create()
+        reported = ReleaseFactory.create(project=project, version="0.11.97")
+        substring = ReleaseFactory.create(project=project, version="0.11.9")
+
+        observer = ObserverFactory.create()
+        UserFactory.create(observer=observer)
+        report = ProjectObservationFactory.create(
+            related=project,
+            observer=observer,
+            kind="is_malware",
+            payload={
+                "inspector_url": (
+                    f"https://inspector.pypi.io/project/{project.name}"
+                    f"/{reported.version}/packages/{project.name}-{reported.version}.tar.gz"
+                ),
+            },
+        )
+
+        detail_page = webtest.get(
+            f"/admin/malware_reports/{report.id}/", status=HTTPStatus.OK
+        )
+
+        modal = detail_page.html.find("div", id="modal-remove-release")
+        reported_box = modal.find("input", id=f"rr-{reported.id}")
+        substring_box = modal.find("input", id=f"rr-{substring.id}")
+
+        assert reported_box.has_attr("checked")
+        assert not substring_box.has_attr("checked")

--- a/warehouse/admin/templates/admin/malware_reports/detail.html
+++ b/warehouse/admin/templates/admin/malware_reports/detail.html
@@ -251,7 +251,7 @@
                          name="versions"
                          value="{{ release.version }}"
                          id="qr-{{ release.id }}"
-                         {% if release.version and release.version in inspector_url %}checked{% endif %}>
+                         {% if release.version and "/" ~ release.version ~ "/" in inspector_url %}checked{% endif %}>
                   <label class="form-check-label" for="qr-{{ release.id }}">
                     <code>{{ release.version }}</code>
                     <small class="text-muted">({{ release.created.strftime('%Y-%m-%d') }})</small>
@@ -302,7 +302,7 @@
                          name="versions"
                          value="{{ release.version }}"
                          id="rr-{{ release.id }}"
-                         {% if release.version and release.version in inspector_url %}checked{% endif %}>
+                         {% if release.version and "/" ~ release.version ~ "/" in inspector_url %}checked{% endif %}>
                   <label class="form-check-label" for="rr-{{ release.id }}">
                     <code>{{ release.version }}</code>
                     <small class="text-muted">({{ release.created.strftime('%Y-%m-%d') }})</small>


### PR DESCRIPTION
Previously would use substring select, so multiple versions could be selected by default if the matched, and if the list was long enough, one might be missed and then inadvertently removed.