### PR TITLE
Add Codeberg icon to project details

### DIFF
--- a/docs/user/project_metadata.md
+++ b/docs/user/project_metadata.md
@@ -113,12 +113,13 @@ An entry URL must point to a domain below to display a custom icon. Custom
 subdomains are also matched. For instance, if `domain.com` is listed, a URL
 ending in `.domain.com` will also match.
 
-| Service   | Icon                           | Domain                    |
-|:----------|:-------------------------------|:--------------------------|
-| Bitbucket | :fontawesome-brands-bitbucket: | `bitbucket.org`           |
-| GitHub    | :fontawesome-brands-github:    | `github.com`, `github.io` |
-| GitLab    | :fontawesome-brands-gitlab:    | `gitlab.com`              |
-| Google    | :fontawesome-brands-google:    | `google.com`              |
+| Service   | Icon                           | Domain                          |
+|:----------|:-------------------------------|:--------------------------------|
+| Bitbucket | :fontawesome-brands-bitbucket: | `bitbucket.org`                 |
+| Codeberg  | :simple-codeberg:              | `codeberg.org`, `codeberg.page` |
+| GitHub    | :fontawesome-brands-github:    | `github.com`, `github.io`       |
+| GitLab    | :fontawesome-brands-gitlab:    | `gitlab.com`                    |
+| Google    | :fontawesome-brands-google:    | `google.com`                    |
 
 
 #### Social Media Platforms

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
         "@fontsource/ewert": "^5.2.8",
         "@fontsource/source-code-pro": "^5.2.7",
         "@fontsource/source-sans-3": "^5.2.9",
-        "@fortawesome/fontawesome-free": "^7.1.0",
+        "@fortawesome/fontawesome-free": "^7.3.0",
         "@hotwired/stimulus": "^3.2.1",
         "@hotwired/stimulus-webpack-helpers": "^1.0.1",
         "@zxcvbn-ts/core": "^3.0.4",
@@ -2382,9 +2382,9 @@
       }
     },
     "node_modules/@fortawesome/fontawesome-free": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-7.2.0.tgz",
