### PR TITLE
feat(admin): make journals pages usable via Tabulator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,8 @@
         "debounce": "^1.2.1",
         "jquery": "^3.7.0",
         "normalize.css": "^8.0.1",
-        "stimulus-autocomplete": "^3.1.0"
+        "stimulus-autocomplete": "^3.1.0",
+        "tabulator-tables": "^6.4.0"
       },
       "devDependencies": {
         "@babel/core": "^7.29.6",
@@ -13595,6 +13596,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/tabulator-tables": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/tabulator-tables/-/tabulator-tables-6.5.2.tgz",
+      "integrity": "sha512-cRL3xsaaf5RzND8KPbn4C9Ce5tzyiQUE01E/10zN50MjdRKl/Gl5nXkzLN6cvEyRfWHCPuqBF92y50CBw20WYA==",
+      "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "debounce": "^1.2.1",
     "jquery": "^3.7.0",
     "normalize.css": "^8.0.1",
-    "stimulus-autocomplete": "^3.1.0"
+    "stimulus-autocomplete": "^3.1.0",
+    "tabulator-tables": "^6.4.0"
   },
   "overrides": {
     "datatables.net": "^1.13.11",

--- a/tests/unit/admin/views/conftest.py
+++ b/tests/unit/admin/views/conftest.py
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+
+def _fake_route_path(name, **kw):
+    """Predictable route_path stub covering the routes the admin views use."""
+    if name == "admin.user.detail":
+        return f"/admin/users/{kw['username']}/"
+    if name == "admin.project.detail":
+        return f"/admin/projects/{kw['project_name']}/"
+    if name == "admin.organization_application.detail":
+        return f"/admin/organization_applications/{kw['organization_application_id']}/"
+    raise AssertionError(f"unexpected route: {name}")  # pragma: no cover
+
+
+@pytest.fixture
+def route_request(db_request):
+    """db_request with a predictable route_path for JSON payload tests."""
+    db_request.route_path = _fake_route_path
+    return db_request

--- a/tests/unit/admin/views/test_helpers.py
+++ b/tests/unit/admin/views/test_helpers.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from psycopg import OperationalError
+from pyramid.httpexceptions import HTTPBadRequest
+from sqlalchemy import func, select, text
+
+from warehouse.admin.views.helpers import estimate_row_count, execute_bounded
+
+from ....common.db.packaging import JournalEntryFactory
+
+
+class TestEstimateRowCount:
+    def test_never_negative(self, db_request):
+        """reltuples is -1 until first ANALYZE; estimates clamp to zero."""
+        assert estimate_row_count(db_request, ["journals"]) >= 0
+
+    def test_reflects_analyzed_rows(self, db_request):
+        JournalEntryFactory.create_batch(7)
+        db_request.db.execute(text("ANALYZE journals"))
+
+        assert estimate_row_count(db_request, ["journals"]) == 7
+
+    def test_sums_multiple_tables(self, db_request):
+        # Each journal entry's submitted_by SubFactory also creates a user.
+        JournalEntryFactory.create_batch(7)
+        db_request.db.execute(text("ANALYZE journals"))
+        db_request.db.execute(text("ANALYZE users"))
+
+        assert estimate_row_count(db_request, ["journals", "users"]) == 14
+
+    def test_unknown_table_is_zero(self, db_request):
+        assert estimate_row_count(db_request, ["no_such_table"]) == 0
+
+
+class TestExecuteBounded:
+    def test_cancelled_query_becomes_bad_request(self, db_request):
+        """A query cancelled by the statement timeout surfaces as a 400."""
+        with pytest.raises(HTTPBadRequest):
+            execute_bounded(db_request, select(func.pg_sleep(1)), timeout_ms=10)
+
+    def test_other_database_errors_propagate(self, db_request, mocker):
+        """Only cancelled queries become a 400; real outages surface.
+
+        warehouse.db re-raises the raw psycopg exception engine-wide, so
+        that is what execute_bounded sees.
+        """
+        mocker.patch.object(
+            db_request.db,
+            "execute",
+            autospec=True,
+            side_effect=OperationalError("server closed the connection"),
+        )
+
+        with pytest.raises(OperationalError):
+            execute_bounded(db_request, select(func.now()), timeout_ms=10_000)

--- a/tests/unit/admin/views/test_journals.py
+++ b/tests/unit/admin/views/test_journals.py
@@ -1,105 +1,453 @@
 # SPDX-License-Identifier: Apache-2.0
 
-import pretend
+import datetime
+
 import pytest
 
 from pyramid.httpexceptions import HTTPBadRequest
+from sqlalchemy import text
+from sqlalchemy.dialects import postgresql
 
 from warehouse.admin.views import journals as views
 
 from ....common.db.accounts import UserFactory
-from ....common.db.packaging import JournalEntryFactory, ProjectFactory
+from ....common.db.packaging import JournalEntryFactory
 
 
-class TestProjectList:
-    def test_no_query(self, db_request):
-        journals = sorted(
-            JournalEntryFactory.create_batch(30),
-            key=lambda j: (j.submitted_date, j.id),
-            reverse=True,
-        )
-        result = views.journals_list(db_request)
+def _tabulator_params(*, page=None, size=None, sort=None, filters=None):
+    """Build the query-string dict Tabulator sends in remote mode."""
+    params = {}
+    if page is not None:
+        params["page"] = str(page)
+    if size is not None:
+        params["size"] = str(size)
+    if sort is not None:
+        params["sort[0][field]"] = sort[0]
+        params["sort[0][dir]"] = sort[1]
+    for i, (field, value) in enumerate((filters or {}).items()):
+        params[f"filter[{i}][field]"] = field
+        params[f"filter[{i}][type]"] = "like"
+        params[f"filter[{i}][value]"] = value
+    return params
 
-        assert result == {"journals": journals[:25], "query": None}
 
-    def test_with_page(self, db_request):
-        journals = sorted(
-            JournalEntryFactory.create_batch(30),
-            key=lambda j: (j.submitted_date, j.id),
-            reverse=True,
-        )
-        db_request.GET["page"] = "2"
-        result = views.journals_list(db_request)
+def _ids_newest_first(journals):
+    """IDs in the view's default order: submitted_date desc, id tiebreak."""
+    return [
+        j.id
+        for j in sorted(journals, key=lambda j: (j.submitted_date, j.id), reverse=True)
+    ]
 
-        assert result == {"journals": journals[25:], "query": None}
 
-    def test_with_invalid_page(self):
-        request = pretend.stub(params={"page": "not an integer"})
+class TestParseTabulatorParams:
+    def test_defaults(self):
+        parsed = views._parse_tabulator_params({})
+        assert parsed.page == 1
+        assert parsed.size == 25
+        assert parsed.sort_field == "submitted_date"
+        assert parsed.sort_dir == "desc"
+        assert parsed.filters == {}
 
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [(-5, 1), (0, 1), (25, 25), (100, 100), (1000, 100)],
+    )
+    def test_size_clamping(self, raw, expected):
+        parsed = views._parse_tabulator_params(_tabulator_params(size=raw))
+        assert parsed.size == expected
+
+    def test_page_clamped_to_one(self):
+        parsed = views._parse_tabulator_params(_tabulator_params(page=-3))
+        assert parsed.page == 1
+
+    @pytest.mark.parametrize(
+        "overrides",
+        [
+            pytest.param({"page": "nope"}, id="bad_page"),
+            pytest.param({"size": "nope"}, id="bad_size"),
+            pytest.param({"page": "999999"}, id="page_too_deep"),
+            pytest.param(
+                {"sort[0][field]": "name", "sort[0][dir]": "sideways"},
+                id="bad_sort_dir",
+            ),
+            pytest.param(
+                {"filter[0][field]": "name", "filter[0][value]": "x" * 501},
+                id="oversized_filter",
+            ),
+        ],
+    )
+    def test_malformed_input_raises(self, overrides):
         with pytest.raises(HTTPBadRequest):
-            views.journals_list(request)
+            views._parse_tabulator_params(_tabulator_params() | overrides)
 
