### PR TITLE
Add data to Organization's details page on the Admin.

### DIFF
--- a/warehouse/admin/templates/admin/organizations/detail.html
+++ b/warehouse/admin/templates/admin/organizations/detail.html
@@ -35,7 +35,60 @@
             {% endif %}
           </p>
         </div>
-      </div>
+          <div class="card-footer p-0">
+            <ul class="nav flex-column">
+              <li class="nav-item">
+                <a href="#organization-details" class="nav-link">
+                  Type <span class="float-right badge bg-info">{{  organization.orgtype }}</span>
+                </a>
+              </li>
+              <li class="nav-item">
+                <a href="#projects" class="nav-link">
+                  Projects <span class="float-right badge bg-primary">{{ organization.projects | list | length }}</span>
+                </a>
+              </li>
+              <li class="nav-item">
+                <a href="#projects" class="nav-link">
+                  Projects - Total Owned Size	<span class="float-right badge bg-success">{{ organization.projects | list | sum(attribute="total_size") | filesizeformat(binary=True) }}</span>
+                </a>
+              </li>
+              <li class="nav-item">
+                <a href="#organization-limits" class="nav-link">
+                  Upload Limit	
+                  <span class="float-right badge bg-info">
+                    {% if organization.upload_limit %}
+                    {{ organization.upload_limit|filesizeformat(binary=True) }}
+                    {% else %}
+                    Default ({{ MAX_FILESIZE|filesizeformat(binary=True) }})
+                    {% endif %}
+                  </span>
+                </a>
+              </li>
+              <li class="nav-item">
+                <a href="#organization-limits" class="nav-link">
+                  Total Size Limit	
+                  <span class="float-right badge bg-info">
+                    {% if organization.total_size_limit %}
+                    {{ organization.total_size_limit|filesizeformat(binary=True) }}
+                    {% else %}
+                    Default ({{ MAX_PROJECT_SIZE|filesizeformat(binary=True) }})
+                    {% endif %}
+                  </span>
+                </a>
+              </li>
+              <li class="nav-item">
+                <a href="#members" class="nav-link">
+                  Members <span class="float-right badge bg-primary">{{  roles | list | length }}</span>
+                </a>
+              </li>
+              <li class="nav-item">
+                <a href="#teams" class="nav-link">
+                  Teams <span class="float-right badge bg-info">{{  organization.teams | list | length }}</span>
+                </a>
+              </li>
+            </ul>
+          </div>
+        </div>
 
       <div class="card">
         <div class="card-header with-border">

--- a/warehouse/admin/templates/admin/organizations/detail.html
+++ b/warehouse/admin/templates/admin/organizations/detail.html
@@ -15,7 +15,7 @@
       <div class="card card-primary">
         <div class="card-body card-widget widget-user-1">
           <div class="widget-user-header">
-            <h3 class="widget-user-username text-center">{{ organization.display_name }}</h3>
+            <h3 class="widget-user-username text-center"><a href="{{ request.route_path('organizations.profile', organization=organization.name)}}">{{ organization.display_name }}</a></h3>
           </div>
         </div>
         <div class="card-body">
@@ -149,7 +149,7 @@
     </div>
 
     <div class="col-md-9">
-      <div class="card">
+      <div class="card" id="organization-details">
         <div class="card-header with-border">
           <h3 class="card-title">Organization Details</h3>
         </div>
@@ -690,14 +690,14 @@
         {% endfor %}
       {% endif %}
 
-      <div class="card">
+      <div class="card"  id="projects">
         <div class="card-header with-border">
           <h3 class="card-title">Projects</h3>
         </div>
 
         <div class="card-body">
           {% if organization.projects %}
-          <table class="table table-hover" id="projects">
+          <table class="table table-hover">
             <thead>
               <tr>
                 <th>Project Name</th>
@@ -719,14 +719,14 @@
         </div>
       </div> <!-- .card -->
 
-      <div class="card">
+      <div class="card" id="members">
         <div class="card-header with-border">
           <h3 class="card-title">Members</h3>
         </div>
 
         <div class="card-body">
           {% if roles %}
-          <table class="table table-hover" id="members">
+          <table class="table table-hover">
             <thead>
               <tr>
                 <th>User</th>
@@ -817,7 +817,7 @@
 
         <div class="card-body">
           {% if organization.invitations %}
-          <table class="table table-hover" id="projects">
+          <table class="table table-hover">
             <thead>
               <tr>
                 <th>User</th>
@@ -839,14 +839,14 @@
         </div>
       </div> <!-- .card -->
 
-      <div class="card">
+      <div class="card"  id="teams">
         <div class="card-header with-border">
           <h3 class="card-title">Teams</h3>
         </div>
 
         <div class="card-body">
           {% if organization.teams %}
-          <table class="table table-hover" id="projects">
+          <table class="table table-hover">
             <thead>
               <tr>
                 <th>Team</th>

--- a/warehouse/admin/templates/admin/users/detail.html
+++ b/warehouse/admin/templates/admin/users/detail.html
@@ -51,7 +51,7 @@
             <img class="img-fluid rounded-circle elevation-2" src="{{ gravatar(request, user.email, size=128) }}" alt="User profile picture">
           </div>
 
-          <h3 class="widget-user-username text-center">{{ user.username }}</h3>
+          <h3 class="widget-user-username text-center"><a href="{{ request.route_path('accounts.profile', username=user.username)}}">{{ user.username }}</a></h3>
           <h5 class="widget-user-desc text-center">{{ user.name }}</h5>
         </div>
 


### PR DESCRIPTION
Addresses Issue https://github.com/pypi/warehouse/issues/20213

Mostly adapted for organizations what was already done for users at
 https://github.com/pypi/warehouse/blob/main/warehouse/admin/templates/admin/users/detail.html#L77-L103

Happy to change the order of the items if anyone has opinions on what would be more ergonomic for admins, or add any other information that might be relevant at a glance!

<img width="1110" height="732" alt="image" src="https://github.com/user-attachments/assets/c544a978-6798-4276-a7c2-38544aea1556" />
