### PR TITLE
fix: delete orphaned release descriptions via DB trigger

### DIFF
--- a/tests/unit/packaging/test_models.py
+++ b/tests/unit/packaging/test_models.py
@@ -15,6 +15,7 @@ from warehouse.macaroons.models import Macaroon
 from warehouse.oidc.models import GitHubPublisher
 from warehouse.organizations.models import OrganizationType, TeamProjectRoleType
 from warehouse.packaging.models import (
+    Description,
     File,
     LifecycleStatus,
     Project,
@@ -435,6 +436,31 @@ class TestProject:
 
         assert db_session.query(Project).filter_by(id=project.id).count() == 0
         assert db_session.query(GitHubPublisher).filter_by(id=publisher.id).count() == 1
+
+    def test_deletion_removes_release_descriptions(self, db_session):
+        """
+        When we remove a Project, ensure that the Description rows belonging to
+        its Releases are removed too, rather than left orphaned.
+
+        The ``releases.description_id`` foreign key points up to
+        ``release_descriptions``, so the database's ``ON DELETE CASCADE`` from
+        ``projects`` to ``releases`` does not reach the descriptions. Without an
+        explicit cleanup, deleting a Project leaves its descriptions behind.
+
+        See: https://github.com/pypi/warehouse/issues/14825
+        """
+        project = DBProjectFactory.create()
+        release = DBReleaseFactory.create(project=project)
+        description_id = release.description_id
+
+        assert db_session.query(Description).filter_by(id=description_id).count() == 1
+
+        db_session.delete(project)
+        # Flush session to trigger any FK constraints
+        db_session.flush()
+
+        assert db_session.query(Project).filter_by(id=project.id).count() == 0
+        assert db_session.query(Description).filter_by(id=description_id).count() == 0
 
     def test_deletion_project_with_macaroon_warning(self, db_session, macaroon_service):
         """
@@ -1185,15 +1211,24 @@ class TestRelease:
 
         assert not release.trusted_published
 
-    def test_description_relationship(self, db_request):
-        """When a Release is deleted, the Description is also deleted."""
+    def test_description_relationship(self, db_session):
+        """
+        When a Release is deleted, its Description is also deleted.
+
+        Enforced at the database level by the
+        ``releases_delete_orphaned_description`` trigger rather than the ORM,
+        since the ``description_id`` foreign key points the "wrong" way for an
+        ``ON DELETE CASCADE`` to reach the description.
+
+        See: https://github.com/pypi/warehouse/issues/14825
+        """
         release = DBReleaseFactory.create()  # also creates a Description
-        description = release.description
+        description_id = release.description_id
 
-        db_request.db.delete(release)
+        db_session.delete(release)
+        db_session.flush()
 
-        assert release in db_request.db.deleted
-        assert description in db_request.db.deleted
+        assert db_session.query(Description).filter_by(id=description_id).count() == 0
 
 
 class TestFile:

--- a/warehouse/migrations/versions/b9d3c5e8f1a2_cascade_delete_release_descriptions.py
+++ b/warehouse/migrations/versions/b9d3c5e8f1a2_cascade_delete_release_descriptions.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Cascade delete release_descriptions when a release is removed
+
+The `releases.description_id` foreign key points up to `release_descriptions`,
+so the `ON DELETE CASCADE` from `projects` to `releases` (and any other path
+that deletes a release without the ORM `delete-orphan` cascade) never reaches
+the description, leaving it orphaned.
+
+Enforce the cleanup at the database level with an `AFTER DELETE` trigger on
+`releases` that removes the description it referenced.
+
+See: https://github.com/pypi/warehouse/issues/14825
+
+Revision ID: b9d3c5e8f1a2
+Revises: a8038ce10051
+Create Date: 2026-06-24 14:30:00.000000
+"""
+
+from alembic import op
+
+revision = "b9d3c5e8f1a2"
+down_revision = "a8038ce10051"
+
+
+def upgrade():
+    op.execute(
+        """CREATE OR REPLACE FUNCTION delete_orphaned_release_description()
+        RETURNS TRIGGER AS $$
+        BEGIN
+            DELETE FROM release_descriptions WHERE id = OLD.description_id;
+            RETURN NULL;
+        END;
+        $$ LANGUAGE plpgsql;
+        """
+    )
+    op.execute(
+        """CREATE TRIGGER releases_delete_orphaned_description
+            AFTER DELETE ON releases
+            FOR EACH ROW EXECUTE PROCEDURE delete_orphaned_release_description();
+        """
+    )
+
+
+def downgrade():
+    op.execute("DROP TRIGGER releases_delete_orphaned_description ON releases;")
+    op.execute("DROP FUNCTION delete_orphaned_release_description;")

--- a/warehouse/packaging/models.py
+++ b/warehouse/packaging/models.py
@@ -722,8 +722,11 @@ class Release(HasObservations, db.Model):
     )
     description: Mapped[Description] = orm.relationship(
         back_populates="release",
-        cascade="all, delete-orphan",
-        single_parent=True,
+        # Cleanup of the orphaned Description is enforced at the database level
+        # by the `releases_delete_orphaned_description` trigger, since the
+        # `description_id` foreign key points the "wrong" way for an ON DELETE
+        # CASCADE to reach it. See: https://github.com/pypi/warehouse/issues/14825
+        passive_deletes=True,
     )
 
     yanked: Mapped[bool_false]


### PR DESCRIPTION
`releases.description_id` points up to `release_descriptions`, so the `ON DELETE CASCADE` from projects to releases never reaches the description. When a release is deleted outside the ORM (a project delete relies on `Project.releases` passive_deletes, so Postgres removes the release rows directly), its description is left behind.

Add an `AFTER DELETE` trigger on `releases` that deletes the referenced description, so it no longer matters which path removed the release. Also drop the `delete-orphan` cascade on `Release.description` (now `passive_deletes`), otherwise the ORM tries to delete the row the trigger already removed and raises `StaleDataError`.

Existing orphans need a separate batched cleanup.
Inverting the FK is the real fix, left for later.

Refs: #14825