### PR TITLE
refactor: defer gcloud heavyweight imports

### DIFF
--- a/tests/unit/test_gcloud.py
+++ b/tests/unit/test_gcloud.py
@@ -1,12 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
+from google.cloud import bigquery
+from google.cloud.storage import Client as storage_Client
+
 from warehouse import gcloud
 
 
 def test_gcloud_bigquery_factory(pyramid_request, mocker):
     client = mocker.sentinel.client
     from_service_account_info = mocker.patch.object(
-        gcloud.bigquery.Client,
+        bigquery.Client,
         "from_service_account_info",
         autospec=True,
         return_value=client,
@@ -26,7 +29,7 @@ def test_gcloud_bigquery_factory(pyramid_request, mocker):
 def test_gcloud_gcs_factory(pyramid_request, mocker):
     client = mocker.sentinel.client
     from_service_account_info = mocker.patch.object(
-        gcloud.storage_Client,
+        storage_Client,
         "from_service_account_info",
         autospec=True,
         return_value=client,
@@ -52,3 +55,9 @@ def test_includeme(mocker):
         mocker.call(gcloud.gcloud_bigquery_factory, name="gcloud.bigquery"),
         mocker.call(gcloud.gcloud_gcs_factory, name="gcloud.gcs"),
     ]
+
+
+def test_no_module_level_google_imports():
+    """The google.cloud imports should be deferred, not at module level."""
+    assert not hasattr(gcloud, "bigquery")
+    assert not hasattr(gcloud, "storage_Client")

--- a/warehouse/gcloud.py
+++ b/warehouse/gcloud.py
@@ -1,10 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
-from google.cloud import bigquery
-from google.cloud.storage import Client as storage_Client
-
 
 def gcloud_bigquery_factory(context, request):
+    # Deferred: avoid the import cost when this backend isn't in use
+    from google.cloud import bigquery  # noqa: PLC0415
+
     service_account_info = request.registry.settings["gcloud.service_account_info"]
     project = request.registry.settings["gcloud.project"]
 
@@ -14,6 +14,9 @@ def gcloud_bigquery_factory(context, request):
 
 
 def gcloud_gcs_factory(context, request):
+    # Deferred: avoid the import cost when this backend isn't in use
+    from google.cloud.storage import Client as storage_Client  # noqa: PLC0415
+
     service_account_info = request.registry.settings["gcloud.service_account_info"]
     project = request.registry.settings["gcloud.project"]
 


### PR DESCRIPTION
If we don't need the libraries at import time, don't import them.