### PR TITLE
feat(admin): close out sibling malware reports

### DIFF
--- a/tests/unit/admin/views/test_malware_reports.py
+++ b/tests/unit/admin/views/test_malware_reports.py
@@ -916,6 +916,109 @@ class TestVerdictRemoveRelease:
             )
         ]
 
+    def test_closes_sibling_reports_for_removed_versions_only(self, db_request):
+        """
+        A remove-release verdict also resolves other open malware reports that
+        concern a removed version, but leaves reports about releases that remain
+        installable open.
+        """
+        project = ProjectFactory.create()
+        ReleaseFactory.create(project=project, version="1.0")
+        ReleaseFactory.create(project=project, version="2.0")
+
+        def _inspector_url(version):
+            return (
+                f"https://inspector.pypi.io/project/{project.name}"
+                f"/{version}/packages/{project.name}-{version}.tar.gz"
+            )
+
+        # The report we act from, about 1.0. Sibling reports below carry
+        # increasing `created` timestamps so the view processes them in a
+        # deterministic order.
+        report = ProjectObservationFactory.create(
+            kind="is_malware",
+            related=project,
+            payload={"inspector_url": _inspector_url("1.0")},
+            additional={
+                "helpscout_conversation_url": "https://example.com/conversation/1"
+            },
+        )
+        # A sibling report, also about 1.0 with a HelpScout url — resolved + tagged.
+        sibling_same = ProjectObservationFactory.create(
+            kind="is_malware",
+            related=project,
+            created=datetime(2026, 1, 1),
+            payload={"inspector_url": _inspector_url("1.0")},
+            additional={
+                "helpscout_conversation_url": "https://example.com/conversation/2"
+            },
+        )
+        # A sibling about 1.0 without a HelpScout url — resolved, no tag.
+        sibling_no_helpscout = ProjectObservationFactory.create(
+            kind="is_malware",
+            related=project,
+            created=datetime(2026, 1, 2),
+            payload={"inspector_url": _inspector_url("1.0")},
+        )
+        # A sibling report about 2.0, which remains installed — should stay open.
+        sibling_other = ProjectObservationFactory.create(
+            kind="is_malware",
+            related=project,
+            created=datetime(2026, 1, 3),
+            payload={"inspector_url": _inspector_url("2.0")},
+        )
+        # An already-resolved sibling about 1.0 — should not be touched again.
+        sibling_resolved = ProjectObservationFactory.create(
+            kind="is_malware",
+            related=project,
+            actions={"existing": "action"},
+            payload={"inspector_url": _inspector_url("1.0")},
+        )
+        # A non-malware report about 1.0 — a different kind, left untouched.
+        sibling_spam = ProjectObservationFactory.create(
+            kind="is_spam",
+            related=project,
+            payload={"inspector_url": _inspector_url("1.0")},
+        )
+
+        helpdesk = _record_helpdesk_tags(db_request)
+        db_request.matchdict["observation_id"] = str(report.id)
+        db_request.POST = self._make_post(
+            confirm=project.name, reason="compromised", versions=["1.0"]
+        )
+        db_request.route_path = lambda *a, **kw: "/admin/malware_reports/"
+        db_request.session = pretend.stub(
+            flash=pretend.call_recorder(lambda *a, **kw: None)
+        )
+        db_request.user = UserFactory.create()
+
+        views.verdict_remove_release(db_request)
+
+        assert len(report.actions) == 1
+        assert len(sibling_same.actions) == 1
+        assert next(iter(sibling_same.actions.values()))["action"] == "remove_release"
+        # A matching sibling without a HelpScout url is still resolved.
+        assert len(sibling_no_helpscout.actions) == 1
+        # A still-installable release keeps its report open.
+        assert sibling_other.actions == {}
+        # An already-resolved report is left as-is.
+        assert sibling_resolved.actions == {"existing": "action"}
+        # A different observation kind is never touched.
+        assert sibling_spam.actions == {}
+
+        # HelpScout is tagged for the acted report and the matching open sibling.
+        tagged_urls = {
+            call.kwargs["conversation_url"] for call in helpdesk.add_tag.calls
+        }
+        assert tagged_urls == {
+            "https://example.com/conversation/1",
+            "https://example.com/conversation/2",
+        }
+        assert all(
+            call.kwargs["tag"] == "removed_release_via_admin"
+            for call in helpdesk.add_tag.calls
+        )
+
     def test_project_already_removed(self, db_request):
         report = ProjectObservationFactory.create(
             kind="is_malware",

--- a/warehouse/admin/views/malware_reports.py
+++ b/warehouse/admin/views/malware_reports.py
@@ -709,6 +709,37 @@ def verdict_remove_release(request: Request):
             tag="removed_release_via_admin",
         )
 
+    # Resolve other open malware reports for this project that concern a removed
+    # version, so they don't linger on the open list needing manual correction.
+    # Reports about releases that remain installable are deliberately left open.
+    sibling_reports = request.db.scalars(
+        select(Observation)
+        .where(
+            Observation.related_id == project.id,
+            Observation.kind == "is_malware",
+            Observation.actions == {},
+            Observation.id != observation.id,
+        )
+        .order_by(Observation.created)
+    ).all()
+    for sibling in sibling_reports:
+        sibling_url = sibling.payload.get("inspector_url", "")
+        if not any(f"/{version}/" in sibling_url for version in versions):
+            continue
+        sibling.actions[int(now.timestamp())] = {
+            "actor": request.user.username,
+            "action": "remove_release",
+            "versions": list(versions),
+            "reason": reason,
+            "created_at": str(now),
+        }
+        sibling_helpscout_url = sibling.additional.get("helpscout_conversation_url")
+        if sibling_helpscout_url:
+            request.find_service(IHelpDeskService).add_tag(
+                conversation_url=sibling_helpscout_url,
+                tag="removed_release_via_admin",
+            )
+
     request.session.flash(
         f"Removed release(s) {', '.join(versions)} of {project_name}",
         queue="success",


### PR DESCRIPTION
Similar to when removing an entire project, close out open reports for the same **version** of a given project.