### PR TITLE
Address issue #20219 Package author is in both verified and unverified metadata

### DIFF
--- a/warehouse/templates/includes/packaging/project-data.html
+++ b/warehouse/templates/includes/packaging/project-data.html
@@ -249,7 +249,7 @@
               <strong>{% trans %}Maintainer:{% endtrans %}</strong> <a href="mailto:{{ release.maintainer_email|format_email|last }}">{{ release.maintainer or release.maintainer_email|format_email|first }}</a>
             </span>
           </li>
-        {% elif release.maintainer %}
+        {% elif release.maintainer and not release.maintainer_email_verified %}
           <li>
             <span>
               <strong>{% trans %}Maintainer:{% endtrans %}</strong> {{ release.maintainer }}

--- a/warehouse/templates/includes/packaging/project-data.html
+++ b/warehouse/templates/includes/packaging/project-data.html
@@ -236,7 +236,7 @@
               <strong>{% trans %}Author:{% endtrans %}</strong> <a href="mailto:{{ release.author_email|format_email|last }}">{{ release.author or release.author_email|format_email|first }}</a>
             </span>
           </li>
-        {% elif release.author %}
+        {% elif release.author and not release.author_email_verified %}
           <li>
             <span>
               <strong>{% trans %}Author:{% endtrans %}</strong> {{ release.author }}


### PR DESCRIPTION
Address issue #20219

Issue was caused by a missing check on https://github.com/pypi/warehouse/blob/9e7644bc4160f295b370f33425379deb0398fccc/warehouse/templates/includes/packaging/project-data.html#L239 for not release.author_email_verified

Verified Author is output on https://github.com/pypi/warehouse/blob/9e7644bc4160f295b370f33425379deb0398fccc/warehouse/templates/includes/packaging/project-data.html#L176

Tested by modifying test db with 

```
UPDATE releases
SET author_email_verified = TRUE
WHERE project_id = (
    SELECT id
    FROM projects
    WHERE normalized_name = 'clandestined'
);
```

to replicate the issue for clandestined and observe issue, fixed issue and observed fixed.

Before:

<img width="339" height="505" alt="Screenshot from 2026-07-11 14-36-31" src="https://github.com/user-attachments/assets/4c62ca68-bbe1-4a67-b985-b0093678ab6d" />

After:

<img width="339" height="505" alt="Screenshot from 2026-07-11 14-37-11" src="https://github.com/user-attachments/assets/280457a6-1dbf-4e69-b709-74e264630ef7" />


All tests and linter ran against branch successfully.

Thanks