### PR TITLE
Guard unittest.mock.sentinel objects from mutation during tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -107,6 +107,27 @@ class _CallRecorder:
         return getattr(self._mock, name)
 
 
+@pytest.fixture(autouse=True)
+def guard_mock_sentinels():
+    yield
+
+    mutations = []
+    # ``unittest.mock`` keeps every named sentinel in this process-global cache.
+    # Inspecting it lets us guard sentinels from mutation that would impact other tests.
+    for name, sentinel in mock.sentinel._sentinels.items():
+        attributes = vars(sentinel)
+        expected_attributes = {"name": name}
+        if attributes != expected_attributes:
+            mutations.append(f"mock.sentinel.{name} (attributes: {sorted(attributes)})")
+            attributes.clear()
+            attributes.update(expected_attributes)
+
+    assert not mutations, (
+        "mock sentinels must not be mutated; use a fresh object instead. Mutated: "
+        + ", ".join(mutations)
+    )
+
+
 @pytest.fixture
 def metrics():
     """Real ``NullMetrics`` with each method wrapped to record calls.

--- a/tests/unit/test_conftest.py
+++ b/tests/unit/test_conftest.py
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest import mock
+
+import pytest
+
+from tests import conftest
+
+
+def test_guard_mock_sentinels_reports_and_restores_mutations():
+    first = mock.sentinel.guard_test_first
+    first.leaked = object()
+
+    guard = conftest.guard_mock_sentinels.__wrapped__()
+    next(guard)
+
+    second = mock.sentinel.guard_test_second
+    second.also_leaked = object()
+
+    with pytest.raises(AssertionError) as exc_info:
+        next(guard)
+
+    assert "mock.sentinel.guard_test_first" in str(exc_info.value)
+    assert "mock.sentinel.guard_test_second" in str(exc_info.value)
+    assert vars(first) == {"name": "guard_test_first"}
+    assert vars(second) == {"name": "guard_test_second"}

--- a/tests/unit/test_tasks.py
+++ b/tests/unit/test_tasks.py
@@ -40,10 +40,11 @@ class TestWarehouseTask:
 
     def test_call(self, mocker):
         registry = types.SimpleNamespace(settings={"warehouse.ip_salt": "peppa"})
+        request = types.SimpleNamespace()
 
         prepared = {
             "registry": registry,
-            "request": mocker.sentinel.request,
+            "request": request,
             "closer": mocker.stub(name="closer"),
         }
         prepare = mocker.patch.object(scripting, "prepare", return_value=prepared)
@@ -57,7 +58,7 @@ class TestWarehouseTask:
 
         assert task() is mocker.sentinel.result
         prepare.assert_called_once_with(registry=registry)
-        runner.assert_called_once_with(mocker.sentinel.request)
+        runner.assert_called_once_with(request)
 
     def test_retry(self, mocker, pyramid_request, metrics):
         class SpecificError(Exception):
@@ -100,6 +101,7 @@ class TestWarehouseTask:
         get_current_request.assert_called_once_with()
 
     def test_request_without_tm(self, mocker):
+        request = types.SimpleNamespace()
         apply_async = mocker.patch.object(
             Task,
             "apply_async",
@@ -107,7 +109,7 @@ class TestWarehouseTask:
             return_value=mocker.sentinel.async_result,
         )
         get_current_request = mocker.patch.object(
-            tasks, "get_current_request", return_value=mocker.sentinel.request
+            tasks, "get_current_request", return_value=request
         )
 
         task = tasks.WarehouseTask()


### PR DESCRIPTION
We have been introducing usage of unittest.mock.sentinel into our test suite pretty broadly.

One of the test ordering issues flagged in #20273 is failing due to mutation of the request sentinel used.

This implements an autouse pytest fixture which inspects the global cache of unittest.mock.sentinel objects and loudly fails if any unittest.mock.sentinel object leaves the test with unexpected mutations.