-    def test_query_basic(self, db_request):
-        project0 = ProjectFactory.create()
-        project1 = ProjectFactory.create()
-        journals0 = sorted(
-            JournalEntryFactory.create_batch(30, name=project0.normalized_name),
-            key=lambda j: (j.submitted_date, j.id),
-            reverse=True,
+    def test_sort_params(self):
+        parsed = views._parse_tabulator_params(_tabulator_params(sort=("name", "asc")))
+        assert parsed.sort_field == "name"
+        assert parsed.sort_dir == "asc"
+
+    @pytest.mark.parametrize("field", ["action", "version", "nonsense"])
+    def test_unsortable_field_falls_back_to_default(self, field):
+        parsed = views._parse_tabulator_params(_tabulator_params(sort=(field, "asc")))
+        assert parsed.sort_field == "submitted_date"
+        assert parsed.sort_dir == "desc"
+
+    def test_filters(self):
+        parsed = views._parse_tabulator_params(
+            _tabulator_params(
+                filters={
+                    "name": "pip",
+                    "submitted_by": "someuser",
+                    "nonsense": "ignored",
+                    "action": "   ",
+                }
+            )
         )
-        JournalEntryFactory.create_batch(30, name=project1.normalized_name)
+        assert parsed.filters == {"name": "pip", "submitted_by": "someuser"}
 
-        db_request.GET["q"] = f"{project0.name}"
-        result = views.journals_list(db_request)
 
-        assert result == {
-            "journals": journals0[:25],
-            "query": f"{project0.name}",
-        }
-
-    def test_query_term_project(self, db_request):
-        project0 = ProjectFactory.create()
-        project1 = ProjectFactory.create()
-        journals0 = sorted(
-            JournalEntryFactory.create_batch(30, name=project0.normalized_name),
-            key=lambda j: (j.submitted_date, j.id),
-            reverse=True,
+class TestBuildJournalsQuery:
+    @pytest.mark.parametrize(
+        ("sort", "expected_order"),
+        [
+            (
+                ("submitted_date", "desc"),
+                "journals.submitted_date DESC, journals.id DESC",
+            ),
+            (
+                ("submitted_date", "asc"),
+                "journals.submitted_date ASC, journals.id ASC",
+            ),
+            (("name", "desc"), "journals.name DESC, journals.id ASC"),
+            (("name", "asc"), "journals.name ASC, journals.id DESC"),
+            (
+                ("submitted_by", "desc"),
+                "journals.submitted_by DESC,"
+                " journals.submitted_date ASC, journals.id ASC",
+            ),
+            (
+                ("submitted_by", "asc"),
+                "journals.submitted_by ASC,"
+                " journals.submitted_date DESC, journals.id DESC",
+            ),
+        ],
+    )
+    def test_order_matches_index_orientation(self, sort, expected_order):
+        """Each sort orders exactly as an index stores it, tiebreaks included."""
+        params = views._parse_tabulator_params(_tabulator_params(sort=sort))
+        sql = str(
+            views._build_journals_query(params).compile(dialect=postgresql.dialect())
         )
-        JournalEntryFactory.create_batch(30, name=project1.normalized_name)
+        assert expected_order in sql
+        # Native NULL ordering only; forcing NULLS LAST onto a DESC sort
+        # would defeat the btree indexes.
+        assert "NULLS" not in sql
 
-        db_request.GET["q"] = f"project:{project0.name}"
-        result = views.journals_list(db_request)
-
-        assert result == {
-            "journals": journals0[:25],
-            "query": f"project:{project0.name}",
-        }
-
-    def test_query_term_user(self, db_request):
-        user0 = UserFactory.create()
-        user1 = UserFactory.create()
-        journals0 = sorted(
-            JournalEntryFactory.create_batch(30, submitted_by=user0),
-            key=lambda j: (j.submitted_date, j.id),
-            reverse=True,
+    def test_name_filtered_chronological_sort_orders_by_id(self):
+        """An exact name filter swaps the date sort for the equivalent id
+        order, so journals_name_id_idx can serve the query natively."""
+        params = views._parse_tabulator_params(
+            _tabulator_params(filters={"name": "pip"})
         )
-        JournalEntryFactory.create_batch(30, submitted_by=user1)
+        sql = str(
+            views._build_journals_query(params).compile(dialect=postgresql.dialect())
+        )
+        assert "ORDER BY journals.id DESC" in sql
+        assert "submitted_date DESC" not in sql
 
-        db_request.GET["q"] = f"user:{user0.username}"
-        result = views.journals_list(db_request)
+    def test_fetches_one_extra_row(self):
+        params = views._parse_tabulator_params(_tabulator_params(page=2, size=10))
+        sql = str(
+            views._build_journals_query(params).compile(
+                dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True}
+            )
+        )
+        assert "LIMIT 11" in sql
+        assert "OFFSET 10" in sql
 
-        assert result == {
-            "journals": journals0[:25],
-            "query": f"user:{user0.username}",
+
+class TestRenderTabulatorPayload:
+    def test_empty_database(self, route_request):
+        assert views._render_tabulator_payload(route_request) == {
+            "last_page": 1,
+            "total": 0,
+            "total_estimate": None,
+            "data": [],
         }
 
-    def test_query_term_version(self, db_request):
-        journals = JournalEntryFactory.create_batch(10)
+    def test_returns_rows_most_recent_first(self, route_request):
+        journals = JournalEntryFactory.create_batch(30)
+        expected_ids = _ids_newest_first(journals)
 
-        db_request.GET["q"] = f"version:{journals[0].version}"
-        result = views.journals_list(db_request)
+        result = views._render_tabulator_payload(route_request)
 
-        assert result == {
-            "journals": [journals[0]],
-            "query": f"version:{journals[0].version}",
-        }
+        assert result["last_page"] == 2
+        assert [row["id"] for row in result["data"]] == expected_ids[:25]
+
+    def test_row_shape(self, route_request):
+        user = UserFactory.create()
+        journal = JournalEntryFactory.create(action="create", submitted_by=user)
+
+        result = views._render_tabulator_payload(route_request)
+
+        assert result["data"] == [
+            {
+                "id": journal.id,
+                "name": journal.name,
+                "version": journal.version,
+                "action": "create",
+                "submitted_date": journal.submitted_date.isoformat(),
+                "submitted_by": user.username,
+                "project_link": f"/admin/projects/{journal.name}/",
+                "submitted_by_link": f"/admin/users/{user.username}/",
+            }
+        ]
+
+    def test_links_none_without_name_or_user(self, route_request):
+        JournalEntryFactory.create(name=None, submitted_by=None)
+
+        result = views._render_tabulator_payload(route_request)
+
+        row = result["data"][0]
+        assert row["project_link"] is None
+        assert row["submitted_by"] is None
+        assert row["submitted_by_link"] is None
+
+    def test_second_page(self, route_request):
+        journals = JournalEntryFactory.create_batch(30)
+        expected_ids = _ids_newest_first(journals)
+        route_request.GET.update(_tabulator_params(page=2))
+
+        result = views._render_tabulator_payload(route_request)
+
+        assert result["last_page"] == 2
+        assert [row["id"] for row in result["data"]] == expected_ids[25:]
+        # The final page is in reach, so the exact total is known.
+        assert result["total"] == 30
+
+    def test_exact_page_boundary_has_no_next_page(self, route_request):
+        JournalEntryFactory.create_batch(25)
+
+        result = views._render_tabulator_payload(route_request)
+
+        assert result["last_page"] == 1
+        assert len(result["data"]) == 25
+        assert result["total"] == 25
+
+    def test_filtered_pagination_is_rolling(self, route_request):
+        """With filters active there is no count, only a next-page probe."""
+        JournalEntryFactory.create_batch(3, name="pip")
+
+        route_request.GET.update(_tabulator_params(size=2, filters={"name": "pip"}))
+        result = views._render_tabulator_payload(route_request)
+
+        assert len(result["data"]) == 2
+        assert result["last_page"] == 2
+        # More filtered pages exist, so no total can be reported.
+        assert result["total"] is None
+        assert result["total_estimate"] is None
+
+    def test_filtered_final_page_reports_exact_total(self, route_request):
+        """A short filtered page pins the exact total without a count query."""
+        JournalEntryFactory.create_batch(3, name="pip")
+        JournalEntryFactory.create(name="numpy")
+
+        route_request.GET.update(_tabulator_params(filters={"name": "pip"}))
+        result = views._render_tabulator_payload(route_request)
+
+        assert result["total"] == 3
+        assert result["total_estimate"] is None
+
+    def test_unfiltered_last_page_uses_estimate(self, route_request):
+        """Unfiltered, the pg_class row estimate sizes the pagination."""
+        JournalEntryFactory.create_batch(10)
+        route_request.db.execute(text("ANALYZE journals"))
+
+        route_request.GET.update(_tabulator_params(size=2))
+        result = views._render_tabulator_payload(route_request)
+
+        assert len(result["data"]) == 2
+        assert result["last_page"] == 5
+        assert result["total"] is None
+        assert result["total_estimate"] == 10
+
+    def test_stale_estimate_clamped_to_rows_fetched(self, route_request, monkeypatch):
+        """A stale table estimate never undercounts rows already fetched."""
+        monkeypatch.setattr(views, "estimate_row_count", lambda *a: 0)
+        JournalEntryFactory.create_batch(3)
+
+        route_request.GET.update(_tabulator_params(size=2))
+        result = views._render_tabulator_payload(route_request)
+
+        assert result["total_estimate"] == 3
+        assert result["last_page"] == 2
+
+    def test_last_page_capped_at_max_offset(self, route_request, monkeypatch):
+        monkeypatch.setattr(views, "_MAX_OFFSET", 4)
+        JournalEntryFactory.create_batch(5)
+        route_request.GET.update(_tabulator_params(page=2, size=2))
+
+        result = views._render_tabulator_payload(route_request)
+
+        assert len(result["data"]) == 2
+        assert result["last_page"] == 2
+
+    def test_name_filter_is_exact(self, route_request):
+        journal = JournalEntryFactory.create(name="Django")
+        JournalEntryFactory.create(name="Django-extras")
+
+        route_request.GET.update(_tabulator_params(filters={"name": "Django"}))
+        result = views._render_tabulator_payload(route_request)
+        assert [row["id"] for row in result["data"]] == [journal.id]
+
+        # Exact name matches are case-sensitive.
+        route_request.GET.update(_tabulator_params(filters={"name": "django"}))
+        result = views._render_tabulator_payload(route_request)
+        assert result["data"] == []
+
+    def test_version_filter_is_exact(self, route_request):
+        journal = JournalEntryFactory.create(version="1.0")
+        JournalEntryFactory.create(version="1.0.1")
+
+        route_request.GET.update(_tabulator_params(filters={"version": "1.0"}))
+        result = views._render_tabulator_payload(route_request)
+
+        assert [row["id"] for row in result["data"]] == [journal.id]
+
+    def test_submitted_by_filter_is_case_insensitive(self, route_request):
+        user = UserFactory.create(username="journaluser")
+        journal = JournalEntryFactory.create(submitted_by=user)
+        JournalEntryFactory.create()
+
+        route_request.GET.update(
+            _tabulator_params(filters={"submitted_by": "JournalUser"})
+        )
+        result = views._render_tabulator_payload(route_request)
+
+        assert [row["id"] for row in result["data"]] == [journal.id]
+
+    def test_action_filter_is_a_prefix_match(self, route_request):
+        matching = JournalEntryFactory.create(action="add Owner someuser")
+        JournalEntryFactory.create(action="remove Owner someuser")
+
+        route_request.GET.update(_tabulator_params(filters={"action": "add Owner"}))
+        result = views._render_tabulator_payload(route_request)
+
+        assert [row["id"] for row in result["data"]] == [matching.id]
+
+    def test_action_filter_escapes_like_wildcards(self, route_request):
+        matching = JournalEntryFactory.create(action="add% literally")
+        JournalEntryFactory.create(action="add Owner someuser")
+
+        route_request.GET.update(_tabulator_params(filters={"action": "add%"}))
+        result = views._render_tabulator_payload(route_request)
+
+        assert [row["id"] for row in result["data"]] == [matching.id]
+
+    def test_multiple_filters_combine_with_and(self, route_request):
+        user = UserFactory.create(username="someuser")
+        matching = JournalEntryFactory.create(name="pip", submitted_by=user)
+        JournalEntryFactory.create(name="pip")
+        JournalEntryFactory.create(submitted_by=user)
+
+        route_request.GET.update(
+            _tabulator_params(filters={"name": "pip", "submitted_by": "someuser"})
+        )
+        result = views._render_tabulator_payload(route_request)
+
+        assert [row["id"] for row in result["data"]] == [matching.id]
+
+    def test_submitted_date_filter_includes_whole_day(self, route_request):
+        on_day = JournalEntryFactory.create(
+            submitted_date=datetime.datetime(2023, 1, 15, 23, 59)
+        )
+        before = JournalEntryFactory.create(
+            submitted_date=datetime.datetime(2023, 1, 10, 8, 0)
+        )
+        JournalEntryFactory.create(submitted_date=datetime.datetime(2023, 1, 16, 0, 0))
+
+        route_request.GET.update(
+            _tabulator_params(filters={"submitted_date": "2023-01-15"})
+        )
+        result = views._render_tabulator_payload(route_request)
+
+        assert [row["id"] for row in result["data"]] == [on_day.id, before.id]
+
+    def test_submitted_date_filter_with_datetime(self, route_request):
+        at_noon = JournalEntryFactory.create(
+            submitted_date=datetime.datetime(2023, 1, 15, 12, 0)
+        )
+        JournalEntryFactory.create(submitted_date=datetime.datetime(2023, 1, 15, 12, 1))
+
+        route_request.GET.update(
+            _tabulator_params(filters={"submitted_date": "2023-01-15T12:00:00"})
+        )
+        result = views._render_tabulator_payload(route_request)
+
+        assert [row["id"] for row in result["data"]] == [at_noon.id]
+
+    def test_submitted_date_filter_invalid(self, route_request):
+        route_request.GET.update(
+            _tabulator_params(filters={"submitted_date": "yesterday"})
+        )
+        with pytest.raises(HTTPBadRequest):
+            views._render_tabulator_payload(route_request)
+
+    def test_desc_sort_places_nulls_first(self, route_request):
+        """Native NULL ordering (first on DESC) keeps the sort on the index."""
+        second = JournalEntryFactory.create(
+            submitted_by=UserFactory.create(username="aaa")
+        )
+        first = JournalEntryFactory.create(
+            submitted_by=UserFactory.create(username="bbb")
+        )
+        unattributed = JournalEntryFactory.create(submitted_by=None)
+
+        route_request.GET.update(_tabulator_params(sort=("submitted_by", "desc")))
+        result = views._render_tabulator_payload(route_request)
+
+        assert [row["id"] for row in result["data"]] == [
+            unattributed.id,
+            first.id,
+            second.id,
+        ]
+
+    def test_last_page_matches_deepest_valid_page(self, route_request, monkeypatch):
+        """last_page never advertises a page the parser would reject."""
+        monkeypatch.setattr(views, "_MAX_OFFSET", 10)
+        JournalEntryFactory.create_batch(13, name="pip")
+
+        # Page 4 with size 3 is the deepest valid page (offset 9 < 10).
+        route_request.GET.update(
+            _tabulator_params(page=4, size=3, filters={"name": "pip"})
+        )
+        result = views._render_tabulator_payload(route_request)
+        assert len(result["data"]) == 3
+        assert result["last_page"] == 4
+
+        # ...and page 5 is exactly where the parser draws the line.
+        with pytest.raises(HTTPBadRequest):
+            views._parse_tabulator_params(_tabulator_params(page=5, size=3))
+
+    def test_sort_by_name_ascending(self, route_request):
+        journals = [
+            JournalEntryFactory.create(name=name) for name in ["beta", "alpha", "zeta"]
+        ]
+
+        route_request.GET.update(_tabulator_params(sort=("name", "asc")))
+        result = views._render_tabulator_payload(route_request)
+
+        expected_ids = [j.id for j in sorted(journals, key=lambda j: (j.name, j.id))]
+        assert [row["id"] for row in result["data"]] == expected_ids
+
+
+class TestJournalsListViews:
+    def test_html_view_returns_empty_context(self, db_request):
+        assert views.journals_list(db_request) == {}
+
+    def test_json_view_returns_payload(self, route_request):
+        journal = JournalEntryFactory.create()
+
+        result = views.journals_list_json(route_request)
+
+        assert result["last_page"] == 1
+        assert [row["id"] for row in result["data"]] == [journal.id]

--- a/tests/unit/admin/views/test_observations.py
+++ b/tests/unit/admin/views/test_observations.py
@@ -23,24 +23,6 @@ from ....common.db.packaging import (
 )
 
 
-def _fake_route_path(name, **kw):
-    """Predictable route_path stub covering the routes the view uses."""
-    if name == "admin.user.detail":
-        return f"/admin/users/{kw['username']}/"
-    if name == "admin.project.detail":
-        return f"/admin/projects/{kw['project_name']}/"
-    if name == "admin.organization_application.detail":
-        return f"/admin/organization_applications/{kw['organization_application_id']}/"
-    raise AssertionError(f"unexpected route: {name}")  # pragma: no cover
-
-
-@pytest.fixture
-def dt_request(db_request):
-    """db_request with a predictable route_path for DataTables payload tests."""
-    db_request.route_path = _fake_route_path
-    return db_request
-
-
 def _datatables_params(
     *,
     draw=1,
@@ -232,15 +214,15 @@ class TestBuildObservationsQuery:
 
 
 class TestRenderDatatablesPayload:
-    def test_empty_database(self, dt_request):
-        dt_request.params = _datatables_params()
-        payload = views._render_datatables_payload(dt_request)
+    def test_empty_database(self, route_request):
+        route_request.params = _datatables_params()
+        payload = views._render_datatables_payload(route_request)
         assert payload["draw"] == 1
         assert payload["recordsFiltered"] == 0
         assert payload["data"] == []
         assert "recordsTotal" in payload
 
-    def test_returns_rows(self, dt_request):
+    def test_returns_rows(self, route_request):
         observer = ObserverFactory.create()
         user = UserFactory.create(username="reporter-1")
         user.observer = observer
@@ -252,8 +234,8 @@ class TestRenderDatatablesPayload:
             summary="malicious install hook",
         )
 
-        dt_request.params = _datatables_params(kind="is_malware")
-        payload = views._render_datatables_payload(dt_request)
+        route_request.params = _datatables_params(kind="is_malware")
+        payload = views._render_datatables_payload(route_request)
 
         assert payload["recordsFiltered"] == 1
         assert len(payload["data"]) == 1
@@ -265,26 +247,28 @@ class TestRenderDatatablesPayload:
         assert row["observer_link"] == "/admin/users/reporter-1/"
         assert row["related_link"] == "/admin/projects/evil-pkg/"
 
-    def test_pagination(self, dt_request):
+    def test_pagination(self, route_request):
         ProjectObservationFactory.create_batch(30, kind="is_malware")
 
-        dt_request.params = _datatables_params(kind="is_malware", start=10, length=10)
-        payload = views._render_datatables_payload(dt_request)
+        route_request.params = _datatables_params(
+            kind="is_malware", start=10, length=10
+        )
+        payload = views._render_datatables_payload(route_request)
 
         assert payload["recordsFiltered"] == 30
         assert len(payload["data"]) == 10
 
-    def test_kind_filter_narrows_results(self, dt_request):
+    def test_kind_filter_narrows_results(self, route_request):
         ProjectObservationFactory.create_batch(3, kind="is_malware")
         ProjectObservationFactory.create_batch(2, kind="is_spam")
 
-        dt_request.params = _datatables_params(kind="is_malware")
-        payload = views._render_datatables_payload(dt_request)
+        route_request.params = _datatables_params(kind="is_malware")
+        payload = views._render_datatables_payload(route_request)
 
         assert payload["recordsFiltered"] == 3
         assert all(r["kind"] == "is_malware" for r in payload["data"])
 
-    def test_global_search_matches_summary(self, dt_request):
+    def test_global_search_matches_summary(self, route_request):
         observer = ObserverFactory.create()
         ProjectObservationFactory.create(
             kind="is_malware", observer=observer, summary="extremely distinctive phrase"
@@ -293,13 +277,15 @@ class TestRenderDatatablesPayload:
             3, kind="is_malware", observer=observer, summary="boring"
         )
 
-        dt_request.params = _datatables_params(kind="is_malware", search="distinctive")
-        payload = views._render_datatables_payload(dt_request)
+        route_request.params = _datatables_params(
+            kind="is_malware", search="distinctive"
+        )
+        payload = views._render_datatables_payload(route_request)
 
         assert payload["recordsFiltered"] == 1
         assert "distinctive" in payload["data"][0]["summary"]
 
-    def test_related_link_none_when_related_deleted(self, dt_request):
+    def test_related_link_none_when_related_deleted(self, route_request):
         observer = ObserverFactory.create()
         ProjectObservationFactory.create(
             kind="is_malware",
@@ -308,23 +294,23 @@ class TestRenderDatatablesPayload:
             related_name="Project(id=None, name='deleted-pkg')",
         )
 
-        dt_request.params = _datatables_params(kind="is_malware")
-        payload = views._render_datatables_payload(dt_request)
+        route_request.params = _datatables_params(kind="is_malware")
+        payload = views._render_datatables_payload(route_request)
 
         assert payload["data"][0]["related_link"] is None
         assert payload["data"][0]["related"] == "deleted-pkg"
 
-    def test_observer_link_none_for_non_user_observer(self, dt_request):
+    def test_observer_link_none_for_non_user_observer(self, route_request):
         observer = ObserverFactory.create()  # Observer with no parent User
         ProjectObservationFactory.create(kind="is_malware", observer=observer)
 
-        dt_request.params = _datatables_params(kind="is_malware")
-        payload = views._render_datatables_payload(dt_request)
+        route_request.params = _datatables_params(kind="is_malware")
+        payload = views._render_datatables_payload(route_request)
 
         assert payload["data"][0]["observer"] == ""
         assert payload["data"][0]["observer_link"] is None
 
-    def test_user_observation_produces_user_link(self, dt_request):
+    def test_user_observation_produces_user_link(self, route_request):
         target_user = UserFactory.create(username="compromised-acct")
         observer = ObserverFactory.create()
         UserFactory.create(username="reporter").observer = observer
@@ -334,12 +320,12 @@ class TestRenderDatatablesPayload:
             related=target_user,
         )
 
-        dt_request.params = _datatables_params(kind="account_abuse")
-        payload = views._render_datatables_payload(dt_request)
+        route_request.params = _datatables_params(kind="account_abuse")
+        payload = views._render_datatables_payload(route_request)
 
         assert payload["data"][0]["related_link"] == "/admin/users/compromised-acct/"
 
-    def test_organization_application_observation_produces_link(self, dt_request):
+    def test_organization_application_observation_produces_link(self, route_request):
         org_app = OrganizationApplicationFactory.create()
         observer = ObserverFactory.create()
         OrganizationApplicationObservationFactory.create(
@@ -348,13 +334,13 @@ class TestRenderDatatablesPayload:
             related=org_app,
         )
 
-        dt_request.params = _datatables_params(kind="information_request")
-        payload = views._render_datatables_payload(dt_request)
+        route_request.params = _datatables_params(kind="information_request")
+        payload = views._render_datatables_payload(route_request)
 
         expected = f"/admin/organization_applications/{org_app.id}/"
         assert payload["data"][0]["related_link"] == expected
 
-    def test_organization_application_note_produces_link(self, dt_request):
+    def test_organization_application_note_produces_link(self, route_request):
         org_app = OrganizationApplicationFactory.create()
         observer = ObserverFactory.create()
         OrganizationApplicationObservationFactory.create(
@@ -363,13 +349,13 @@ class TestRenderDatatablesPayload:
             related=org_app,
         )
 
-        dt_request.params = _datatables_params(kind="admin_note")
-        payload = views._render_datatables_payload(dt_request)
+        route_request.params = _datatables_params(kind="admin_note")
+        payload = views._render_datatables_payload(route_request)
 
         expected = f"/admin/organization_applications/{org_app.id}/"
         assert payload["data"][0]["related_link"] == expected
 
-    def test_project_observation_with_unparseable_related_name(self, dt_request):
+    def test_project_observation_with_unparseable_related_name(self, route_request):
         """
         A project observation whose related_name doesn't match the
         Project(name='...') repr pattern should fall back to no link.
@@ -383,13 +369,13 @@ class TestRenderDatatablesPayload:
             related_name="mangled-repr-without-name",
         )
 
-        dt_request.params = _datatables_params(kind="is_malware")
-        payload = views._render_datatables_payload(dt_request)
+        route_request.params = _datatables_params(kind="is_malware")
+        payload = views._render_datatables_payload(route_request)
 
         assert payload["data"][0]["related_link"] is None
         assert payload["data"][0]["related"] == "mangled-repr-without-name"
 
-    def test_user_observation_with_unparseable_related_name(self, dt_request):
+    def test_user_observation_with_unparseable_related_name(self, route_request):
         """
         User observation with a still-present related_id but a related_name
         the regex can't parse and render plain text and no link.
@@ -403,12 +389,12 @@ class TestRenderDatatablesPayload:
             related_name="not-a-parseable-repr",
         )
 
-        dt_request.params = _datatables_params(kind="account_abuse")
-        payload = views._render_datatables_payload(dt_request)
+        route_request.params = _datatables_params(kind="account_abuse")
+        payload = views._render_datatables_payload(route_request)
 
         assert payload["data"][0]["related_link"] is None
 
-    def test_filtered_count_when_page_past_end(self, dt_request):
+    def test_filtered_count_when_page_past_end(self, route_request):
         """
         Seed 3 matching rows, request a page whose offset lands past the end.
         `_count_filtered` runs through the kind-filter branch.
@@ -418,13 +404,13 @@ class TestRenderDatatablesPayload:
             3, kind="is_malware", observer=observer, summary="needle phrase"
         )
 
-        dt_request.params = _datatables_params(kind="is_malware", start=10, length=5)
-        payload = views._render_datatables_payload(dt_request)
+        route_request.params = _datatables_params(kind="is_malware", start=10, length=5)
+        payload = views._render_datatables_payload(route_request)
 
         assert payload["data"] == []
         assert payload["recordsFiltered"] == 3
 
-    def test_filtered_count_with_search_when_page_past_end(self, dt_request):
+    def test_filtered_count_with_search_when_page_past_end(self, route_request):
         """
         Same as `test_filtered_count_when_page_past_end`, with a search value set,
         exercising the `ILIKE` branch of `_count_filtered`.
@@ -434,15 +420,15 @@ class TestRenderDatatablesPayload:
             2, kind="is_malware", observer=observer, summary="needle phrase"
         )
 
