### PR TITLE
Mock dns.resolver calls in prohibited-MX-domain tests

### DIFF
--- a/tests/unit/manage/test_forms.py
+++ b/tests/unit/manage/test_forms.py
@@ -162,6 +162,22 @@ class TestSaveAccountForm:
         )
 
 
+def _mock_dns_resolution(monkeypatch, mx_record_domain):
+    """
+    Mock DNS resolution of an MX host's IP and its PTR record, so tests
+    exercising the PTR-resolution lines in `NewEmailMixin.validate_email` do
+    not depend on live, possibly-flaky network DNS lookups.
+    """
+    mock_a_record = mock.Mock(address="192.0.2.1")
+    mock_ptr_record = mock.Mock()
+    mock_ptr_record.target.to_text.return_value = f"{mx_record_domain}."
+
+    monkeypatch.setattr("dns.resolver.resolve", mock.Mock(return_value=[mock_a_record]))
+    monkeypatch.setattr(
+        "dns.resolver.resolve_address", mock.Mock(return_value=[mock_ptr_record])
+    )
+
+
 class TestAddEmailForm:
     @pytest.mark.usefixtures("no_email_deliverability_check")
     def test_validate(self, metrics):
@@ -272,18 +288,7 @@ class TestAddEmailForm:
             mock_function,
         )
 
-        # Mock DNS resolution of the MX host's IP and its PTR record, so this
-        # test's coverage of the PTR-resolution lines does not depend on live,
-        # possibly-flaky network DNS lookups.
-        mock_a_record = mock.Mock(address="192.0.2.1")
-        mock_ptr_record = mock.Mock()
-        mock_ptr_record.target.to_text.return_value = f"{mx_record_domain}."
-        monkeypatch.setattr(
-            "dns.resolver.resolve", lambda *args, **kwargs: [mock_a_record]
-        )
-        monkeypatch.setattr(
-            "dns.resolver.resolve_address", lambda *args, **kwargs: [mock_ptr_record]
-        )
+        _mock_dns_resolution(monkeypatch, mx_record_domain)
 
         prohibited_mx_domain = ProhibitedEmailDomain(
             domain=prohibited_domain,
@@ -341,18 +346,7 @@ class TestAddEmailForm:
             mock_function,
         )
 
-        # Mock DNS resolution of the MX host's IP and its PTR record, so this
-        # test's coverage of the PTR-resolution lines does not depend on live,
-        # possibly-flaky network DNS lookups.
-        mock_a_record = mock.Mock(address="192.0.2.1")
-        mock_ptr_record = mock.Mock()
-        mock_ptr_record.target.to_text.return_value = f"{mx_record_domain}."
-        monkeypatch.setattr(
-            "dns.resolver.resolve", lambda *args, **kwargs: [mock_a_record]
-        )
-        monkeypatch.setattr(
-            "dns.resolver.resolve_address", lambda *args, **kwargs: [mock_ptr_record]
-        )
+        _mock_dns_resolution(monkeypatch, mx_record_domain)
 
         prohibited_mx_domain = ProhibitedEmailDomain(
             domain=prohibited_domain,

--- a/tests/unit/manage/test_forms.py
+++ b/tests/unit/manage/test_forms.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+from unittest import mock
+
 import pretend
 import pytest
 import wtforms
@@ -270,6 +272,19 @@ class TestAddEmailForm:
             mock_function,
         )
 
+        # Mock DNS resolution of the MX host's IP and its PTR record, so this
+        # test's coverage of the PTR-resolution lines does not depend on live,
+        # possibly-flaky network DNS lookups.
+        mock_a_record = mock.Mock(address="192.0.2.1")
+        mock_ptr_record = mock.Mock()
+        mock_ptr_record.target.to_text.return_value = f"{mx_record_domain}."
+        monkeypatch.setattr(
+            "dns.resolver.resolve", lambda *args, **kwargs: [mock_a_record]
+        )
+        monkeypatch.setattr(
+            "dns.resolver.resolve_address", lambda *args, **kwargs: [mock_ptr_record]
+        )
+
         prohibited_mx_domain = ProhibitedEmailDomain(
             domain=prohibited_domain,
             is_mx_record=True,
@@ -324,6 +339,19 @@ class TestAddEmailForm:
         monkeypatch.setattr(
             "email_validator.deliverability.validate_email_deliverability",
             mock_function,
+        )
+
+        # Mock DNS resolution of the MX host's IP and its PTR record, so this
+        # test's coverage of the PTR-resolution lines does not depend on live,
+        # possibly-flaky network DNS lookups.
+        mock_a_record = mock.Mock(address="192.0.2.1")
+        mock_ptr_record = mock.Mock()
+        mock_ptr_record.target.to_text.return_value = f"{mx_record_domain}."
+        monkeypatch.setattr(
+            "dns.resolver.resolve", lambda *args, **kwargs: [mock_a_record]
+        )
+        monkeypatch.setattr(
+            "dns.resolver.resolve_address", lambda *args, **kwargs: [mock_ptr_record]
         )
 
         prohibited_mx_domain = ProhibitedEmailDomain(


### PR DESCRIPTION
## Summary

`TestAddEmailForm.test_prohibited_mx_domain_error` and `test_prohibited_mx_domain_passes` (`tests/unit/manage/test_forms.py`) mock `email_validator.deliverability.validate_email_deliverability` to control the MX records returned, but they don't mock the subsequent `dns.resolver.resolve` / `dns.resolver.resolve_address` calls that `NewEmailMixin.validate_email` makes (`warehouse/accounts/forms.py`) to resolve the MX host to an IP and then a PTR domain.

Those two calls hit live DNS during the test run. Whether the PTR-resolution lines execute (and get counted toward coverage) or get skipped — caught by the surrounding `contextlib.suppress(dns.resolver.NoAnswer, ...)` — depends on real network/DNS conditions at test time, which is exactly the flakiness described in #20284: the same code passes tests either way, but coverage varies between runs.

## Changes
- `tests/unit/manage/test_forms.py`: in both `test_prohibited_mx_domain_error` and `test_prohibited_mx_domain_passes`, monkeypatch `dns.resolver.resolve` and `dns.resolver.resolve_address` (via `unittest.mock.Mock`, not `pretend`, per the issue) to return a fixed A record and PTR record, so the PTR-resolution branch runs the same way on every run regardless of network conditions.

## How to test
- [x] Ran `pytest tests/unit/manage/test_forms.py::TestAddEmailForm -v` against a local Postgres — 9 passed
- [x] Ran the full `tests/unit/manage/test_forms.py` (85 passed) and `tests/unit/accounts/test_forms.py` (94 passed)
- [x] This repo runs pytest with `--disable-socket` by default, so if the mocks didn't fully intercept the DNS calls, these tests would fail with a socket-blocked error instead of silently hitting the network — all passing confirms no real network call occurs
- [x] `ruff check` and `ruff format --diff` on the changed file are clean

## Related issue
Closes #20284