### PR TITLE
migrate to mailpit for local development SMTP

### DIFF
--- a/dev/environment
+++ b/dev/environment
@@ -43,7 +43,7 @@ SIMPLE_BACKEND=warehouse.packaging.services.LocalSimpleStorage path=/var/opt/war
 DOCS_BACKEND=warehouse.packaging.services.LocalDocsStorage path=/var/opt/warehouse/docs/
 SPONSORLOGOS_BACKEND=warehouse.admin.services.LocalSponsorLogoStorage path=/var/opt/warehouse/sponsorlogos/
 ORIGIN_CACHE=warehouse.cache.origin.fastly.NullFastlyCache api_key=some_api_key service_id=some_service_id
-MAIL_BACKEND=warehouse.email.services.ConsoleAndSMTPEmailSender host=maildev port=1025 ssl=false sender=noreply@pypi.org
+MAIL_BACKEND=warehouse.email.services.ConsoleAndSMTPEmailSender host=mailpit port=1025 ssl=false sender=noreply@pypi.org
 
 BREACHED_EMAILS=warehouse.accounts.NullEmailBreachedService
 BREACHED_PASSWORDS=warehouse.accounts.NullPasswordBreachedService

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ volumes:
   pgdata:
   cachedata:
   node_modules:
+  mailpit_data:
 
 services:
   db:
@@ -212,11 +213,15 @@ services:
       - node_modules:/opt/warehouse/src/node_modules
       - caches:/opt/warehouse/src/.cache
 
-  maildev:
-    image: maildev/maildev:2.2.1
+  mailpit:
+    image: axllent/mailpit:v1.30.4
+    environment:
+      MP_DATABASE: /data/mailpit.db
     ports:
-      - "1080:1080"
+      - "1080:8025"
       - "1025:1025"
+    volumes:
+      - mailpit_data:/data
 
   notdatadog:
     image: warehouse:docker-compose

--- a/docs/dev/development/email.md
+++ b/docs/dev/development/email.md
@@ -45,6 +45,7 @@ Calling a function with the `_email` decorator does the following:
 ## Testing e-mails
 
 When an email is sent in the development environment, it's printed in the
-console, and sent to the `maildev` service using SMTP. `maildev` is a
+console, and sent to the `mailpit` service using SMTP. `mailpit` is a
 service defined in `docker-compose.yml` that receives emails, stores them and
-lets you read them from a web interface at <http://localhost:1080>.
+lets you read them from a web interface at <http://localhost:1080>. Messages
+are stored in a Docker volume so they persist across container recreations.


### PR DESCRIPTION
[Mailpit](https://mailpit.axllent.org/) is a bit more feature rich than maildev in my experience.

This also adds persistence across container restarts while I'm futzing.

I chose to map the web UI to the same port that maildev used for muscle memory purposes