-        dt_request.params = _datatables_params(
+        route_request.params = _datatables_params(
             kind="is_malware", search="needle", start=10, length=5
         )
-        payload = views._render_datatables_payload(dt_request)
+        payload = views._render_datatables_payload(route_request)
 
         assert payload["data"] == []
         assert payload["recordsFiltered"] == 2
 
-    def test_filtered_count_without_kind_filter(self, dt_request):
+    def test_filtered_count_without_kind_filter(self, route_request):
         """
         No `kind` filter but a search value: `_count_filtered` takes the
         polymorphic path (base = Observation, no kind predicate).
@@ -452,13 +438,13 @@ class TestRenderDatatablesPayload:
             kind="is_malware", observer=observer, summary="needle phrase"
         )
 
-        dt_request.params = _datatables_params(search="needle", start=10, length=5)
-        payload = views._render_datatables_payload(dt_request)
+        route_request.params = _datatables_params(search="needle", start=10, length=5)
+        payload = views._render_datatables_payload(route_request)
 
         assert payload["data"] == []
         assert payload["recordsFiltered"] == 1
 
-    def test_observer_resolution_is_batched(self, dt_request, query_recorder):
+    def test_observer_resolution_is_batched(self, route_request, query_recorder):
         observer_a = ObserverFactory.create()
         observer_b = ObserverFactory.create()
         UserFactory.create(username="alice").observer = observer_a
@@ -466,9 +452,9 @@ class TestRenderDatatablesPayload:
         for observer in (observer_a, observer_b, observer_a, observer_b):
             ProjectObservationFactory.create(kind="is_malware", observer=observer)
 
-        dt_request.params = _datatables_params(kind="is_malware")
+        route_request.params = _datatables_params(kind="is_malware")
         with query_recorder:
-            views._render_datatables_payload(dt_request)
+            views._render_datatables_payload(route_request)
         # Expected queries:
         # total estimate + main windowed query + observer resolution = 3.
         # Regression sentinel for N+1s on observer or related.
@@ -480,9 +466,9 @@ class TestObservationsListViews:
         result = views.observations_list(db_request)
         assert result == {"observation_kinds": list(ObservationKind)}
 
-    def test_json_view_returns_payload(self, dt_request):
-        dt_request.params = _datatables_params()
-        result = views.observations_list_json(dt_request)
+    def test_json_view_returns_payload(self, route_request):
+        route_request.params = _datatables_params()
+        result = views.observations_list_json(route_request)
         assert set(result.keys()) == {
             "draw",
             "recordsTotal",

--- a/tests/unit/admin/views/test_projects.py
+++ b/tests/unit/admin/views/test_projects.py
@@ -183,6 +183,7 @@ class TestProjectDetail:
             "releases": [],
             "maintainers": roles,
             "journal": journals[:30],
+            "journal_count": 75,
             "oidc_publishers": oidc_publishers,
             "ONE_MIB": views.ONE_MIB,
             "MAX_FILESIZE": warehouse.constants.MAX_FILESIZE,
@@ -505,95 +506,19 @@ class TestProjectReleasesList:
 
 
 class TestProjectJournalsList:
-    def test_no_query(self, db_request):
+    def test_returns_project(self, db_request):
         project = ProjectFactory.create()
-        journals = sorted(
-            JournalEntryFactory.create_batch(30, name=project.name),
-            key=lambda x: (x.submitted_date, x.id),
-            reverse=True,
-        )
         db_request.matchdict["project_name"] = project.normalized_name
+
         result = views.journals_list(project, db_request)
 
-        assert result == {"journals": journals[:25], "project": project, "query": None}
-
-    def test_with_page(self, db_request):
-        project = ProjectFactory.create()
-        journals = sorted(
-            JournalEntryFactory.create_batch(30, name=project.name),
-            key=lambda x: (x.submitted_date, x.id),
-            reverse=True,
-        )
-        db_request.matchdict["project_name"] = project.normalized_name
-        db_request.GET["page"] = "2"
-        result = views.journals_list(project, db_request)
-
-        assert result == {"journals": journals[25:], "project": project, "query": None}
-
-    def test_with_invalid_page(self, db_request):
-        project = ProjectFactory.create()
-        db_request.matchdict["project_name"] = project.normalized_name
-        db_request.GET["page"] = "not an integer"
-
-        with pytest.raises(HTTPBadRequest):
-            views.journals_list(project, db_request)
-
-    def test_version_query(self, db_request):
-        project = ProjectFactory.create()
-        journals = sorted(
-            JournalEntryFactory.create_batch(30, name=project.name),
-            key=lambda x: (x.submitted_date, x.id),
-            reverse=True,
-        )
-        db_request.matchdict["project_name"] = project.normalized_name
-        db_request.GET["q"] = f"version:{journals[3].version}"
-        result = views.journals_list(project, db_request)
-
-        assert result == {
-            "journals": [journals[3]],
-            "project": project,
-            "query": f"version:{journals[3].version}",
-        }
-
-    def test_invalid_key_query(self, db_request):
-        project = ProjectFactory.create()
-        journals = sorted(
-            JournalEntryFactory.create_batch(30, name=project.name),
-            key=lambda x: (x.submitted_date, x.id),
-            reverse=True,
-        )
-        db_request.matchdict["project_name"] = project.normalized_name
-        db_request.GET["q"] = "user:username"
-        result = views.journals_list(project, db_request)
-
-        assert result == {
-            "journals": journals[:25],
-            "project": project,
-            "query": "user:username",
-        }
-
-    def test_basic_query(self, db_request):
-        project = ProjectFactory.create()
-        journals = sorted(
-            JournalEntryFactory.create_batch(30, name=project.name),
-            key=lambda x: (x.submitted_date, x.id),
-            reverse=True,
-        )
-        db_request.matchdict["project_name"] = project.normalized_name
-        db_request.GET["q"] = f"{journals[3].version}"
-        result = views.journals_list(project, db_request)
-
-        assert result == {
-            "journals": journals[:25],
-            "project": project,
-            "query": f"{journals[3].version}",
-        }
+        assert result == {"project": project}
 
     def test_non_normalized_name(self, db_request):
         project = ProjectFactory.create(name="NotNormalized")
         db_request.matchdict["project_name"] = str(project.name)
-        db_request.current_route_path = pretend.call_recorder(
-            lambda *a, **kw: "/admin/projects/the-redirect/journals/"
+        db_request.current_route_path = lambda *a, **kw: (
+            "/admin/projects/the-redirect/journals/"
         )
         with pytest.raises(HTTPMovedPermanently):
             views.journals_list(project, db_request)

--- a/warehouse/admin/static/css/admin.css
+++ b/warehouse/admin/static/css/admin.css
@@ -8,6 +8,8 @@
 @import "admin-lte/plugins/datatables-buttons/css/buttons.bootstrap4.css";
 @import "admin-lte/plugins/datatables-rowgroup/css/rowGroup.bootstrap4.css";
 
+@import "tabulator-tables/dist/css/tabulator_bootstrap4.css";
+
 @import "admin-lte/dist/css/adminlte.css";
 
 /* Admin styles for the Warehouse project (PyPI) */

--- a/warehouse/admin/static/js/journals.js
+++ b/warehouse/admin/static/js/journals.js
@@ -1,0 +1,132 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+import { TabulatorFull as Tabulator } from "tabulator-tables";
+
+// Build linked cells as DOM nodes so journal-supplied values are never
+// interpreted as HTML. Columns without a formatter use Tabulator's default
+// `plaintext` formatter, which entity-escapes values itself.
+function linkCell(urlField) {
+  return function (cell) {
+    const value = cell.getValue();
+    if (!value) {
+      return "";
+    }
+    const url = cell.getRow().getData()[urlField];
+    if (!url) {
+      return document.createTextNode(value);
+    }
+    const link = document.createElement("a");
+    link.href = url;
+    link.textContent = value;
+    return link;
+  };
+}
+
+function dateCell(cell) {
+  const value = cell.getValue();
+  return value ? value.replace("T", " ").slice(0, 19) : "";
+}
+
+const element = document.getElementById("journals-table");
+if (element) {
+  // Project-scoped pages pin the name filter via a data attribute: a page
+  // headed "Journal Entries For <project>" must not show other projects'
+  // entries.
+  const pinnedName = element.dataset.filterName;
+
+  const columns = [
+    {
+      title: "Name",
+      field: "name",
+      formatter: linkCell("project_link"),
+      headerFilterPlaceholder: "exact name",
+      // A pinned filter renders as a disabled input the user cannot edit.
+      headerFilterParams: pinnedName
+        ? { elementAttributes: { disabled: "disabled" } }
+        : {},
+    },
+    {
+      title: "Version",
+      field: "version",
+      headerFilterPlaceholder: "exact version",
+      headerSort: false,
+      width: 140,
+    },
+    {
+      title: "Date",
+      field: "submitted_date",
+      formatter: dateCell,
+      headerFilterPlaceholder: "on/before YYYY-MM-DD",
+      width: 200,
+    },
+    {
+      title: "Submitted By",
+      field: "submitted_by",
+      formatter: linkCell("submitted_by_link"),
+      headerFilterPlaceholder: "username",
+      width: 200,
+    },
+    {
+      title: "Action",
+      field: "action",
+      headerFilterPlaceholder: "action prefix",
+      headerSort: false,
+    },
+  ];
+
+  // Allow deep-linking any filterable column, e.g.
+  // /admin/journals/?submitted_by=someuser; the pin wins over a
+  // query-param override.
+  const query = new URLSearchParams(window.location.search);
+  if (pinnedName) {
+    query.set("name", pinnedName);
+  }
+  const initialHeaderFilter = columns
+    .map((column) => column.field)
+    .filter((field) => query.get(field))
+    .map((field) => ({ field: field, value: query.get(field) }));
+
+  // The latest response, kept for the footer counter. The server sends an
+  // exact `total` when the final page is in reach and a `total_estimate`
+  // when browsing unfiltered; both are null mid-way through a filtered
+  // result, where counting is what made the old page time out.
+  let lastResponse = null;
+
+  new Tabulator(element, {
+    layout: "fitColumns",
+    placeholder: "No matching journal entries",
+    pagination: true,
+    paginationMode: "remote",
+    paginationSize: 25,
+    ajaxResponse: function (url, params, response) {
+      lastResponse = response;
+      return response;
+    },
+    paginationCounter: function (pageSize, currentRow) {
+      if (!lastResponse?.data.length) {
+        return; // the table placeholder already says there are no rows
+      }
+      const first = currentRow.toLocaleString();
+      const last = (currentRow + lastResponse.data.length - 1).toLocaleString();
+      const total = lastResponse.total ?? lastResponse.total_estimate;
+      if (total == null) {
+        return document.createTextNode(`Showing rows ${first}-${last}`);
+      }
+      const approx = lastResponse.total == null ? "~" : "";
+      return document.createTextNode(
+        `Showing ${first}-${last} of ${approx}${total.toLocaleString()} rows`,
+      );
+    },
+    sortMode: "remote",
+    filterMode: "remote",
+    columnHeaderSortMulti: false,
+    ajaxURL: element.dataset.url,
+    initialSort: [{ column: "submitted_date", dir: "desc" }],
+    initialHeaderFilter: initialHeaderFilter,
+    columnDefaults: {
+      headerFilter: "input",
+      headerFilterLiveFilter: false,
+    },
+    columns: columns,
+  });
+}

--- a/warehouse/admin/static/js/warehouse.js
+++ b/warehouse/admin/static/js/warehouse.js
@@ -24,6 +24,7 @@ import "admin-lte/build/js/AdminLTE";
 import "./treeview";
 import "./observer_charts";
 import "./project_charts";
+import "./journals";
 
 // Get our timeago function
 import timeAgo from "warehouse/utils/timeago";

--- a/warehouse/admin/templates/admin/journals/list.html
+++ b/warehouse/admin/templates/admin/journals/list.html
@@ -2,8 +2,6 @@
 
 {% extends "admin/base.html" %}
 
-{% import "admin/utils/pagination.html" as pagination %}
-
 {% block title %}Journal Entries{% endblock %}
 
 {% block breadcrumb %}
@@ -13,55 +11,14 @@
 {% block content %}
 <div class="card">
   <div class="card-body">
-    <form>
-      <div class="input-group input-group-lg">
-        <input name="q" type="text" class="form-control input-lg" placeholder="Search: supported terms are user: project: version:"{% if query %} value="{{ query }}"{% endif %}>
-        <div class="input-group-btn input-group-append">
-          <button type="submit" class="btn btn-default"><i class="fa fa-search"></i></button>
-        </div>
-      </div>
-    </form>
-  </div>
-</div>
-
-<div class="card">
-  <div class="card-body table-responsive p-0">
-    <table class="table table-hover table-striped">
-      <thead>
-      <tr>
-        <th>Name</th>
-        <th>Version</th>
-        <th>Date</th>
-        <th>Submitted By</th>
-        <th>Action</th>
-      </tr>
-      </thead>
-      <tbody>
-      {% for journal in journals %}
-      <tr>
-        <td><a href="{{ request.route_path('admin.project.detail', project_name=journal.name) }}">{{ journal.name }}</a></td>
-        <td>{{ journal.version }}</td>
-        <td>{{ journal.submitted_date }}</td>
-        <td><a href="{{ request.route_path('admin.user.detail', username=journal.submitted_by.username) }}">{{ journal.submitted_by.username }}</a></td>
-        <td>{{ journal.action }}</td>
-      </tr>
-      {% endfor %}
-      </tbody>
-    </table>
-  </div>
-
-  <div class="card-footer">
-    <div class="row">
-      <div class="col-sm-5">
-        {{ pagination.summary(journals) }}
-      </div>
-
-      <div class="col-sm-7">
-        <div class="float-right">
-          {{ pagination.paginate(journals) }}
-        </div>
-      </div>
-    </div>
+    <p class="text-muted">
+      Name and version filters match exactly (case-sensitive), username
+      matches exactly (case-insensitive), action matches as a prefix, and
+      date shows entries on or before a <code>YYYY-MM-DD</code> date.
+      Press Enter to apply a filter.
+    </p>
+    <div id="journals-table"
+         data-url="{{ request.route_path('admin.journals.list') }}"></div>
   </div>
 </div>
 {% endblock content %}

--- a/warehouse/admin/templates/admin/projects/detail.html
+++ b/warehouse/admin/templates/admin/projects/detail.html
@@ -654,8 +654,8 @@
   <div class="card-header">
     <h3 class="card-title">Journals</h3>
     <div class="card-tools">
-      {% if journal %}
-      <span class="badge badge-secondary">{{ journal|length }}</span>
+      {% if journal_count %}
+      <span class="badge badge-secondary">{{ "{:,}".format(journal_count) }}</span>
       {% endif %}
       <button type="button" class="btn btn-tool" data-card-widget="collapse"><i class="fas fa-plus"></i>
       </button>

--- a/warehouse/admin/templates/admin/projects/journals_list.html
+++ b/warehouse/admin/templates/admin/projects/journals_list.html
@@ -2,8 +2,6 @@
 
 {% extends "admin/base.html" %}
 
-{% import "admin/utils/pagination.html" as pagination %}
-
 {% block title %}Journal Entries For {{ project.name }}{% endblock %}
 
 {% block breadcrumb %}
@@ -15,55 +13,9 @@
 {% block content %}
 <div class="card">
   <div class="card-body">
-    <form>
-      <div class="input-group input-group-lg">
-        <input name="q" type="text" class="form-control input-lg" placeholder="Search"{% if query %} value="{{ query }}"{% endif %}>
-        <div class="input-group-btn input-group-append">
-          <button type="submit" class="btn btn-default"><i class="fa fa-search"></i></button>
-        </div>
-      </div>
-    </form>
-  </div>
-</div>
-
-<div class="card">
-  <div class="card-body table-responsive p-0">
-    <table class="table table-hover table-striped">
-      <thead>
-      <tr>
-        <th>Name</th>
-        <th>Version</th>
-        <th>Date</th>
-        <th>Submitted By</th>
-        <th>Action</th>
-      </tr>
-      </thead>
-
-      <tbody>
-      {% for journal in journals %}
-      <tr>
-        <td>{{ journal.name }}</td>
-        <td>{{ journal.version }}</td>
-        <td>{{ journal.submitted_date }}</td>
-        <td><a href="{{ request.route_path('admin.user.detail', username=journal.submitted_by.username) }}">{{ journal.submitted_by.username }}</a></td>
-        <td>{{ journal.action }}</td>
-      </tr>
-      {% endfor %}
-      </tbody>
-    </table>
-
-    <div class="card-footer row">
-      <div class="col-sm-5">
-          {{ pagination.summary(journals) }}
-      </div>
-
-      <div class="col-sm-7">
-        <div class="float-right">
-            {{ pagination.paginate(journals) }}
-        </div>
-      </div>
-    </div>
-
+    <div id="journals-table"
+         data-url="{{ request.route_path('admin.journals.list') }}"
+         data-filter-name="{{ project.name }}"></div>
   </div>
 </div>
 {% endblock content %}

--- a/warehouse/admin/templates/admin/users/detail.html
+++ b/warehouse/admin/templates/admin/users/detail.html
@@ -1259,7 +1259,7 @@
           </table>
         </div>
         <div class="card-footer">
-          <a href="{{ request.route_path('admin.journals.list', _query={"q": "user:" + user.username}) }}"
+          <a href="{{ request.route_path('admin.journals.list', _query={"submitted_by": user.username}) }}"
              class="btn btn-primary">View all journals for username</a>
         </div>
       </div>

--- a/warehouse/admin/views/helpers.py
+++ b/warehouse/admin/views/helpers.py
@@ -4,8 +4,16 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from psycopg.errors import QueryCanceled
+from pyramid.httpexceptions import HTTPBadRequest
+from sqlalchemy import func, select, text
+
 if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+    from typing import Any
+
     from pyramid.request import Request
+    from sqlalchemy import Row, Select
 
 # Valid time periods for filtering
 ALLOWED_DAYS = (30, 60, 90)
@@ -19,3 +27,52 @@ def parse_days_param(request: Request, allowed: tuple[int, ...] = ALLOWED_DAYS) 
         return days if days in allowed else DEFAULT_DAYS
     except ValueError, TypeError:
         return DEFAULT_DAYS
+
+
+def estimate_row_count(request: Request, table_names: Iterable[str]) -> int:
+    """Estimate total rows across tables via pg_class.reltuples — sub-millisecond.
+
+    reltuples is -1 for never-analyzed tables, so each table's estimate is
+    clamped to zero. Only relations in the public schema are considered, so
+    a same-named table in another schema cannot skew the estimate.
+
+    For exact, periodically-refreshed counts of a few core tables, see
+    warehouse.utils.row_counter instead; this helper is for tables too
+    large to COUNT(*).
+    """
+    result = request.db.execute(
+        text(
+            "SELECT COALESCE(SUM(GREATEST(reltuples, 0))::bigint, 0) FROM pg_class "
+            "WHERE relname = ANY(:names) AND relkind = 'r' "
+            "AND relnamespace = 'public'::regnamespace"
+        ),
+        {"names": list(table_names)},
+    ).scalar()
+    return int(result)
+
+
+def execute_bounded(
+    request: Request, stmt: Select[Any], *, timeout_ms: int
+) -> Sequence[Row[Any]]:
+    """Run a query under a statement timeout, turning timeouts into a 400.
+
+    A query the indexes cannot serve would otherwise scan until the
+    connection drops. The timeout stays in force for the remainder of the
+    transaction, so any later statements in the same request run under it
+    too (only cancellations raised *here* become a 400). Other database
+    errors — connection drops, deadlocks — surface as server errors.
+
+    The raw psycopg exception is caught because warehouse.db unwraps
+    SQLAlchemy's DBAPIError back to the driver exception engine-wide.
+    """
+    try:
+        # set_config(..., is_local=true) scopes the timeout to this
+        # transaction, so it does not leak to the pooled connection.
+        request.db.execute(
+            select(func.set_config("statement_timeout", str(timeout_ms), True))
+        )
+        return request.db.execute(stmt).all()
+    except QueryCanceled:
+        raise HTTPBadRequest(
+            "Query took too long; narrow your filters and try again."
+        ) from None

--- a/warehouse/admin/views/journals.py
+++ b/warehouse/admin/views/journals.py
@@ -1,61 +1,296 @@
 # SPDX-License-Identifier: Apache-2.0
 
-import shlex
+"""Admin views for Journal Entries.
 
-from paginate_sqlalchemy import SqlalchemyOrmPage as SQLAlchemyORMPage
+The journals table is one of the largest in the database (hundreds of
+millions of rows), so these views deliberately avoid whole-table counts
+and unbounded scans. The list page is a Tabulator table fed by a JSON
+endpoint speaking Tabulator's remote pagination/sort/filter protocol.
+
+See: https://github.com/pypi/warehouse/issues/14541
+"""
+
+from __future__ import annotations
+
+import math
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import TYPE_CHECKING
+
 from pyramid.httpexceptions import HTTPBadRequest
 from pyramid.view import view_config
-from sqlalchemy import and_
-from sqlalchemy.orm import joinedload
+from sqlalchemy import select
 
+from warehouse.admin.views.helpers import estimate_row_count, execute_bounded
 from warehouse.authnz import Permissions
+from warehouse.cache.http import add_vary
 from warehouse.packaging.models import JournalEntry
-from warehouse.utils.paginate import paginate_url_factory
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping
+    from typing import Any
+
+    from pyramid.request import Request
+    from sqlalchemy import Select
+    from sqlalchemy.sql import ColumnElement
+
+_DEFAULT_PAGE_SIZE = 25
+_MAX_PAGE_SIZE = 100
+# Deepest row reachable via pagination; keeps OFFSET scans bounded.
+# Anything further back should be reached by filtering instead.
+_MAX_OFFSET = 10_000
+_MAX_FILTER_LENGTH = 500
+# Backstop for filter/sort combinations the indexes cannot serve, e.g. an
+# action prefix that matches nothing. Timed-out queries become a 400.
+_STATEMENT_TIMEOUT_MS = 10_000
+
+
+def _submitted_on_or_before(value: str) -> ColumnElement[bool]:
+    """Match journal entries submitted on or before an ISO date/datetime.
+
+    Paired with the default newest-first sort, this jumps to any point in
+    history without deep OFFSETs, using the submitted_date index.
+    """
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError:
+        raise HTTPBadRequest(
+            "'submitted_date' filter must be an ISO date, e.g. 2023-01-31."
+        ) from None
+    if len(value) == 10:  # date-only: include the whole day
+        return JournalEntry.submitted_date < parsed + timedelta(days=1)
+    return JournalEntry.submitted_date <= parsed
+
+
+# Exact matches use the existing btree indexes on the journals table.
+# `submitted_by` is CITEXT, so equality is case-insensitive. `action` has
+# no index, so a prefix match is best-effort: ordered scans find common
+# actions quickly, and the statement timeout bounds the rare ones.
+_FILTER_BUILDERS: dict[str, Callable[[str], ColumnElement[bool]]] = {
+    "name": lambda v: JournalEntry.name == v,
+    "version": lambda v: JournalEntry.version == v,
+    "submitted_by": lambda v: JournalEntry._submitted_by == v,
+    "action": lambda v: JournalEntry.action.startswith(v, autoescape=True),
+    "submitted_date": _submitted_on_or_before,
+}
+
+# Sortable columns are backed by an index; `action` is not, and `version`
+# is text, where a lexicographic order would only mislead.
+_SORTABLE_FIELDS = frozenset({"submitted_date", "name", "submitted_by"})
+
+
+@dataclass(frozen=True)
+class _TabulatorParams:
+    page: int
+    size: int
+    sort_field: str
+    sort_dir: str
+    filters: dict[str, str]
+
+    @property
+    def offset(self) -> int:
+        return (self.page - 1) * self.size
+
+
+def _parse_tabulator_params(params: Mapping[str, str]) -> _TabulatorParams:
+    """Parse and validate Tabulator's remote ajax query params."""
+    try:
+        page = max(1, int(params.get("page", "1")))
+    except ValueError:
+        raise HTTPBadRequest("'page' must be an integer.") from None
+
+    try:
+        raw_size = int(params.get("size", str(_DEFAULT_PAGE_SIZE)))
+    except ValueError:
+        raise HTTPBadRequest("'size' must be an integer.") from None
+    size = min(max(1, raw_size), _MAX_PAGE_SIZE)
+
+    sort_field = "submitted_date"
+    sort_dir = "desc"
+    requested_field = params.get("sort[0][field]")
+    if requested_field is not None:
+        requested_dir = params.get("sort[0][dir]", "desc")
+        if requested_dir not in ("asc", "desc"):
+            raise HTTPBadRequest("'sort[0][dir]' must be 'asc' or 'desc'.")
+        if requested_field in _SORTABLE_FIELDS:
+            sort_field = requested_field
+            sort_dir = requested_dir
+
+    filters: dict[str, str] = {}
+    i = 0
+    while (field := params.get(f"filter[{i}][field]")) is not None:
+        value = (params.get(f"filter[{i}][value]") or "").strip()
+        if len(value) > _MAX_FILTER_LENGTH:
+            raise HTTPBadRequest(
+                f"Filter values must be <= {_MAX_FILTER_LENGTH} characters."
+            )
+        if value and field in _FILTER_BUILDERS:
+            filters[field] = value
+        i += 1
+
+    parsed = _TabulatorParams(
+        page=page, size=size, sort_field=sort_field, sort_dir=sort_dir, filters=filters
+    )
+    if parsed.offset >= _MAX_OFFSET:
+        raise HTTPBadRequest(f"Cannot paginate beyond {_MAX_OFFSET} rows.")
+    return parsed
+
+
+def _build_order_by(params: _TabulatorParams) -> tuple[ColumnElement[Any], ...]:
+    """Choose an ordering the indexes can serve without a sort step.
+
+    Plain asc/desc keeps PostgreSQL's native NULL placement (last on ASC,
+    first on DESC), which is what the btree indexes store, and each
+    tiebreak follows its index's stored orientation — a same-direction
+    tiebreak would force a sort over every row of the first sort-key group.
+    """
+    desc = params.sort_dir == "desc"
+    if params.sort_field == "name":
+        # journals_name_id_idx stores (name ASC, id DESC).
+        if desc:
+            return (JournalEntry.name.desc(), JournalEntry.id.asc())
+        return (JournalEntry.name.asc(), JournalEntry.id.desc())
+    if params.sort_field == "submitted_by":
+        # journals_submitted_by_and_reverse_date_idx stores
+        # (submitted_by ASC, submitted_date DESC).
+        if desc:
+            return (
+                JournalEntry._submitted_by.desc(),
+                JournalEntry.submitted_date.asc(),
+                JournalEntry.id.asc(),
+            )
+        return (
+            JournalEntry._submitted_by.asc(),
+            JournalEntry.submitted_date.desc(),
+            JournalEntry.id.desc(),
+        )
+    if "name" in params.filters:
+        # Chronological sort with an exact name filter: id order is
+        # equivalent (ids are kept monotonic, see ensure_monotonic_journals)
+        # and journals_name_id_idx serves it without scanning other
+        # projects' rows out of the date index.
+        return (JournalEntry.id.desc() if desc else JournalEntry.id.asc(),)
+    # journals_submitted_date_id_idx stores (submitted_date ASC, id ASC).
+    if desc:
+        return (JournalEntry.submitted_date.desc(), JournalEntry.id.desc())
+    return (JournalEntry.submitted_date.asc(), JournalEntry.id.asc())
+
+
+def _build_journals_query(params: _TabulatorParams) -> Select[Any]:
+    """Build the page SELECT, fetching one extra row to detect a next page."""
+    conditions = [
+        _FILTER_BUILDERS[field](value) for field, value in params.filters.items()
+    ]
+
+    return (
+        select(
+            JournalEntry.id,
+            JournalEntry.name,
+            JournalEntry.version,
+            JournalEntry.action,
+            JournalEntry.submitted_date,
+            JournalEntry._submitted_by.label("submitted_by"),
+        )
+        .where(*conditions)
+        .order_by(*_build_order_by(params))
+        .limit(params.size + 1)
+        .offset(params.offset)
+    )
+
+
+def _render_tabulator_payload(request: Request) -> dict[str, Any]:
+    """Execute the page query and shape Tabulator's expected response."""
+    params = _parse_tabulator_params(request.params)
+    rows = execute_bounded(
+        request, _build_journals_query(params), timeout_ms=_STATEMENT_TIMEOUT_MS
+    )
+
+    # The deepest page the parser will accept for this size.
+    max_page = math.ceil(_MAX_OFFSET / params.size)
+    has_more = len(rows) > params.size
+    page_rows = rows[: params.size]
+    total: int | None = None
+    total_estimate: int | None = None
+    if not has_more:
+        # The final page is in reach, so the exact total is known without
+        # a count query: everything skipped plus everything returned.
+        last_page = params.page
+        total = params.offset + len(page_rows)
+    elif params.filters:
+        # Counting filtered matches is unbounded work on this table, so
+        # filtered pagination only advertises one page past the current one.
+        last_page = min(params.page + 1, max_page)
+    else:
+        # Unfiltered, the pg_class row estimate is accurate enough to size
+        # the pagination controls, bounded by the offset cap. Clamp to the
+        # rows already fetched (probe row included, so a next page is
+        # always advertised) in case the estimate is stale.
+        total_estimate = max(
+            estimate_row_count(request, [JournalEntry.__tablename__]),
+            params.offset + len(rows),
+        )
+        last_page = min(math.ceil(total_estimate / params.size), max_page)
+
+    # Project-scoped pages repeat the same name on every row; generate each
+    # distinct link once.
+    project_links = {
+        name: request.route_path("admin.project.detail", project_name=name)
+        for name in {row.name for row in page_rows} - {None}
+    }
+    user_links = {
+        username: request.route_path("admin.user.detail", username=username)
+        for username in {row.submitted_by for row in page_rows} - {None}
+    }
+    data = [
+        {
+            "id": row.id,
+            "name": row.name,
+            "version": row.version,
+            "action": row.action,
+            "submitted_date": row.submitted_date.isoformat(),
+            "submitted_by": row.submitted_by,
+            "project_link": project_links.get(row.name),
+            "submitted_by_link": user_links.get(row.submitted_by),
+        }
+        for row in page_rows
+    ]
+
+    # `total` is exact when set; `total_estimate` is the table estimate for
+    # unfiltered browsing. Both are null when more filtered pages exist.
+    return {
+        "last_page": last_page,
+        "total": total,
+        "total_estimate": total_estimate,
+        "data": data,
+    }
 
 
 @view_config(
     route_name="admin.journals.list",
     renderer="warehouse.admin:templates/admin/journals/list.html",
+    accept="text/html",
+    decorator=[add_vary("Accept")],
     permission=Permissions.AdminJournalRead,
+    request_method="GET",
     uses_session=True,
+    require_csrf=True,
+    require_methods=False,
 )
-def journals_list(request):
-    q = request.params.get("q")
+def journals_list(request: Request) -> dict[str, Any]:
+    return {}
 
-    try:
-        page_num = int(request.params.get("page", 1))
-    except ValueError:
-        raise HTTPBadRequest("'page' must be an integer.") from None
 
-    journals_query = (
-        request.db.query(JournalEntry)
-        .options(joinedload(JournalEntry.submitted_by))
-        .order_by(JournalEntry.submitted_date.desc(), JournalEntry.id.desc())
-    )
-
-    if q:
-        terms = shlex.split(q)
-
-        filters = []
-        for term in terms:
-            if ":" in term:
-                field, value = term.split(":", 1)
-                if field.lower() == "project":
-                    filters.append(JournalEntry.name.ilike(value))
-                if field.lower() == "version":
-                    filters.append(JournalEntry.version.ilike(value))
-                if field.lower() == "user":
-                    filters.append(JournalEntry._submitted_by.like(value))
-            else:
-                filters.append(JournalEntry.name.ilike(term))
-
-        journals_query = journals_query.filter(and_(*filters))
-
-    journals = SQLAlchemyORMPage(
-        journals_query,
-        page=page_num,
-        items_per_page=25,
-        url_maker=paginate_url_factory(request),
-    )
-
-    return {"journals": journals, "query": q}
+@view_config(
+    route_name="admin.journals.list",
+    renderer="json",
+    accept="application/json",
+    decorator=[add_vary("Accept")],
+    permission=Permissions.AdminJournalRead,
+    request_method="GET",
+    uses_session=True,
+    require_csrf=True,
+    require_methods=False,
+)
+def journals_list_json(request: Request) -> dict[str, Any]:
+    return _render_tabulator_payload(request)

--- a/warehouse/admin/views/observations.py
+++ b/warehouse/admin/views/observations.py
@@ -15,11 +15,12 @@ import packaging.utils
 
 from pyramid.httpexceptions import HTTPBadRequest
 from pyramid.view import view_config
-from sqlalchemy import func, or_, select, text
+from sqlalchemy import func, or_, select
 
 from warehouse.accounts.models import User
-from warehouse.admin.views.helpers import parse_days_param
+from warehouse.admin.views.helpers import estimate_row_count, parse_days_param
 from warehouse.authnz import Permissions
+from warehouse.cache.http import add_vary
 from warehouse.observations.models import (
     OBSERVATION_KIND_MAP,
     Observation,
@@ -221,18 +222,6 @@ def _count_filtered(request: Request, params: _DataTablesParams) -> int:
     )
 
 
-def _count_all_observations(request: Request) -> int:
-    """Estimate unfiltered total via pg_class.reltuples — sub-millisecond."""
-    result = request.db.execute(
-        text(
-            "SELECT COALESCE(SUM(reltuples)::bigint, 0) FROM pg_class "
-            "WHERE relname = ANY(:names) AND relkind = 'r'"
-        ),
-        {"names": list(_OBSERVATION_TABLE_NAMES)},
-    ).scalar()
-    return int(result or 0)
-
-
 def _resolve_observers(
     request: Request, observer_ids: set[UUID]
 ) -> dict[UUID, str | None]:
@@ -324,7 +313,7 @@ def _render_datatables_payload(request: Request) -> dict[str, Any]:
 
     return {
         "draw": params.draw,
-        "recordsTotal": _count_all_observations(request),
+        "recordsTotal": estimate_row_count(request, _OBSERVATION_TABLE_NAMES),
         "recordsFiltered": records_filtered,
         "data": data,
     }
@@ -379,6 +368,7 @@ def _fetch_malware_observations(request: Request, cutoff_date: datetime) -> list
     route_name="admin.observations.list",
     renderer="warehouse.admin:templates/admin/observations/list.html",
     accept="text/html",
+    decorator=[add_vary("Accept")],
     permission=Permissions.AdminObservationsRead,
     request_method="GET",
     uses_session=True,
@@ -393,6 +383,7 @@ def observations_list(request: Request) -> dict[str, Any]:
     route_name="admin.observations.list",
     renderer="json",
     accept="application/json",
+    decorator=[add_vary("Accept")],
     permission=Permissions.AdminObservationsRead,
     request_method="GET",
     uses_session=True,

--- a/warehouse/admin/views/projects.py
+++ b/warehouse/admin/views/projects.py
@@ -200,6 +200,18 @@ def project_detail(project, request):
         .order_by(JournalEntry.submitted_date.desc(), JournalEntry.id.desc())
         .limit(30)
     )
