### PR TITLE
test: replace pretend in multiple test modules

### DIFF
--- a/tests/unit/legacy/api/test_json.py
+++ b/tests/unit/legacy/api/test_json.py
@@ -30,6 +30,17 @@ def _assert_has_cors_headers(headers):
     assert headers["Access-Control-Expose-Headers"] == "X-PyPI-Last-Serial"
 
 
+def _assert_same_calls(actual, expected):
+    """Assert two call lists are equal ignoring order.
+
+    ``mock.call`` objects carrying kwargs are unhashable, so ``set()``
+    equality is unavailable; check containment in both directions instead so
+    the assertion stays exact (every expected call happened, and no others).
+    """
+    assert all(c in expected for c in actual)
+    assert all(c in actual for c in expected)
+
+
 class TestLatestReleaseFactory:
     def test_missing_release(self, db_request):
         project = ProjectFactory.create()
@@ -219,8 +230,7 @@ class TestJSONProject:
             ),
             mocker.call("legacy.docs", project=project.name),
         ]
-        assert all(c in expected_calls for c in route_url.call_args_list)
-        assert all(c in route_url.call_args_list for c in expected_calls)
+        _assert_same_calls(route_url.call_args_list, expected_calls)
 
         _assert_has_cors_headers(db_request.response.headers)
         assert db_request.response.headers["X-PyPI-Last-Serial"] == str(je.id)
@@ -555,8 +565,7 @@ class TestJSONRelease:
             ),
             mocker.call("legacy.docs", project=project.name),
         ]
-        assert all(c in expected_calls for c in route_url.call_args_list)
-        assert all(c in route_url.call_args_list for c in expected_calls)
+        _assert_same_calls(route_url.call_args_list, expected_calls)
 
         _assert_has_cors_headers(db_request.response.headers)
         assert db_request.response.headers["X-PyPI-Last-Serial"] == str(je.id)
@@ -658,8 +667,7 @@ class TestJSONRelease:
                 "packaging.release", name=project.name, version=release.version
             ),
         ]
-        assert all(c in expected_calls for c in route_url.call_args_list)
-        assert all(c in route_url.call_args_list for c in expected_calls)
+        _assert_same_calls(route_url.call_args_list, expected_calls)
 
         _assert_has_cors_headers(db_request.response.headers)
         assert db_request.response.headers["X-PyPI-Last-Serial"] == str(je.id)

--- a/tests/unit/legacy/api/test_json.py
+++ b/tests/unit/legacy/api/test_json.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-import pretend
 import pytest
 
 from pyramid.httpexceptions import HTTPMovedPermanently, HTTPNotFound
@@ -123,13 +122,16 @@ class TestLatestReleaseFactory:
 
 
 class TestJSONProject:
-    def test_normalizing_redirects(self, db_request):
+    def test_normalizing_redirects(self, db_request, mocker):
         project = ProjectFactory.create()
         release = ReleaseFactory.create(project=project, version="1.0")
 
         db_request.matchdict = {"name": project.name.swapcase()}
