### PR TITLE
Add dark mode styles

### DIFF
--- a/tests/frontend/dark_mode_styles_test.js
+++ b/tests/frontend/dark_mode_styles_test.js
@@ -1,0 +1,169 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/* global beforeAll, describe, expect, it */
+
+import { TextDecoder } from "util";
+
+globalThis.TextDecoder = TextDecoder;
+
+let compileString;
+
+beforeAll(async () => {
+  ({ compileString } = await import("sass-embedded"));
+});
+
+describe("dark mode styles", () => {
+  it("sets the base page colors and links from the preferred color scheme", () => {
+    const { css } = compileString("@use 'warehouse/static/sass/base/typography';", {
+      loadPaths: ["."],
+      style: "expanded",
+    });
+
+    expect(css).toContain("@media (prefers-color-scheme: dark)");
+    expect(css).toContain("color-scheme: dark");
+    expect(css).toContain("color: #bbb");
+    expect(css).toContain("background-color: #000");
+    expect(css).toContain("color: rgb(147.5, 215.2312138728, 255)");
+  });
+
+  it("dims the footer background from the preferred color scheme", () => {
+    const { css } = compileString("@use 'warehouse/static/sass/blocks/footer';", {
+      loadPaths: ["."],
+      style: "expanded",
+    });
+
+    expect(css).toContain("@media (prefers-color-scheme: dark)");
+    expect(css).toContain("background-color: rgb(0, 76.8670520231, 122)");
+  });
+
+  it("dims project cards from the preferred color scheme", () => {
+    const { css } = compileString("@use 'warehouse/static/sass/blocks/package-snippet';", {
+      loadPaths: ["."],
+      style: "expanded",
+    });
+
+    expect(css).toContain("@media (prefers-color-scheme: dark)");
+    expect(css).toContain("background-color: #111");
+    expect(css).toContain("border-color: #333");
+    expect(css).toContain("color: #bbb");
+    expect(css).toContain("background-color: #080808");
+    expect(css).toContain("border-color: #888");
+    expect(css).toContain("filter: brightness(0.8)");
+    expect(css.indexOf("color: #464646")).toBeLessThan(css.indexOf("color: #bbb"));
+  });
+
+  it("keeps the admin include readable from the preferred color scheme", () => {
+    const { css } = compileString("@use 'warehouse/static/sass/blocks/admin-include';", {
+      loadPaths: ["."],
+      style: "expanded",
+    });
+
+    expect(css).toContain("@media (prefers-color-scheme: dark)");
+    expect(css).toContain("#21090d");
+    expect(css).toContain("#4a1018");
+    expect(css).toContain("color: #fff");
+  });
+
+  it("sets search inputs from the preferred color scheme", () => {
+    const { css } = compileString("@use 'warehouse/static/sass/blocks/search-form';", {
+      loadPaths: ["."],
+      style: "expanded",
+    });
+
+    expect(css).toContain("@media (prefers-color-scheme: dark)");
+    expect(css).toContain("background-color: #000");
+    expect(css).toContain("border-color: #333");
+    expect(css).toContain("color: #bbb");
+  });
+
+  it("dims disabled buttons from the preferred color scheme", () => {
+    const { css } = compileString("@use 'warehouse/static/sass/blocks/button';", {
+      loadPaths: ["."],
+      style: "expanded",
+    });
+
+    expect(css).toContain("@media (prefers-color-scheme: dark)");
+    expect(css).toContain("background-color: #1a1a1a");
+    expect(css).toContain("border-color: #333");
+    expect(css).toContain("color: #bbb");
+  });
+
+  it("keeps outline buttons readable from the preferred color scheme", () => {
+    const { css } = compileString("@use 'warehouse/static/sass/blocks/button';", {
+      loadPaths: ["."],
+      style: "expanded",
+    });
+
+    expect(css).toContain("@media (prefers-color-scheme: dark)");
+    expect(css).toContain("border-color: #888");
+    expect(css).toContain("color: #bbb");
+    expect(css).toContain("background-color: #111");
+  });
+
+  it("sets form fields from the preferred color scheme", () => {
+    const { css } = compileString("@use 'warehouse/static/sass/base/forms';", {
+      loadPaths: ["."],
+      style: "expanded",
+    });
+
+    expect(css).toContain("@media (prefers-color-scheme: dark)");
+    expect(css).toContain("background-color: #000");
+    expect(css).toContain("border-color: #333");
+    expect(css).toContain("color: #bbb");
+  });
+
+  it("keeps horizontal tabs readable from the preferred color scheme", () => {
+    const { css } = compileString("@use 'warehouse/static/sass/blocks/horizontal-tabs';", {
+      loadPaths: ["."],
+      style: "expanded",
+    });
+
+    expect(css).toContain("@media (prefers-color-scheme: dark)");
+    expect(css).toContain("background-color: #000");
+    expect(css).toContain("border-color: #333");
+    expect(css).toContain("color: #bbb");
+    expect(css).toContain("background-color: #111");
+    expect(css).toContain("color: rgb(147.5, 215.2312138728, 255)");
+  });
+
+  it("sets the homepage statistics section from the preferred color scheme", () => {
+    const { css } = compileString(
+      "@use 'warehouse/static/sass/blocks/horizontal-section'; @use 'warehouse/static/sass/blocks/statistics-bar';",
+      {
+        loadPaths: ["."],
+        style: "expanded",
+      },
+    );
+
+    expect(css).toContain("@media (prefers-color-scheme: dark)");
+    expect(css).toContain("background-color: #000");
+    expect(css).toContain("border-bottom-color: #333");
+    expect(css).toContain("border-top-color: #333");
+    expect(css).toContain("color: #bbb");
+  });
+
+  it("sets the homepage intro text from the preferred color scheme", () => {
+    const { css } = compileString(
+      "@use 'warehouse/static/sass/blocks/about-pypi'; @use 'warehouse/static/sass/blocks/lede-paragraph';",
+      {
+        loadPaths: ["."],
+        style: "expanded",
+      },
+    );
+
+    expect(css).toContain("@media (prefers-color-scheme: dark)");
+    expect(css).toContain("color: #bbb");
+    expect(css.indexOf(".lede-paragraph")).toBeLessThan(css.lastIndexOf("color: #bbb"));
+  });
+
+  it("keeps vertical tab hover readable from the preferred color scheme", () => {
+    const { css } = compileString("@use 'warehouse/static/sass/blocks/vertical-tabs';", {
+      loadPaths: ["."],
+      style: "expanded",
+    });
+
+    expect(css).toContain("@media (prefers-color-scheme: dark)");
+    expect(css).toContain("background-color: #111");
+    expect(css).toContain("color: rgb(147.5, 215.2312138728, 255)");
+  });
+});