+    # The card lists only the newest entries; the badge shows the true
+    # count. A short first page already proves the total; otherwise
+    # count(*) is an index-only scan on journals_name_idx.
+    if len(journal) < 30:
+        journal_count = len(journal)
+    else:
+        journal_count = (
+            request.db.query(func.count())
+            .select_from(JournalEntry)
+            .filter(JournalEntry.name == project.name)
+            .scalar()
+        )
     observations = list(
         request.db.query(project.Observation)
         .options(joinedload(project.Observation.observer))
@@ -213,6 +225,7 @@ def project_detail(project, request):
         "releases": releases,
         "maintainers": maintainers,
         "journal": journal,
+        "journal_count": journal_count,
         "oidc_publishers": project.oidc_publishers,
         "ONE_MIB": ONE_MIB,
         "MAX_FILESIZE": MAX_FILESIZE,
@@ -534,7 +547,11 @@ def release_render(release, request):
     uses_session=True,
 )
 def journals_list(project, request):
-    q = request.params.get("q")
+    """Render the shell for a project-scoped journals Tabulator table.
+
+    The table itself is fed by the shared JSON endpoint behind
+    `admin.journals.list`, pre-filtered on this project's name.
+    """
     project_name = request.matchdict["project_name"]
 
     if project_name != project.normalized_name:
@@ -542,39 +559,7 @@ def journals_list(project, request):
             request.current_route_path(project_name=project.normalized_name)
         )
 
-    try:
-        page_num = int(request.params.get("page", 1))
-    except ValueError:
-        raise HTTPBadRequest("'page' must be an integer.") from None
-
-    journals_query = (
-        request.db.query(JournalEntry)
-        .options(joinedload(JournalEntry.submitted_by))
-        .filter(JournalEntry.name == project.name)
-        .order_by(JournalEntry.submitted_date.desc(), JournalEntry.id.desc())
-    )
-
-    if q:
-        terms = shlex.split(q)
-
-        filters = []
-        for term in terms:
-            if ":" in term:
-                field, value = term.split(":", 1)
-                if field.lower() == "version":
-                    filters.append(JournalEntry.version.ilike(value))
-
-        filters = filters or [True]
-        journals_query = journals_query.filter(or_(False, *filters))
-
-    journals = SQLAlchemyORMPage(
-        journals_query,
-        page=page_num,
-        items_per_page=25,
-        url_maker=paginate_url_factory(request),
-    )
-
-    return {"journals": journals, "project": project, "query": q}
+    return {"project": project}
 
 
 @view_config(

--- a/warehouse/db.py
+++ b/warehouse/db.py
@@ -177,6 +177,10 @@ def unwrap_dbapi_exceptions(context):
     """
     Listens for SQLAlchemy errors and raises the original
     DBAPI (e.g., psycopg) exception instead.
+
+    Downstream code depends on receiving the raw driver exception, e.g.
+    warehouse.admin.views.helpers.execute_bounded catches psycopg's
+    QueryCanceled directly.
     """
     if (
         isinstance(context.sqlalchemy_exception, DBAPIError)

--- a/warehouse/utils/row_counter.py
+++ b/warehouse/utils/row_counter.py
@@ -8,6 +8,8 @@ from warehouse import db, tasks
 from warehouse.accounts.models import User
 from warehouse.packaging.models import File, Project, Release
 
+# Exact counts, refreshed by a periodic task. For tables too large to
+# COUNT(*), use warehouse.admin.views.helpers.estimate_row_count instead.
 COUNTED_TABLES = [User, Project, Release, File]
 
 


### PR DESCRIPTION
The journals page ran a `count(*)` over the whole journals table (hundreds of millions of rows) on every load and timed out before rendering anything.

Replace the global and per-project journals pages with a Tabulator table fed by a shared JSON endpoint that never counts:

- fetch one row past the page size to detect a next page, and cap pagination depth at 10,000 rows
- size unfiltered pagination from the pg_class.reltuples estimate
- filter only on indexed columns: name and version exact, submitted_by exact (CITEXT, so case-insensitive), action by prefix, and a date filter for entries on or before a given day
- sort only on indexed columns (NULLs last), newest first by default
- run page queries under a 10s statement timeout so an unindexable filter degrades to a clear error instead of a hung worker

Filters can be pre-set from the query string, so the "view all journals" button on user detail pages deep-links to a filtered table, and the per-project page pins its name filter onto the same endpoint.

Tabulator is the jQuery-free table library AdminLTE 4 adopted after dropping DataTables, so this is also a first incremental step in that direction.
Refs: https://adminlte.io/themes/v4/docs/integrations.html
Refs: https://www.tabulator.info/

Closes #14541