-        db_request.current_route_path = pretend.call_recorder(
-            lambda name: "/project/the-redirect/"
+        current_route_path = mocker.patch.object(
+            db_request,
+            "current_route_path",
+            autospec=True,
+            return_value="/project/the-redirect/",
         )
 
         resp = json.json_project(release, db_request)
@@ -137,11 +139,9 @@ class TestJSONProject:
         assert isinstance(resp, HTTPMovedPermanently)
         assert resp.headers["Location"] == "/project/the-redirect/"
         _assert_has_cors_headers(resp.headers)
-        assert db_request.current_route_path.calls == [
-            pretend.call(name=project.normalized_name)
-        ]
+        current_route_path.assert_called_once_with(name=project.normalized_name)
 
-    def test_renders(self, pyramid_config, db_request, db_session):
+    def test_renders(self, pyramid_config, db_request, db_session, mocker):
         project = ProjectFactory.create(has_docs=True)
         description_content_type = "text/x-rst"
         url = "/the/fake/url/"
@@ -202,21 +202,25 @@ class TestJSONProject:
         JournalEntryFactory.reset_sequence()
         je = JournalEntryFactory.create(name=project.name, submitted_by=user)
 
-        db_request.route_url = pretend.call_recorder(lambda *args, **kw: url)
+        route_url = mocker.patch.object(
+            db_request, "route_url", autospec=True, return_value=url
+        )
         db_request.matchdict = {"name": project.normalized_name}
 
         result = json.json_project(releases[-1], db_request)
 
-        assert set(db_request.route_url.calls) == {
-            pretend.call("packaging.file", path=files[0].path),
-            pretend.call("packaging.file", path=files[1].path),
-            pretend.call("packaging.file", path=files[2].path),
-            pretend.call("packaging.project", name=project.name),
-            pretend.call(
+        expected_calls = [
+            mocker.call("packaging.file", path=files[0].path),
+            mocker.call("packaging.file", path=files[1].path),
+            mocker.call("packaging.file", path=files[2].path),
+            mocker.call("packaging.project", name=project.name),
+            mocker.call(
                 "packaging.release", name=project.name, version=releases[3].version
             ),
-            pretend.call("legacy.docs", project=project.name),
-        }
+            mocker.call("legacy.docs", project=project.name),
+        ]
+        assert all(c in expected_calls for c in route_url.call_args_list)
+        assert all(c in route_url.call_args_list for c in expected_calls)
 
         _assert_has_cors_headers(db_request.response.headers)
         assert db_request.response.headers["X-PyPI-Last-Serial"] == str(je.id)
@@ -369,13 +373,16 @@ class TestJSONProject:
 
 
 class TestJSONProjectSlash:
-    def test_normalizing_redirects(self, db_request):
+    def test_normalizing_redirects(self, db_request, mocker):
         project = ProjectFactory.create()
         release = ReleaseFactory.create(project=project, version="1.0")
 
         db_request.matchdict = {"name": project.name.swapcase()}
-        db_request.current_route_path = pretend.call_recorder(
-            lambda name: "/project/the-redirect/"
+        current_route_path = mocker.patch.object(
+            db_request,
+            "current_route_path",
+            autospec=True,
+            return_value="/project/the-redirect/",
         )
 
         resp = json.json_project_slash(release, db_request)
@@ -383,9 +390,7 @@ class TestJSONProjectSlash:
         assert isinstance(resp, HTTPMovedPermanently)
         assert resp.headers["Location"] == "/project/the-redirect/"
         _assert_has_cors_headers(resp.headers)
-        assert db_request.current_route_path.calls == [
-            pretend.call(name=project.normalized_name)
-        ]
+        current_route_path.assert_called_once_with(name=project.normalized_name)
 
 
 class TestReleaseFactory:
@@ -447,15 +452,18 @@ class TestReleaseFactory:
 
 
 class TestJSONRelease:
-    def test_normalizing_redirects(self, db_request):
+    def test_normalizing_redirects(self, db_request, mocker):
         release = ReleaseFactory.create(version="3.0")
 
         db_request.matchdict = {
             "name": release.project.name.swapcase(),
             "version": "3.0",
         }
-        db_request.current_route_path = pretend.call_recorder(
-            lambda name: "/project/the-redirect/3.0/"
+        current_route_path = mocker.patch.object(
+            db_request,
+            "current_route_path",
+            autospec=True,
+            return_value="/project/the-redirect/3.0/",
         )
 
         resp = json.json_release(release, db_request)
@@ -463,11 +471,9 @@ class TestJSONRelease:
         assert isinstance(resp, HTTPMovedPermanently)
         assert resp.headers["Location"] == "/project/the-redirect/3.0/"
         _assert_has_cors_headers(resp.headers)
-        assert db_request.current_route_path.calls == [
-            pretend.call(name=release.project.normalized_name)
-        ]
+        current_route_path.assert_called_once_with(name=release.project.normalized_name)
 
-    def test_detail_renders(self, pyramid_config, db_request, db_session):
+    def test_detail_renders(self, pyramid_config, db_request, db_session, mocker):
         project = ProjectFactory.create(has_docs=True)
         description_content_type = "text/x-rst"
         url = "/the/fake/url/"
@@ -531,7 +537,9 @@ class TestJSONRelease:
         JournalEntryFactory.reset_sequence()
         je = JournalEntryFactory.create(name=project.name, submitted_by=user)
 
-        db_request.route_url = pretend.call_recorder(lambda *args, **kw: url)
+        route_url = mocker.patch.object(
+            db_request, "route_url", autospec=True, return_value=url
+        )
         db_request.matchdict = {
             "name": project.normalized_name,
             "version": "3.0",
@@ -539,14 +547,16 @@ class TestJSONRelease:
 
         result = json.json_release(releases[-1], db_request)
 
-        assert set(db_request.route_url.calls) == {
-            pretend.call("packaging.file", path=files[-1].path),
-            pretend.call("packaging.project", name=project.name),
-            pretend.call(
+        expected_calls = [
+            mocker.call("packaging.file", path=files[-1].path),
+            mocker.call("packaging.project", name=project.name),
+            mocker.call(
                 "packaging.release", name=project.name, version=releases[-1].version
             ),
-            pretend.call("legacy.docs", project=project.name),
-        }
+            mocker.call("legacy.docs", project=project.name),
+        ]
+        assert all(c in expected_calls for c in route_url.call_args_list)
+        assert all(c in route_url.call_args_list for c in expected_calls)
 
         _assert_has_cors_headers(db_request.response.headers)
         assert db_request.response.headers["X-PyPI-Last-Serial"] == str(je.id)
@@ -616,7 +626,7 @@ class TestJSONRelease:
             },
         }
 
-    def test_minimal_renders(self, pyramid_config, db_request):
+    def test_minimal_renders(self, pyramid_config, db_request, mocker):
         project = ProjectFactory.create(has_docs=False)
         release = ReleaseFactory.create(project=project, version="0.1")
         file = FileFactory.create(
@@ -631,7 +641,9 @@ class TestJSONRelease:
         je = JournalEntryFactory.create(name=project.name, submitted_by=user)
 
         url = "/the/fake/url/"
-        db_request.route_url = pretend.call_recorder(lambda *args, **kw: url)
+        route_url = mocker.patch.object(
+            db_request, "route_url", autospec=True, return_value=url
+        )
         db_request.matchdict = {
             "name": project.normalized_name,
             "version": release.canonical_version,
@@ -639,13 +651,15 @@ class TestJSONRelease:
 
         result = json.json_release(release, db_request)
 
-        assert set(db_request.route_url.calls) == {
-            pretend.call("packaging.file", path=file.path),
-            pretend.call("packaging.project", name=project.name),
-            pretend.call(
+        expected_calls = [
+            mocker.call("packaging.file", path=file.path),
+            mocker.call("packaging.project", name=project.name),
+            mocker.call(
                 "packaging.release", name=project.name, version=release.version
             ),
-        }
+        ]
+        assert all(c in expected_calls for c in route_url.call_args_list)
+        assert all(c in route_url.call_args_list for c in expected_calls)
 
         _assert_has_cors_headers(db_request.response.headers)
         assert db_request.response.headers["X-PyPI-Last-Serial"] == str(je.id)
@@ -716,7 +730,9 @@ class TestJSONRelease:
         }
 
     @pytest.mark.parametrize("withdrawn", [None, "2022-06-28T16:39:06Z"])
-    def test_vulnerabilities_renders(self, pyramid_config, db_request, withdrawn):
+    def test_vulnerabilities_renders(
+        self, pyramid_config, db_request, withdrawn, mocker
+    ):
         project = ProjectFactory.create(has_docs=False)
         release = ReleaseFactory.create(project=project, version="0.1")
         VulnerabilityRecordFactory.create(
@@ -732,7 +748,7 @@ class TestJSONRelease:
         )
 
         url = "/the/fake/url/"
-        db_request.route_url = pretend.call_recorder(lambda *args, **kw: url)
+        mocker.patch.object(db_request, "route_url", autospec=True, return_value=url)
         db_request.matchdict = {
             "name": project.normalized_name,
             "version": release.canonical_version,
@@ -754,7 +770,7 @@ class TestJSONRelease:
         ]
         assert result["ownership"] == {"roles": [], "organization": None}
 
-    def test_ownership_with_organization(self, pyramid_config, db_request):
+    def test_ownership_with_organization(self, pyramid_config, db_request, mocker):
         release = ReleaseFactory.create()
         project = release.project
 
@@ -783,7 +799,9 @@ class TestJSONRelease:
             project=project,
         )
 
-        db_request.route_url = pretend.call_recorder(lambda *args, **kw: "/url/")
+        mocker.patch.object(
+            db_request, "route_url", autospec=True, return_value="/url/"
+        )
         db_request.matchdict = {
             "name": project.normalized_name,
             "version": release.canonical_version,
@@ -803,15 +821,18 @@ class TestJSONRelease:
 
 
 class TestJSONReleaseSlash:
-    def test_normalizing_redirects(self, db_request):
+    def test_normalizing_redirects(self, db_request, mocker):
         release = ReleaseFactory.create(version="3.0")
 
         db_request.matchdict = {
             "name": release.project.name.swapcase(),
             "version": "3.0",
         }
-        db_request.current_route_path = pretend.call_recorder(
-            lambda name: "/project/the-redirect/3.0/"
+        current_route_path = mocker.patch.object(
+            db_request,
+            "current_route_path",
+            autospec=True,
+            return_value="/project/the-redirect/3.0/",
         )
 
         resp = json.json_release_slash(release, db_request)
@@ -819,6 +840,4 @@ class TestJSONReleaseSlash:
         assert isinstance(resp, HTTPMovedPermanently)
         assert resp.headers["Location"] == "/project/the-redirect/3.0/"
         _assert_has_cors_headers(resp.headers)
-        assert db_request.current_route_path.calls == [
-            pretend.call(name=release.project.normalized_name)
-        ]
+        current_route_path.assert_called_once_with(name=release.project.normalized_name)

--- a/tests/unit/legacy/api/test_pypi.py
+++ b/tests/unit/legacy/api/test_pypi.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-import pretend
 import pytest
 
 from pyramid.httpexceptions import HTTPBadRequest, HTTPMovedPermanently, HTTPNotFound
@@ -29,14 +28,13 @@ def test_exc_with_message():
         ),
     ],
 )
-def test_forklifted(settings, expected_domain):
-    request = pretend.stub(
-        domain="example.com", registry=pretend.stub(settings=settings)
-    )
+def test_forklifted(settings, expected_domain, pyramid_request):
+    pyramid_request.domain = "example.com"
+    pyramid_request.registry.settings.update(settings)
 
     information_url = "TODO"
 
-    resp = pypi.forklifted(request)
+    resp = pypi.forklifted(pyramid_request)
 
     assert resp.status_code == 410
     assert resp.status == (
@@ -52,9 +50,9 @@ def test_doap(pyramid_request):
     assert resp.status == "410 DOAP is no longer supported."
 
 
-def test_forbidden_legacy():
-    exc, request = pretend.stub(), pretend.stub()
-    resp = pypi.forbidden_legacy(exc, request)
+def test_forbidden_legacy(mocker):
+    exc = mocker.sentinel.exc
+    resp = pypi.forbidden_legacy(exc, mocker.sentinel.request)
     assert resp is exc
 
 
@@ -65,42 +63,44 @@ def test_list_classifiers(db_request):
     assert resp.text == "\n".join(sorted_classifiers)
 
 
-def test_search():
-    term = pretend.stub()
-    request = pretend.stub(
-        params={"term": term},
-        route_path=pretend.call_recorder(lambda *a, **kw: "/the/path"),
+def test_search(pyramid_request, mocker):
+    term = mocker.sentinel.term
+    pyramid_request.params = {"term": term}
+    route_path = mocker.patch.object(
+        pyramid_request, "route_path", autospec=True, return_value="/the/path"
     )
 
-    result = pypi.search(request)
+    result = pypi.search(pyramid_request)
 
     assert isinstance(result, HTTPMovedPermanently)
     assert result.headers["Location"] == "/the/path"
     assert result.status_code == 301
-    assert request.route_path.calls == [pretend.call("search", _query={"q": term})]
+    route_path.assert_called_once_with("search", _query={"q": term})
 
 
 class TestBrowse:
-    def test_browse(self, db_request):
+    def test_browse(self, db_request, mocker):
         classifier = ClassifierFactory.create(classifier="foo :: bar")
 
         db_request.params = {"c": str(classifier.id)}
-        db_request.route_path = pretend.call_recorder(lambda *a, **kw: "/the/path")
+        route_path = mocker.patch.object(
+            db_request, "route_path", autospec=True, return_value="/the/path"
+        )
 
         result = pypi.browse(db_request)
 
         assert isinstance(result, HTTPMovedPermanently)
         assert result.headers["Location"] == "/the/path"
         assert result.status_code == 301
-        assert db_request.route_path.calls == [
-            pretend.call("search", _query={"c": classifier.classifier})
-        ]
+        route_path.assert_called_once_with(
+            "search", _query={"c": classifier.classifier}
+        )
 
-    def test_browse_no_id(self):
-        request = pretend.stub(params={})
+    def test_browse_no_id(self, pyramid_request):
+        pyramid_request.params = {}
 
         with pytest.raises(HTTPNotFound):
-            pypi.browse(request)
+            pypi.browse(pyramid_request)
 
     def test_browse_bad_id(self, db_request):
         db_request.params = {"c": "99999"}
@@ -108,21 +108,24 @@ class TestBrowse:
         with pytest.raises(HTTPNotFound):
             pypi.browse(db_request)
 
-    def test_brows_invalid_id(self, request):
-        request = pretend.stub(params={"c": '7"'})
+    def test_brows_invalid_id(self, pyramid_request):
+        pyramid_request.params = {"c": '7"'}
 
         with pytest.raises(HTTPNotFound):
-            pypi.browse(request)
+            pypi.browse(pyramid_request)
 
 
 class TestFiles:
-    def test_files(self, db_request):
+    def test_files(self, db_request, mocker):
         name = "pip"
         version = "10.0.0"
 
         db_request.params = {"name": name, "version": version}
-        db_request.route_path = pretend.call_recorder(
-            lambda *a, **kw: f"/project/{name}/{version}/#files"
+        route_path = mocker.patch.object(
+            db_request,
+            "route_path",
+            autospec=True,
+            return_value=f"/project/{name}/{version}/#files",
         )
 
         result = pypi.files(db_request)
@@ -130,11 +133,9 @@ class TestFiles:
         assert isinstance(result, HTTPMovedPermanently)
         assert result.headers["Location"] == (f"/project/{name}/{version}/#files")
         assert result.status_code == 301
-        assert db_request.route_path.calls == [
-            pretend.call(
-                "packaging.release", name=name, version=version, _anchor="files"
-            )
-        ]
+        route_path.assert_called_once_with(
+            "packaging.release", name=name, version=version, _anchor="files"
+        )
 
     def test_files_no_version(self, db_request):
         name = "pip"
@@ -154,13 +155,16 @@ class TestFiles:
 
 
 class TestDisplay:
-    def test_display(self, db_request):
+    def test_display(self, db_request, mocker):
         name = "pip"
         version = "10.0.0"
 
         db_request.params = {"name": name, "version": version}
-        db_request.route_path = pretend.call_recorder(
-            lambda *a, **kw: f"/project/{name}/{version}/"
+        route_path = mocker.patch.object(
+            db_request,
+            "route_path",
+            autospec=True,
+            return_value=f"/project/{name}/{version}/",
         )
 
         result = pypi.display(db_request)
@@ -168,17 +172,17 @@ class TestDisplay:
         assert isinstance(result, HTTPMovedPermanently)
         assert result.headers["Location"] == (f"/project/{name}/{version}/")
         assert result.status_code == 301
-        assert db_request.route_path.calls == [
-            pretend.call("packaging.release", name=name, version=version)
-        ]
+        route_path.assert_called_once_with(
+            "packaging.release", name=name, version=version
+        )
 
-    def test_display_no_version(self, db_request):
+    def test_display_no_version(self, db_request, mocker):
         name = "pip"
 
         db_request.params = {"name": name}
 
-        db_request.route_path = pretend.call_recorder(
-            lambda *a, **kw: f"/project/{name}/"
+        route_path = mocker.patch.object(
+            db_request, "route_path", autospec=True, return_value=f"/project/{name}/"
         )
 
         result = pypi.display(db_request)
@@ -186,9 +190,7 @@ class TestDisplay:
         assert isinstance(result, HTTPMovedPermanently)
         assert result.headers["Location"] == (f"/project/{name}/")
         assert result.status_code == 301
-        assert db_request.route_path.calls == [
-            pretend.call("packaging.project", name=name)
-        ]
+        route_path.assert_called_once_with("packaging.project", name=name)
 
     def test_display_no_name(self, db_request):
         version = "10.0.0"

--- a/tests/unit/legacy/api/xmlrpc/test_cache.py
+++ b/tests/unit/legacy/api/xmlrpc/test_cache.py
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import types
+
 import celery
-import pretend
 import pytest
 import redis
 
@@ -25,9 +26,8 @@ def func_test(arg0, arg1, kwarg0=0, kwarg1=1):
 
 
 class TestXMLRPCCache:
-    def test_null_cache(self):
-        purger = pretend.call_recorder(lambda tags: None)
-        service = NullXMLRPCCache("null://", purger)
+    def test_null_cache(self, mocker):
+        service = NullXMLRPCCache("null://", mocker.stub(name="purger"))
 
         assert service.fetch(
             func_test, (1, 2), {"kwarg0": 3, "kwarg1": 4}, None, None, None
@@ -37,38 +37,30 @@ class TestXMLRPCCache:
 
 
 class TestRedisXMLRPCCache:
-    def test_redis_cache(self, monkeypatch):
-        strict_redis_obj = pretend.stub()
-        strict_redis_cls = pretend.stub(
-            from_url=pretend.call_recorder(lambda url, db=None: strict_redis_obj)
-        )
-        monkeypatch.setattr(redis, "StrictRedis", strict_redis_cls)
+    def test_redis_cache(self, mocker):
+        strict_redis = mocker.patch.object(redis, "StrictRedis", autospec=True)
+        strict_redis.from_url.return_value = mocker.sentinel.strict_redis_obj
 
-        redis_lru_obj = pretend.stub(
-            fetch=pretend.call_recorder(
-                lambda func, args, kwargs, key, tag, expires: func(*args, **kwargs)
-            ),
-            purge=pretend.call_recorder(lambda tag: None),
+        redis_lru_cls = mocker.patch.object(
+            warehouse.legacy.api.xmlrpc.cache, "RedisLru", autospec=True
         )
-        redis_lru_cls = pretend.call_recorder(
-            lambda redis_conn, **kwargs: redis_lru_obj
+        redis_lru_obj = redis_lru_cls.return_value
+
+        def fetch_side_effect(func, args, kwargs, key, tag, expires):
+            return func(*args, **kwargs)
+
+        redis_lru_obj.fetch.side_effect = fetch_side_effect
+        redis_lru_obj.purge.return_value = None
+
+        service = RedisXMLRPCCache("redis://localhost:6379", mocker.stub(name="purger"))
+
+        strict_redis.from_url.assert_called_once_with("redis://localhost:6379", db=0)
+        redis_lru_cls.assert_called_once_with(
+            mocker.sentinel.strict_redis_obj,
+            name="lru",
+            expires=None,
+            metric_reporter=None,
         )
-        monkeypatch.setattr(
-            warehouse.legacy.api.xmlrpc.cache, "RedisLru", redis_lru_cls
-        )
-
-        purger = pretend.call_recorder(lambda tags: None)
-
-        service = RedisXMLRPCCache("redis://localhost:6379", purger)
-
-        assert strict_redis_cls.from_url.calls == [
-            pretend.call("redis://localhost:6379", db=0)
-        ]
-        assert redis_lru_cls.calls == [
-            pretend.call(
-                strict_redis_obj, name="lru", expires=None, metric_reporter=None
-            )
-        ]
 
         assert service.fetch(
             func_test, (1, 2), {"kwarg0": 3, "kwarg1": 4}, None, None, None
@@ -76,12 +68,10 @@ class TestRedisXMLRPCCache:
 
         assert service.purge(None) is None
 
-        assert redis_lru_obj.fetch.calls == [
-            pretend.call(
-                func_test, (1, 2), {"kwarg0": 3, "kwarg1": 4}, None, None, None
-            )
-        ]
-        assert redis_lru_obj.purge.calls == [pretend.call(None)]
+        redis_lru_obj.fetch.assert_called_once_with(
+            func_test, (1, 2), {"kwarg0": 3, "kwarg1": 4}, None, None, None
+        )
+        redis_lru_obj.purge.assert_called_once_with(None)
 
 
 class TestIncludeMe:
@@ -93,107 +83,88 @@ class TestIncludeMe:
             ("null://", "NullXMLRPCCache"),
         ],
     )
-    def test_configuration(self, url, cache_class, monkeypatch):
-        client_obj = pretend.stub()
-        client_cls = pretend.stub(
-            create_service=pretend.call_recorder(lambda *a, **kw: client_obj)
-        )
-        monkeypatch.setattr(cache, cache_class, client_cls)
+    def test_configuration(self, url, cache_class, mocker):
+        mocker.patch.object(cache, cache_class, autospec=True)
 
-        registry = {}
-        config = pretend.stub(
-            add_view_deriver=pretend.call_recorder(
-                lambda deriver, over=None, under=None: None
-            ),
-            register_service_factory=pretend.call_recorder(
-                lambda service, iface=None: None
-            ),
-            registry=pretend.stub(
-                settings={"warehouse.xmlrpc.cache.url": url},
-                __setitem__=registry.__setitem__,
+        config = types.SimpleNamespace(
+            add_view_deriver=mocker.stub(name="add_view_deriver"),
+            register_service_factory=mocker.stub(name="register_service_factory"),
+            registry=types.SimpleNamespace(
+                settings={"warehouse.xmlrpc.cache.url": url}
             ),
         )
 
         cache.includeme(config)
 
-        assert config.add_view_deriver.calls == [
-            pretend.call(
-                cache.cached_return_view, under="rendered_view", over="mapped_view"
-            )
-        ]
-
-    def test_no_url_configuration(self, monkeypatch):
-        registry = {}
-        config = pretend.stub(
-            registry=pretend.stub(settings={}, __setitem__=registry.__setitem__)
+        config.add_view_deriver.assert_called_once_with(
+            cache.cached_return_view, under="rendered_view", over="mapped_view"
         )
+
+    def test_no_url_configuration(self):
+        config = types.SimpleNamespace(registry=types.SimpleNamespace(settings={}))
 
         with pytest.raises(ConfigurationError):
             cache.includeme(config)
 
-    def test_bad_url_configuration(self, monkeypatch):
-        registry = {}
-        config = pretend.stub(
-            registry=pretend.stub(
-                settings={"warehouse.xmlrpc.cache.url": "memcached://"},
-                __setitem__=registry.__setitem__,
+    def test_bad_url_configuration(self):
+        config = types.SimpleNamespace(
+            registry=types.SimpleNamespace(
+                settings={"warehouse.xmlrpc.cache.url": "memcached://"}
             )
         )
 
         with pytest.raises(ConfigurationError):
             cache.includeme(config)
 
-    def test_bad_expires_configuration(self, monkeypatch):
-        client_obj = pretend.stub()
-        client_cls = pretend.call_recorder(lambda *a, **kw: client_obj)
-        monkeypatch.setattr(cache, "NullXMLRPCCache", client_cls)
-
-        registry = {}
-        config = pretend.stub(
-            registry=pretend.stub(
+    def test_bad_expires_configuration(self):
+        config = types.SimpleNamespace(
+            registry=types.SimpleNamespace(
                 settings={
                     "warehouse.xmlrpc.cache.url": "null://",
                     "warehouse.xmlrpc.cache.expires": "Never",
-                },
-                __setitem__=registry.__setitem__,
+                }
             )
         )
 
         with pytest.raises(ConfigurationError):
             cache.includeme(config)
 
-    def test_create_null_service(self):
-        purge_tags = pretend.stub(delay=pretend.call_recorder(lambda tag: None))
-        request = pretend.stub(
-            registry=pretend.stub(settings={"warehouse.xmlrpc.cache.url": "null://"}),
-            task=lambda f: purge_tags,
+    def test_create_null_service(self, pyramid_request, mocker):
+        pyramid_request.registry.settings.update(
+            {"warehouse.xmlrpc.cache.url": "null://"}
         )
-        service = NullXMLRPCCache.create_service(None, request)
+        delay = mocker.stub(name="delay")
+        pyramid_request.task = mocker.Mock(return_value=mocker.Mock(delay=delay))
+
+        service = NullXMLRPCCache.create_service(None, pyramid_request)
         service.purge_tags(["wu", "tang", "4", "evah"])
+
         assert isinstance(service, NullXMLRPCCache)
-        assert service._purger is purge_tags.delay
-        assert purge_tags.delay.calls == [
-            pretend.call("wu"),
-            pretend.call("tang"),
-            pretend.call("4"),
-            pretend.call("evah"),
+        assert service._purger is delay
+        assert delay.call_args_list == [
+            mocker.call("wu"),
+            mocker.call("tang"),
+            mocker.call("4"),
+            mocker.call("evah"),
         ]
 
-    def test_create_redis_service(self):
-        purge_tags = pretend.stub(delay=pretend.call_recorder(lambda tag: None))
-        request = pretend.stub(
-            registry=pretend.stub(settings={"warehouse.xmlrpc.cache.url": "redis://"}),
-            task=lambda f: purge_tags,
+    def test_create_redis_service(self, pyramid_request, mocker):
+        pyramid_request.registry.settings.update(
+            {"warehouse.xmlrpc.cache.url": "redis://"}
         )
-        service = RedisXMLRPCCache.create_service(None, request)
+        delay = mocker.stub(name="delay")
+        pyramid_request.task = mocker.Mock(return_value=mocker.Mock(delay=delay))
+
+        service = RedisXMLRPCCache.create_service(None, pyramid_request)
         service.purge_tags(["wu", "tang", "4", "evah"])
+
         assert isinstance(service, RedisXMLRPCCache)
-        assert service._purger is purge_tags.delay
-        assert purge_tags.delay.calls == [
-            pretend.call("wu"),
-            pretend.call("tang"),
-            pretend.call("4"),
-            pretend.call("evah"),
+        assert service._purger is delay
+        assert delay.call_args_list == [
+            mocker.call("wu"),
+            mocker.call("tang"),
+            mocker.call("4"),
+            mocker.call("evah"),
         ]
 
 
@@ -210,7 +181,7 @@ class TestRedisLru:
             func_test, [0, 1], {"kwarg0": 2, "kwarg1": 3}, None, None, None
         )
 
-    def test_redis_custom_metrics(self, metrics, mockredis):
+    def test_redis_custom_metrics(self, metrics, mockredis, mocker):
         redis_lru = RedisLru(mockredis, metric_reporter=metrics)
 
         expected = func_test(0, 1, kwarg0=2, kwarg1=3)
@@ -221,12 +192,12 @@ class TestRedisLru:
         assert expected == redis_lru.fetch(
             func_test, [0, 1], {"kwarg0": 2, "kwarg1": 3}, None, None, None
         )
-        assert metrics.increment.calls == [
-            pretend.call("lru.cache.miss"),
-            pretend.call("lru.cache.hit"),
+        assert metrics.increment.call_args_list == [
+            mocker.call("lru.cache.miss"),
+            mocker.call("lru.cache.hit"),
         ]
 
-    def test_redis_purge(self, metrics, mockredis):
+    def test_redis_purge(self, metrics, mockredis, mocker):
         redis_lru = RedisLru(mockredis, metric_reporter=metrics)
 
         expected = func_test(0, 1, kwarg0=2, kwarg1=3)
@@ -244,20 +215,19 @@ class TestRedisLru:
         assert expected == redis_lru.fetch(
             func_test, [0, 1], {"kwarg0": 2, "kwarg1": 3}, None, "test", None
         )
-        assert metrics.increment.calls == [
-            pretend.call("lru.cache.miss"),
-            pretend.call("lru.cache.hit"),
-            pretend.call("lru.cache.purge"),
-            pretend.call("lru.cache.miss"),
-            pretend.call("lru.cache.hit"),
+        assert metrics.increment.call_args_list == [
+            mocker.call("lru.cache.miss"),
+            mocker.call("lru.cache.hit"),
+            mocker.call("lru.cache.purge"),
+            mocker.call("lru.cache.miss"),
+            mocker.call("lru.cache.hit"),
         ]
 
-    def test_redis_down(self, metrics):
-        down_redis = pretend.stub(
-            hget=pretend.raiser(redis.exceptions.RedisError),
-            pipeline=pretend.raiser(redis.exceptions.RedisError),
-            scan_iter=pretend.raiser(redis.exceptions.RedisError),
-        )
+    def test_redis_down(self, metrics, mocker):
+        down_redis = mocker.create_autospec(redis.StrictRedis, instance=True)
+        down_redis.hget.side_effect = redis.exceptions.RedisError
+        down_redis.pipeline.side_effect = redis.exceptions.RedisError
+        down_redis.scan_iter.side_effect = redis.exceptions.RedisError
         redis_lru = RedisLru(down_redis, metric_reporter=metrics)
 
         expected = func_test(0, 1, kwarg0=2, kwarg1=3)
@@ -271,14 +241,14 @@ class TestRedisLru:
         with pytest.raises(CacheError):
             redis_lru.purge("test")
 
-        assert metrics.increment.calls == [
-            pretend.call("lru.cache.error"),  # Failed get
-            pretend.call("lru.cache.miss"),
-            pretend.call("lru.cache.error"),  # Failed add
-            pretend.call("lru.cache.error"),  # Failed get
-            pretend.call("lru.cache.miss"),
-            pretend.call("lru.cache.error"),  # Failed add
-            pretend.call("lru.cache.error"),  # Failed purge
+        assert metrics.increment.call_args_list == [
+            mocker.call("lru.cache.error"),  # Failed get
+            mocker.call("lru.cache.miss"),
+            mocker.call("lru.cache.error"),  # Failed add
+            mocker.call("lru.cache.error"),  # Failed get
+            mocker.call("lru.cache.miss"),
+            mocker.call("lru.cache.error"),  # Failed add
+            mocker.call("lru.cache.error"),  # Failed purge
         ]
 
 
@@ -287,151 +257,122 @@ class TestDeriver:
         ("service_available", "xmlrpc_cache"),
         [(True, True), (True, False), (False, True), (False, False)],
     )
-    def test_deriver(self, service_available, xmlrpc_cache, mockredis):
-        context = pretend.stub()
-        purger = pretend.call_recorder(lambda tags: None)
-        service = RedisXMLRPCCache("redis://127.0.0.2:6379/0", purger)
+    def test_deriver(self, service_available, xmlrpc_cache, mockredis, mocker):
+        service = RedisXMLRPCCache(
+            "redis://127.0.0.2:6379/0", mocker.stub(name="purger")
+        )
         service.redis_conn = mockredis
         service.redis_lru.conn = mockredis
         if service_available:
-            _find_service = pretend.call_recorder(lambda *args, **kwargs: service)
+            find_service = mocker.Mock(return_value=service)
         else:
-            _find_service = pretend.raiser(LookupError)
-        request = pretend.stub(
-            find_service=_find_service, rpc_method="rpc_method", rpc_args=(0, 1)
+            find_service = mocker.Mock(side_effect=LookupError)
+        request = types.SimpleNamespace(
+            find_service=find_service, rpc_method="rpc_method", rpc_args=(0, 1)
         )
         response = {}
+        view = mocker.Mock(return_value=response, __name__="view")
 
-        @pretend.call_recorder
-        def view(context, request):
-            return response
-
-        info = pretend.stub(options={}, exception_only=False)
-        info.options["xmlrpc_cache"] = xmlrpc_cache
+        info = types.SimpleNamespace(
+            options={"xmlrpc_cache": xmlrpc_cache}, exception_only=False
+        )
         derived_view = cached_return_view(view, info)
 
-        assert derived_view(context, request) is response
-        assert view.calls == [pretend.call(context, request)]
+        assert derived_view(mocker.sentinel.context, request) is response
+        view.assert_called_once_with(mocker.sentinel.context, request)
 
     @pytest.mark.parametrize(
         ("service_available", "xmlrpc_cache"),
         [(True, True), (True, False), (False, True), (False, False)],
     )
-    def test_custom_tag(self, service_available, xmlrpc_cache):
-        context = pretend.stub()
-        service = pretend.stub(
-            fetch=pretend.call_recorder(
-                lambda func, args, kwargs, key, tag, expires: func(*args, **kwargs)
-            )
-        )
+    def test_custom_tag(self, service_available, xmlrpc_cache, mocker):
+        service = NullXMLRPCCache("null://", mocker.stub(name="purger"))
         if service_available:
-            _find_service = pretend.call_recorder(lambda *args, **kwargs: service)
+            find_service = mocker.Mock(return_value=service)
         else:
-            _find_service = pretend.raiser(LookupError)
-        request = pretend.stub(
-            find_service=_find_service,
+            find_service = mocker.Mock(side_effect=LookupError)
+        request = types.SimpleNamespace(
+            find_service=find_service,
             rpc_method="rpc_method",
             rpc_args=("warehouse", "1.0.0"),
         )
         response = {}
+        view = mocker.Mock(return_value=response)
 
-        @pretend.call_recorder
-        def view(context, request):
-            return response
-
-        info = pretend.stub(options={}, exception_only=False)
-        info.options["xmlrpc_cache"] = xmlrpc_cache
-        info.options["xmlrpc_cache_tag"] = "arg1/%s"
-        info.options["xmlrpc_cache_arg_index"] = 1
+        info = types.SimpleNamespace(
+            options={
+                "xmlrpc_cache": xmlrpc_cache,
+                "xmlrpc_cache_tag": "arg1/%s",
+                "xmlrpc_cache_arg_index": 1,
+            },
+            exception_only=False,
+        )
         derived_view = cached_return_view(view, info)
 
-        assert derived_view(context, request) is response
-        assert view.calls == [pretend.call(context, request)]
+        assert derived_view(mocker.sentinel.context, request) is response
+        view.assert_called_once_with(mocker.sentinel.context, request)
 
     @pytest.mark.parametrize(
         ("service_available", "xmlrpc_cache"),
         [(True, True), (True, False), (False, True), (False, False)],
     )
-    def test_down_redis(self, service_available, xmlrpc_cache):
-        context = pretend.stub()
-        service = pretend.stub(
-            fetch=pretend.raiser(CacheError), purge=pretend.raiser(CacheError)
-        )
+    def test_down_redis(self, service_available, xmlrpc_cache, mocker):
+        service = NullXMLRPCCache("null://", mocker.stub(name="purger"))
+        mocker.patch.object(service, "fetch", side_effect=CacheError)
         if service_available:
-            _find_service = pretend.call_recorder(lambda *args, **kwargs: service)
+            find_service = mocker.Mock(return_value=service)
         else:
-            _find_service = pretend.raiser(LookupError)
-        request = pretend.stub(
-            find_service=_find_service, rpc_method="rpc_method", rpc_args=(0, 1)
+            find_service = mocker.Mock(side_effect=LookupError)
+        request = types.SimpleNamespace(
+            find_service=find_service, rpc_method="rpc_method", rpc_args=(0, 1)
         )
-        response = pretend.stub()
+        response = mocker.sentinel.response
+        view = mocker.Mock(return_value=response)
 
-        @pretend.call_recorder
-        def view(context, request):
-            return response
-
-        info = pretend.stub(options={}, exception_only=False)
-        info.options["xmlrpc_cache"] = xmlrpc_cache
+        info = types.SimpleNamespace(
+            options={"xmlrpc_cache": xmlrpc_cache}, exception_only=False
+        )
         derived_view = cached_return_view(view, info)  # miss
         derived_view = cached_return_view(view, info)  # hit
 
-        assert derived_view(context, request) is response
-        assert view.calls == [pretend.call(context, request)]
+        assert derived_view(mocker.sentinel.context, request) is response
+        view.assert_called_once_with(mocker.sentinel.context, request)
 
 
 class TestPurgeTask:
-    def test_purges_successfully(self, monkeypatch):
-        task = pretend.stub()
-        service = pretend.stub(purge=pretend.call_recorder(lambda k: None))
-        request = pretend.stub(
-            find_service=pretend.call_recorder(lambda iface: service),
-            log=pretend.stub(info=pretend.call_recorder(lambda *args, **kwargs: None)),
-        )
+    def test_purges_successfully(self, pyramid_request, mocker):
+        service = NullXMLRPCCache("null://", mocker.stub(name="purger"))
+        purge = mocker.spy(service, "purge")
+        pyramid_request.find_service = mocker.Mock(return_value=service)
 
-        services.purge_tag(task, request, "foo")
+        services.purge_tag(mocker.sentinel.task, pyramid_request, "foo")
 
-        assert request.find_service.calls == [pretend.call(IXMLRPCCache)]
-        assert service.purge.calls == [pretend.call("foo")]
-        assert request.log.info.calls == [pretend.call("Purging %s", "foo")]
+        pyramid_request.find_service.assert_called_once_with(IXMLRPCCache)
+        purge.assert_called_once_with("foo")
+        pyramid_request.log.info.assert_called_once_with("Purging %s", "foo")
 
     @pytest.mark.parametrize("exception_type", [CacheError])
-    def test_purges_fails(self, monkeypatch, exception_type):
+    def test_purges_fails(self, pyramid_request, mocker, exception_type):
         exc = exception_type()
 
-        class Cache:
-            @staticmethod
-            @pretend.call_recorder
-            def purge(key):
-                raise exc
-
-        class Task:
-            @staticmethod
-            @pretend.call_recorder
-            def retry(exc):
-                raise celery.exceptions.Retry
-
-        task = Task()
-        service = Cache()
-        request = pretend.stub(
-            find_service=pretend.call_recorder(lambda iface: service),
-            log=pretend.stub(
-                info=pretend.call_recorder(lambda *args, **kwargs: None),
-                error=pretend.call_recorder(lambda *args, **kwargs: None),
-            ),
-        )
+        service = NullXMLRPCCache("null://", mocker.stub(name="purger"))
+        purge = mocker.patch.object(service, "purge", side_effect=exc)
+        task = mocker.Mock()
+        task.retry.side_effect = celery.exceptions.Retry
+        pyramid_request.find_service = mocker.Mock(return_value=service)
 
         with pytest.raises(celery.exceptions.Retry):
-            services.purge_tag(task, request, "foo")
+            services.purge_tag(task, pyramid_request, "foo")
 
-        assert request.find_service.calls == [pretend.call(IXMLRPCCache)]
-        assert service.purge.calls == [pretend.call("foo")]
-        assert task.retry.calls == [pretend.call(exc=exc)]
-        assert request.log.info.calls == [pretend.call("Purging %s", "foo")]
-        assert request.log.error.calls == [
-            pretend.call("Error purging %s: %s", "foo", str(exception_type()))
-        ]
+        pyramid_request.find_service.assert_called_once_with(IXMLRPCCache)
+        purge.assert_called_once_with("foo")
+        task.retry.assert_called_once_with(exc=exc)
+        pyramid_request.log.info.assert_called_once_with("Purging %s", "foo")
+        pyramid_request.log.error.assert_called_once_with(
+            "Error purging %s: %s", "foo", str(exception_type())
+        )
 
-    def test_store_purge_keys(self):
+    def test_store_purge_keys(self, mocker):
         class Type1:
             pass
 
@@ -444,7 +385,7 @@ class TestPurgeTask:
         class Type4:
             pass
 
-        config = pretend.stub(
+        config = types.SimpleNamespace(
             registry={
                 "cache_keys": {
                     Type1: lambda o: cache.CacheKeys(cache=[], purge=["type_1"]),
@@ -453,11 +394,11 @@ class TestPurgeTask:
                 }
             }
         )
-        session = pretend.stub(
+        session = types.SimpleNamespace(
             info={}, new={Type1()}, dirty={Type2()}, deleted={Type3(), Type4()}
         )
 
-        cache.store_purge_keys(config, session, pretend.stub())
+        cache.store_purge_keys(config, session, mocker.sentinel.flush_context)
 
         assert session.info["warehouse.legacy.api.xmlrpc.cache.purges"] == {
             "type_1",
@@ -466,12 +407,13 @@ class TestPurgeTask:
             "foo",
         }
 
-    def test_execute_purge(self, app_config):
-        service = pretend.stub(purge_tags=pretend.call_recorder(lambda purges: None))
-        factory = pretend.call_recorder(lambda ctx, config: service)
+    def test_execute_purge(self, app_config, mocker):
+        service = NullXMLRPCCache("null://", mocker.stub(name="purger"))
+        purge_tags = mocker.spy(service, "purge_tags")
+        factory = mocker.Mock(return_value=service)
         app_config.register_service_factory(factory, IXMLRPCCache)
         app_config.commit()
-        session = pretend.stub(
+        session = types.SimpleNamespace(
             info={
                 "warehouse.legacy.api.xmlrpc.cache.purges": {
                     "type_1",
@@ -483,19 +425,14 @@ class TestPurgeTask:
 
         cache.execute_purge(app_config, session)
 
-        assert factory.calls == [pretend.call(None, app_config)]
-        assert service.purge_tags.calls == [
-            pretend.call({"type_1", "type_2", "foobar"})
-        ]
+        factory.assert_called_once_with(None, app_config)
+        purge_tags.assert_called_once_with({"type_1", "type_2", "foobar"})
         assert "warehouse.legacy.api.xmlrpc.cache.purges" not in session.info
 
-    def test_execute_unsuccessful_purge(self):
-        @pretend.call_recorder
-        def find_service_factory(interface):
-            raise LookupError
-
-        config = pretend.stub(find_service_factory=find_service_factory)
-        session = pretend.stub(
+    def test_execute_unsuccessful_purge(self, mocker):
+        find_service_factory = mocker.Mock(side_effect=LookupError)
+        config = types.SimpleNamespace(find_service_factory=find_service_factory)
+        session = types.SimpleNamespace(
             info={
                 "warehouse.legacy.api.xmlrpc.cache.purges": {
                     "type_1",
@@ -507,5 +444,5 @@ class TestPurgeTask:
 
         cache.execute_purge(config, session)
 
-        assert find_service_factory.calls == [pretend.call(IXMLRPCCache)]
+        find_service_factory.assert_called_once_with(IXMLRPCCache)
         assert "warehouse.legacy.api.xmlrpc.cache.purges" not in session.info

--- a/tests/unit/legacy/api/xmlrpc/test_xmlrpc.py
+++ b/tests/unit/legacy/api/xmlrpc/test_xmlrpc.py
@@ -2,7 +2,6 @@
 
 import datetime
 
-import pretend
 import pytest
 
 from pyramid.httpexceptions import HTTPMethodNotAllowed
@@ -10,6 +9,7 @@ from pyramid_rpc.xmlrpc import XmlRpcApplicationError
 
 from warehouse.legacy.api.xmlrpc import views as xmlrpc
 from warehouse.packaging.models import Classifier
+from warehouse.rate_limiting import RateLimiter
 from warehouse.rate_limiting.interfaces import IRateLimiter, WindowStats
 
 from .....common.db.accounts import UserFactory
@@ -22,64 +22,64 @@ from .....common.db.packaging import (
 
 
 class TestRateLimiting:
-    def test_ratelimiting_pass(self, pyramid_services, pyramid_request, metrics):
+    def test_ratelimiting_pass(
+        self, pyramid_services, pyramid_request, metrics, mocker
+    ):
         def view(context, request):
             return None
 
         ratelimited_view = xmlrpc.ratelimit()(view)
-        context = pretend.stub()
         pyramid_request.remote_addr = "127.0.0.1"
         stats = [
             WindowStats(
                 amount=3600, window_seconds=3600, remaining=42, resets_in_seconds=10
             )
         ]
-        fake_rate_limiter = pretend.stub(
-            test=lambda *a: True,
-            hit=lambda *a: True,
-            resets_in=lambda *a: None,
-            get_window_stats=lambda *a: stats,
-        )
+        fake_rate_limiter = mocker.create_autospec(RateLimiter, instance=True)
+        fake_rate_limiter.test.return_value = True
+        fake_rate_limiter.hit.return_value = True
+        fake_rate_limiter.resets_in.return_value = None
+        fake_rate_limiter.get_window_stats.return_value = stats
         pyramid_services.register_service(
             fake_rate_limiter, IRateLimiter, None, name="xmlrpc.client"
         )
-        ratelimited_view(context, pyramid_request)
+        ratelimited_view(mocker.sentinel.context, pyramid_request)
 
-        assert metrics.increment.calls == [
-            pretend.call("warehouse.xmlrpc.ratelimiter.hit", tags=[])
-        ]
+        metrics.increment.assert_called_once_with(
+            "warehouse.xmlrpc.ratelimiter.hit", tags=[]
+        )
         snapshots = pyramid_request._rate_limit_snapshots
         assert [s.name for s in snapshots] == ["xmlrpc.client"]
         assert snapshots[0].partition_key == "ip"
         assert snapshots[0].stats is stats
 
-    def test_ratelimiting_block(self, pyramid_services, pyramid_request, metrics):
+    def test_ratelimiting_block(
+        self, pyramid_services, pyramid_request, metrics, mocker
+    ):
         def view(context, request):
             pytest.fail("view should not be called")
 
         ratelimited_view = xmlrpc.ratelimit()(view)
-        context = pretend.stub()
         pyramid_request.remote_addr = "127.0.0.1"
-        fake_rate_limiter = pretend.stub(
-            test=lambda *a: False,
-            hit=lambda *a: True,
-            resets_in=lambda *a: None,
-            get_window_stats=lambda *a: [],
-        )
+        fake_rate_limiter = mocker.create_autospec(RateLimiter, instance=True)
+        fake_rate_limiter.test.return_value = False
+        fake_rate_limiter.hit.return_value = True
+        fake_rate_limiter.resets_in.return_value = None
+        fake_rate_limiter.get_window_stats.return_value = []
         pyramid_services.register_service(
             fake_rate_limiter, IRateLimiter, None, name="xmlrpc.client"
         )
         with pytest.raises(xmlrpc.XMLRPCWrappedError) as exc:
-            ratelimited_view(context, pyramid_request)
+            ratelimited_view(mocker.sentinel.context, pyramid_request)
 
         assert exc.value.faultString == (
             "HTTPTooManyRequests: The action could not be performed because there "
             "were too many requests by the client."
         )
 
-        assert metrics.increment.calls == [
-            pretend.call("warehouse.xmlrpc.ratelimiter.exceeded", tags=[])
-        ]
+        metrics.increment.assert_called_once_with(
+            "warehouse.xmlrpc.ratelimiter.exceeded", tags=[]
+        )
 
     @pytest.mark.parametrize(
         ("resets_in_delta", "expected"),
@@ -89,25 +89,29 @@ class TestRateLimiting:
         ],
     )
     def test_ratelimiting_block_with_hint(
-        self, pyramid_services, pyramid_request, metrics, resets_in_delta, expected
+        self,
+        pyramid_services,
+        pyramid_request,
+        metrics,
+        mocker,
+        resets_in_delta,
+        expected,
     ):
         def view(context, request):
             pytest.fail("view should not be called")
 
         ratelimited_view = xmlrpc.ratelimit()(view)
-        context = pretend.stub()
         pyramid_request.remote_addr = "127.0.0.1"
-        fake_rate_limiter = pretend.stub(
-            test=lambda *a: False,
-            hit=lambda *a: True,
-            resets_in=lambda *a: resets_in_delta,
-            get_window_stats=lambda *a: [],
-        )
+        fake_rate_limiter = mocker.create_autospec(RateLimiter, instance=True)
+        fake_rate_limiter.test.return_value = False
+        fake_rate_limiter.hit.return_value = True
+        fake_rate_limiter.resets_in.return_value = resets_in_delta
+        fake_rate_limiter.get_window_stats.return_value = []
         pyramid_services.register_service(
             fake_rate_limiter, IRateLimiter, None, name="xmlrpc.client"
         )
         with pytest.raises(xmlrpc.XMLRPCWrappedError) as exc:
-            ratelimited_view(context, pyramid_request)
+            ratelimited_view(mocker.sentinel.context, pyramid_request)
 
         assert exc.value.faultString == (
             "HTTPTooManyRequests: The action could not be performed because there "
@@ -115,9 +119,9 @@ class TestRateLimiting:
             f"{expected} seconds."
         )
 
-        assert metrics.increment.calls == [
-            pretend.call("warehouse.xmlrpc.ratelimiter.exceeded", tags=[])
-        ]
+        metrics.increment.assert_called_once_with(
+            "warehouse.xmlrpc.ratelimiter.exceeded", tags=[]
+        )
 
 
 class TestSearch:
@@ -139,7 +143,7 @@ class TestSearch:
             "https://warehouse.pypa.io/api-reference/xml-rpc.html#deprecated-methods "
             "for more information."
         )
-        assert metrics.increment.calls == []
+        metrics.increment.assert_not_called()
 
 
 def test_list_packages(pyramid_request):

--- a/tests/unit/legacy/test_action_routing.py
+++ b/tests/unit/legacy/test_action_routing.py
@@ -1,35 +1,32 @@
 # SPDX-License-Identifier: Apache-2.0
 
-import pretend
+from pyramid.config import Configurator
 
 from warehouse.legacy import action_routing
 
 
-def test_add_pypi_action_route():
-    config = pretend.stub(add_route=pretend.call_recorder(lambda *a, **k: None))
+def test_add_pypi_action_route(mocker):
+    config = mocker.Mock(spec=Configurator)
 
     action_routing.add_pypi_action_route(config, "the name", "the action")
 
-    assert config.add_route.calls == [
-        pretend.call("the name", "/pypi", pypi_action="the action")
-    ]
-
-
-def test_includeme():
-    config = pretend.stub(
-        add_route_predicate=pretend.call_recorder(lambda name, pred: None),
-        add_directive=pretend.call_recorder(lambda name, f, action_wrap: None),
+    config.add_route.assert_called_once_with(
+        "the name", "/pypi", pypi_action="the action"
     )
+
+
+def test_includeme(mocker):
+    config = mocker.Mock(spec=Configurator)
 
     action_routing.includeme(config)
 
-    assert config.add_directive.calls == [
-        pretend.call(
+    assert config.add_directive.call_args_list == [
+        mocker.call(
             "add_pypi_action_route",
             action_routing.add_pypi_action_route,
             action_wrap=False,
         ),
-        pretend.call(
+        mocker.call(
             "add_pypi_action_redirect",
             action_routing.add_pypi_action_redirect,
             action_wrap=False,

--- a/tests/unit/macaroons/test_caveats.py
+++ b/tests/unit/macaroons/test_caveats.py
@@ -3,11 +3,11 @@
 import dataclasses
 import time
 
-import pretend
 import pytest
 
 from pydantic.dataclasses import dataclass
 from pymacaroons import Macaroon
+from pyramid.testing import DummySecurityPolicy
 
 from warehouse.accounts import _oidc_publisher
 from warehouse.accounts.utils import UserContext
@@ -46,10 +46,14 @@ def test_bools():
     assert bool(Failure("anything")) is False
 
 
-def test_caveat_verify_fails():
+def test_caveat_verify_fails(mocker):
     caveat = Caveat()
     with pytest.raises(NotImplementedError):
-        caveat.verify(pretend.stub(), pretend.stub(), pretend.stub())
+        caveat.verify(
+            mocker.sentinel.request,
+            mocker.sentinel.context,
+            mocker.sentinel.permission,
+        )
 
 
 @pytest.mark.parametrize(
@@ -143,7 +147,7 @@ class TestDeserialization:
     def test_valid_test_valid_deserialization_request_user(
         self, pyramid_request, pyramid_config
     ):
-        pyramid_request.user = pretend.stub(id="a uuid")
+        pyramid_request.user = UserFactory.build(id="a uuid")
         assert deserialize(b'{"version": 1, "permissions": "user"}') == RequestUser(
             user_id="a uuid"
         )
@@ -168,179 +172,216 @@ class TestDeserialization:
 
 
 class TestExpirationCaveat:
-    def test_verify_not_before(self):
+    def test_verify_not_before(self, mocker):
         not_before = int(time.time()) + 60
         expiry = not_before + 60
 
         caveat = Expiration(expires_at=expiry, not_before=not_before)
-        result = caveat.verify(pretend.stub(), pretend.stub(), pretend.stub())
+        result = caveat.verify(
+            mocker.sentinel.request,
+            mocker.sentinel.context,
+            mocker.sentinel.permission,
+        )
 
         assert result == Failure("token is expired")
 
-    def test_verify_already_expired(self):
+    def test_verify_already_expired(self, mocker):
         not_before = int(time.time()) - 10
         expiry = not_before - 5
 
         caveat = Expiration(expires_at=expiry, not_before=not_before)
-        result = caveat.verify(pretend.stub(), pretend.stub(), pretend.stub())
+        result = caveat.verify(
+            mocker.sentinel.request,
+            mocker.sentinel.context,
+            mocker.sentinel.permission,
+        )
 
         assert result == Failure("token is expired")
 
-    def test_verify_ok(self):
+    def test_verify_ok(self, mocker):
         not_before = int(time.time()) - 10
         expiry = int(time.time()) + 60
 
         caveat = Expiration(expires_at=expiry, not_before=not_before)
-        result = caveat.verify(pretend.stub(), pretend.stub(), pretend.stub())
+        result = caveat.verify(
+            mocker.sentinel.request,
+            mocker.sentinel.context,
+            mocker.sentinel.permission,
+        )
 
         assert result == Success()
 
 
 class TestProjectNameCaveat:
-    def test_verify_invalid_context(self):
+    def test_verify_invalid_context(self, mocker):
         caveat = ProjectName(normalized_names=[])
-        result = caveat.verify(pretend.stub(), pretend.stub(), pretend.stub())
+        result = caveat.verify(
+            mocker.sentinel.request,
+            mocker.sentinel.context,
+            mocker.sentinel.permission,
+        )
 
         assert result == Failure(
             "project-scoped token used outside of a project context"
         )
 
-    def test_verify_invalid_project_id(self, db_request):
+    def test_verify_invalid_project_id(self, db_request, mocker):
         project = ProjectFactory.create(name="foobar")
 
         caveat = ProjectName(normalized_names=["not_foobar"])
-        result = caveat.verify(db_request, project, pretend.stub())
+        result = caveat.verify(db_request, project, mocker.sentinel.permission)
 
         assert result == Failure(
             f"project-scoped token is not valid for project: {project.name!r}"
         )
 
-    def test_verify_ok(self, db_request):
+    def test_verify_ok(self, db_request, mocker):
         project = ProjectFactory.create(name="foobar")
 
         caveat = ProjectName(normalized_names=["foobar"])
-        result = caveat.verify(db_request, project, pretend.stub())
+        result = caveat.verify(db_request, project, mocker.sentinel.permission)
 
         assert result == Success()
 
 
 class TestProjectIDsCaveat:
-    def test_verify_invalid_context(self):
+    def test_verify_invalid_context(self, mocker):
         caveat = ProjectID(project_ids=[])
-        result = caveat.verify(pretend.stub(), pretend.stub(), pretend.stub())
+        result = caveat.verify(
+            mocker.sentinel.request,
+            mocker.sentinel.context,
+            mocker.sentinel.permission,
+        )
 
         assert result == Failure(
             "project-scoped token used outside of a project context"
         )
 
-    def test_verify_invalid_project_id(self, db_request):
+    def test_verify_invalid_project_id(self, db_request, mocker):
         project = ProjectFactory.create(name="foobar")
 
         caveat = ProjectID(project_ids=["not-foobars-uuid"])
-        result = caveat.verify(db_request, project, pretend.stub())
+        result = caveat.verify(db_request, project, mocker.sentinel.permission)
 
         assert result == Failure(
             f"project-scoped token is not valid for project: {project.name!r}"
         )
 
-    def test_verify_ok(self, db_request):
+    def test_verify_ok(self, db_request, mocker):
         project = ProjectFactory.create(name="foobar")
 
         caveat = ProjectID(project_ids=[str(project.id)])
-        result = caveat.verify(db_request, project, pretend.stub())
+        result = caveat.verify(db_request, project, mocker.sentinel.permission)
 
         assert result == Success()
 
 
 class TestRequestUserCaveat:
-    def test_verify_no_identity(self):
+    def test_verify_no_identity(self, pyramid_request, mocker):
+        # pyramid_request.identity defaults to None with no policy registered.
         caveat = RequestUser(user_id="invalid")
         result = caveat.verify(
-            pretend.stub(identity=None), pretend.stub(), pretend.stub()
+            pyramid_request, mocker.sentinel.context, mocker.sentinel.permission
         )
 
         assert result == Failure("token with user restriction without a user")
 
-    def test_verify_invalid_identity_no_user(self):
+    def test_verify_invalid_identity_no_user(
+        self, pyramid_request, pyramid_config, mocker
+    ):
+        pyramid_config.set_security_policy(
+            DummySecurityPolicy(identity=mocker.sentinel.identity)
+        )
+
         caveat = RequestUser(user_id="invalid")
         result = caveat.verify(
-            pretend.stub(identity=pretend.stub()), pretend.stub(), pretend.stub()
+            pyramid_request, mocker.sentinel.context, mocker.sentinel.permission
         )
 
         assert result == Failure("token with user restriction without a user")
 
-    def test_verify_invalid_identity_no_macaroon(self, db_request):
+    def test_verify_invalid_identity_no_macaroon(
+        self, db_request, pyramid_config, mocker
+    ):
         user = UserFactory.create()
         user_context = UserContext(user, None)
+        pyramid_config.set_security_policy(DummySecurityPolicy(identity=user_context))
 
         caveat = RequestUser(user_id=str(user.id))
         result = caveat.verify(
-            pretend.stub(identity=user_context), pretend.stub(), pretend.stub()
+            db_request, mocker.sentinel.context, mocker.sentinel.permission
         )
 
         assert result == Failure("token with user restriction without a macaroon")
 
-    def test_verify_invalid_user_id(self, db_request):
+    def test_verify_invalid_user_id(self, db_request, pyramid_config, mocker):
         user = UserFactory.create()
-        user_context = UserContext(user, pretend.stub())
+        user_context = UserContext(user, mocker.sentinel.macaroon)
+        pyramid_config.set_security_policy(DummySecurityPolicy(identity=user_context))
 
         caveat = RequestUser(user_id="invalid")
         result = caveat.verify(
-            pretend.stub(identity=user_context), pretend.stub(), pretend.stub()
+            db_request, mocker.sentinel.context, mocker.sentinel.permission
         )
 
         assert result == Failure(
             "current user does not match user restriction in token"
         )
 
-    def test_verify_ok(self, db_request):
+    def test_verify_ok(self, db_request, pyramid_config, mocker):
         user = UserFactory.create()
-        user_context = UserContext(user, pretend.stub())
+        user_context = UserContext(user, mocker.sentinel.macaroon)
+        pyramid_config.set_security_policy(DummySecurityPolicy(identity=user_context))
 
         caveat = RequestUser(user_id=str(user.id))
         result = caveat.verify(
-            pretend.stub(identity=user_context), pretend.stub(), pretend.stub()
+            db_request, mocker.sentinel.context, mocker.sentinel.permission
         )
 
         assert result == Success()
 
 
 class TestOIDCPublisherCaveat:
-    def test_verify_no_identity(self):
+    def test_verify_no_identity(self, pyramid_request, mocker):
+        # pyramid_request.oidc_publisher defaults to None.
         caveat = OIDCPublisher(oidc_publisher_id="invalid")
         result = caveat.verify(
-            pretend.stub(identity=None, oidc_publisher=None),
-            pretend.stub(),
-            pretend.stub(),
+            pyramid_request,
+            mocker.sentinel.context,
+            mocker.sentinel.permission,
         )
 
         assert result == Failure(
             "OIDC scoped token used outside of an OIDC identified request"
         )
 
-    def test_verify_invalid_publisher_id(self, db_request):
+    def test_verify_invalid_publisher_id(self, db_request, pyramid_config, mocker):
         identity = PublisherTokenContext(GitHubPublisherFactory.create(), None)
-        request = pretend.stub(identity=identity)
-        request.oidc_publisher = _oidc_publisher(request)
+        pyramid_config.set_security_policy(DummySecurityPolicy(identity=identity))
+        db_request.oidc_publisher = _oidc_publisher(db_request)
 
         caveat = OIDCPublisher(oidc_publisher_id="invalid")
-        result = caveat.verify(request, pretend.stub(), pretend.stub())
+        result = caveat.verify(
+            db_request, mocker.sentinel.context, mocker.sentinel.permission
+        )
 
         assert result == Failure(
             "current OIDC publisher does not match publisher restriction in token"
         )
 
-    def test_verify_invalid_context(self, db_request):
+    def test_verify_invalid_context(self, db_request, pyramid_config, mocker):
         identity = PublisherTokenContext(GitHubPublisherFactory.create(), None)
-        request = pretend.stub(identity=identity)
-        request.oidc_publisher = _oidc_publisher(request)
+        pyramid_config.set_security_policy(DummySecurityPolicy(identity=identity))
+        db_request.oidc_publisher = _oidc_publisher(db_request)
 
-        caveat = OIDCPublisher(oidc_publisher_id=str(request.oidc_publisher.id))
-        result = caveat.verify(request, pretend.stub(), pretend.stub())
+        caveat = OIDCPublisher(oidc_publisher_id=str(db_request.oidc_publisher.id))
+        result = caveat.verify(
+            db_request, mocker.sentinel.context, mocker.sentinel.permission
+        )
 
         assert result == Failure("OIDC scoped token used outside of a project context")
 
-    def test_verify_invalid_project(self, db_request):
+    def test_verify_invalid_project(self, db_request, pyramid_config, mocker):
         foobar = ProjectFactory.create(name="foobar")
         foobaz = ProjectFactory.create(name="foobaz")
 
@@ -349,15 +390,15 @@ class TestOIDCPublisherCaveat:
         identity = PublisherTokenContext(
             GitHubPublisherFactory.create(projects=[foobar]), None
         )
-        request = pretend.stub(identity=identity)
-        request.oidc_publisher = _oidc_publisher(request)
-        caveat = OIDCPublisher(oidc_publisher_id=str(request.oidc_publisher.id))
+        pyramid_config.set_security_policy(DummySecurityPolicy(identity=identity))
+        db_request.oidc_publisher = _oidc_publisher(db_request)
+        caveat = OIDCPublisher(oidc_publisher_id=str(db_request.oidc_publisher.id))
 
-        result = caveat.verify(request, foobaz, pretend.stub())
+        result = caveat.verify(db_request, foobaz, mocker.sentinel.permission)
 
         assert result == Failure("OIDC scoped token is not valid for project 'foobaz'")
 
-    def test_verify_ok(self, db_request):
+    def test_verify_ok(self, db_request, pyramid_config, mocker):
         foobar = ProjectFactory.create(name="foobar")
 
         # This OIDC publisher is only registered to "foobar", so it should
@@ -365,11 +406,11 @@ class TestOIDCPublisherCaveat:
         identity = PublisherTokenContext(
             GitHubPublisherFactory.create(projects=[foobar]), None
         )
-        request = pretend.stub(identity=identity)
-        request.oidc_publisher = _oidc_publisher(request)
-        caveat = OIDCPublisher(oidc_publisher_id=str(request.oidc_publisher.id))
+        pyramid_config.set_security_policy(DummySecurityPolicy(identity=identity))
+        db_request.oidc_publisher = _oidc_publisher(db_request)
+        caveat = OIDCPublisher(oidc_publisher_id=str(db_request.oidc_publisher.id))
 
-        result = caveat.verify(request, foobar, pretend.stub())
+        result = caveat.verify(db_request, foobar, mocker.sentinel.permission)
 
         assert result == Success()
 
@@ -383,54 +424,76 @@ class TestCaveatRegistry:
 
 
 class TestVerification:
-    def test_verify_invalid_signature(self):
+    def test_verify_invalid_signature(self, mocker):
         m = Macaroon(location="somewhere", identifier="something", key=b"a secure key")
         status = verify(
-            m, b"a different key", pretend.stub(), pretend.stub(), pretend.stub()
+            m,
+            b"a different key",
+            mocker.sentinel.request,
+            mocker.sentinel.context,
+            mocker.sentinel.permission,
         )
         assert not status
         assert status.msg == "signatures do not match"
 
-    def test_caveat_returns_false(self):
+    def test_caveat_returns_false(self, mocker):
         m = Macaroon(location="somewhere", identifier="something", key=b"a secure key")
         m.add_first_party_caveat(serialize(Expiration(expires_at=10, not_before=0)))
         status = verify(
-            m, b"a secure key", pretend.stub(), pretend.stub(), pretend.stub()
+            m,
+            b"a secure key",
+            mocker.sentinel.request,
+            mocker.sentinel.context,
+            mocker.sentinel.permission,
         )
         assert not status
         assert status.msg == "token is expired"
 
-    def test_caveat_errors_on_deserialize(self):
+    def test_caveat_errors_on_deserialize(self, mocker):
         m = Macaroon(location="somewhere", identifier="something", key=b"a secure key")
         m.add_first_party_caveat(b"[]")
         status = verify(
-            m, b"a secure key", pretend.stub(), pretend.stub(), pretend.stub()
+            m,
+            b"a secure key",
+            mocker.sentinel.request,
+            mocker.sentinel.context,
+            mocker.sentinel.permission,
         )
         assert not status
         assert status.msg == "caveat array cannot be empty"
 
-    def test_valid_caveat(self):
+    def test_valid_caveat(self, mocker):
         now = int(time.time())
         m = Macaroon(location="somewhere", identifier="something", key=b"a secure key")
         m.add_first_party_caveat(
             serialize(Expiration(expires_at=now + 1000, not_before=now - 1000))
         )
         status = verify(
-            m, b"a secure key", pretend.stub(), pretend.stub(), pretend.stub()
+            m,
+            b"a secure key",
+            mocker.sentinel.request,
+            mocker.sentinel.context,
+            mocker.sentinel.permission,
         )
         assert status
         assert status.msg == "signature and caveats OK"
 
-    def test_generic_exception(self, monkeypatch):
-        def _raiser(*args, **kwargs):
-            raise Exception("my generic exception")
-
-        monkeypatch.setattr(caveats, "deserialize", _raiser)
+    def test_generic_exception(self, mocker):
+        mocker.patch.object(
+            caveats,
+            "deserialize",
+            autospec=True,
+            side_effect=Exception("my generic exception"),
+        )
 
         m = Macaroon(location="somewhere", identifier="something", key=b"a secure key")
         m.add_first_party_caveat(serialize(Expiration(expires_at=1, not_before=1)))
         status = verify(
-            m, b"a secure key", pretend.stub(), pretend.stub(), pretend.stub()
+            m,
+            b"a secure key",
+            mocker.sentinel.request,
+            mocker.sentinel.context,
+            mocker.sentinel.permission,
         )
         assert not status
         assert status.msg == "unknown error"

--- a/tests/unit/macaroons/test_security_policy.py
+++ b/tests/unit/macaroons/test_security_policy.py
@@ -1,11 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
-import pretend
+import types
+
 import pytest
 
 from pyramid.authorization import Allow
 from pyramid.interfaces import ISecurityPolicy
 from pyramid.security import Denied
+from pyramid.testing import DummySecurityPolicy
 from zope.interface.verify import verifyClass
 
 from warehouse.accounts.interfaces import IUserService
@@ -16,6 +18,9 @@ from warehouse.macaroons.interfaces import IMacaroonService
 from warehouse.macaroons.services import InvalidMacaroonError
 from warehouse.oidc.interfaces import SignedClaims
 from warehouse.oidc.utils import PublisherTokenContext
+
+from ...common.db.accounts import UserFactory
+from ...common.db.macaroons import MacaroonFactory
 
 
 @pytest.mark.parametrize(
@@ -29,13 +34,11 @@ from warehouse.oidc.utils import PublisherTokenContext
         ("basic X190b2tlbl9fOmZvb2Jhcg==", "foobar"),  # "__token__:foobar"
     ],
 )
-def test_extract_http_macaroon(auth, result, metrics):
-    request = pretend.stub(
-        find_service=pretend.call_recorder(lambda *a, **kw: metrics),
-        headers=pretend.stub(get=pretend.call_recorder(lambda k: auth)),
-    )
+def test_extract_http_macaroon(auth, result, pyramid_request):
+    if auth is not None:
+        pyramid_request.headers["Authorization"] = auth
 
-    assert security_policy._extract_http_macaroon(request) == result
+    assert security_policy._extract_http_macaroon(pyramid_request) == result
 
 
 @pytest.mark.parametrize(
@@ -59,223 +62,203 @@ class TestMacaroonSecurityPolicy:
             security_policy.MacaroonSecurityPolicy,
         )
 
-    def test_noops(self):
+    def test_noops(self, mocker):
         policy = security_policy.MacaroonSecurityPolicy()
         with pytest.raises(NotImplementedError):
-            policy.authenticated_userid(pretend.stub())
+            policy.authenticated_userid(mocker.sentinel.request)
 
-    def test_forget_and_remember(self):
+    def test_forget_and_remember(self, mocker):
         policy = security_policy.MacaroonSecurityPolicy()
 
-        assert policy.forget(pretend.stub()) == []
-        assert policy.remember(pretend.stub(), pretend.stub()) == []
+        assert policy.forget(mocker.sentinel.request) == []
+        assert policy.remember(mocker.sentinel.request, mocker.sentinel.userid) == []
 
-    def test_identity_no_http_macaroon(self, monkeypatch):
+    def test_identity_no_http_macaroon(self, pyramid_request, mocker):
         policy = security_policy.MacaroonSecurityPolicy()
 
-        vary_cb = pretend.stub()
-        add_vary_cb = pretend.call_recorder(lambda *v: vary_cb)
-        monkeypatch.setattr(security_policy, "add_vary_callback", add_vary_cb)
-
-        extract_http_macaroon = pretend.call_recorder(lambda r: None)
-        monkeypatch.setattr(
-            security_policy, "_extract_http_macaroon", extract_http_macaroon
+        add_vary_cb = mocker.spy(security_policy, "add_vary_callback")
+        extract_http_macaroon = mocker.patch.object(
+            security_policy, "_extract_http_macaroon", autospec=True, return_value=None
         )
+        add_response_callback = mocker.spy(pyramid_request, "add_response_callback")
 
-        request = pretend.stub(
-            add_response_callback=pretend.call_recorder(lambda cb: None)
-        )
+        assert policy.identity(pyramid_request) is None
+        extract_http_macaroon.assert_called_once_with(pyramid_request)
 
-        assert policy.identity(request) is None
-        assert extract_http_macaroon.calls == [pretend.call(request)]
+        add_vary_cb.assert_called_once_with("Authorization")
+        add_response_callback.assert_called_once_with(add_vary_cb.spy_return)
 
-        assert add_vary_cb.calls == [pretend.call("Authorization")]
-        assert request.add_response_callback.calls == [pretend.call(vary_cb)]
-
-    def test_identity_no_db_macaroon(self, monkeypatch):
+    def test_identity_no_db_macaroon(self, pyramid_request, macaroon_service, mocker):
         policy = security_policy.MacaroonSecurityPolicy()
 
-        vary_cb = pretend.stub()
-        add_vary_cb = pretend.call_recorder(lambda *v: vary_cb)
-        monkeypatch.setattr(security_policy, "add_vary_callback", add_vary_cb)
+        add_vary_cb = mocker.spy(security_policy, "add_vary_callback")
+        extract_http_macaroon = mocker.patch.object(
+            security_policy,
+            "_extract_http_macaroon",
+            autospec=True,
+            return_value=mocker.sentinel.raw_macaroon,
+        )
+        mocker.patch.object(
+            macaroon_service,
+            "find_from_raw",
+            autospec=True,
+            side_effect=InvalidMacaroonError,
+        )
+        find_service = mocker.spy(pyramid_request, "find_service")
+        add_response_callback = mocker.spy(pyramid_request, "add_response_callback")
 
-        raw_macaroon = pretend.stub()
-        extract_http_macaroon = pretend.call_recorder(lambda r: raw_macaroon)
-        monkeypatch.setattr(
-            security_policy, "_extract_http_macaroon", extract_http_macaroon
+        assert policy.identity(pyramid_request) is None
+        extract_http_macaroon.assert_called_once_with(pyramid_request)
+        find_service.assert_called_once_with(IMacaroonService, context=None)
+        macaroon_service.find_from_raw.assert_called_once_with(
+            mocker.sentinel.raw_macaroon
         )
 
-        macaroon_service = pretend.stub(
-            find_from_raw=pretend.call_recorder(pretend.raiser(InvalidMacaroonError)),
+        add_vary_cb.assert_called_once_with("Authorization")
+        add_response_callback.assert_called_once_with(add_vary_cb.spy_return)
+
+    def test_identity_disabled_user(
+        self, pyramid_request, macaroon_service, user_service, mocker
+    ):
+        policy = security_policy.MacaroonSecurityPolicy()
+
+        add_vary_cb = mocker.spy(security_policy, "add_vary_callback")
+        extract_http_macaroon = mocker.patch.object(
+            security_policy,
+            "_extract_http_macaroon",
+            autospec=True,
+            return_value=mocker.sentinel.raw_macaroon,
         )
 
-        request = pretend.stub(
-            add_response_callback=pretend.call_recorder(lambda cb: None),
-            find_service=pretend.call_recorder(lambda iface, **kw: macaroon_service),
+        user = UserFactory.build(id="deadbeef-dead-beef-deadbeef-dead")
+        macaroon = MacaroonFactory.build(user=user, oidc_publisher=None)
+        mocker.patch.object(
+            macaroon_service, "find_from_raw", autospec=True, return_value=macaroon
+        )
+        mocker.patch.object(
+            user_service, "is_disabled", autospec=True, return_value=(True, Exception)
         )
 
-        assert policy.identity(request) is None
-        assert extract_http_macaroon.calls == [pretend.call(request)]
-        assert request.find_service.calls == [
-            pretend.call(IMacaroonService, context=None),
+        find_service = mocker.spy(pyramid_request, "find_service")
+        add_response_callback = mocker.spy(pyramid_request, "add_response_callback")
+
+        assert policy.identity(pyramid_request) is None
+        extract_http_macaroon.assert_called_once_with(pyramid_request)
+        assert find_service.call_args_list == [
+            mocker.call(IMacaroonService, context=None),
+            mocker.call(IUserService, context=None),
         ]
-        assert macaroon_service.find_from_raw.calls == [pretend.call(raw_macaroon)]
+        macaroon_service.find_from_raw.assert_called_once_with(
+            mocker.sentinel.raw_macaroon
+        )
+        user_service.is_disabled.assert_called_once_with(
+            "deadbeef-dead-beef-deadbeef-dead"
+        )
 
-        assert add_vary_cb.calls == [pretend.call("Authorization")]
-        assert request.add_response_callback.calls == [pretend.call(vary_cb)]
+        add_vary_cb.assert_called_once_with("Authorization")
+        add_response_callback.assert_called_once_with(add_vary_cb.spy_return)
 
-    def test_identity_disabled_user(self, monkeypatch):
+    def test_identity_user(
+        self, pyramid_request, macaroon_service, user_service, mocker
+    ):
         policy = security_policy.MacaroonSecurityPolicy()
 
-        vary_cb = pretend.stub()
-        add_vary_cb = pretend.call_recorder(lambda *v: vary_cb)
-        monkeypatch.setattr(security_policy, "add_vary_callback", add_vary_cb)
-
-        raw_macaroon = pretend.stub()
-        extract_http_macaroon = pretend.call_recorder(lambda r: raw_macaroon)
-        monkeypatch.setattr(
-            security_policy, "_extract_http_macaroon", extract_http_macaroon
+        add_vary_cb = mocker.spy(security_policy, "add_vary_callback")
+        extract_http_macaroon = mocker.patch.object(
+            security_policy,
+            "_extract_http_macaroon",
+            autospec=True,
+            return_value=mocker.sentinel.raw_macaroon,
         )
 
-        user = pretend.stub(id="deadbeef-dead-beef-deadbeef-dead")
-        macaroon = pretend.stub(user=user, oidc_publisher=None)
-        macaroon_service = pretend.stub(
-            find_from_raw=pretend.call_recorder(lambda rm: macaroon),
+        user = UserFactory.build(id="deadbeef-dead-beef-deadbeef-dead")
+        macaroon = MacaroonFactory.build(user=user, oidc_publisher=None)
+        mocker.patch.object(
+            macaroon_service, "find_from_raw", autospec=True, return_value=macaroon
+        )
+        mocker.patch.object(
+            user_service, "is_disabled", autospec=True, return_value=(False, Exception)
         )
 
-        user_service = pretend.stub(
-            is_disabled=pretend.call_recorder(lambda user_id: (True, Exception)),
-        )
+        find_service = mocker.spy(pyramid_request, "find_service")
+        add_response_callback = mocker.spy(pyramid_request, "add_response_callback")
 
-        request = pretend.stub(
-            add_response_callback=pretend.call_recorder(lambda cb: None),
-            find_service=pretend.call_recorder(
-                lambda iface, **kw: {
-                    IMacaroonService: macaroon_service,
-                    IUserService: user_service,
-                }[iface]
-            ),
-        )
-
-        assert policy.identity(request) is None
-        assert extract_http_macaroon.calls == [pretend.call(request)]
-        assert request.find_service.calls == [
-            pretend.call(IMacaroonService, context=None),
-            pretend.call(IUserService, context=None),
+        assert policy.identity(pyramid_request) == UserContext(user, macaroon)
+        extract_http_macaroon.assert_called_once_with(pyramid_request)
+        assert find_service.call_args_list == [
+            mocker.call(IMacaroonService, context=None),
+            mocker.call(IUserService, context=None),
         ]
-        assert macaroon_service.find_from_raw.calls == [pretend.call(raw_macaroon)]
-        assert user_service.is_disabled.calls == [
-            pretend.call("deadbeef-dead-beef-deadbeef-dead")
-        ]
+        macaroon_service.find_from_raw.assert_called_once_with(
+            mocker.sentinel.raw_macaroon
+        )
+        user_service.is_disabled.assert_called_once_with(
+            "deadbeef-dead-beef-deadbeef-dead"
+        )
 
-        assert add_vary_cb.calls == [pretend.call("Authorization")]
-        assert request.add_response_callback.calls == [pretend.call(vary_cb)]
+        add_vary_cb.assert_called_once_with("Authorization")
+        add_response_callback.assert_called_once_with(add_vary_cb.spy_return)
 
-    def test_identity_user(self, monkeypatch):
+    def test_identity_oidc_publisher(self, pyramid_request, macaroon_service, mocker):
         policy = security_policy.MacaroonSecurityPolicy()
 
-        vary_cb = pretend.stub()
-        add_vary_cb = pretend.call_recorder(lambda *v: vary_cb)
-        monkeypatch.setattr(security_policy, "add_vary_callback", add_vary_cb)
-
-        raw_macaroon = pretend.stub()
-        extract_http_macaroon = pretend.call_recorder(lambda r: raw_macaroon)
-        monkeypatch.setattr(
-            security_policy, "_extract_http_macaroon", extract_http_macaroon
+        add_vary_cb = mocker.spy(security_policy, "add_vary_callback")
+        extract_http_macaroon = mocker.patch.object(
+            security_policy,
+            "_extract_http_macaroon",
+            autospec=True,
+            return_value=mocker.sentinel.raw_macaroon,
         )
 
-        user = pretend.stub(id="deadbeef-dead-beef-deadbeef-dead")
-        macaroon = pretend.stub(user=user, oidc_publisher=None)
-        macaroon_service = pretend.stub(
-            find_from_raw=pretend.call_recorder(lambda rm: macaroon),
-        )
-
-        user_service = pretend.stub(
-            is_disabled=pretend.call_recorder(lambda user_id: (False, Exception)),
-        )
-
-        request = pretend.stub(
-            add_response_callback=pretend.call_recorder(lambda cb: None),
-            find_service=pretend.call_recorder(
-                lambda iface, **kw: {
-                    IMacaroonService: macaroon_service,
-                    IUserService: user_service,
-                }[iface]
-            ),
-        )
-
-        assert policy.identity(request) == UserContext(user, macaroon)
-        assert extract_http_macaroon.calls == [pretend.call(request)]
-        assert request.find_service.calls == [
-            pretend.call(IMacaroonService, context=None),
-            pretend.call(IUserService, context=None),
-        ]
-        assert macaroon_service.find_from_raw.calls == [pretend.call(raw_macaroon)]
-        assert user_service.is_disabled.calls == [
-            pretend.call("deadbeef-dead-beef-deadbeef-dead")
-        ]
-
-        assert add_vary_cb.calls == [pretend.call("Authorization")]
-        assert request.add_response_callback.calls == [pretend.call(vary_cb)]
-
-    def test_identity_oidc_publisher(self, monkeypatch):
-        policy = security_policy.MacaroonSecurityPolicy()
-
-        vary_cb = pretend.stub()
-        add_vary_cb = pretend.call_recorder(lambda *v: vary_cb)
-        monkeypatch.setattr(security_policy, "add_vary_callback", add_vary_cb)
-
-        raw_macaroon = pretend.stub()
-        extract_http_macaroon = pretend.call_recorder(lambda r: raw_macaroon)
-        monkeypatch.setattr(
-            security_policy, "_extract_http_macaroon", extract_http_macaroon
-        )
-
-        oidc_publisher = pretend.stub()
+        oidc_publisher = mocker.sentinel.oidc_publisher
         oidc_additional = {"oidc": {"foo": "bar"}}
-        macaroon = pretend.stub(
+        macaroon = MacaroonFactory.build(
             user=None, oidc_publisher=oidc_publisher, additional=oidc_additional
         )
-        macaroon_service = pretend.stub(
-            find_from_raw=pretend.call_recorder(lambda rm: macaroon),
+        mocker.patch.object(
+            macaroon_service, "find_from_raw", autospec=True, return_value=macaroon
         )
 
-        request = pretend.stub(
-            add_response_callback=pretend.call_recorder(lambda cb: None),
-            find_service=pretend.call_recorder(lambda iface, **kw: macaroon_service),
-        )
+        find_service = mocker.spy(pyramid_request, "find_service")
+        add_response_callback = mocker.spy(pyramid_request, "add_response_callback")
 
-        identity = policy.identity(request)
+        identity = policy.identity(pyramid_request)
         assert identity
         assert identity.publisher is oidc_publisher
         assert identity == PublisherTokenContext(
             oidc_publisher, SignedClaims(oidc_additional["oidc"])
         )
 
-        assert extract_http_macaroon.calls == [pretend.call(request)]
-        assert request.find_service.calls == [
-            pretend.call(IMacaroonService, context=None),
-            pretend.call(IUserService, context=None),
+        extract_http_macaroon.assert_called_once_with(pyramid_request)
+        assert find_service.call_args_list == [
+            mocker.call(IMacaroonService, context=None),
+            mocker.call(IUserService, context=None),
         ]
-        assert macaroon_service.find_from_raw.calls == [pretend.call(raw_macaroon)]
-
-        assert add_vary_cb.calls == [pretend.call("Authorization")]
-        assert request.add_response_callback.calls == [pretend.call(vary_cb)]
-
-    def test_permits_invalid_macaroon(self, monkeypatch):
-        macaroon_service = pretend.stub(
-            verify=pretend.raiser(InvalidMacaroonError("foo"))
+        macaroon_service.find_from_raw.assert_called_once_with(
+            mocker.sentinel.raw_macaroon
         )
-        request = pretend.stub(
-            find_service=pretend.call_recorder(lambda interface, **kw: macaroon_service)
+
+        add_vary_cb.assert_called_once_with("Authorization")
+        add_response_callback.assert_called_once_with(add_vary_cb.spy_return)
+
+    def test_permits_invalid_macaroon(self, pyramid_request, macaroon_service, mocker):
+        mocker.patch.object(
+            macaroon_service,
+            "verify",
+            autospec=True,
+            side_effect=InvalidMacaroonError("foo"),
         )
-        _extract_http_macaroon = pretend.call_recorder(lambda r: "not a real macaroon")
-        monkeypatch.setattr(
-            security_policy, "_extract_http_macaroon", _extract_http_macaroon
+        mocker.patch.object(
+            security_policy,
+            "_extract_http_macaroon",
+            autospec=True,
+            return_value="not a real macaroon",
         )
 
         policy = security_policy.MacaroonSecurityPolicy()
-        result = policy.permits(request, pretend.stub(), Permissions.ProjectsUpload)
+        result = policy.permits(
+            pyramid_request, mocker.sentinel.context, Permissions.ProjectsUpload
+        )
 
         assert result == Denied("")
         assert result.s == "Invalid API Token: foo"
@@ -283,27 +266,37 @@ class TestMacaroonSecurityPolicy:
     @pytest.mark.parametrize(
         ("principals", "expected"), [(["user:5"], True), (["user:1"], False)]
     )
-    def test_permits_valid_macaroon(self, monkeypatch, principals, expected):
-        macaroon_service = pretend.stub(
-            verify=pretend.call_recorder(lambda *a: pretend.stub())
+    def test_permits_valid_macaroon(
+        self,
+        pyramid_request,
+        pyramid_config,
+        macaroon_service,
+        mocker,
+        principals,
+        expected,
+    ):
+        mocker.patch.object(
+            macaroon_service,
+            "verify",
+            autospec=True,
+            return_value=mocker.sentinel.verified,
         )
-        request = pretend.stub(
-            identity=pretend.stub(__principals__=lambda: principals),
-            find_service=pretend.call_recorder(
-                lambda interface, **kw: macaroon_service
-            ),
-        )
-        _extract_http_macaroon = pretend.call_recorder(lambda r: "not a real macaroon")
-        monkeypatch.setattr(
-            security_policy, "_extract_http_macaroon", _extract_http_macaroon
+        mocker.patch.object(
+            security_policy,
+            "_extract_http_macaroon",
+            autospec=True,
+            return_value="not a real macaroon",
         )
 
-        context = pretend.stub(
+        identity = types.SimpleNamespace(__principals__=lambda: principals)
+        pyramid_config.set_security_policy(DummySecurityPolicy(identity=identity))
+
+        context = types.SimpleNamespace(
             __acl__=[(Allow, "user:5", [Permissions.ProjectsUpload])]
         )
 
         policy = security_policy.MacaroonSecurityPolicy()
-        result = policy.permits(request, context, Permissions.ProjectsUpload)
+        result = policy.permits(pyramid_request, context, Permissions.ProjectsUpload)
 
         assert bool(result) == expected
 
@@ -312,15 +305,19 @@ class TestMacaroonSecurityPolicy:
         [Permissions.AccountManage, Permissions.ProjectsWrite, "nonexistent"],
     )
     def test_denies_valid_macaroon_for_incorrect_permission(
-        self, monkeypatch, invalid_permission
+        self, mocker, invalid_permission
     ):
-        _extract_http_macaroon = pretend.call_recorder(lambda r: "not a real macaroon")
-        monkeypatch.setattr(
-            security_policy, "_extract_http_macaroon", _extract_http_macaroon
+        mocker.patch.object(
+            security_policy,
+            "_extract_http_macaroon",
+            autospec=True,
+            return_value="not a real macaroon",
         )
 
         policy = security_policy.MacaroonSecurityPolicy()
-        result = policy.permits(pretend.stub(), pretend.stub(), invalid_permission)
+        result = policy.permits(
+            mocker.sentinel.request, mocker.sentinel.context, invalid_permission
+        )
 
         assert result == Denied("")
         assert result.s == (

--- a/tests/unit/macaroons/test_services.py
+++ b/tests/unit/macaroons/test_services.py
@@ -3,10 +3,8 @@
 import binascii
 import struct
 
-from unittest import mock
 from uuid import uuid4
 
-import pretend
 import pymacaroons
 import pytest
 
@@ -20,17 +18,14 @@ from ...common.db.accounts import UserFactory
 from ...common.db.oidc import GitHubPublisherFactory
 
 
-def test_database_macaroon_factory():
-    db = pretend.stub()
-    request = pretend.stub(db=db)
-
-    service = services.database_macaroon_factory(pretend.stub(), request)
-    assert service.db is db
+def test_database_macaroon_factory(db_request):
+    service = services.database_macaroon_factory(None, db_request)
+    assert service.db is db_request.db
 
 
 class TestDatabaseMacaroonService:
-    def test_creation(self):
-        session = pretend.stub()
+    def test_creation(self, mocker):
+        session = mocker.sentinel.session
         service = services.DatabaseMacaroonService(session)
 
         assert service.db is session
@@ -191,7 +186,7 @@ class TestDatabaseMacaroonService:
 
         assert user.id == user_id
 
-    def test_verify_unprefixed_macaroon(self, macaroon_service):
+    def test_verify_unprefixed_macaroon(self, macaroon_service, mocker):
         raw_macaroon = pymacaroons.Macaroon(
             location="fake location",
             identifier=str(uuid4()),
@@ -203,10 +198,13 @@ class TestDatabaseMacaroonService:
             services.InvalidMacaroonError, match="malformed or nonexistent macaroon"
         ):
             macaroon_service.verify(
-                raw_macaroon, pretend.stub(), pretend.stub(), pretend.stub()
+                raw_macaroon,
+                mocker.sentinel.request,
+                mocker.sentinel.context,
+                mocker.sentinel.permissions,
             )
 
-    def test_verify_no_macaroon(self, macaroon_service):
+    def test_verify_no_macaroon(self, macaroon_service, mocker):
         raw_macaroon = pymacaroons.Macaroon(
             location="fake location",
             identifier=str(uuid4()),
@@ -219,10 +217,13 @@ class TestDatabaseMacaroonService:
             services.InvalidMacaroonError, match="deleted or nonexistent macaroon"
         ):
             macaroon_service.verify(
-                raw_macaroon, pretend.stub(), pretend.stub(), pretend.stub()
+                raw_macaroon,
+                mocker.sentinel.request,
+                mocker.sentinel.context,
+                mocker.sentinel.permissions,
             )
 
-    def test_verify_invalid_macaroon(self, monkeypatch, user_service, macaroon_service):
+    def test_verify_invalid_macaroon(self, mocker, user_service, macaroon_service):
         user = UserFactory.create()
         raw_macaroon, _ = macaroon_service.create_macaroon(
             "fake location",
@@ -231,32 +232,31 @@ class TestDatabaseMacaroonService:
             user_id=user.id,
         )
 
-        verify = pretend.call_recorder(lambda m, k, r, c, p: WarehouseDenied("foo"))
-        monkeypatch.setattr(caveats, "verify", verify)
+        verify = mocker.patch.object(
+            caveats, "verify", autospec=True, return_value=WarehouseDenied("foo")
+        )
 
-        request = pretend.stub()
-        context = pretend.stub()
-        permissions = pretend.stub()
+        request = mocker.sentinel.request
+        context = mocker.sentinel.context
+        permissions = mocker.sentinel.permissions
 
         with pytest.raises(services.InvalidMacaroonError, match="foo"):
             macaroon_service.verify(raw_macaroon, request, context, permissions)
-        assert verify.calls == [
-            pretend.call(mock.ANY, mock.ANY, request, context, permissions)
-        ]
+        verify.assert_called_once_with(
+            mocker.ANY, mocker.ANY, request, context, permissions
+        )
 
-    def test_deserialize_raw_macaroon_when_none(self, monkeypatch):
-        raw_macaroon = None
-        _extract_func = pretend.call_recorder(lambda a: raw_macaroon)
-        monkeypatch.setattr(services, "_extract_raw_macaroon", _extract_func)
+    def test_deserialize_raw_macaroon_when_none(self, mocker):
+        _extract_func = mocker.patch.object(
+            services, "_extract_raw_macaroon", autospec=True, return_value=None
+        )
 
         with pytest.raises(
             services.InvalidMacaroonError, match="malformed or nonexistent macaroon"
         ):
-            services.deserialize_raw_macaroon(raw_macaroon)
+            services.deserialize_raw_macaroon(None)
 
-        assert services._extract_raw_macaroon.calls == [
-            pretend.call(raw_macaroon),
-        ]
+        _extract_func.assert_called_once_with(None)
 
     @pytest.mark.parametrize(
         "exception",
@@ -271,12 +271,15 @@ class TestDatabaseMacaroonService:
             Exception,  # https://github.com/ecordell/pymacaroons/issues/50
         ],
     )
-    def test_deserialize_raw_macaroon(self, monkeypatch, exception):
-        raw_macaroon = pretend.stub()
-        monkeypatch.setattr(services, "_extract_raw_macaroon", lambda a: raw_macaroon)
-        monkeypatch.setattr(
-            pymacaroons.Macaroon, "deserialize", pretend.raiser(exception)
+    def test_deserialize_raw_macaroon(self, mocker, exception):
+        raw_macaroon = mocker.sentinel.raw_macaroon
+        mocker.patch.object(
+            services,
+            "_extract_raw_macaroon",
+            autospec=True,
+            return_value=raw_macaroon,
         )
+        mocker.patch.object(pymacaroons.Macaroon, "deserialize", side_effect=exception)
 
         with pytest.raises(services.InvalidMacaroonError):
             services.deserialize_raw_macaroon(raw_macaroon)
@@ -285,7 +288,7 @@ class TestDatabaseMacaroonService:
         with pytest.raises(services.InvalidMacaroonError):
             macaroon_service.verify("pypi-thiswillnotdeserialize", None, None, None)
 
-    def test_verify_valid_macaroon(self, monkeypatch, macaroon_service):
+    def test_verify_valid_macaroon(self, mocker, macaroon_service):
         user = UserFactory.create()
         raw_macaroon, _ = macaroon_service.create_macaroon(
             "fake location",
@@ -294,17 +297,18 @@ class TestDatabaseMacaroonService:
             user_id=user.id,
         )
 
-        verify = pretend.call_recorder(lambda m, k, r, c, p: True)
-        monkeypatch.setattr(caveats, "verify", verify)
+        verify = mocker.patch.object(
+            caveats, "verify", autospec=True, return_value=True
+        )
 
-        request = pretend.stub()
-        context = pretend.stub()
-        permissions = pretend.stub()
+        request = mocker.sentinel.request
+        context = mocker.sentinel.context
+        permissions = mocker.sentinel.permissions
 
         assert macaroon_service.verify(raw_macaroon, request, context, permissions)
-        assert verify.calls == [
-            pretend.call(mock.ANY, mock.ANY, request, context, permissions)
-        ]
+        verify.assert_called_once_with(
+            mocker.ANY, mocker.ANY, request, context, permissions
+        )
 
     def test_delete_macaroon(self, user_service, macaroon_service):
         user = UserFactory.create()

--- a/tests/unit/macaroons/test_utils.py
+++ b/tests/unit/macaroons/test_utils.py
@@ -1,14 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
-import pretend
-
 from tests.common.db.accounts import UserFactory
 from warehouse.accounts.utils import UserContext
 from warehouse.utils.security_policy import principals_for
 
 
-def test_user_context_principals(db_request):
+def test_user_context_principals(db_request, mocker):
     user = UserFactory.create()
     assert principals_for(
-        UserContext(user=user, macaroon=pretend.stub())
+        UserContext(user=user, macaroon=mocker.sentinel.macaroon)
     ) == principals_for(user)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,12 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
+import types
 
 from datetime import timedelta
-from unittest import mock
 
 import orjson
-import pretend
 import pytest
 
 from pyramid import renderers
@@ -19,38 +18,39 @@ from warehouse.utils.wsgi import ProxyFixer, VhmRootRemover
 
 
 class TestRequireHTTPSTween:
-    def test_noops_when_disabled(self):
-        handler = pretend.stub()
-        registry = pretend.stub(
-            settings=pretend.stub(get=pretend.call_recorder(lambda k, v: False))
-        )
+    def test_noops_when_disabled(self, mocker):
+        registry = mocker.Mock()
+        registry.settings.get.return_value = False
 
-        assert config.require_https_tween_factory(handler, registry) is handler
-        assert registry.settings.get.calls == [pretend.call("enforce_https", True)]
+        assert (
+            config.require_https_tween_factory(mocker.sentinel.handler, registry)
+            is mocker.sentinel.handler
+        )
+        registry.settings.get.assert_called_once_with("enforce_https", True)
 
     @pytest.mark.parametrize(
         ("params", "scheme"),
         [({}, "https"), ({":action": "thing"}, "https"), ({}, "http")],
     )
-    def test_allows_through(self, params, scheme):
-        request = pretend.stub(params=params, scheme=scheme)
-        response = pretend.stub()
-        handler = pretend.call_recorder(lambda req: response)
-        registry = pretend.stub(settings=pretend.stub(get=lambda k, v: True))
+    def test_allows_through(self, params, scheme, pyramid_request, mocker):
+        pyramid_request.params = params
+        pyramid_request.scheme = scheme
+        handler = mocker.Mock(return_value=mocker.sentinel.response)
+        registry = types.SimpleNamespace(settings={"enforce_https": True})
 
         tween = config.require_https_tween_factory(handler, registry)
 
-        assert tween(request) is response
-        assert handler.calls == [pretend.call(request)]
+        assert tween(pyramid_request) is mocker.sentinel.response
+        handler.assert_called_once_with(pyramid_request)
 
     @pytest.mark.parametrize(("params", "scheme"), [({":action": "thing"}, "http")])
-    def test_rejects(self, params, scheme):
-        request = pretend.stub(params=params, scheme=scheme)
-        handler = pretend.stub()
-        registry = pretend.stub(settings=pretend.stub(get=lambda k, v: True))
+    def test_rejects(self, params, scheme, pyramid_request, mocker):
+        pyramid_request.params = params
+        pyramid_request.scheme = scheme
+        registry = types.SimpleNamespace(settings={"enforce_https": True})
 
-        tween = config.require_https_tween_factory(handler, registry)
-        resp = tween(request)
+        tween = config.require_https_tween_factory(mocker.sentinel.handler, registry)
+        resp = tween(pyramid_request)
 
         assert resp.status == "403 SSL is required"
         assert resp.headers["X-Fastly-Error"] == "803"
@@ -62,25 +62,22 @@ class TestRequireHTTPSTween:
     ("path", "expected"),
     [("/foo/bar/", True), ("/static/wat/", False), ("/_debug_toolbar/thing/", False)],
 )
-def test_activate_hook(path, expected):
-    request = pretend.stub(path=path)
-    assert config.activate_hook(request) == expected
+def test_activate_hook(path, expected, pyramid_request):
+    pyramid_request.path = path
+    assert config.activate_hook(pyramid_request) == expected
 
 
 @pytest.mark.parametrize("route_kw", [None, {}, {"foo": "bar"}])
-def test_template_view(route_kw):
-    configobj = pretend.stub(
-        add_route=pretend.call_recorder(lambda *a, **kw: None),
-        add_view=pretend.call_recorder(lambda *a, **kw: None),
-    )
+def test_template_view(route_kw, mocker):
+    configobj = mocker.Mock(spec=["add_route", "add_view"])
 
     config.template_view(configobj, "test", "/test/", "test.html", route_kw=route_kw)
 
-    assert configobj.add_route.calls == [
-        pretend.call("test", "/test/", **({} if route_kw is None else route_kw))
+    assert configobj.add_route.call_args_list == [
+        mocker.call("test", "/test/", **({} if route_kw is None else route_kw))
     ]
-    assert configobj.add_view.calls == [
-        pretend.call(renderer="test.html", route_name="test")
+    assert configobj.add_view.call_args_list == [
+        mocker.call(renderer="test.html", route_name="test")
     ]
 
 
@@ -225,14 +222,14 @@ def test_maybe_set_redis(monkeypatch, environ, coercer, default, db, expected):
         ({"my settings": "the settings value"}, config.Environment.development),
     ],
 )
-def test_configure(monkeypatch, settings, environment):
-    json_renderer_obj = pretend.stub()
-    json_renderer_cls = pretend.call_recorder(lambda **kw: json_renderer_obj)
-    monkeypatch.setattr(renderers, "JSON", json_renderer_cls)
+def test_configure(monkeypatch, mocker, settings, environment):
+    json_renderer_cls = mocker.patch.object(
+        renderers, "JSON", return_value=mocker.sentinel.json_renderer_obj
+    )
 
-    xmlrpc_renderer_obj = pretend.stub()
-    xmlrpc_renderer_cls = pretend.call_recorder(lambda **kw: xmlrpc_renderer_obj)
-    monkeypatch.setattr(config, "XMLRPCRenderer", xmlrpc_renderer_cls)
+    xmlrpc_renderer_cls = mocker.patch.object(
+        config, "XMLRPCRenderer", return_value=mocker.sentinel.xmlrpc_renderer_obj
+    )
 
     # Ignore all environment variables in the test environment, except for WAREHOUSE_ENV
     monkeypatch.setattr(
@@ -260,40 +257,43 @@ def test_configure(monkeypatch, settings, environment):
             }
 
     configurator_settings = {}
-    configurator_obj = pretend.stub(
-        registry=FakeRegistry(),
-        set_root_factory=pretend.call_recorder(lambda rf: None),
-        include=pretend.call_recorder(lambda include: None),
-        add_directive=pretend.call_recorder(lambda name, fn, **k: None),
-        add_wsgi_middleware=pretend.call_recorder(lambda m, *a, **kw: None),
-        add_renderer=pretend.call_recorder(lambda name, renderer: None),
-        add_request_method=pretend.call_recorder(lambda fn: None),
-        add_jinja2_renderer=pretend.call_recorder(lambda renderer: None),
-        add_jinja2_search_path=pretend.call_recorder(lambda path, name: None),
-        get_settings=lambda: configurator_settings,
-        add_settings=pretend.call_recorder(configurator_settings.update),
-        add_tween=pretend.call_recorder(lambda tween_factory, **kw: None),
-        add_static_view=pretend.call_recorder(lambda *a, **kw: None),
-        add_cache_buster=pretend.call_recorder(lambda spec, buster: None),
-        whitenoise_serve_static=pretend.call_recorder(lambda *a, **kw: None),
-        whitenoise_add_files=pretend.call_recorder(lambda *a, **kw: None),
-        whitenoise_add_manifest=pretend.call_recorder(lambda *a, **kw: None),
-        scan=pretend.call_recorder(lambda categories, ignore: None),
-        commit=pretend.call_recorder(lambda: None),
-        add_view_deriver=pretend.call_recorder(lambda *a, **kw: None),
+    configurator_obj = mocker.Mock(
+        spec=[
+            "registry",
+            "set_root_factory",
+            "include",
+            "add_directive",
+            "add_wsgi_middleware",
+            "add_renderer",
+            "add_request_method",
+            "add_jinja2_renderer",
+            "add_jinja2_search_path",
+            "get_settings",
+            "add_settings",
+            "add_tween",
+            "add_static_view",
+            "add_cache_buster",
+            "whitenoise_serve_static",
+            "whitenoise_add_files",
+            "whitenoise_add_manifest",
+            "scan",
+            "commit",
+            "add_view_deriver",
+        ]
     )
-    configurator_cls = pretend.call_recorder(lambda settings: configurator_obj)
-    monkeypatch.setattr(config, "Configurator", configurator_cls)
-
-    cachebuster_obj = pretend.stub()
-    cachebuster_cls = pretend.call_recorder(lambda p, **kw: cachebuster_obj)
-    monkeypatch.setattr(config, "ManifestCacheBuster", cachebuster_cls)
-
-    transaction_manager = pretend.stub()
-    transaction = pretend.stub(
-        TransactionManager=pretend.call_recorder(lambda: transaction_manager)
+    configurator_obj.registry = FakeRegistry()
+    configurator_obj.get_settings.return_value = configurator_settings
+    configurator_obj.add_settings.side_effect = configurator_settings.update
+    configurator_cls = mocker.patch.object(
+        config, "Configurator", return_value=configurator_obj
     )
-    monkeypatch.setattr(config, "transaction", transaction)
+
+    cachebuster_cls = mocker.patch.object(
+        config, "ManifestCacheBuster", return_value=mocker.sentinel.cachebuster_obj
+    )
+
+    transaction = mocker.patch.object(config, "transaction")
+    transaction.TransactionManager.return_value = mocker.sentinel.transaction_manager
 
     result = config.configure(settings=settings.copy() if settings else None)
 
@@ -368,23 +368,25 @@ def test_configure(monkeypatch, settings, environment):
     if settings is not None:
         expected_settings.update(settings)
 
-    assert configurator_cls.calls == [pretend.call(settings=expected_settings)]
+    assert configurator_cls.call_args_list == [mocker.call(settings=expected_settings)]
     assert result is configurator_obj
-    assert configurator_obj.set_root_factory.calls == [pretend.call(config.RootFactory)]
-    assert configurator_obj.add_wsgi_middleware.calls == [
-        pretend.call(
+    assert configurator_obj.set_root_factory.call_args_list == [
+        mocker.call(config.RootFactory)
+    ]
+    assert configurator_obj.add_wsgi_middleware.call_args_list == [
+        mocker.call(
             ProxyFixer, token="insecure token", ip_salt="insecure salt", num_proxies=1
         ),
-        pretend.call(VhmRootRemover),
+        mocker.call(VhmRootRemover),
     ]
-    assert configurator_obj.include.calls == (
+    assert configurator_obj.include.call_args_list == (
         [
-            pretend.call("pyramid_services"),
-            pretend.call(".metrics"),
-            pretend.call(".csrf"),
+            mocker.call("pyramid_services"),
+            mocker.call(".metrics"),
+            mocker.call(".csrf"),
         ]
         + [
-            pretend.call(x)
+            mocker.call(x)
             for x in [
                 (
                     "pyramid_debugtoolbar"
@@ -395,90 +397,93 @@ def test_configure(monkeypatch, settings, environment):
             if x is not None
         ]
         + [
-            pretend.call(".logging"),
-            pretend.call("pyramid_jinja2"),
-            pretend.call(".filters"),
-            pretend.call("pyramid_mailer"),
-            pretend.call("pyramid_retry"),
-            pretend.call("pyramid_tm"),
-            pretend.call(".rate_limiting"),
-            pretend.call(".legacy.api.xmlrpc"),
-            pretend.call(".legacy.api.xmlrpc.cache"),
-            pretend.call("pyramid_rpc.xmlrpc"),
-            pretend.call(".legacy.action_routing"),
-            pretend.call(".predicates"),
-            pretend.call(".i18n"),
-            pretend.call(".db"),
-            pretend.call(".tasks"),
-            pretend.call(".static"),
-            pretend.call(".search"),
-            pretend.call(".aws"),
-            pretend.call(".b2"),
-            pretend.call(".gcloud"),
-            pretend.call(".sessions"),
-            pretend.call(".cache.http"),
-            pretend.call(".cache.origin"),
-            pretend.call(".cache"),
-            pretend.call(".email"),
-            pretend.call(".accounts"),
-            pretend.call(".macaroons"),
-            pretend.call(".oidc"),
-            pretend.call(".attestations"),
-            pretend.call(".manage"),
-            pretend.call(".organizations"),
-            pretend.call(".subscriptions"),
-            pretend.call(".packaging"),
-            pretend.call(".redirects"),
-            pretend.call("pyramid_redirect"),
-            pretend.call(".routes"),
-            pretend.call(".sponsors"),
-            pretend.call(".banners"),
-            pretend.call(".admin"),
-            pretend.call(".forklift"),
-            pretend.call(".api.config"),
-            pretend.call(".utils.wsgi"),
-            pretend.call(".sentry"),
-            pretend.call(".csp"),
-            pretend.call(".referrer_policy"),
-            pretend.call(".captcha"),
-            pretend.call(".helpdesk"),
-            pretend.call(".http"),
-            pretend.call(".utils.row_counter"),
+            mocker.call(".logging"),
+            mocker.call("pyramid_jinja2"),
+            mocker.call(".filters"),
+            mocker.call("pyramid_mailer"),
+            mocker.call("pyramid_retry"),
+            mocker.call("pyramid_tm"),
+            mocker.call(".rate_limiting"),
+            mocker.call(".legacy.api.xmlrpc"),
+            mocker.call(".legacy.api.xmlrpc.cache"),
+            mocker.call("pyramid_rpc.xmlrpc"),
+            mocker.call(".legacy.action_routing"),
+            mocker.call(".predicates"),
+            mocker.call(".i18n"),
+            mocker.call(".db"),
+            mocker.call(".tasks"),
+            mocker.call(".static"),
+            mocker.call(".search"),
+            mocker.call(".aws"),
+            mocker.call(".b2"),
+            mocker.call(".gcloud"),
+            mocker.call(".sessions"),
+            mocker.call(".cache.http"),
+            mocker.call(".cache.origin"),
+            mocker.call(".cache"),
+            mocker.call(".email"),
+            mocker.call(".accounts"),
+            mocker.call(".macaroons"),
+            mocker.call(".oidc"),
+            mocker.call(".attestations"),
+            mocker.call(".manage"),
+            mocker.call(".organizations"),
+            mocker.call(".subscriptions"),
+            mocker.call(".packaging"),
+            mocker.call(".redirects"),
+            mocker.call("pyramid_redirect"),
+            mocker.call(".routes"),
+            mocker.call(".sponsors"),
+            mocker.call(".banners"),
+            mocker.call(".admin"),
+            mocker.call(".forklift"),
+            mocker.call(".api.config"),
+            mocker.call(".utils.wsgi"),
+            mocker.call(".sentry"),
+            mocker.call(".csp"),
+            mocker.call(".referrer_policy"),
+            mocker.call(".captcha"),
+            mocker.call(".helpdesk"),
+            mocker.call(".http"),
+            mocker.call(".utils.row_counter"),
         ]
-        + [pretend.call(x) for x in [configurator_settings.get("warehouse.theme")] if x]
-        + [pretend.call(".sanity")]
+        + [mocker.call(x) for x in [configurator_settings.get("warehouse.theme")] if x]
+        + [mocker.call(".sanity")]
     )
-    assert configurator_obj.add_jinja2_renderer.calls == [
-        pretend.call(".html"),
-        pretend.call(".txt"),
-        pretend.call(".xml"),
+    assert configurator_obj.add_jinja2_renderer.call_args_list == [
+        mocker.call(".html"),
+        mocker.call(".txt"),
+        mocker.call(".xml"),
     ]
-    assert configurator_obj.add_jinja2_search_path.calls == [
-        pretend.call("warehouse:templates", name=".html"),
-        pretend.call("warehouse:templates", name=".txt"),
-        pretend.call("warehouse:templates", name=".xml"),
+    assert configurator_obj.add_jinja2_search_path.call_args_list == [
+        mocker.call("warehouse:templates", name=".html"),
+        mocker.call("warehouse:templates", name=".txt"),
+        mocker.call("warehouse:templates", name=".xml"),
     ]
-    assert configurator_obj.add_settings.calls == [
-        pretend.call({"jinja2.newstyle": True}),
-        pretend.call({"jinja2.i18n.domain": "messages"}),
-        pretend.call({"jinja2.lstrip_blocks": True}),
-        pretend.call({"jinja2.trim_blocks": True}),
-        pretend.call({"retry.attempts": 3}),
-        pretend.call(
+    assert configurator_obj.add_settings.call_args_list == [
+        mocker.call({"jinja2.newstyle": True}),
+        mocker.call({"jinja2.i18n.domain": "messages"}),
+        mocker.call({"jinja2.lstrip_blocks": True}),
+        mocker.call({"jinja2.trim_blocks": True}),
+        mocker.call({"retry.attempts": 3}),
+        mocker.call(
             {
-                "tm.manager_hook": mock.ANY,
+                "tm.manager_hook": mocker.ANY,
                 "tm.activate_hook": config.activate_hook,
                 "tm.annotate_user": False,
             }
         ),
-        pretend.call({"pyramid_redirect.structlog": True}),
-        pretend.call({"http": {"verify": "/etc/ssl/certs/"}}),
+        mocker.call({"pyramid_redirect.structlog": True}),
+        mocker.call({"http": {"verify": "/etc/ssl/certs/"}}),
     ]
-    add_settings_dict = configurator_obj.add_settings.calls[5].args[0]
-    assert add_settings_dict["tm.manager_hook"](pretend.stub()) is transaction_manager
-    assert configurator_obj.add_tween.calls == [
-        pretend.call("warehouse.config.require_https_tween_factory"),
-        pretend.call(
+    add_settings_dict = configurator_obj.add_settings.call_args_list[5].args[0]
+    assert (
+        add_settings_dict["tm.manager_hook"](mocker.sentinel.request)
+        is mocker.sentinel.transaction_manager
+    )
+    assert configurator_obj.add_tween.call_args_list == [
+        mocker.call("warehouse.config.require_https_tween_factory"),
+        mocker.call(
             "warehouse.utils.compression.compression_tween_factory",
             over=[
                 "warehouse.cache.http.conditional_http_tween_factory",
@@ -487,29 +492,29 @@ def test_configure(monkeypatch, settings, environment):
             ],
         ),
     ]
-    assert configurator_obj.add_static_view.calls == [
-        pretend.call("static", "warehouse:static/dist/", cache_max_age=315360000)
+    assert configurator_obj.add_static_view.call_args_list == [
+        mocker.call("static", "warehouse:static/dist/", cache_max_age=315360000)
     ]
-    assert configurator_obj.add_cache_buster.calls == [
-        pretend.call("warehouse:static/dist/", cachebuster_obj)
+    assert configurator_obj.add_cache_buster.call_args_list == [
+        mocker.call("warehouse:static/dist/", mocker.sentinel.cachebuster_obj)
     ]
-    assert cachebuster_cls.calls == [
-        pretend.call("warehouse:static/dist/manifest.json", reload=False, strict=True)
+    assert cachebuster_cls.call_args_list == [
+        mocker.call("warehouse:static/dist/manifest.json", reload=False, strict=True)
     ]
-    assert configurator_obj.whitenoise_serve_static.calls == [
-        pretend.call(autorefresh=False, max_age=315360000)
+    assert configurator_obj.whitenoise_serve_static.call_args_list == [
+        mocker.call(autorefresh=False, max_age=315360000)
     ]
-    assert configurator_obj.whitenoise_add_files.calls == [
-        pretend.call("warehouse:static/dist/", prefix="/static/")
+    assert configurator_obj.whitenoise_add_files.call_args_list == [
+        mocker.call("warehouse:static/dist/", prefix="/static/")
     ]
-    assert configurator_obj.whitenoise_add_manifest.calls == [
-        pretend.call("warehouse:static/dist/manifest.json", prefix="/static/")
+    assert configurator_obj.whitenoise_add_manifest.call_args_list == [
+        mocker.call("warehouse:static/dist/manifest.json", prefix="/static/")
     ]
-    assert configurator_obj.add_directive.calls == [
-        pretend.call("add_template_view", config.template_view, action_wrap=False)
+    assert configurator_obj.add_directive.call_args_list == [
+        mocker.call("add_template_view", config.template_view, action_wrap=False)
     ]
-    assert configurator_obj.scan.calls == [
-        pretend.call(
+    assert configurator_obj.scan.call_args_list == [
+        mocker.call(
             categories=(
                 "pyramid",
                 "warehouse",
@@ -517,27 +522,27 @@ def test_configure(monkeypatch, settings, environment):
             ignore=["warehouse.migrations.env", "warehouse.celery", "warehouse.wsgi"],
         )
     ]
-    assert configurator_obj.commit.calls == [pretend.call()]
-    assert configurator_obj.add_renderer.calls == [
-        pretend.call("json", json_renderer_obj),
-        pretend.call("xmlrpc", xmlrpc_renderer_obj),
+    assert configurator_obj.commit.call_args_list == [mocker.call()]
+    assert configurator_obj.add_renderer.call_args_list == [
+        mocker.call("json", mocker.sentinel.json_renderer_obj),
+        mocker.call("xmlrpc", mocker.sentinel.xmlrpc_renderer_obj),
     ]
-    assert configurator_obj.add_view_deriver.calls == [
-        pretend.call(
+    assert configurator_obj.add_view_deriver.call_args_list == [
+        mocker.call(
             config.reject_duplicate_post_keys_view,
             over="rendered_view",
             under="decorated_view",
         )
     ]
 
-    assert json_renderer_cls.calls == [
-        pretend.call(
+    assert json_renderer_cls.call_args_list == [
+        mocker.call(
             serializer=orjson.dumps,
             option=orjson.OPT_SORT_KEYS | orjson.OPT_APPEND_NEWLINE,
         )
     ]
 
-    assert xmlrpc_renderer_cls.calls == [pretend.call(allow_none=True)]
+    assert xmlrpc_renderer_cls.call_args_list == [mocker.call(allow_none=True)]
 
 
 def test_root_factory_access_control_list():

--- a/tests/unit/test_routes.py
+++ b/tests/unit/test_routes.py
@@ -1,618 +1,586 @@
 # SPDX-License-Identifier: Apache-2.0
 
-import pretend
 import pytest
 
 from warehouse.routes import includeme
 
 
 @pytest.mark.parametrize("warehouse", [None, "pypi.io"])
-def test_routes(warehouse):
-    docs_route_url = pretend.stub()
+def test_routes(warehouse, mocker):
+    docs_route_url = mocker.sentinel.docs_route_url
 
-    class FakeConfig:
-        def __init__(self):
-            self.registry = pretend.stub(
-                settings={
-                    "docs.url": docs_route_url,
-                    "files.url": "https://files.example.com/packages/{path}",
-                }
-            )
-            if warehouse:
-                self.registry.settings["warehouse.domain"] = warehouse
+    settings = {
+        "docs.url": docs_route_url,
+        "files.url": "https://files.example.com/packages/{path}",
+    }
+    if warehouse:
+        settings["warehouse.domain"] = warehouse
 
-        def get_settings(self):
-            return self.registry.settings
+    config = mocker.Mock(
+        spec=[
+            "get_settings",
+            "registry",
+            "add_route",
+            "add_template_view",
+            "add_redirect",
+            "add_redirect_rule",
+            "add_pypi_action_route",
+            "add_pypi_action_redirect",
+            "add_xmlrpc_endpoint",
+        ]
+    )
+    config.get_settings.return_value = settings
+    config.registry.settings = settings
 
-        @staticmethod
-        @pretend.call_recorder
-        def add_route(*args, **kwargs):
-            pass
-
-        @staticmethod
-        @pretend.call_recorder
-        def add_template_view(*args, **kwargs):
-            pass
-
-        @staticmethod
-        @pretend.call_recorder
-        def add_redirect(*args, **kwargs):
-            pass
-
-        @staticmethod
-        @pretend.call_recorder
-        def add_pypi_action_route(name, action, **kwargs):
-            pass
-
-        @staticmethod
-        @pretend.call_recorder
-        def add_pypi_action_redirect(action, target, **kwargs):
-            pass
-
-        @staticmethod
-        @pretend.call_recorder
-        def add_xmlrpc_endpoint(endpoint, pattern, header, domain=None):
-            pass
-
-        @staticmethod
-        @pretend.call_recorder
-        def add_redirect_rule(*args, **kwargs):
-            pass
-
-    config = FakeConfig()
     includeme(config)
 
-    assert config.add_route.calls == [
-        pretend.call("health", "/_health/"),
-        pretend.call("force-status", r"/_force-status/{status:[45]\d\d}/"),
-        pretend.call("index", "/", domain=warehouse),
-        pretend.call("locale", "/locale/", domain=warehouse),
-        pretend.call("favicon.ico", "/favicon.ico", domain=warehouse),
-        pretend.call("robots.txt", "/robots.txt", domain=warehouse),
-        pretend.call(
+    assert config.add_route.call_args_list == [
+        mocker.call("health", "/_health/"),
+        mocker.call("force-status", r"/_force-status/{status:[45]\d\d}/"),
+        mocker.call("index", "/", domain=warehouse),
+        mocker.call("locale", "/locale/", domain=warehouse),
+        mocker.call("favicon.ico", "/favicon.ico", domain=warehouse),
+        mocker.call("robots.txt", "/robots.txt", domain=warehouse),
+        mocker.call(
             "funding-manifest-urls",
             "/.well-known/funding-manifest-urls",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "security-txt",
             "/.well-known/security.txt",
             domain=warehouse,
         ),
-        pretend.call("opensearch.xml", "/opensearch.xml", domain=warehouse),
-        pretend.call("index.sitemap.xml", "/sitemap.xml", domain=warehouse),
-        pretend.call("bucket.sitemap.xml", "/{bucket}.sitemap.xml", domain=warehouse),
-        pretend.call(
+        mocker.call("opensearch.xml", "/opensearch.xml", domain=warehouse),
+        mocker.call("index.sitemap.xml", "/sitemap.xml", domain=warehouse),
+        mocker.call("bucket.sitemap.xml", "/{bucket}.sitemap.xml", domain=warehouse),
+        mocker.call(
             "includes.current-user-indicator",
             "/_includes/authed/current-user-indicator/",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "includes.flash-messages",
             "/_includes/unauthed/flash-messages/",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "includes.session-notifications",
             "/_includes/authed/session-notifications/",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "includes.current-user-profile-callout",
             "/_includes/authed/current-user-profile-callout/{username}",
             factory="warehouse.accounts.models:UserFactory",
             traverse="/{username}",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "includes.edit-project-button",
             "/_includes/authed/edit-project-button/{project_name}",
             factory="warehouse.packaging.models:ProjectFactory",
             traverse="/{project_name}",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "includes.profile-actions",
             "/_includes/authed/profile-actions/{username}",
             factory="warehouse.accounts.models:UserFactory",
             traverse="/{username}",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "includes.profile-public-email",
             "/_includes/authed/profile-public-email/{username}",
             factory="warehouse.accounts.models:UserFactory",
             traverse="/{username}",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "includes.sidebar-sponsor-logo",
             "/_includes/unauthed/sidebar-sponsor-logo/",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "includes.administer-project-include",
             "/_includes/authed/administer-project-include/{project_name}",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "includes.administer-user-include",
             "/_includes/authed/administer-user-include/{user_name}",
             factory="warehouse.accounts.models:UserFactory",
             traverse="/{user_name}",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "includes.administer-organization-include",
             "/_includes/authed/administer-organization-include/{organization}",
             factory="warehouse.organizations.models:OrganizationFactory",
             traverse="/{organization}",
             domain=warehouse,
         ),
-        pretend.call("classifiers", "/classifiers/", domain=warehouse),
-        pretend.call("search", "/search/", domain=warehouse),
-        pretend.call("stats", "/stats/", accept="text/html", domain=warehouse),
-        pretend.call(
+        mocker.call("classifiers", "/classifiers/", domain=warehouse),
+        mocker.call("search", "/search/", domain=warehouse),
+        mocker.call("stats", "/stats/", accept="text/html", domain=warehouse),
+        mocker.call(
             "stats.json", "/stats/", accept="application/json", domain=warehouse
         ),
-        pretend.call(
+        mocker.call(
             "security-key-giveaway", "/security-key-giveaway/", domain=warehouse
         ),
-        pretend.call(
+        mocker.call(
             "accounts.profile",
             "/user/{username}/",
             factory="warehouse.accounts.models:UserFactory",
             traverse="/{username}",
             domain=warehouse,
         ),
-        pretend.call("accounts.search", "/accounts/search/", domain=warehouse),
-        pretend.call(
+        mocker.call("accounts.search", "/accounts/search/", domain=warehouse),
+        mocker.call(
             "organizations.profile",
             "/org/{organization}/",
             factory="warehouse.organizations.models:OrganizationFactory",
             traverse="/{organization}",
             domain=warehouse,
         ),
-        pretend.call("accounts.login", "/account/login/", domain=warehouse),
-        pretend.call("accounts.two-factor", "/account/two-factor/", domain=warehouse),
-        pretend.call(
+        mocker.call("accounts.login", "/account/login/", domain=warehouse),
+        mocker.call("accounts.two-factor", "/account/two-factor/", domain=warehouse),
+        mocker.call(
             "accounts.webauthn-authenticate.options",
             "/account/webauthn-authenticate/options",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "accounts.webauthn-authenticate.validate",
             "/account/webauthn-authenticate/validate",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "accounts.reauthenticate", "/account/reauthenticate/", domain=warehouse
         ),
-        pretend.call(
+        mocker.call(
             "accounts.recovery-code", "/account/recovery-code/", domain=warehouse
         ),
-        pretend.call("accounts.logout", "/account/logout/", domain=warehouse),
-        pretend.call("accounts.register", "/account/register/", domain=warehouse),
-        pretend.call(
+        mocker.call("accounts.logout", "/account/logout/", domain=warehouse),
+        mocker.call("accounts.register", "/account/register/", domain=warehouse),
+        mocker.call(
             "accounts.request-password-reset",
             "/account/request-password-reset/",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "accounts.reset-password", "/account/reset-password/", domain=warehouse
         ),
-        pretend.call(
+        mocker.call(
             "accounts.confirm-login", "/account/confirm-login/", domain=warehouse
         ),
-        pretend.call(
+        mocker.call(
             "accounts.verify-email", "/account/verify-email/", domain=warehouse
         ),
-        pretend.call(
+        mocker.call(
             "accounts.verify-organization-role",
             "/account/verify-organization-role/",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "accounts.verify-project-role",
             "/account/verify-project-role/",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "accounts.view-terms-of-service",
             "/account/view-terms-of-service/",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "manage.unverified-account", "/manage/unverified-account/", domain=warehouse
         ),
-        pretend.call("manage.account", "/manage/account/", domain=warehouse),
-        pretend.call(
+        mocker.call("manage.account", "/manage/account/", domain=warehouse),
+        mocker.call(
             "manage.account.publishing", "/manage/account/publishing/", domain=warehouse
         ),
-        pretend.call(
+        mocker.call(
             "manage.account.two-factor",
             "/manage/account/two-factor/",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "manage.account.totp-provision",
             "/manage/account/totp-provision",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "manage.account.totp-provision.image",
             "/manage/account/totp-provision/image",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "manage.account.webauthn-provision",
             "/manage/account/webauthn-provision",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "manage.account.webauthn-provision.options",
             "/manage/account/webauthn-provision/options",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "manage.account.webauthn-provision.validate",
             "/manage/account/webauthn-provision/validate",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "manage.account.webauthn-provision.delete",
             "/manage/account/webauthn-provision/delete",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "manage.account.recovery-codes.generate",
             "/manage/account/recovery-codes/generate",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "manage.account.recovery-codes.regenerate",
             "/manage/account/recovery-codes/regenerate",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "manage.account.recovery-codes.burn",
             "/manage/account/recovery-codes/burn",
             domain=warehouse,
         ),
-        pretend.call(
-            "manage.account.token", "/manage/account/token/", domain=warehouse
-        ),
-        pretend.call(
+        mocker.call("manage.account.token", "/manage/account/token/", domain=warehouse),
+        mocker.call(
             "manage.account.associations.github.connect",
             "/manage/account/associations/github/connect",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "manage.account.associations.github.callback",
             "/manage/account/associations/github/callback",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "manage.account.associations.gitlab.connect",
             "/manage/account/associations/gitlab/connect",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "manage.account.associations.gitlab.callback",
             "/manage/account/associations/gitlab/callback",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "manage.account.associations.delete",
             "/manage/account/associations/delete",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "manage.organizations.application",
             "/manage/organizations/application/{organization_application_id}/",
             factory="warehouse.organizations.models:OrganizationApplicationFactory",
             traverse="/{organization_application_id}",
             domain=warehouse,
         ),
-        pretend.call(
-            "manage.organizations", "/manage/organizations/", domain=warehouse
-        ),
-        pretend.call(
+        mocker.call("manage.organizations", "/manage/organizations/", domain=warehouse),
+        mocker.call(
             "manage.organization.settings",
             "/manage/organization/{organization_name}/settings/",
             factory="warehouse.organizations.models:OrganizationFactory",
             traverse="/{organization_name}",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "manage.organization.activate_subscription",
             "/manage/organization/{organization_name}/subscription/activate/",
             factory="warehouse.organizations.models:OrganizationFactory",
             traverse="/{organization_name}",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "manage.organization.subscription",
             "/manage/organization/{organization_name}/subscription/",
             factory="warehouse.organizations.models:OrganizationFactory",
             traverse="/{organization_name}",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "manage.organization.projects",
             "/manage/organization/{organization_name}/projects/",
             factory="warehouse.organizations.models:OrganizationFactory",
             traverse="/{organization_name}",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "manage.organization.teams",
             "/manage/organization/{organization_name}/teams/",
             factory="warehouse.organizations.models:OrganizationFactory",
             traverse="/{organization_name}",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "manage.organization.publishing",
             "/manage/organization/{organization_name}/publishing/",
             factory="warehouse.organizations.models:OrganizationFactory",
             traverse="/{organization_name}",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "manage.organization.roles",
             "/manage/organization/{organization_name}/people/",
             factory="warehouse.organizations.models:OrganizationFactory",
             traverse="/{organization_name}",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "manage.organization.revoke_invite",
             "/manage/organization/{organization_name}/people/revoke_invite/",
             factory="warehouse.organizations.models:OrganizationFactory",
             traverse="/{organization_name}",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "manage.organization.resend_invite",
             "/manage/organization/{organization_name}/people/resend_invite/",
             factory="warehouse.organizations.models:OrganizationFactory",
             traverse="/{organization_name}",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "manage.organization.change_role",
             "/manage/organization/{organization_name}/people/change/",
             factory="warehouse.organizations.models:OrganizationFactory",
             traverse="/{organization_name}",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "manage.organization.delete_role",
             "/manage/organization/{organization_name}/people/delete/",
             factory="warehouse.organizations.models:OrganizationFactory",
             traverse="/{organization_name}",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "manage.organization.history",
             "/manage/organization/{organization_name}/history/",
             factory="warehouse.organizations.models:OrganizationFactory",
             traverse="/{organization_name}",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "manage.team.settings",
             "/manage/organization/{organization_name}/team/{team_name}/settings/",
             factory="warehouse.organizations.models:TeamFactory",
             traverse="/{organization_name}/{team_name}",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "manage.team.projects",
             "/manage/organization/{organization_name}/team/{team_name}/projects/",
             factory="warehouse.organizations.models:TeamFactory",
             traverse="/{organization_name}/{team_name}",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "manage.team.roles",
             "/manage/organization/{organization_name}/team/{team_name}/members/",
             factory="warehouse.organizations.models:TeamFactory",
             traverse="/{organization_name}/{team_name}",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "manage.team.delete_role",
             "/manage/organization/{organization_name}/team/{team_name}/members/delete/",
             factory="warehouse.organizations.models:TeamFactory",
             traverse="/{organization_name}/{team_name}",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "manage.team.history",
             "/manage/organization/{organization_name}/team/{team_name}/history/",
             factory="warehouse.organizations.models:TeamFactory",
             traverse="/{organization_name}/{team_name}",
             domain=warehouse,
         ),
-        pretend.call("manage.projects", "/manage/projects/", domain=warehouse),
-        pretend.call(
+        mocker.call("manage.projects", "/manage/projects/", domain=warehouse),
+        mocker.call(
             "manage.project.settings",
             "/manage/project/{project_name}/settings/",
             factory="warehouse.packaging.models:ProjectFactory",
             traverse="/{project_name}",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "manage.project.settings.publishing",
             "/manage/project/{project_name}/settings/publishing/",
             factory="warehouse.packaging.models:ProjectFactory",
             traverse="/{project_name}",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "manage.project.remove_organization_project",
             "/manage/project/{project_name}/remove_organization_project/",
             factory="warehouse.packaging.models:ProjectFactory",
             traverse="/{project_name}",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "manage.project.transfer_organization_project",
             "/manage/project/{project_name}/transfer_organization_project/",
             factory="warehouse.packaging.models:ProjectFactory",
             traverse="/{project_name}",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "manage.project.delete_project",
             "/manage/project/{project_name}/delete_project/",
             factory="warehouse.packaging.models:ProjectFactory",
             traverse="/{project_name}",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "manage.project.destroy_docs",
             "/manage/project/{project_name}/delete_project_docs/",
             factory="warehouse.packaging.models:ProjectFactory",
             traverse="/{project_name}",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "manage.project.releases",
             "/manage/project/{project_name}/releases/",
             factory="warehouse.packaging.models:ProjectFactory",
             traverse="/{project_name}",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "manage.project.release",
             "/manage/project/{project_name}/release/{version}/",
             factory="warehouse.packaging.models:ProjectFactory",
             traverse="/{project_name}/{version}",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "manage.project.roles",
             "/manage/project/{project_name}/collaboration/",
             factory="warehouse.packaging.models:ProjectFactory",
             traverse="/{project_name}",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "manage.project.revoke_invite",
             "/manage/project/{project_name}/collaboration/revoke_invite/",
             factory="warehouse.packaging.models:ProjectFactory",
             traverse="/{project_name}",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "manage.project.change_role",
             "/manage/project/{project_name}/collaboration/change/",
             factory="warehouse.packaging.models:ProjectFactory",
             traverse="/{project_name}",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "manage.project.delete_role",
             "/manage/project/{project_name}/collaboration/delete/",
             factory="warehouse.packaging.models:ProjectFactory",
             traverse="/{project_name}",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "manage.project.change_team_project_role",
             "/manage/project/{project_name}/collaboration/change_team/",
             factory="warehouse.packaging.models:ProjectFactory",
             traverse="/{project_name}",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "manage.project.delete_team_project_role",
             "/manage/project/{project_name}/collaboration/delete_team/",
             factory="warehouse.packaging.models:ProjectFactory",
             traverse="/{project_name}",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "manage.project.documentation",
             "/manage/project/{project_name}/documentation/",
             factory="warehouse.packaging.models:ProjectFactory",
             traverse="/{project_name}",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "manage.project.archive",
             "/manage/project/{project_name}/archive/",
             factory="warehouse.packaging.models:ProjectFactory",
             traverse="/{project_name}",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "manage.project.unarchive",
             "/manage/project/{project_name}/unarchive/",
             factory="warehouse.packaging.models:ProjectFactory",
             traverse="/{project_name}",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "manage.project.history",
             "/manage/project/{project_name}/history/",
             factory="warehouse.packaging.models:ProjectFactory",
             traverse="/{project_name}",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "packaging.project",
             "/project/{name}/",
             factory="warehouse.packaging.models:ProjectFactory",
             traverse="/{name}",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "packaging.project.submit_malware_observation",
             "/project/{name}/submit-malware-report/",
             factory="warehouse.packaging.models:ProjectFactory",
             traverse="/{name}",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "packaging.release",
             "/project/{name}/{version}/",
             factory="warehouse.packaging.models:ProjectFactory",
             traverse="/{name}/{version}",
             domain=warehouse,
         ),
-        pretend.call("packaging.file", "https://files.example.com/packages/{path}"),
-        pretend.call("ses.hook", "/_/ses-hook/", domain=warehouse),
-        pretend.call("rss.updates", "/rss/updates.xml", domain=warehouse),
-        pretend.call("rss.packages", "/rss/packages.xml", domain=warehouse),
-        pretend.call(
+        mocker.call("packaging.file", "https://files.example.com/packages/{path}"),
+        mocker.call("ses.hook", "/_/ses-hook/", domain=warehouse),
+        mocker.call("rss.updates", "/rss/updates.xml", domain=warehouse),
+        mocker.call("rss.packages", "/rss/packages.xml", domain=warehouse),
+        mocker.call(
             "rss.project.releases",
             "/rss/project/{name}/releases.xml",
             factory="warehouse.packaging.models:ProjectFactory",
             traverse="/{name}/",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "integrations.secrets.disclose-token",
             "/_/secrets/disclose-token",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "integrations.github.disclose-token",
             "/_/github/disclose-token",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "integrations.vulnerabilities.osv.report",
             "/_/vulnerabilities/osv/report",
             domain=warehouse,
         ),
-        pretend.call("api.billing.webhook", "/billing/webhook/", domain=warehouse),
-        pretend.call("api.simple.index", "/simple/", domain=warehouse),
-        pretend.call(
+        mocker.call("api.billing.webhook", "/billing/webhook/", domain=warehouse),
+        mocker.call("api.simple.index", "/simple/", domain=warehouse),
+        mocker.call(
             "api.simple.detail",
             "/simple/{name}/",
             factory="warehouse.packaging.models:ProjectFactory",
@@ -620,13 +588,13 @@ def test_routes(warehouse):
             domain=warehouse,
         ),
         # API URLs
-        pretend.call(
+        mocker.call(
             "api.echo",
             "/danger-api/echo",
             auth_methods={"macaroon"},
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "api.projects.observations",
             "/danger-api/projects/{name}/observations",
             factory="warehouse.packaging.models:ProjectFactory",
@@ -635,7 +603,7 @@ def test_routes(warehouse):
             domain=warehouse,
         ),
         # PEP 740 URLs
-        pretend.call(
+        mocker.call(
             "integrity.provenance",
             "/integrity/{project_name}/{release}/{filename}/provenance",
             factory="warehouse.packaging.models:ProjectFactory",
@@ -643,84 +611,84 @@ def test_routes(warehouse):
             domain=warehouse,
         ),
         # Mock URLs
-        pretend.call(
+        mocker.call(
             "mock.billing.checkout-session",
             "/mock/billing/{organization_name}/checkout/",
             factory="warehouse.organizations.models:OrganizationFactory",
             traverse="/{organization_name}",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "mock.billing.portal-session",
             "/mock/billing/{organization_name}/portal/",
             factory="warehouse.organizations.models:OrganizationFactory",
             traverse="/{organization_name}",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "mock.billing.trigger-checkout-session-completed",
             "/mock/billing/{organization_name}/checkout/completed/",
             factory="warehouse.organizations.models:OrganizationFactory",
             traverse="/{organization_name}",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "legacy.api.json.project",
             "/pypi/{name}/json",
             factory="warehouse.legacy.api.json.latest_release_factory",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "legacy.api.json.project_slash",
             "/pypi/{name}/json/",
             factory="warehouse.legacy.api.json.latest_release_factory",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "legacy.api.json.release",
             "/pypi/{name}/{version}/json",
             factory="warehouse.legacy.api.json.release_factory",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "legacy.api.json.release_slash",
             "/pypi/{name}/{version}/json/",
             factory="warehouse.legacy.api.json.release_factory",
             domain=warehouse,
         ),
-        pretend.call("legacy.docs", docs_route_url),
+        mocker.call("legacy.docs", docs_route_url),
     ]
 
-    assert config.add_template_view.calls == [
-        pretend.call(
+    assert config.add_template_view.call_args_list == [
+        mocker.call(
             "sitemap",
             "/sitemap/",
             "pages/sitemap.html",
             route_kw={"domain": warehouse},
             view_kw={"has_translations": True},
         ),
-        pretend.call(
+        mocker.call(
             "help",
             "/help/",
             "pages/help.html",
             route_kw={"domain": warehouse},
             view_kw={"has_translations": True},
         ),
-        pretend.call(
+        mocker.call(
             "security",
             "/security/",
             "pages/security.html",
             route_kw={"domain": warehouse},
             view_kw={"has_translations": True},
         ),
-        pretend.call(
+        mocker.call(
             "sponsors",
             "/sponsors/",
             "pages/sponsors.html",
             route_kw={"domain": warehouse},
             view_kw={"has_translations": True},
         ),
-        pretend.call(
+        mocker.call(
             "trademarks",
             "/trademarks/",
             "pages/trademarks.html",
@@ -729,73 +697,73 @@ def test_routes(warehouse):
         ),
     ]
 
-    assert config.add_redirect.calls == [
-        pretend.call("/sponsor/", "/sponsors/", domain=warehouse),
-        pretend.call("/u/{username}/", "/user/{username}/", domain=warehouse),
-        pretend.call("/2fa/", "/manage/account/two-factor/", domain=warehouse),
-        pretend.call("/p/{name}/", "/project/{name}/", domain=warehouse),
-        pretend.call(
+    assert config.add_redirect.call_args_list == [
+        mocker.call("/sponsor/", "/sponsors/", domain=warehouse),
+        mocker.call("/u/{username}/", "/user/{username}/", domain=warehouse),
+        mocker.call("/2fa/", "/manage/account/two-factor/", domain=warehouse),
+        mocker.call("/p/{name}/", "/project/{name}/", domain=warehouse),
+        mocker.call(
             "/p/{name}/{version}/", "/project/{name}/{version}/", domain=warehouse
         ),
-        pretend.call("/pypi/{name}/", "/project/{name}/", domain=warehouse),
-        pretend.call(
+        mocker.call("/pypi/{name}/", "/project/{name}/", domain=warehouse),
+        mocker.call(
             "/pypi/{name}/{version}/", "/project/{name}/{version}/", domain=warehouse
         ),
-        pretend.call("/pypi/", "/", domain=warehouse),
-        pretend.call(
+        mocker.call("/pypi/", "/", domain=warehouse),
+        mocker.call(
             "/packages/{path:.*}",
             "https://files.example.com/packages/{path}",
             domain=warehouse,
         ),
     ]
 
-    assert config.add_redirect_rule.calls == [
-        pretend.call(
+    assert config.add_redirect_rule.call_args_list == [
+        mocker.call(
             f"https?://({warehouse}|localhost)/policy/terms-of-use/",
             "https://policies.python.org/pypi.org/Terms-of-Use/",
         ),
-        pretend.call(
+        mocker.call(
             f"https?://({warehouse}|localhost)/policy/acceptable-use-policy/",
             "https://policies.python.org/pypi.org/Acceptable-Use-Policy/",
         ),
     ]
 
-    assert config.add_pypi_action_route.calls == [
-        pretend.call("legacy.api.pypi.file_upload", "file_upload", domain=warehouse),
-        pretend.call("legacy.api.pypi.submit", "submit", domain=warehouse),
-        pretend.call(
+    assert config.add_pypi_action_route.call_args_list == [
+        mocker.call("legacy.api.pypi.file_upload", "file_upload", domain=warehouse),
+        mocker.call("legacy.api.pypi.submit", "submit", domain=warehouse),
+        mocker.call(
             "legacy.api.pypi.submit_pkg_info", "submit_pkg_info", domain=warehouse
         ),
-        pretend.call("legacy.api.pypi.doc_upload", "doc_upload", domain=warehouse),
-        pretend.call("legacy.api.pypi.doap", "doap", domain=warehouse),
-        pretend.call(
+        mocker.call("legacy.api.pypi.doc_upload", "doc_upload", domain=warehouse),
+        mocker.call("legacy.api.pypi.doap", "doap", domain=warehouse),
+        mocker.call(
             "legacy.api.pypi.list_classifiers", "list_classifiers", domain=warehouse
         ),
-        pretend.call("legacy.api.pypi.search", "search", domain=warehouse),
-        pretend.call("legacy.api.pypi.browse", "browse", domain=warehouse),
-        pretend.call("legacy.api.pypi.files", "files", domain=warehouse),
-        pretend.call("legacy.api.pypi.display", "display", domain=warehouse),
+        mocker.call("legacy.api.pypi.search", "search", domain=warehouse),
+        mocker.call("legacy.api.pypi.browse", "browse", domain=warehouse),
+        mocker.call("legacy.api.pypi.files", "files", domain=warehouse),
+        mocker.call("legacy.api.pypi.display", "display", domain=warehouse),
     ]
 
-    assert config.add_pypi_action_redirect.calls == [
-        pretend.call("rss", "/rss/updates.xml", domain=warehouse),
-        pretend.call("packages_rss", "/rss/packages.xml", domain=warehouse),
+    assert config.add_pypi_action_redirect.call_args_list == [
+        mocker.call("rss", "/rss/updates.xml", domain=warehouse),
+        mocker.call("packages_rss", "/rss/packages.xml", domain=warehouse),
     ]
 
-    assert config.add_xmlrpc_endpoint.calls == [
-        pretend.call(
+    assert config.add_xmlrpc_endpoint.call_args_list == [
+        mocker.call(
             "xmlrpc.pypi",
             pattern="/pypi",
             header="Content-Type:text/xml",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "xmlrpc.pypi_slash",
             pattern="/pypi/",
             header="Content-Type:text/xml",
             domain=warehouse,
         ),
-        pretend.call(
+        mocker.call(
             "xmlrpc.RPC2",
             pattern="/RPC2",
             header="Content-Type:text/xml",

--- a/tests/unit/test_tasks.py
+++ b/tests/unit/test_tasks.py
@@ -1,8 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
-from unittest import mock
+import types
 
-import pretend
 import pytest
 import transaction
 
@@ -39,44 +38,35 @@ class TestWarehouseTask:
         obj = task_type()
         obj.__header__(object())
 
-    def test_call(self, monkeypatch):
-        request = pretend.stub()
-        registry = pretend.stub(settings={"warehouse.ip_salt": "peppa"})
-        result = pretend.stub()
+    def test_call(self, mocker):
+        registry = types.SimpleNamespace(settings={"warehouse.ip_salt": "peppa"})
 
         prepared = {
             "registry": registry,
-            "request": request,
-            "closer": pretend.call_recorder(lambda: None),
+            "request": mocker.sentinel.request,
+            "closer": mocker.stub(name="closer"),
         }
-        prepare = pretend.call_recorder(lambda *a, **kw: prepared)
-        monkeypatch.setattr(scripting, "prepare", prepare)
+        prepare = mocker.patch.object(scripting, "prepare", return_value=prepared)
 
-        @pretend.call_recorder
-        def runner(irequest):
-            assert irequest is request
-            return result
+        runner = mocker.Mock(return_value=mocker.sentinel.result)
 
         task = tasks.WarehouseTask()
         task.app = Celery()
-        task.app.pyramid_config = pretend.stub(registry=registry)
+        task.app.pyramid_config = types.SimpleNamespace(registry=registry)
         task.run = runner
 
-        assert task() is result
-        assert prepare.calls == [pretend.call(registry=registry)]
-        assert runner.calls == [pretend.call(request)]
+        assert task() is mocker.sentinel.result
+        prepare.assert_called_once_with(registry=registry)
+        runner.assert_called_once_with(mocker.sentinel.request)
 
-    def test_retry(self, monkeypatch, metrics):
+    def test_retry(self, mocker, pyramid_request, metrics):
         class SpecificError(Exception):
             pass
 
         def runner(self):
             raise self.retry(exc=SpecificError)
 
-        request = pretend.stub(
-            find_service=lambda *a, **kw: metrics,
-        )
-        monkeypatch.setattr(tasks, "get_current_request", lambda: request)
+        mocker.patch.object(tasks, "get_current_request", return_value=pyramid_request)
 
         task = tasks.WarehouseTask()
         task.app = Celery()
@@ -86,105 +76,96 @@ class TestWarehouseTask:
         with pytest.raises(SpecificError):
             task.run(task)
 
-        assert metrics.increment.calls == [
-            pretend.call("warehouse.task.retried", tags=["task:warehouse.test.task"])
-        ]
-
-    def test_without_request(self, monkeypatch):
-        async_result = pretend.stub()
-        apply_async = pretend.call_recorder(lambda *a, **kw: async_result)
-
-        get_current_request = pretend.call_recorder(lambda: None)
-        monkeypatch.setattr(tasks, "get_current_request", get_current_request)
-
-        task = tasks.WarehouseTask()
-        task.app = Celery()
-
-        monkeypatch.setattr(Task, "apply_async", apply_async)
-
-        assert task.apply_async() is async_result
-
-        assert apply_async.calls == [
-            pretend.call(
-                task,
-            )
-        ]
-        assert get_current_request.calls == [pretend.call()]
-
-    def test_request_without_tm(self, monkeypatch):
-        async_result = pretend.stub()
-        apply_async = pretend.call_recorder(lambda *a, **kw: async_result)
-
-        request = pretend.stub()
-        get_current_request = pretend.call_recorder(lambda: request)
-        monkeypatch.setattr(tasks, "get_current_request", get_current_request)
-
-        task = tasks.WarehouseTask()
-        task.app = Celery()
-
-        monkeypatch.setattr(Task, "apply_async", apply_async)
-
-        assert task.apply_async() is async_result
-
-        assert apply_async.calls == [
-            pretend.call(
-                task,
-            )
-        ]
-        assert get_current_request.calls == [pretend.call()]
-
-    def test_request_after_commit(self, monkeypatch):
-        manager = pretend.stub(
-            addAfterCommitHook=pretend.call_recorder(lambda *a, **kw: None)
+        metrics.increment.assert_called_once_with(
+            "warehouse.task.retried", tags=["task:warehouse.test.task"]
         )
-        request = pretend.stub(
-            tm=pretend.stub(get=pretend.call_recorder(lambda: manager))
+
+    def test_without_request(self, mocker):
+        apply_async = mocker.patch.object(
+            Task,
+            "apply_async",
+            autospec=True,
+            return_value=mocker.sentinel.async_result,
         )
-        get_current_request = pretend.call_recorder(lambda: request)
-        monkeypatch.setattr(tasks, "get_current_request", get_current_request)
+        get_current_request = mocker.patch.object(
+            tasks, "get_current_request", return_value=None
+        )
 
         task = tasks.WarehouseTask()
         task.app = Celery()
 
-        args = (pretend.stub(), pretend.stub())
-        kwargs = {
-            "foo": pretend.stub(),
-        }
+        assert task.apply_async() is mocker.sentinel.async_result
+
+        apply_async.assert_called_once_with(task)
+        get_current_request.assert_called_once_with()
+
+    def test_request_without_tm(self, mocker):
+        apply_async = mocker.patch.object(
+            Task,
+            "apply_async",
+            autospec=True,
+            return_value=mocker.sentinel.async_result,
+        )
+        get_current_request = mocker.patch.object(
+            tasks, "get_current_request", return_value=mocker.sentinel.request
+        )
+
+        task = tasks.WarehouseTask()
+        task.app = Celery()
+
+        assert task.apply_async() is mocker.sentinel.async_result
+
+        apply_async.assert_called_once_with(task)
+        get_current_request.assert_called_once_with()
+
+    def test_request_after_commit(self, mocker):
+        manager = mocker.Mock()
+        request = mocker.Mock()
+        request.tm.get.return_value = manager
+        get_current_request = mocker.patch.object(
+            tasks, "get_current_request", return_value=request
+        )
+
+        task = tasks.WarehouseTask()
+        task.app = Celery()
+
+        args = (mocker.sentinel.arg0, mocker.sentinel.arg1)
+        kwargs = {"foo": mocker.sentinel.foo}
 
         assert task.apply_async(*args, **kwargs) is None
-        assert get_current_request.calls == [pretend.call()]
-        assert request.tm.get.calls == [pretend.call()]
-        assert manager.addAfterCommitHook.calls == [
-            pretend.call(task._after_commit_hook, args=args, kws=kwargs)
-        ]
+        get_current_request.assert_called_once_with()
+        request.tm.get.assert_called_once_with()
+        manager.addAfterCommitHook.assert_called_once_with(
+            task._after_commit_hook, args=args, kws=kwargs
+        )
 
     @pytest.mark.parametrize("success", [True, False])
-    def test_after_commit_hook(self, monkeypatch, success):
-        args = [pretend.stub(), pretend.stub()]
-        kwargs = {"foo": pretend.stub(), "bar": pretend.stub()}
+    def test_after_commit_hook(self, mocker, success):
+        args = [mocker.sentinel.arg0, mocker.sentinel.arg1]
+        kwargs = {"foo": mocker.sentinel.foo, "bar": mocker.sentinel.bar}
 
-        apply_async = pretend.call_recorder(lambda *a, **kw: None)
+        apply_async = mocker.patch.object(
+            Task, "apply_async", autospec=True, return_value=None
+        )
 
         task = tasks.WarehouseTask()
         task.app = Celery()
-
-        monkeypatch.setattr(Task, "apply_async", apply_async)
 
         task._after_commit_hook(success, *args, **kwargs)
 
         if success:
-            assert apply_async.calls == [pretend.call(task, *args, **kwargs)]
+            apply_async.assert_called_once_with(task, *args, **kwargs)
         else:
-            assert apply_async.calls == []
+            apply_async.assert_not_called()
 
-    def test_creates_request(self, monkeypatch):
-        registry = pretend.stub(settings={"warehouse.ip_salt": "peppa"})
-        pyramid_env = {"request": pretend.stub()}
+    def test_creates_request(self, mocker):
+        registry = types.SimpleNamespace(settings={"warehouse.ip_salt": "peppa"})
+        pyramid_env = {"request": types.SimpleNamespace()}
 
-        monkeypatch.setattr(scripting, "prepare", lambda *a, **k: pyramid_env)
+        mocker.patch.object(scripting, "prepare", return_value=pyramid_env)
 
         obj = tasks.WarehouseTask()
-        obj.app.pyramid_config = pretend.stub(registry=registry)
+        obj.app.pyramid_config = types.SimpleNamespace(registry=registry)
 
         request = obj.get_request()
 
@@ -198,33 +179,22 @@ class TestWarehouseTask:
             == "cc9dfe9c4e6b6579bbf789d04339bd2d7f10aadf84ff4394193d99f14a0333f0"
         )
 
-    def test_reuses_request(self):
-        pyramid_env = {"request": pretend.stub()}
+    def test_reuses_request(self, mocker):
+        pyramid_env = {"request": mocker.sentinel.request}
 
         obj = tasks.WarehouseTask()
-        obj.request_stack = pretend.stub(top=None)
+        obj.request_stack = types.SimpleNamespace(top=None)
         obj.request.update(pyramid_env=pyramid_env)
 
-        assert obj.get_request() is pyramid_env["request"]
+        assert obj.get_request() is mocker.sentinel.request
 
-    def test_run_creates_transaction(self, metrics):
-        result = pretend.stub()
-        arg = pretend.stub()
-        kwarg = pretend.stub()
-
-        request = pretend.stub(
-            tm=pretend.stub(
-                __enter__=pretend.call_recorder(lambda *a, **kw: None),
-                __exit__=pretend.call_recorder(lambda *a, **kw: None),
-            ),
+    def test_run_creates_transaction(self, mocker, metrics):
+        request = types.SimpleNamespace(
+            tm=mocker.MagicMock(),
             find_service=lambda *a, **kw: metrics,
         )
 
-        @pretend.call_recorder
-        def run(arg_, *, kwarg_=None):
-            assert arg_ is arg
-            assert kwarg_ is kwarg
-            return result
+        run = mocker.Mock(return_value=mocker.sentinel.result)
 
         task_type = type(
             "Foo",
@@ -235,19 +205,21 @@ class TestWarehouseTask:
         obj = task_type()
         obj.get_request = lambda: request
 
-        assert obj.run(arg, kwarg_=kwarg) is result
-        assert run.calls == [pretend.call(arg, kwarg_=kwarg)]
-        assert request.tm.__enter__.calls == [pretend.call()]
-        assert request.tm.__exit__.calls == [pretend.call(None, None, None)]
-        assert metrics.timed.calls == [
-            pretend.call("warehouse.task.run", tags=["task:warehouse.test.task"])
-        ]
-        assert metrics.increment.calls == [
-            pretend.call("warehouse.task.start", tags=["task:warehouse.test.task"]),
-            pretend.call("warehouse.task.complete", tags=["task:warehouse.test.task"]),
+        assert obj.run(mocker.sentinel.arg, kwarg_=mocker.sentinel.kwarg) is (
+            mocker.sentinel.result
+        )
+        run.assert_called_once_with(mocker.sentinel.arg, kwarg_=mocker.sentinel.kwarg)
+        request.tm.__enter__.assert_called_once_with()
+        request.tm.__exit__.assert_called_once_with(None, None, None)
+        metrics.timed.assert_called_once_with(
+            "warehouse.task.run", tags=["task:warehouse.test.task"]
+        )
+        assert metrics.increment.call_args_list == [
+            mocker.call("warehouse.task.start", tags=["task:warehouse.test.task"]),
+            mocker.call("warehouse.task.complete", tags=["task:warehouse.test.task"]),
         ]
 
-    def test_run_retries_failed_transaction(self, metrics):
+    def test_run_retries_failed_transaction(self, mocker, metrics):
         class RetryThisError(RetryableException):
             pass
 
@@ -267,11 +239,8 @@ class TestWarehouseTask:
             },
         )
 
-        request = pretend.stub(
-            tm=pretend.stub(
-                __enter__=pretend.call_recorder(lambda *a, **kw: None),
-                __exit__=pretend.call_recorder(lambda *a, **kw: None),
-            ),
+        request = types.SimpleNamespace(
+            tm=mocker.MagicMock(),
             find_service=lambda *a, **kw: metrics,
         )
 
@@ -281,19 +250,17 @@ class TestWarehouseTask:
         with pytest.raises(RetryError):
             obj.run()
 
-        assert request.tm.__enter__.calls == [pretend.call()]
-        assert request.tm.__exit__.calls == [
-            pretend.call(RetryError, mock.ANY, mock.ANY)
-        ]
-        assert metrics.timed.calls == [
-            pretend.call("warehouse.task.run", tags=["task:warehouse.test.task"])
-        ]
-        assert metrics.increment.calls == [
-            pretend.call("warehouse.task.start", tags=["task:warehouse.test.task"]),
-            pretend.call("warehouse.task.retried", tags=["task:warehouse.test.task"]),
+        request.tm.__enter__.assert_called_once_with()
+        request.tm.__exit__.assert_called_once_with(RetryError, mocker.ANY, mocker.ANY)
+        metrics.timed.assert_called_once_with(
+            "warehouse.task.run", tags=["task:warehouse.test.task"]
+        )
+        assert metrics.increment.call_args_list == [
+            mocker.call("warehouse.task.start", tags=["task:warehouse.test.task"]),
+            mocker.call("warehouse.task.retried", tags=["task:warehouse.test.task"]),
         ]
 
-    def test_run_doesnt_retries_failed_transaction(self, metrics):
+    def test_run_doesnt_retries_failed_transaction(self, mocker, metrics):
         class DontRetryThisError(Exception):
             pass
 
@@ -306,11 +273,8 @@ class TestWarehouseTask:
             {"name": "warehouse.test.task", "run": staticmethod(run)},
         )
 
-        request = pretend.stub(
-            tm=pretend.stub(
-                __enter__=pretend.call_recorder(lambda *a, **kw: None),
-                __exit__=pretend.call_recorder(lambda *a, **kw: None),
-            ),
+        request = types.SimpleNamespace(
+            tm=mocker.MagicMock(),
             find_service=lambda *a, **kw: metrics,
         )
 
@@ -320,127 +284,115 @@ class TestWarehouseTask:
         with pytest.raises(DontRetryThisError):
             obj.run()
 
-        assert request.tm.__enter__.calls == [pretend.call()]
-        assert request.tm.__exit__.calls == [
-            pretend.call(DontRetryThisError, mock.ANY, mock.ANY)
-        ]
-        assert metrics.timed.calls == [
-            pretend.call("warehouse.task.run", tags=["task:warehouse.test.task"])
-        ]
-        assert metrics.increment.calls == [
-            pretend.call("warehouse.task.start", tags=["task:warehouse.test.task"]),
-            pretend.call("warehouse.task.failed", tags=["task:warehouse.test.task"]),
+        request.tm.__enter__.assert_called_once_with()
+        request.tm.__exit__.assert_called_once_with(
+            DontRetryThisError, mocker.ANY, mocker.ANY
+        )
+        metrics.timed.assert_called_once_with(
+            "warehouse.task.run", tags=["task:warehouse.test.task"]
+        )
+        assert metrics.increment.call_args_list == [
+            mocker.call("warehouse.task.start", tags=["task:warehouse.test.task"]),
+            mocker.call("warehouse.task.failed", tags=["task:warehouse.test.task"]),
         ]
 
-    def test_after_return_without_pyramid_env(self):
+    def test_after_return_without_pyramid_env(self, mocker):
         obj = tasks.WarehouseTask()
-        obj.request_stack = pretend.stub(top=None)
+        obj.request_stack = types.SimpleNamespace(top=None)
         assert (
             obj.after_return(
-                pretend.stub(),
-                pretend.stub(),
-                pretend.stub(),
-                pretend.stub(),
-                pretend.stub(),
-                pretend.stub(),
+                mocker.sentinel.status,
+                mocker.sentinel.retval,
+                mocker.sentinel.task_id,
+                mocker.sentinel.args,
+                mocker.sentinel.kwargs,
+                mocker.sentinel.einfo,
             )
             is None
         )
 
-    def test_after_return_closes_env_runs_request_callbacks(self):
+    def test_after_return_closes_env_runs_request_callbacks(self, mocker):
         obj = tasks.WarehouseTask()
-        obj.request_stack = pretend.stub(top=None)
-        obj.request.pyramid_env = {
-            "request": pretend.stub(
-                _process_finished_callbacks=pretend.call_recorder(lambda: None)
-            ),
-            "closer": pretend.call_recorder(lambda: None),
-        }
+        obj.request_stack = types.SimpleNamespace(top=None)
+        inner_request = mocker.Mock()
+        closer = mocker.Mock()
+        obj.request.pyramid_env = {"request": inner_request, "closer": closer}
 
         obj.after_return(
-            pretend.stub(),
-            pretend.stub(),
-            pretend.stub(),
-            pretend.stub(),
-            pretend.stub(),
-            pretend.stub(),
+            mocker.sentinel.status,
+            mocker.sentinel.retval,
+            mocker.sentinel.task_id,
+            mocker.sentinel.args,
+            mocker.sentinel.kwargs,
+            mocker.sentinel.einfo,
         )
 
-        assert obj.request.pyramid_env["request"]._process_finished_callbacks.calls == [
-            pretend.call()
-        ]
-        assert obj.request.pyramid_env["closer"].calls == [pretend.call()]
+        inner_request._process_finished_callbacks.assert_called_once_with()
+        closer.assert_called_once_with()
 
 
 class TestCeleryTaskGetter:
-    def test_gets_task(self):
-        task_func = pretend.stub(__name__="task_func", __module__="tests.foo")
-        task_obj = pretend.stub()
-        celery_app = pretend.stub(
+    def test_gets_task(self, mocker):
+        task_func = types.SimpleNamespace(__name__="task_func", __module__="tests.foo")
+        celery_app = types.SimpleNamespace(
             gen_task_name=lambda func, module: module + "." + func,
-            tasks={"tests.foo.task_func": task_obj},
+            tasks={"tests.foo.task_func": mocker.sentinel.task_obj},
         )
-        assert tasks._get_task(celery_app, task_func) is task_obj
+        assert tasks._get_task(celery_app, task_func) is mocker.sentinel.task_obj
 
-    def test_get_task_via_request(self):
-        task_func = pretend.stub(__name__="task_func", __module__="tests.foo")
-        task_obj = pretend.stub()
-        celery_app = pretend.stub(
+    def test_get_task_via_request(self, mocker):
+        task_func = types.SimpleNamespace(__name__="task_func", __module__="tests.foo")
+        celery_app = types.SimpleNamespace(
             gen_task_name=lambda func, module: module + "." + func,
-            tasks={"tests.foo.task_func": task_obj},
+            tasks={"tests.foo.task_func": mocker.sentinel.task_obj},
         )
 
-        request = pretend.stub(registry={"celery.app": celery_app})
+        request = types.SimpleNamespace(registry={"celery.app": celery_app})
         get_task = tasks._get_task_from_request(request)
 
-        assert get_task(task_func) is task_obj
+        assert get_task(task_func) is mocker.sentinel.task_obj
 
-    def test_get_task_via_config(self):
-        task_func = pretend.stub(__name__="task_func", __module__="tests.foo")
-        task_obj = pretend.stub()
-        celery_app = pretend.stub(
+    def test_get_task_via_config(self, mocker):
+        task_func = types.SimpleNamespace(__name__="task_func", __module__="tests.foo")
+        celery_app = types.SimpleNamespace(
             gen_task_name=lambda func, module: module + "." + func,
-            tasks={"tests.foo.task_func": task_obj},
+            tasks={"tests.foo.task_func": mocker.sentinel.task_obj},
         )
 
-        config = pretend.stub(registry={"celery.app": celery_app})
+        config = types.SimpleNamespace(registry={"celery.app": celery_app})
 
         assert tasks._get_task_from_config(config, task_func)
 
 
-def test_add_periodic_task():
-    signature = pretend.stub()
-    task_obj = pretend.stub(s=lambda: signature)
-    celery_app = pretend.stub(
-        add_periodic_task=pretend.call_recorder(lambda *a, **k: None)
-    )
+def test_add_periodic_task(mocker):
+    task_obj = types.SimpleNamespace(s=lambda: mocker.sentinel.signature)
+    celery_app = mocker.Mock()
     actions = []
-    config = pretend.stub(
-        action=pretend.call_recorder(lambda d, f, order: actions.append(f)),
-        registry={"celery.app": celery_app},
-        task=pretend.call_recorder(lambda t: task_obj),
-    )
+    config = mocker.Mock(spec=["action", "task", "registry"])
+    config.action.side_effect = lambda d, f, order: actions.append(f)
+    config.task.return_value = task_obj
+    config.registry = {"celery.app": celery_app}
 
-    schedule = pretend.stub()
-    func = pretend.stub()
-
-    tasks._add_periodic_task(config, schedule, func)
+    tasks._add_periodic_task(config, mocker.sentinel.schedule, mocker.sentinel.func)
 
     for action in actions:
         action()
 
-    assert config.action.calls == [pretend.call(None, mock.ANY, order=100)]
-    assert config.task.calls == [pretend.call(func)]
-    assert celery_app.add_periodic_task.calls == [
-        pretend.call(schedule, signature, args=(), kwargs=(), name=None)
-    ]
+    config.action.assert_called_once_with(None, mocker.ANY, order=100)
+    config.task.assert_called_once_with(mocker.sentinel.func)
+    celery_app.add_periodic_task.assert_called_once_with(
+        mocker.sentinel.schedule,
+        mocker.sentinel.signature,
+        args=(),
+        kwargs=(),
+        name=None,
+    )
 
 
-def test_make_celery_app():
-    celery_app = pretend.stub()
-    config = pretend.stub(registry={"celery.app": celery_app})
+def test_make_celery_app(mocker):
+    config = types.SimpleNamespace(registry={"celery.app": mocker.sentinel.celery_app})
 
-    assert tasks._get_celery_app(config) is celery_app
+    assert tasks._get_celery_app(config) is mocker.sentinel.celery_app
 
 
 @pytest.mark.parametrize(
@@ -477,23 +429,21 @@ def test_make_celery_app():
         ),
     ],
 )
-def test_includeme(env, ssl, broker_redis_url, expected_url, transport_options):
-    registry_dict = {}
-    config = pretend.stub(
-        action=pretend.call_recorder(lambda *a, **kw: None),
-        add_directive=pretend.call_recorder(lambda *a, **kw: None),
-        add_request_method=pretend.call_recorder(lambda *a, **kw: None),
-        registry=pretend.stub(
-            __getitem__=registry_dict.__getitem__,
-            __setitem__=registry_dict.__setitem__,
-            settings={
-                "warehouse.env": env,
-                "celery.broker_redis_url": broker_redis_url,
-                "celery.result_url": pretend.stub(),
-                "celery.scheduler_url": pretend.stub(),
-            },
-        ),
+def test_includeme(mocker, env, ssl, broker_redis_url, expected_url, transport_options):
+    class Registry(dict):
+        pass
+
+    registry = Registry()
+    registry.settings = {
+        "warehouse.env": env,
+        "celery.broker_redis_url": broker_redis_url,
+        "celery.result_url": mocker.sentinel.result_url,
+        "celery.scheduler_url": mocker.sentinel.scheduler_url,
+    }
+    config = mocker.Mock(
+        spec=["action", "add_directive", "add_request_method", "registry"]
     )
+    config.registry = registry
     tasks.includeme(config)
 
     app = config.registry["celery.app"]
@@ -515,12 +465,12 @@ def test_includeme(env, ssl, broker_redis_url, expected_url, transport_options):
         "REDBEAT_REDIS_URL": (config.registry.settings["celery.scheduler_url"]),
     }.items():
         assert app.conf[key] == value
-    assert config.action.calls == [pretend.call(("celery", "finalize"), app.finalize)]
-    assert config.add_directive.calls == [
-        pretend.call("add_periodic_task", tasks._add_periodic_task, action_wrap=False),
-        pretend.call("make_celery_app", tasks._get_celery_app, action_wrap=False),
-        pretend.call("task", tasks._get_task_from_config, action_wrap=False),
+    config.action.assert_called_once_with(("celery", "finalize"), app.finalize)
+    assert config.add_directive.call_args_list == [
+        mocker.call("add_periodic_task", tasks._add_periodic_task, action_wrap=False),
+        mocker.call("make_celery_app", tasks._get_celery_app, action_wrap=False),
+        mocker.call("task", tasks._get_task_from_config, action_wrap=False),
     ]
-    assert config.add_request_method.calls == [
-        pretend.call(tasks._get_task_from_request, name="task", reify=True)
-    ]
+    config.add_request_method.assert_called_once_with(
+        tasks._get_task_from_request, name="task", reify=True
+    )


### PR DESCRIPTION
See each commit for simpler review.
Largely mechanical replacement of `pretend`.

Refs: #18880 