--- a/warehouse/static/sass/base/_forms.scss
+++ b/warehouse/static/sass/base/_forms.scss
@@ -49,6 +49,23 @@
   &:focus {
     @include input-field-active-styles;
   }
+
+  @media (prefers-color-scheme: dark) {
+    background-color: colours.$black;
+    border-color: #333;
+    color: colours.$light-grey;
+
+    &::placeholder {
+      color: colours.$light-grey;
+    }
+
+    &:hover,
+    &:active,
+    &:focus {
+      box-shadow: inset 0 0 0 1px colours.$primary-color-light;
+      border-color: colours.$primary-color-light;
+    }
+  }
 }
 
 input[type="checkbox"] {
@@ -63,6 +80,12 @@ input[type="checkbox"] {
   cursor: not-allowed;
   box-shadow: none;
   background-color: colours.$base-grey;
+
+  @media (prefers-color-scheme: dark) {
+    background-color: #1a1a1a;
+    border-color: #333;
+    color: #777;
+  }
 }
 
 label {

--- a/warehouse/static/sass/base/_typography.scss
+++ b/warehouse/static/sass/base/_typography.scss
@@ -26,6 +26,13 @@ body {
   color: colours.$text-color;
   background-color: colours.$background-color;
   direction: ltr;
+
+  @media (prefers-color-scheme: dark) {
+    // Follow the browser color-scheme preference without requiring an application toggle.
+    color-scheme: dark;
+    color: colours.$light-grey;
+    background-color: colours.$black;
+  }
 }
 
 
@@ -104,6 +111,10 @@ strong {
 
 a {
   @include link-utilities.primary-underlined-link;
+
+  @media (prefers-color-scheme: dark) {
+    @include link-utilities.colored-link(colours.$primary-color-light);
+  }
 
   // Add 'external link' icon to most external links
   &[target="_blank"]:not(.copy-tooltip, .sponsors__sponsor) {

--- a/warehouse/static/sass/blocks/_about-pypi.scss
+++ b/warehouse/static/sass/blocks/_about-pypi.scss
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 @use "../settings/breakpoints";
+@use "../settings/colours";
 @use "../settings/grid";
 @use "../tools/layout-utilities";
 
@@ -45,6 +46,10 @@
 
   &__text {
     text-align: left;
+
+    @media (prefers-color-scheme: dark) {
+      color: colours.$light-grey;
+    }
 
     @media only screen and (max-width: breakpoints.$small-tablet) {
       display: block;

--- a/warehouse/static/sass/blocks/_admin-include.scss
+++ b/warehouse/static/sass/blocks/_admin-include.scss
@@ -14,8 +14,15 @@
 .admin-include {
   padding: 0.5rem;
   background: repeating-linear-gradient(45deg, #ececec, #ececec 10px, color.adjust(colours.$danger-color, $alpha: -0.8) 10px, color.adjust(colours.$danger-color, $alpha: -0.8) 20px);
+  color: colours.$text-color;
 
   justify-items: center;
+
+  @media (prefers-color-scheme: dark) {
+    // Keep the admin warning banner readable on dark pages.
+    background: repeating-linear-gradient(45deg, #21090d, #21090d 10px, #4a1018 10px, #4a1018 20px);
+    color: colours.$white;
+  }
 
   form {
     display: inline;

--- a/warehouse/static/sass/blocks/_button.scss
+++ b/warehouse/static/sass/blocks/_button.scss
@@ -56,6 +56,19 @@
     outline: none;
   }
 
+  @media (prefers-color-scheme: dark) {
+    border-color: #888;
+    color: colours.$light-grey;
+
+    &:hover,
+    &:active,
+    &:focus {
+      background-color: #111;
+      border-color: colours.$primary-color-light;
+      color: colours.$primary-color-light;
+    }
+  }
+
   &--small {
     font-size: fonts.$small-font-size;
     padding: 6px 8px;
@@ -90,6 +103,20 @@
   &--tertiary {
     border-color: colours.$light-grey;
     background-color: colours.$white;
+
+    @media (prefers-color-scheme: dark) {
+      background-color: #111;
+      border-color: #888;
+      color: colours.$light-grey;
+
+      &:hover,
+      &:active,
+      &:focus {
+        background-color: #080808;
+        border-color: colours.$primary-color-light;
+        color: colours.$primary-color-light;
+      }
+    }
   }
 
   &--danger {
@@ -150,6 +177,20 @@
       border-color: color.adjust(colours.$background-color, $lightness: -5%);
       color: color.adjust(colours.$background-color, $lightness: -12%);
       outline: none;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      background-color: #1a1a1a;
+      border-color: #333;
+      color: colours.$light-grey;
+
+      &:focus,
+      &:hover,
+      &:active {
+        background-color: #1a1a1a;
+        border-color: #333;
+        color: colours.$light-grey;
+      }
     }
   }
 

--- a/warehouse/static/sass/blocks/_footer.scss
+++ b/warehouse/static/sass/blocks/_footer.scss
@@ -38,6 +38,11 @@
   padding: 60px 0;
   width: 100%;
 
+  @media (prefers-color-scheme: dark) {
+    // Reduce the visual weight of the footer against a black page background.
+    background-color: colours.$primary-color-dark;
+  }
+
   @media only screen and (max-width: breakpoints.$mobile) {
     padding-top: 40px 0;
   }

--- a/warehouse/static/sass/blocks/_horizontal-section.scss
+++ b/warehouse/static/sass/blocks/_horizontal-section.scss
@@ -34,6 +34,12 @@
     background-color: colours.$base-grey;
     border-bottom: 1px solid color.adjust(colours.$base-grey, $lightness: -10%);
     border-top: 1px solid color.adjust(colours.$base-grey, $lightness: -10%);
+
+    @media (prefers-color-scheme: dark) {
+      background-color: colours.$black;
+      border-bottom-color: #333;
+      border-top-color: #333;
+    }
   }
 
   &--medium {

--- a/warehouse/static/sass/blocks/_horizontal-tabs.scss
+++ b/warehouse/static/sass/blocks/_horizontal-tabs.scss
@@ -1,5 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
+@use "../settings/colours";
+
 .horizontal-tabs {
   margin-top: 30px;
 
@@ -7,6 +9,11 @@
     overflow: hidden;
     border: 1px solid #ccc;
     background-color: #f1f1f1;
+
+    @media (prefers-color-scheme: dark) {
+      border-color: #333;
+      background-color: colours.$black;
+    }
 
     button {
       background-color: inherit;
@@ -17,13 +24,28 @@
       padding: 14px 16px;
       transition: 0.3s;
 
+      @media (prefers-color-scheme: dark) {
+        background-color: colours.$black;
+        color: colours.$light-grey;
+      }
+
       &:hover {
         background-color: #ddd;
+
+        @media (prefers-color-scheme: dark) {
+          background-color: #111;
+          color: colours.$primary-color-light;
+        }
       }
 
       &.is-active {
         background-color: #006dad;
         color: #fff;
+
+        @media (prefers-color-scheme: dark) {
+          background-color: colours.$primary-color;
+          color: colours.$white;
+        }
       }
     }
   }
@@ -33,6 +55,12 @@
     padding: 20px;
     border: 1px solid #ccc;
     border-top: none;
+
+    @media (prefers-color-scheme: dark) {
+      border-color: #333;
+      background-color: colours.$black;
+      color: colours.$light-grey;
+    }
 
     &.is-hidden {
       display: none;

--- a/warehouse/static/sass/blocks/_lede-paragraph.scss
+++ b/warehouse/static/sass/blocks/_lede-paragraph.scss
@@ -14,4 +14,8 @@
   font-weight: fonts.$bold-font-weight;
   font-size: 1.2rem;
   color: color.adjust(colours.$text-color, $lightness: 10%);
+
+  @media (prefers-color-scheme: dark) {
+    color: colours.$light-grey;
+  }
 }

--- a/warehouse/static/sass/blocks/_search-form.scss
+++ b/warehouse/static/sass/blocks/_search-form.scss
@@ -31,6 +31,22 @@
     padding-right: 28px;
     min-width: auto;
     border-color: colours.$white;
+
+    @media (prefers-color-scheme: dark) {
+      background-color: colours.$black;
+      border-color: #333;
+      color: colours.$light-grey;
+
+      &::placeholder {
+        color: colours.$light-grey;
+      }
+
+      &:hover,
+      &:active,
+      &:focus {
+        border-color: colours.$primary-color-light;
+      }
+    }
   }
 
   &__button {
@@ -43,6 +59,10 @@
     background-color: transparent;
     color: color.mix(colours.$text-color, colours.$border-color, 50%);
     font-size: 18px;
+
+    @media (prefers-color-scheme: dark) {
+      color: colours.$light-grey;
+    }
   }
 
   &--primary {

--- a/warehouse/static/sass/blocks/_snippet.scss
+++ b/warehouse/static/sass/blocks/_snippet.scss
@@ -100,4 +100,42 @@
       margin-bottom: 30px;
     }
   }
+
+  @media (prefers-color-scheme: dark) {
+    // Keep list cards distinct without using a bright surface on dark pages.
+    background-color: #111;
+    border-color: #333;
+    box-shadow: none;
+
+    &:hover,
+    &:active {
+      background-color: #080808;
+      border-color: #888;
+    }
+
+    @media only screen and (min-width: breakpoints.$tablet + 1px) {
+      position: relative;
+      background-image: none;
+
+      &::before {
+        content: "";
+        position: absolute;
+        left: 18px;
+        top: 50%;
+        width: 45px;
+        height: 45px;
+        transform: translateY(-50%);
+        background: $snippet-icon-png center / contain no-repeat;
+        background-image: $snippet-icon-svg, linear-gradient(transparent, transparent);
+        filter: brightness(0.8);
+        pointer-events: none;
+      }
+    }
+
+    &__created,
+    &__description,
+    &__meta {
+      color: colours.$light-grey;
+    }
+  }
 }

--- a/warehouse/static/sass/blocks/_statistics-bar.scss
+++ b/warehouse/static/sass/blocks/_statistics-bar.scss
@@ -26,6 +26,10 @@
     margin: 0;
     box-sizing: border-box;
 
+    @media (prefers-color-scheme: dark) {
+      color: colours.$light-grey;
+    }
+
     @media only screen and (max-width: breakpoints.$tablet) {
       font-size: fonts.$base-font-size;
     }

--- a/warehouse/static/sass/blocks/_vertical-tabs.scss
+++ b/warehouse/static/sass/blocks/_vertical-tabs.scss
@@ -116,6 +116,20 @@
       box-shadow: 0 0 0 2px colours.$primary-color;
     }
 
+    @media (prefers-color-scheme: dark) {
+      color: colours.$light-grey;
+
+      &:hover {
+        background-color: #111;
+        color: colours.$primary-color-light;
+      }
+
+      &:active,
+      &:focus {
+        box-shadow: 0 0 0 2px colours.$primary-color-light;
+      }
+    }
+
     &--mobile {
       display: none;
       @media only screen and (max-width: breakpoints.$tablet) {
@@ -139,6 +153,10 @@
       background: colours.$primary-color;
       color: colours.$white;
       border-color: transparent;
+
+      @media (prefers-color-scheme: dark) {
+        color: colours.$white;
+      }
     }
 
     &--condensed {


### PR DESCRIPTION
## Summary

Adds `prefers-color-scheme: dark` styling for core Warehouse surfaces, including body text, forms, buttons, cards, tabs, footer, and homepage sections.

This addresses dark-mode contrast issues across the main, project, and manage pages so text, inputs, cards, and tab surfaces remain readable on dark backgrounds.

Closes: #10391

## Tests

- `npm test -- dark_mode_styles_test.js`
- `npm run stylelint -- warehouse/static/sass/blocks/_lede-paragraph.scss`
- `npm run lint -- tests/frontend/dark_mode_styles_test.js`
- `npm run build`

<img width="1198" height="1650" alt="image" src="https://github.com/user-attachments/assets/c7058adb-d89a-4704-a32d-cecf16d9c672" />

<img width="1200" height="1920" alt="image" src="https://github.com/user-attachments/assets/ba7614e9-490b-43c2-8c38-7fe2e3292fc9" />

<img width="1200" height="1920" alt="image" src="https://github.com/user-attachments/assets/5dca7d24-7156-4167-ad97-9fe2c0a01a37" />