-      "integrity": "sha512-3DguDv/oUE+7vjMeTSOjCSG+KeawgVQOHrKRnvUuqYh1mfArrh7s+s8hXW3e4RerBA1+Wh+hBqf8sJNpqNrBWg==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-7.3.1.tgz",
+      "integrity": "sha512-wmglKKPDIkgV3aWlZzWECCPoGIkYCulzBwxG9+w7rc5BGapZ6cPMpoPOT8k36J0Ni7PPX6c/rsoMWfS4d1MUMg==",
       "license": "(CC-BY-4.0 AND OFL-1.1 AND MIT)",
       "engines": {
         "node": ">=6"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@fontsource/ewert": "^5.2.8",
     "@fontsource/source-code-pro": "^5.2.7",
     "@fontsource/source-sans-3": "^5.2.9",
-    "@fortawesome/fontawesome-free": "^7.1.0",
+    "@fortawesome/fontawesome-free": "^7.3.0",
     "@hotwired/stimulus": "^3.2.1",
     "@hotwired/stimulus-webpack-helpers": "^1.0.1",
     "@zxcvbn-ts/core": "^3.0.4",

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -1083,9 +1083,9 @@ msgstr ""
 #: warehouse/templates/manage/project/release.html:253
 #: warehouse/templates/manage/project/releases.html:157
 #: warehouse/templates/manage/project/releases.html:210
-#: warehouse/templates/packaging/detail.html:472
-#: warehouse/templates/packaging/detail.html:490
-#: warehouse/templates/packaging/detail.html:506
+#: warehouse/templates/packaging/detail.html:474
+#: warehouse/templates/packaging/detail.html:492
+#: warehouse/templates/packaging/detail.html:508
 #: warehouse/templates/pages/classifiers.html:17
 #: warehouse/templates/pages/help.html:7
 #: warehouse/templates/pages/help.html:441
@@ -3116,8 +3116,8 @@ msgstr ""
 #: warehouse/templates/manage/account/recovery_codes-provision.html:53
 #: warehouse/templates/manage/account/totp-provision.html:46
 #: warehouse/templates/manage/unverified-account.html:200
-#: warehouse/templates/packaging/detail.html:151
-#: warehouse/templates/packaging/detail.html:526
+#: warehouse/templates/packaging/detail.html:153
+#: warehouse/templates/packaging/detail.html:528
 #: warehouse/templates/pages/classifiers.html:42
 msgid "Copy to clipboard"
 msgstr ""
@@ -3129,7 +3129,7 @@ msgstr ""
 #: warehouse/templates/manage/account/recovery_codes-provision.html:54
 #: warehouse/templates/manage/account/totp-provision.html:47
 #: warehouse/templates/manage/unverified-account.html:201
-#: warehouse/templates/packaging/detail.html:527
+#: warehouse/templates/packaging/detail.html:529
 #: warehouse/templates/pages/classifiers.html:43
 msgid "Copy"
 msgstr ""
@@ -6921,12 +6921,12 @@ msgid "Back to projects"
 msgstr ""
 
 #: warehouse/templates/manage/project/manage_project_base.html:51
-#: warehouse/templates/packaging/detail.html:336
+#: warehouse/templates/packaging/detail.html:338
 msgid "This project has been quarantined."
 msgstr ""
 
 #: warehouse/templates/manage/project/manage_project_base.html:53
-#: warehouse/templates/packaging/detail.html:338
+#: warehouse/templates/packaging/detail.html:340
 msgid ""
 "PyPI Admins need to review this project before it can be restored. While "
 "in quarantine, the project is not installable by clients, and cannot be "
@@ -6935,8 +6935,8 @@ msgstr ""
 
 #: warehouse/templates/manage/project/manage_project_base.html:60
 #: warehouse/templates/manage/project/release.html:46
-#: warehouse/templates/packaging/detail.html:345
-#: warehouse/templates/packaging/detail.html:362
+#: warehouse/templates/packaging/detail.html:347
+#: warehouse/templates/packaging/detail.html:364
 #, python-format
 msgid ""
 "Read more in the <a href=\"%(href)s\">project in quarantine</a> help "
@@ -6944,7 +6944,7 @@ msgid ""
 msgstr ""
 
 #: warehouse/templates/manage/project/manage_project_base.html:67
-#: warehouse/templates/packaging/detail.html:369
+#: warehouse/templates/packaging/detail.html:371
 msgid "This project has been archived."
 msgstr ""
 
@@ -7030,12 +7030,12 @@ msgid "view release"
 msgstr ""
 
 #: warehouse/templates/manage/project/release.html:36
-#: warehouse/templates/packaging/detail.html:352
+#: warehouse/templates/packaging/detail.html:354
 msgid "This release has been quarantined."
 msgstr ""
 
 #: warehouse/templates/manage/project/release.html:38
-#: warehouse/templates/packaging/detail.html:354
+#: warehouse/templates/packaging/detail.html:356
 msgid ""
 "PyPI Admins need to review this release before it can be restored. While "
 "in quarantine, the release is not installable by clients, and cannot be "
@@ -7820,152 +7820,152 @@ msgstr ""
 msgid "%(org)s has not uploaded any projects to PyPI, yet"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:88
+#: warehouse/templates/packaging/detail.html:90
 msgid "view details"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:98
-#: warehouse/templates/packaging/detail.html:105
+#: warehouse/templates/packaging/detail.html:100
+#: warehouse/templates/packaging/detail.html:107
 #, python-format
 msgid "%(title)s"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:117
+#: warehouse/templates/packaging/detail.html:119
 #, python-format
 msgid "RSS: latest releases for %(project_name)s"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:153
+#: warehouse/templates/packaging/detail.html:155
 msgid "Copy PIP instructions"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:163
+#: warehouse/templates/packaging/detail.html:165
 msgid "This project has been quarantined"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:168
+#: warehouse/templates/packaging/detail.html:170
 msgid "This release has been quarantined"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:174
+#: warehouse/templates/packaging/detail.html:176
 msgid "This release has been yanked"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:182
+#: warehouse/templates/packaging/detail.html:184
 #, python-format
 msgid "Stable version available (%(version)s)"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:187
+#: warehouse/templates/packaging/detail.html:189
 #, python-format
 msgid "Newer version available (%(version)s)"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:192
+#: warehouse/templates/packaging/detail.html:194
 msgid "Latest release"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:197
+#: warehouse/templates/packaging/detail.html:199
 #, python-format
 msgid "Released: %(release_date)s"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:210
+#: warehouse/templates/packaging/detail.html:212
 msgid "No project description provided"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:222
+#: warehouse/templates/packaging/detail.html:224
 msgid "Navigation"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:223
-#: warehouse/templates/packaging/detail.html:276
+#: warehouse/templates/packaging/detail.html:225
+#: warehouse/templates/packaging/detail.html:278
 #, python-format
 msgid "Navigation for %(project)s"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:232
-#: warehouse/templates/packaging/detail.html:285
+#: warehouse/templates/packaging/detail.html:234
+#: warehouse/templates/packaging/detail.html:287
 msgid "Project description. Focus will be moved to the description."
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:234
-#: warehouse/templates/packaging/detail.html:287
-#: warehouse/templates/packaging/detail.html:383
+#: warehouse/templates/packaging/detail.html:236
+#: warehouse/templates/packaging/detail.html:289
+#: warehouse/templates/packaging/detail.html:385
 msgid "Project description"
-msgstr ""
-
-#: warehouse/templates/packaging/detail.html:243
-#: warehouse/templates/packaging/detail.html:307
-msgid "Release history. Focus will be moved to the history panel."
 msgstr ""
 
 #: warehouse/templates/packaging/detail.html:245
 #: warehouse/templates/packaging/detail.html:309
-#: warehouse/templates/packaging/detail.html:411
-msgid "Release history"
+msgid "Release history. Focus will be moved to the history panel."
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:255
-#: warehouse/templates/packaging/detail.html:319
-msgid "Download files. Focus will be moved to the project files."
+#: warehouse/templates/packaging/detail.html:247
+#: warehouse/templates/packaging/detail.html:311
+#: warehouse/templates/packaging/detail.html:413
+msgid "Release history"
 msgstr ""
 
 #: warehouse/templates/packaging/detail.html:257
 #: warehouse/templates/packaging/detail.html:321
-#: warehouse/templates/packaging/detail.html:470
+msgid "Download files. Focus will be moved to the project files."
+msgstr ""
+
+#: warehouse/templates/packaging/detail.html:259
+#: warehouse/templates/packaging/detail.html:323
+#: warehouse/templates/packaging/detail.html:472
 msgid "Download files"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:271
+#: warehouse/templates/packaging/detail.html:273
 msgid "Report project as malware"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:296
+#: warehouse/templates/packaging/detail.html:298
 msgid "Project details. Focus will be moved to the project details."
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:298
-#: warehouse/templates/packaging/detail.html:399
+#: warehouse/templates/packaging/detail.html:300
+#: warehouse/templates/packaging/detail.html:401
 msgid "Project details"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:371
+#: warehouse/templates/packaging/detail.html:373
 msgid ""
 "The maintainers of this project have marked this project as archived. No "
 "new releases are expected."
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:379
-#: warehouse/templates/packaging/detail.html:452
+#: warehouse/templates/packaging/detail.html:381
+#: warehouse/templates/packaging/detail.html:454
 msgid "Reason this release was yanked:"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:388
+#: warehouse/templates/packaging/detail.html:390
 msgid "The author of this package has not provided a project description"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:413
+#: warehouse/templates/packaging/detail.html:415
 msgid "Release notifications"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:414
+#: warehouse/templates/packaging/detail.html:416
 msgid "RSS feed"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:425
+#: warehouse/templates/packaging/detail.html:427
 msgid "This version"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:443
+#: warehouse/templates/packaging/detail.html:445
 msgid "pre-release"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:446
+#: warehouse/templates/packaging/detail.html:448
 msgid "yanked"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:472
+#: warehouse/templates/packaging/detail.html:474
 #, python-format
 msgid ""
 "Download the file for your platform. If you're not sure which to choose, "
@@ -7973,34 +7973,34 @@ msgid ""
 "target=\"_blank\" rel=\"noopener\">installing packages</a>."
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:475
+#: warehouse/templates/packaging/detail.html:477
 msgid "Source Distribution"
 msgid_plural "Source Distributions"
 msgstr[0] ""
 msgstr[1] ""
 
-#: warehouse/templates/packaging/detail.html:489
+#: warehouse/templates/packaging/detail.html:491
 msgid "No source distribution files available for this release."
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:490
+#: warehouse/templates/packaging/detail.html:492
 #, python-format
 msgid ""
 "See tutorial on <a href=\"%(href)s\" title=\"%(title)s\" "
 "target=\"_blank\" rel=\"noopener\">generating distribution archives</a>."
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:496
+#: warehouse/templates/packaging/detail.html:498
 msgid "Built Distribution"
 msgid_plural "Built Distributions"
 msgstr[0] ""
 msgstr[1] ""
 
-#: warehouse/templates/packaging/detail.html:503
+#: warehouse/templates/packaging/detail.html:505
 msgid "Filter files by name, interpreter, ABI, and platform."
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:506
+#: warehouse/templates/packaging/detail.html:508
 #, python-format
 msgid ""
 "If you're not sure about the file name format, learn more about <a "
@@ -8008,20 +8008,20 @@ msgid ""
 "rel=\"noopener\">wheel file names</a>."
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:510
+#: warehouse/templates/packaging/detail.html:512
 msgid "The dropdown lists show the available interpreters, ABIs, and platforms."
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:513
+#: warehouse/templates/packaging/detail.html:515
 msgid "Enable javascript to be able to filter the list of wheel files."
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:517
+#: warehouse/templates/packaging/detail.html:519
 msgid "Copy a direct link to the current filters"
 msgstr ""
 
-#: warehouse/templates/packaging/detail.html:535
-#: warehouse/templates/packaging/detail.html:540
+#: warehouse/templates/packaging/detail.html:537
+#: warehouse/templates/packaging/detail.html:542
 msgid "File name"
 msgstr ""
 

--- a/warehouse/templates/packaging/detail.html
+++ b/warehouse/templates/packaging/detail.html
@@ -18,6 +18,8 @@
     {% set icon = "fab fa-github" %}
   {% elif parsed.netloc == "gitlab.com" or parsed.netloc.endswith(".gitlab.com") %}
     {% set icon = "fab fa-gitlab" %}
+  {% elif parsed.netloc in ["codeberg.org", "codeberg.page"] or parsed.netloc.endswith((".codeberg.org", ".codeberg.page")) %}
+    {% set icon = "fab fa-codeberg" %}
   {% elif parsed.netloc == "gitter.im" or parsed.netloc.endswith(".gitter.im") %}
     {% set icon = "fab fa-gitter" %}
   {% elif parsed.netloc in ["discord.com", "discordapp.com", "discord.gg"] %}


### PR DESCRIPTION
With more projects moving / being created on Codeberg, it would be nice if PyPI would show a proper icon for links pointing there (as opposed to just an “external link” arrow). This PR adds Codeberg logo rendering for project links pointing to `codeberg.org` (repositories) and `codeberg.page` (Codeberg Pages; static sites hosting similar to GitHub Pages). The new icon was added to Font Awesome v7.3.0, so the version of the icon pack was also bumped.

This PR also updates the docs, but because mkdocs-material only bundles FA v7.1.0, I used the icon from Simple Icons icon pack (also bundled with mkdocs-material)

| Before | After |
| ------ | ----- |
| ![Project details of a PyPI package; "Source code" link has a generic icon](https://github.com/user-attachments/assets/a78985c8-6047-4062-8cfa-2599a78770ad) | ![Project details of a PyPI package; "Source code" link has Codeberg logo as icon](https://github.com/user-attachments/assets/43fb66bb-6ec6-4ad3-a942-ace5423739e9) |