### PR TITLE
Organization Application Internal Notes on the Admin

### DIFF
--- a/tests/unit/admin/test_routes.py
+++ b/tests/unit/admin/test_routes.py
@@ -113,6 +113,11 @@ def test_includeme(mocker):
             "/admin/organization_applications/{organization_application_id}/decline/",
             domain=warehouse,
         ),
+        mocker.call(
+            "admin.organization_application.addnote",
+            "/admin/organization_applications/{organization_application_id}/addnote/",
+            domain=warehouse,
+        ),
         mocker.call("admin.user.list", "/admin/users/", domain=warehouse),
         mocker.call(
             "admin.user.detail",

--- a/tests/unit/admin/views/test_observations.py
+++ b/tests/unit/admin/views/test_observations.py
@@ -354,6 +354,21 @@ class TestRenderDatatablesPayload:
         expected = f"/admin/organization_applications/{org_app.id}/"
         assert payload["data"][0]["related_link"] == expected
 
+    def test_organization_application_note_produces_link(self, dt_request):
+        org_app = OrganizationApplicationFactory.create()
+        observer = ObserverFactory.create()
+        OrganizationApplicationObservationFactory.create(
+            kind="admin_note",
+            observer=observer,
+            related=org_app,
+        )
+
+        dt_request.params = _datatables_params(kind="admin_note")
+        payload = views._render_datatables_payload(dt_request)
+
+        expected = f"/admin/organization_applications/{org_app.id}/"
+        assert payload["data"][0]["related_link"] == expected
+
     def test_project_observation_with_unparseable_related_name(self, dt_request):
         """
         A project observation whose related_name doesn't match the

--- a/tests/unit/admin/views/test_organization_applications.py
+++ b/tests/unit/admin/views/test_organization_applications.py
@@ -815,3 +815,97 @@ class TestOrganizationApplicationActions:
 
         with pytest.raises(HTTPNotFound):
             views.organization_application_decline(request)
+
+    def test_addnote(self, db_request):
+        admin = UserFactory.create()
+        user = UserFactory.create()
+        organization_application = OrganizationApplicationFactory.create(
+            name="example", submitted_by=user
+        )
+
+        organization_service = pretend.stub(
+            get_organization_application=lambda *a, **kw: organization_application,
+            add_organization_application_note=pretend.call_recorder(
+                lambda *a, **kw: organization_application
+            ),
+        )
+
+        db_request.matchdict = {
+            "organization_application_id": organization_application.id
+        }
+        db_request.params = {"message": "Some internal note"}
+        db_request.user = admin
+        db_request.route_path = pretend.call_recorder(_organization_application_routes)
+        db_request.find_service = pretend.call_recorder(
+            lambda iface, context: organization_service
+        )
+        db_request.session.flash = pretend.call_recorder(lambda *a, **kw: None)
+
+        result = views.organization_application_add_note(db_request)
+
+        assert organization_service.add_organization_application_note.calls == [
+            pretend.call(organization_application.id, db_request),
+        ]
+        assert db_request.session.flash.calls == [
+            pretend.call(
+                f'Note added to "{organization_application.name}" application',
+                queue="success",
+            ),
+        ]
+        assert result.status_code == 303
+        assert (
+            result.location
+            == f"/admin/organization_applications/{organization_application.id}/"
+        )
+
+    def test_addnote_no_message(self, db_request):
+        admin = UserFactory.create()
+        user = UserFactory.create()
+        organization_application = OrganizationApplicationFactory.create(
+            name="example", submitted_by=user
+        )
+
+        organization_service = pretend.stub(
+            get_organization_application=lambda *a, **kw: organization_application,
+            add_organization_application_note=pretend.call_recorder(
+                pretend.raiser(ValueError)
+            ),
+        )
+
+        db_request.matchdict = {
+            "organization_application_id": organization_application.id
+        }
+        db_request.params = {}
+        db_request.user = admin
+        db_request.route_path = pretend.call_recorder(_organization_application_routes)
+        db_request.find_service = pretend.call_recorder(
+            lambda iface, context: organization_service
+        )
+        db_request.session.flash = pretend.call_recorder(lambda *a, **kw: None)
+
+        result = views.organization_application_add_note(db_request)
+
+        assert organization_service.add_organization_application_note.calls == [
+            pretend.call(organization_application.id, db_request),
+        ]
+        assert db_request.session.flash.calls == [
+            pretend.call("No note text provided", queue="error"),
+        ]
+        assert result.status_code == 303
+        assert (
+            result.location
+            == f"/admin/organization_applications/{organization_application.id}/"
+        )
+
+    def test_addnote_not_found(self):
+        organization_service = pretend.stub(
+            get_organization_application=lambda *a, **kw: None,
+        )
+        request = pretend.stub(
+            flags=pretend.stub(enabled=lambda *a: False),
+            find_service=lambda *a, **kw: organization_service,
+            matchdict={"organization_application_id": pretend.stub()},
+        )
+
+        with pytest.raises(HTTPNotFound):
+            views.organization_application_add_note(request)

--- a/tests/unit/admin/views/test_organization_applications.py
+++ b/tests/unit/admin/views/test_organization_applications.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
-import pretend
+import uuid
+
 import pytest
 
 from pyramid.httpexceptions import HTTPNotFound
@@ -11,6 +12,7 @@ from tests.common.db.organizations import (
     OrganizationFactory,
 )
 from warehouse.admin.views import organizations as views
+from warehouse.organizations import services
 from warehouse.organizations.models import (
     OrganizationApplicationStatus,
     OrganizationType,
@@ -255,18 +257,14 @@ class TestOrganizationApplicationDetail:
         db_request.POST["orgtype"] = organization_application.orgtype
         db_request.POST = MultiDict(db_request.POST)
 
-        db_request.session.flash = pretend.call_recorder(lambda *a, **kw: None)
         db_request.current_route_path = lambda *a, **kw: "/the/url/"
 
         result = views.organization_application_detail(db_request)
 
         assert result.status_code == 303
         assert result.location == "/the/url/"
-        assert db_request.session.flash.calls == [
-            pretend.call(
-                f"Application for {organization_application.name!r} updated",
-                queue="success",
-            )
+        assert db_request.session.pop_flash("success") == [
+            f"Application for {organization_application.name!r} updated"
         ]
 
         assert organization_application.name == new_org_name
@@ -351,126 +349,81 @@ class TestOrganizationApplicationDetail:
         assert set(result["conflicting_applications"]) == set(conflicting_applications)
         assert result["organization_application"] == organization_application
 
-    def test_detail_not_found(self):
-        organization_service = pretend.stub(
-            get_organization_application=lambda *a, **kw: None,
-        )
-        request = pretend.stub(
-            flags=pretend.stub(enabled=lambda *a: False),
-            find_service=lambda *a, **kw: organization_service,
-            matchdict={"organization_application_id": pretend.stub()},
-        )
+    def test_detail_not_found(self, db_request):
+        db_request.matchdict["organization_application_id"] = uuid.uuid4()
 
         with pytest.raises(HTTPNotFound):
-            views.organization_application_detail(request)
+            views.organization_application_detail(db_request)
 
 
 class TestOrganizationApplicationActions:
-    def test_approve(self, db_request):
+    def test_approve(self, db_request, mocker):
+        send_approved = mocker.patch.object(
+            services, "send_new_organization_approved_email"
+        )
         admin = UserFactory.create()
         user = UserFactory.create()
         organization_application = OrganizationApplicationFactory.create(
             name="example", submitted_by=user
         )
-        organization = OrganizationFactory.create(name="example")
 
-        organization_service = pretend.stub(
-            get_organization_application=lambda *a, **kw: organization_application,
-            approve_organization_application=pretend.call_recorder(
-                lambda *a, **kw: organization
-            ),
+        db_request.matchdict["organization_application_id"] = (
+            organization_application.id
         )
-
-        db_request.matchdict = {
-            "organization_application_id": organization_application.id
-        }
-        db_request.params = {
-            "organization_name": organization_application.name,
-            "message": "Welcome!",
-        }
+        db_request.params["organization_name"] = organization_application.name
+        db_request.params["message"] = "Welcome!"
         db_request.user = admin
-        db_request.route_path = pretend.call_recorder(_organization_application_routes)
-        db_request.find_service = pretend.call_recorder(
-            lambda iface, context: organization_service
-        )
-        db_request.session.flash = pretend.call_recorder(lambda *a, **kw: None)
+        db_request.route_path = _organization_application_routes
 
         result = views.organization_application_approve(db_request)
 
-        assert organization_service.approve_organization_application.calls == [
-            pretend.call(organization_application.id, db_request),
-        ]
-        assert db_request.session.flash.calls == [
-            pretend.call(
-                f'Request for "{organization_application.name}" organization approved',
-                queue="success",
-            ),
+        organization = organization_application.organization
+        assert organization is not None
+        assert organization_application.status == OrganizationApplicationStatus.Approved
+        send_approved.assert_called_once_with(
+            db_request,
+            user,
+            organization_name=organization.name,
+            message="Welcome!",
+        )
+        assert db_request.session.pop_flash("success") == [
+            f'Request for "{organization.name}" organization approved'
         ]
         assert result.status_code == 303
         assert result.location == f"/admin/organizations/{organization.id}/"
 
-    def test_approve_turbo_mode(self, db_request):
+    def test_approve_turbo_mode(self, db_request, mocker):
+        mocker.patch.object(services, "send_new_organization_approved_email")
         admin = UserFactory.create()
         user = UserFactory.create()
         organization_application = OrganizationApplicationFactory.create(
             name="example", submitted_by=user
         )
-        organization = OrganizationFactory.create(name="example")
 
-        def _approve(*a, **kw):
-            db_request.db.delete(organization_application)
-            return organization
-
-        organization_service = pretend.stub(
-            get_organization_application=lambda *a, **kw: organization_application,
-            approve_organization_application=pretend.call_recorder(_approve),
+        db_request.matchdict["organization_application_id"] = (
+            organization_application.id
         )
-
-        db_request.matchdict = {
-            "organization_application_id": organization_application.id
-        }
-        db_request.params = {
-            "organization_name": organization_application.name,
-            "message": "Welcome!",
-            "organization_applications_turbo_mode": "true",
-        }
+        db_request.params["organization_name"] = organization_application.name
+        db_request.params["message"] = "Welcome!"
+        db_request.params["organization_applications_turbo_mode"] = "true"
         db_request.user = admin
-        db_request.route_path = pretend.call_recorder(_organization_application_routes)
-        db_request.find_service = pretend.call_recorder(
-            lambda iface, context: organization_service
-        )
-        db_request.session.flash = pretend.call_recorder(lambda *a, **kw: None)
+        db_request.route_path = _organization_application_routes
 
         result = views.organization_application_approve(db_request)
 
-        assert organization_service.approve_organization_application.calls == [
-            pretend.call(organization_application.id, db_request),
-        ]
-        assert db_request.session.flash.calls == [
-            pretend.call(
-                f'Request for "{organization_application.name}" organization approved',
-                queue="success",
-            ),
-            pretend.call(
-                "No more Organization Applications to review!",
-                queue="success",
-            ),
+        organization = organization_application.organization
+        assert db_request.session.pop_flash("success") == [
+            f'Request for "{organization.name}" organization approved',
+            "No more Organization Applications to review!",
         ]
         assert result.status_code == 303
         assert result.location == "/admin/"
 
-    def test_approve_not_found(self):
-        organization_service = pretend.stub(
-            get_organization_application=lambda *a, **kw: None,
-        )
-        request = pretend.stub(
-            flags=pretend.stub(enabled=lambda *a: False),
-            find_service=lambda *a, **kw: organization_service,
-            matchdict={"organization_application_id": pretend.stub()},
-        )
+    def test_approve_not_found(self, db_request):
+        db_request.matchdict["organization_application_id"] = uuid.uuid4()
 
         with pytest.raises(HTTPNotFound):
-            views.organization_application_approve(request)
+            views.organization_application_approve(db_request)
 
     def test_defer(self, db_request):
         admin = UserFactory.create()
@@ -479,34 +432,17 @@ class TestOrganizationApplicationActions:
             name="example", submitted_by=user
         )
 
-        organization_service = pretend.stub(
-            get_organization_application=lambda *a, **kw: organization_application,
-            defer_organization_application=pretend.call_recorder(
-                lambda *a, **kw: organization_application
-            ),
+        db_request.matchdict["organization_application_id"] = (
+            organization_application.id
         )
-
-        db_request.matchdict = {
-            "organization_application_id": organization_application.id
-        }
-        db_request.params = {}
         db_request.user = admin
-        db_request.route_path = pretend.call_recorder(_organization_application_routes)
-        db_request.find_service = pretend.call_recorder(
-            lambda iface, context: organization_service
-        )
-        db_request.session.flash = pretend.call_recorder(lambda *a, **kw: None)
+        db_request.route_path = _organization_application_routes
 
         result = views.organization_application_defer(db_request)
 
-        assert organization_service.defer_organization_application.calls == [
-            pretend.call(organization_application.id, db_request),
-        ]
-        assert db_request.session.flash.calls == [
-            pretend.call(
-                f'Request for "{organization_application.name}" organization deferred',
-                queue="success",
-            ),
+        assert organization_application.status == OrganizationApplicationStatus.Deferred
+        assert db_request.session.pop_flash("success") == [
+            f'Request for "{organization_application.name}" organization deferred'
         ]
         assert result.status_code == 303
         assert (
@@ -521,92 +457,65 @@ class TestOrganizationApplicationActions:
             name="example", submitted_by=user
         )
 
-        organization_service = pretend.stub(
-            get_organization_application=lambda *a, **kw: organization_application,
-            defer_organization_application=pretend.call_recorder(
-                lambda *a, **kw: organization_application
-            ),
+        db_request.matchdict["organization_application_id"] = (
+            organization_application.id
         )
-
-        db_request.matchdict = {
-            "organization_application_id": organization_application.id
-        }
-        db_request.params = {"organization_applications_turbo_mode": "true"}
+        db_request.params["organization_applications_turbo_mode"] = "true"
         db_request.user = admin
-        db_request.route_path = pretend.call_recorder(_organization_application_routes)
-        db_request.find_service = pretend.call_recorder(
-            lambda iface, context: organization_service
-        )
-        db_request.session.flash = pretend.call_recorder(lambda *a, **kw: None)
+        db_request.route_path = _organization_application_routes
 
         result = views.organization_application_defer(db_request)
 
-        assert organization_service.defer_organization_application.calls == [
-            pretend.call(organization_application.id, db_request),
-        ]
-        assert db_request.session.flash.calls == [
-            pretend.call(
-                f'Request for "{organization_application.name}" organization deferred',
-                queue="success",
-            ),
+        assert organization_application.status == OrganizationApplicationStatus.Deferred
+        assert db_request.session.pop_flash("success") == [
+            f'Request for "{organization_application.name}" organization deferred',
+            "No more Organization Applications to review!",
         ]
         assert result.status_code == 303
-        assert (
-            result.location
-            == f"/admin/organization_applications/{organization_application.id}/"
-        )
+        assert result.location == "/admin/"
 
-    def test_defer_not_found(self):
-        organization_service = pretend.stub(
-            get_organization_application=lambda *a, **kw: None,
-        )
-        request = pretend.stub(
-            flags=pretend.stub(enabled=lambda *a: False),
-            find_service=lambda *a, **kw: organization_service,
-            matchdict={"organization_application_id": pretend.stub()},
-        )
+    def test_defer_not_found(self, db_request):
+        db_request.matchdict["organization_application_id"] = uuid.uuid4()
 
         with pytest.raises(HTTPNotFound):
-            views.organization_application_defer(request)
+            views.organization_application_defer(db_request)
 
-    def test_request_more_information(self, db_request):
+    def test_request_more_information(self, db_request, mocker):
+        send_email = mocker.patch.object(
+            services, "send_new_organization_moreinformationneeded_email"
+        )
         admin = UserFactory.create()
         user = UserFactory.create()
         organization_application = OrganizationApplicationFactory.create(
             name="example", submitted_by=user
         )
 
-        organization_service = pretend.stub(
-            get_organization_application=lambda *a, **kw: organization_application,
-            request_more_information=pretend.call_recorder(
-                lambda *a, **kw: organization_application
-            ),
+        db_request.matchdict["organization_application_id"] = (
+            organization_application.id
         )
-
-        db_request.matchdict = {
-            "organization_application_id": organization_application.id
-        }
-        db_request.params = {"message": "Welcome!"}
+        db_request.params["message"] = "Welcome!"
         db_request.user = admin
-        db_request.route_path = pretend.call_recorder(_organization_application_routes)
-        db_request.find_service = pretend.call_recorder(
-            lambda iface, context: organization_service
-        )
-        db_request.session.flash = pretend.call_recorder(lambda *a, **kw: None)
+        db_request.route_path = _organization_application_routes
 
         result = views.organization_application_request_more_information(db_request)
 
-        assert organization_service.request_more_information.calls == [
-            pretend.call(organization_application.id, db_request),
-        ]
-        assert db_request.session.flash.calls == [
-            pretend.call(
-                (
-                    f'Request for more info from "{organization_application.name}" '
-                    "organization sent"
-                ),
-                queue="success",
-            ),
+        assert (
+            organization_application.status
+            == OrganizationApplicationStatus.MoreInformationNeeded
+        )
+        assert len(organization_application.observations) == 1
+        send_email.assert_called_once_with(
+            db_request,
+            user,
+            organization_name=organization_application.name,
+            organization_application_id=organization_application.id,
+            message="Welcome!",
+        )
+        assert db_request.session.pop_flash("success") == [
+            (
+                f'Request for more info from "{organization_application.name}" '
+                "organization sent"
+            )
         ]
         assert result.status_code == 303
         assert (
@@ -614,142 +523,102 @@ class TestOrganizationApplicationActions:
             == f"/admin/organization_applications/{organization_application.id}/"
         )
 
-    def test_request_more_information_turbo_mode(self, db_request):
+    def test_request_more_information_turbo_mode(self, db_request, mocker):
+        mocker.patch.object(
+            services, "send_new_organization_moreinformationneeded_email"
+        )
         admin = UserFactory.create()
         user = UserFactory.create()
         organization_application = OrganizationApplicationFactory.create(
             name="example", submitted_by=user
         )
 
-        organization_service = pretend.stub(
-            get_organization_application=lambda *a, **kw: organization_application,
-            request_more_information=pretend.call_recorder(
-                lambda *a, **kw: organization_application
-            ),
+        db_request.matchdict["organization_application_id"] = (
+            organization_application.id
         )
-
-        db_request.matchdict = {
-            "organization_application_id": organization_application.id
-        }
-        db_request.params = {
-            "message": "Welcome!",
-            "organization_applications_turbo_mode": "true",
-        }
+        db_request.params["message"] = "Welcome!"
+        db_request.params["organization_applications_turbo_mode"] = "true"
         db_request.user = admin
-        db_request.route_path = pretend.call_recorder(_organization_application_routes)
-        db_request.find_service = pretend.call_recorder(
-            lambda iface, context: organization_service
-        )
-        db_request.session.flash = pretend.call_recorder(lambda *a, **kw: None)
+        db_request.route_path = _organization_application_routes
 
         result = views.organization_application_request_more_information(db_request)
 
-        assert organization_service.request_more_information.calls == [
-            pretend.call(organization_application.id, db_request),
-        ]
-        assert db_request.session.flash.calls == [
-            pretend.call(
-                (
-                    f'Request for more info from "{organization_application.name}" '
-                    "organization sent"
-                ),
-                queue="success",
+        assert (
+            organization_application.status
+            == OrganizationApplicationStatus.MoreInformationNeeded
+        )
+        assert db_request.session.pop_flash("success") == [
+            (
+                f'Request for more info from "{organization_application.name}" '
+                "organization sent"
             ),
+            "No more Organization Applications to review!",
         ]
         assert result.status_code == 303
-        assert (
-            result.location
-            == f"/admin/organization_applications/{organization_application.id}/"
-        )
+        assert result.location == "/admin/"
 
-    def test_request_more_information_for_not_found(self):
-        organization_service = pretend.stub(
-            get_organization_application=lambda *a, **kw: None,
-        )
-        request = pretend.stub(
-            flags=pretend.stub(enabled=lambda *a: False),
-            find_service=lambda *a, **kw: organization_service,
-            matchdict={"organization_application_id": pretend.stub()},
-        )
+    def test_request_more_information_for_not_found(self, db_request):
+        db_request.matchdict["organization_application_id"] = uuid.uuid4()
 
         with pytest.raises(HTTPNotFound):
-            views.organization_application_request_more_information(request)
+            views.organization_application_request_more_information(db_request)
 
-    def test_request_more_information_no_message(self, db_request):
+    def test_request_more_information_no_message(self, db_request, mocker):
+        send_email = mocker.patch.object(
+            services, "send_new_organization_moreinformationneeded_email"
+        )
         admin = UserFactory.create()
         user = UserFactory.create()
         organization_application = OrganizationApplicationFactory.create(
             name="example", submitted_by=user
         )
 
-        organization_service = pretend.stub(
-            get_organization_application=lambda *a, **kw: organization_application,
-            request_more_information=pretend.call_recorder(pretend.raiser(ValueError)),
+        db_request.matchdict["organization_application_id"] = (
+            organization_application.id
         )
-
-        db_request.matchdict = {
-            "organization_application_id": organization_application.id
-        }
-        db_request.params = {}
         db_request.user = admin
-        db_request.route_path = pretend.call_recorder(_organization_application_routes)
-        db_request.find_service = pretend.call_recorder(
-            lambda iface, context: organization_service
-        )
-        db_request.session.flash = pretend.call_recorder(lambda *a, **kw: None)
+        db_request.route_path = _organization_application_routes
 
         result = views.organization_application_request_more_information(db_request)
 
-        assert organization_service.request_more_information.calls == [
-            pretend.call(organization_application.id, db_request),
-        ]
-        assert db_request.session.flash.calls == [
-            pretend.call("No message provided", queue="error"),
-        ]
+        assert len(organization_application.observations) == 0
+        send_email.assert_not_called()
+        assert db_request.session.pop_flash("error") == ["No message provided"]
         assert result.status_code == 303
         assert (
             result.location
             == f"/admin/organization_applications/{organization_application.id}/"
         )
 
-    def test_decline(self, db_request):
+    def test_decline(self, db_request, mocker):
+        send_email = mocker.patch.object(
+            services, "send_new_organization_declined_email"
+        )
         admin = UserFactory.create()
         user = UserFactory.create()
         organization_application = OrganizationApplicationFactory.create(
             name="example", submitted_by=user
         )
 
-        organization_service = pretend.stub(
-            get_organization_application=lambda *a, **kw: organization_application,
-            decline_organization_application=pretend.call_recorder(
-                lambda *a, **kw: organization_application
-            ),
+        db_request.matchdict["organization_application_id"] = (
+            organization_application.id
         )
-
-        db_request.matchdict = {
-            "organization_application_id": organization_application.id
-        }
-        db_request.params = {
-            "organization_name": organization_application.name,
-            "message": "Sorry!",
-        }
+        db_request.params["organization_name"] = organization_application.name
+        db_request.params["message"] = "Sorry!"
         db_request.user = admin
-        db_request.route_path = pretend.call_recorder(_organization_application_routes)
-        db_request.find_service = pretend.call_recorder(
-            lambda iface, context: organization_service
-        )
-        db_request.session.flash = pretend.call_recorder(lambda *a, **kw: None)
+        db_request.route_path = _organization_application_routes
 
         result = views.organization_application_decline(db_request)
 
-        assert organization_service.decline_organization_application.calls == [
-            pretend.call(organization_application.id, db_request),
-        ]
-        assert db_request.session.flash.calls == [
-            pretend.call(
-                f'Request for "{organization_application.name}" organization declined',
-                queue="success",
-            ),
+        assert organization_application.status == OrganizationApplicationStatus.Declined
+        send_email.assert_called_once_with(
+            db_request,
+            user,
+            organization_name=organization_application.name,
+            message="Sorry!",
+        )
+        assert db_request.session.pop_flash("success") == [
+            f'Request for "{organization_application.name}" organization declined'
         ]
         assert result.status_code == 303
         assert (
@@ -757,64 +626,38 @@ class TestOrganizationApplicationActions:
             == f"/admin/organization_applications/{organization_application.id}/"
         )
 
-    def test_decline_turbo_mode(self, db_request):
+    def test_decline_turbo_mode(self, db_request, mocker):
+        mocker.patch.object(services, "send_new_organization_declined_email")
         admin = UserFactory.create()
         user = UserFactory.create()
         organization_application = OrganizationApplicationFactory.create(
             name="example", submitted_by=user
         )
 
-        organization_service = pretend.stub(
-            get_organization_application=lambda *a, **kw: organization_application,
-            decline_organization_application=pretend.call_recorder(
-                lambda *a, **kw: organization_application
-            ),
+        db_request.matchdict["organization_application_id"] = (
+            organization_application.id
         )
-
-        db_request.matchdict = {
-            "organization_application_id": organization_application.id
-        }
-        db_request.params = {
-            "organization_name": organization_application.name,
-            "message": "Sorry!",
-            "organization_applications_turbo_mode": "true",
-        }
+        db_request.params["organization_name"] = organization_application.name
+        db_request.params["message"] = "Sorry!"
+        db_request.params["organization_applications_turbo_mode"] = "true"
         db_request.user = admin
-        db_request.route_path = pretend.call_recorder(_organization_application_routes)
-        db_request.find_service = pretend.call_recorder(
-            lambda iface, context: organization_service
-        )
-        db_request.session.flash = pretend.call_recorder(lambda *a, **kw: None)
+        db_request.route_path = _organization_application_routes
 
         result = views.organization_application_decline(db_request)
 
-        assert organization_service.decline_organization_application.calls == [
-            pretend.call(organization_application.id, db_request),
-        ]
-        assert db_request.session.flash.calls == [
-            pretend.call(
-                f'Request for "{organization_application.name}" organization declined',
-                queue="success",
-            ),
+        assert organization_application.status == OrganizationApplicationStatus.Declined
+        assert db_request.session.pop_flash("success") == [
+            f'Request for "{organization_application.name}" organization declined',
+            "No more Organization Applications to review!",
         ]
         assert result.status_code == 303
-        assert (
-            result.location
-            == f"/admin/organization_applications/{organization_application.id}/"
-        )
+        assert result.location == "/admin/"
 
-    def test_decline_not_found(self):
-        organization_service = pretend.stub(
-            get_organization_application=lambda *a, **kw: None,
-        )
-        request = pretend.stub(
-            flags=pretend.stub(enabled=lambda *a: False),
-            find_service=lambda *a, **kw: organization_service,
-            matchdict={"organization_application_id": pretend.stub()},
-        )
+    def test_decline_not_found(self, db_request):
+        db_request.matchdict["organization_application_id"] = uuid.uuid4()
 
         with pytest.raises(HTTPNotFound):
-            views.organization_application_decline(request)
+            views.organization_application_decline(db_request)
 
     def test_addnote(self, db_request):
         admin = UserFactory.create()
@@ -823,34 +666,21 @@ class TestOrganizationApplicationActions:
             name="example", submitted_by=user
         )
 
-        organization_service = pretend.stub(
-            get_organization_application=lambda *a, **kw: organization_application,
-            add_organization_application_note=pretend.call_recorder(
-                lambda *a, **kw: organization_application
-            ),
+        db_request.matchdict["organization_application_id"] = (
+            organization_application.id
         )
-
-        db_request.matchdict = {
-            "organization_application_id": organization_application.id
-        }
-        db_request.params = {"message": "Some internal note"}
+        db_request.params["message"] = "Some internal note"
         db_request.user = admin
-        db_request.route_path = pretend.call_recorder(_organization_application_routes)
-        db_request.find_service = pretend.call_recorder(
-            lambda iface, context: organization_service
-        )
-        db_request.session.flash = pretend.call_recorder(lambda *a, **kw: None)
+        db_request.route_path = _organization_application_routes
 
         result = views.organization_application_add_note(db_request)
 
-        assert organization_service.add_organization_application_note.calls == [
-            pretend.call(organization_application.id, db_request),
-        ]
-        assert db_request.session.flash.calls == [
-            pretend.call(
-                f'Note added to "{organization_application.name}" application',
-                queue="success",
-            ),
+        assert len(organization_application.observations) == 1
+        assert organization_application.observations[0].payload == {
+            "message": "Some internal note"
+        }
+        assert db_request.session.pop_flash("success") == [
+            f'Note added to "{organization_application.name}" application'
         ]
         assert result.status_code == 303
         assert (
@@ -865,47 +695,24 @@ class TestOrganizationApplicationActions:
             name="example", submitted_by=user
         )
 
-        organization_service = pretend.stub(
-            get_organization_application=lambda *a, **kw: organization_application,
-            add_organization_application_note=pretend.call_recorder(
-                pretend.raiser(ValueError)
-            ),
+        db_request.matchdict["organization_application_id"] = (
+            organization_application.id
         )
-
-        db_request.matchdict = {
-            "organization_application_id": organization_application.id
-        }
-        db_request.params = {}
         db_request.user = admin
-        db_request.route_path = pretend.call_recorder(_organization_application_routes)
-        db_request.find_service = pretend.call_recorder(
-            lambda iface, context: organization_service
-        )
-        db_request.session.flash = pretend.call_recorder(lambda *a, **kw: None)
+        db_request.route_path = _organization_application_routes
 
         result = views.organization_application_add_note(db_request)
 
-        assert organization_service.add_organization_application_note.calls == [
-            pretend.call(organization_application.id, db_request),
-        ]
-        assert db_request.session.flash.calls == [
-            pretend.call("No note text provided", queue="error"),
-        ]
+        assert len(organization_application.observations) == 0
+        assert db_request.session.pop_flash("error") == ["No note text provided"]
         assert result.status_code == 303
         assert (
             result.location
             == f"/admin/organization_applications/{organization_application.id}/"
         )
 
-    def test_addnote_not_found(self):
-        organization_service = pretend.stub(
-            get_organization_application=lambda *a, **kw: None,
-        )
-        request = pretend.stub(
-            flags=pretend.stub(enabled=lambda *a: False),
-            find_service=lambda *a, **kw: organization_service,
-            matchdict={"organization_application_id": pretend.stub()},
-        )
+    def test_addnote_not_found(self, db_request):
+        db_request.matchdict["organization_application_id"] = uuid.uuid4()
 
         with pytest.raises(HTTPNotFound):
-            views.organization_application_add_note(request)
+            views.organization_application_add_note(db_request)

--- a/tests/unit/admin/views/test_organization_applications.py
+++ b/tests/unit/admin/views/test_organization_applications.py
@@ -474,6 +474,30 @@ class TestOrganizationApplicationActions:
         assert result.status_code == 303
         assert result.location == "/admin/"
 
+    def test_defer_turbo_mode_with_next_application(self, db_request):
+        admin = UserFactory.create()
+        user = UserFactory.create()
+        organization_application = OrganizationApplicationFactory.create(
+            name="example", submitted_by=user
+        )
+        next_application = OrganizationApplicationFactory.create(name="next")
+
+        db_request.matchdict["organization_application_id"] = (
+            organization_application.id
+        )
+        db_request.params["organization_applications_turbo_mode"] = "true"
+        db_request.user = admin
+        db_request.route_path = _organization_application_routes
+
+        result = views.organization_application_defer(db_request)
+
+        assert organization_application.status == OrganizationApplicationStatus.Deferred
+        assert result.status_code == 303
+        assert (
+            result.location
+            == f"/admin/organization_applications/{next_application.id}/"
+        )
+
     def test_defer_not_found(self, db_request):
         db_request.matchdict["organization_application_id"] = uuid.uuid4()
 

--- a/tests/unit/organizations/test_models.py
+++ b/tests/unit/organizations/test_models.py
@@ -80,6 +80,21 @@ class TestOrganizationApplication:
 
         assert organization_application.notes == [note]
 
+    def test_conversation(self, db_session):
+        organization_application = DBOrganizationApplicationFactory.create()
+        older_request = OrganizationApplicationObservationFactory.create(
+            related=organization_application,
+            kind=ObservationKind.InformationRequest.value[0],
+            created=datetime.datetime(2021, 1, 1),
+        )
+        newer_note = OrganizationApplicationObservationFactory.create(
+            related=organization_application,
+            kind=ObservationKind.AdminNote.value[0],
+            created=datetime.datetime(2021, 6, 1),
+        )
+
+        assert organization_application.conversation == [older_request, newer_note]
+
 
 class TestOrganizationFactory:
     @pytest.mark.parametrize(("name", "normalized"), [("foo", "foo"), ("Bar", "bar")])

--- a/tests/unit/organizations/test_models.py
+++ b/tests/unit/organizations/test_models.py
@@ -12,6 +12,7 @@ from pyramid.httpexceptions import HTTPPermanentRedirect
 from pyramid.location import lineage
 
 from warehouse.authnz import Permissions
+from warehouse.observations.models import ObservationKind
 from warehouse.organizations.models import (
     OIDCIssuerType,
     OrganizationApplicationFactory,
@@ -23,6 +24,7 @@ from warehouse.organizations.models import (
 from ...common.db.accounts import UserFactory as DBUserFactory
 from ...common.db.organizations import (
     OrganizationApplicationFactory as DBOrganizationApplicationFactory,
+    OrganizationApplicationObservationFactory,
     OrganizationFactory as DBOrganizationFactory,
     OrganizationManualActivationFactory as DBOrganizationManualActivationFactory,
     OrganizationNameCatalogFactory as DBOrganizationNameCatalogFactory,
@@ -64,6 +66,19 @@ class TestOrganizationApplication:
                 (Permissions.OrganizationApplicationsManage,),
             )
         ]
+
+    def test_notes(self, db_session):
+        organization_application = DBOrganizationApplicationFactory.create()
+        note = OrganizationApplicationObservationFactory.create(
+            related=organization_application,
+            kind=ObservationKind.AdminNote.value[0],
+        )
+        OrganizationApplicationObservationFactory.create(
+            related=organization_application,
+            kind=ObservationKind.InformationRequest.value[0],
+        )
+
+        assert organization_application.notes == [note]
 
 
 class TestOrganizationFactory:

--- a/tests/unit/organizations/test_services.py
+++ b/tests/unit/organizations/test_services.py
@@ -8,6 +8,7 @@ from zope.interface.verify import verifyClass
 
 from warehouse.accounts.models import User
 from warehouse.events.tags import EventTag
+from warehouse.observations.models import ObservationKind
 from warehouse.organizations import services
 from warehouse.organizations.interfaces import IOrganizationService
 from warehouse.organizations.models import (
@@ -292,6 +293,38 @@ class TestDatabaseOrganizationService:
 
         assert len(organization_application.observations) == 0
         send_email.assert_not_called()
+
+    def test_add_organization_application_note(self, db_request, organization_service):
+        admin = UserFactory(username="admin", is_superuser=True)
+        db_request.user = admin
+        db_request.params["message"] = "some note"
+
+        organization_application = OrganizationApplicationFactory.create()
+        organization_service.add_organization_application_note(
+            organization_application.id, db_request
+        )
+
+        assert len(organization_application.observations) == 1
+        observation = organization_application.observations[0]
+        assert observation.kind == ObservationKind.AdminNote.value[0]
+        assert observation.payload == {"message": "some note"}
+        assert (
+            organization_application.status == OrganizationApplicationStatus.Submitted
+        )
+
+    def test_add_organization_application_note_no_message(
+        self, db_request, organization_service
+    ):
+        admin = UserFactory(username="admin", is_superuser=True)
+        db_request.user = admin
+
+        organization_application = OrganizationApplicationFactory.create()
+        with pytest.raises(ValueError):  # noqa: PT011
+            organization_service.add_organization_application_note(
+                organization_application.id, db_request
+            )
+
+        assert len(organization_application.observations) == 0
 
     def test_decline_organization_application(
         self, db_request, organization_service, mocker

--- a/warehouse/admin/routes.py
+++ b/warehouse/admin/routes.py
@@ -113,6 +113,11 @@ def includeme(config):
         "/admin/organization_applications/{organization_application_id}/decline/",
         domain=warehouse,
     )
+    config.add_route(
+        "admin.organization_application.addnote",
+        "/admin/organization_applications/{organization_application_id}/addnote/",
+        domain=warehouse,
+    )
 
     # User related Admin pages
     config.add_route("admin.user.list", "/admin/users/", domain=warehouse)

--- a/warehouse/admin/templates/admin/organization_applications/detail.html
+++ b/warehouse/admin/templates/admin/organization_applications/detail.html
@@ -26,6 +26,17 @@
 </div>
 {% endmacro %}
 
+{% macro chat_message(name, timestamp, email, text, right=False) %}
+<div class="direct-chat-msg{% if right %} right{% endif %}">
+  <div class="direct-chat-infos clearfix">
+    <span class="direct-chat-name float-{{ "right" if right else "left" }}">{{ name }}</span>
+    <span class="direct-chat-timestamp float-{{ "left" if right else "right" }}">{{ timestamp }}</span>
+  </div>
+  <img class="direct-chat-img" src="{{ gravatar(request, email, size=128) }}" alt="Message User Image">
+  <div class="direct-chat-text preserve-line-breaks">{{ text }}</div>
+</div>
+{% endmacro %}
+
 {% block content %}
   <div class="row">
     <div class="col-md-3">
@@ -554,57 +565,30 @@
           <h3 class="card-title">Information Requests</h3>
         </div>
         <div class="card-body">
-        {% for information_request in information_requests|reverse %}
-        <div class="card {% if information_request.additional.response %}card-neutral{% else %}card-warning{% endif %} direct-chat direct-chat-primary"</div>
-          <div class="card-body">
-            <div class="direct-chat-messages unset-height">
-              <div class="direct-chat-msg">
-                <div class="direct-chat-infos clearfix">
-                  <span class="direct-chat-name float-left">{{ information_request.observer.parent.username }} (PyPI)</span>
-                  <span class="direct-chat-timestamp float-right">{{ information_request.created|format_datetime }}</span>
-                </div>
-                <img class="direct-chat-img" src="{{ gravatar(request, information_request.observer.parent.email, size=128) }}" alt="Message User Image">
-                <div class="direct-chat-text preserve-line-breaks">{{ information_request.payload.message }}</div>
+        {% for entry in organization_application.conversation %}
+          {% if entry.kind == "admin_note" %}
+          <div class="card card-warning card-outline direct-chat direct-chat-primary">
+            <div class="card-body">
+              <div class="direct-chat-messages unset-height">
+                {{ chat_message(entry.observer.parent.username ~ " (Internal Note)", entry.created|format_datetime, entry.observer.parent.email, entry.payload.message) }}
               </div>
-              {% if information_request.additional.response %}
-              <div class="direct-chat-msg right">
-                <div class="direct-chat-infos clearfix">
-                  <span class="direct-chat-name float-right">{{ organization_application.submitted_by.username }}</span>
-                  <span class="direct-chat-timestamp float-left">{{ information_request.additional.response_time|parse_isoformat|format_datetime }}</span>
-                </div>
-                <img class="direct-chat-img" src="{{ gravatar(request, organization_application.submitted_by.email, size=128) }}" alt="Message User Image">
-                <div class="direct-chat-text preserve-line-breaks">{{ information_request.additional.response }}</div>
-              </div>
-              {% endif %}
             </div>
           </div>
-        </div>
+          {% else %}
+          <div class="card {% if entry.additional.response %}card-neutral{% else %}card-warning{% endif %} direct-chat direct-chat-primary">
+            <div class="card-body">
+              <div class="direct-chat-messages unset-height">
+                {{ chat_message(entry.observer.parent.username ~ " (PyPI)", entry.created|format_datetime, entry.observer.parent.email, entry.payload.message) }}
+                {% if entry.additional.response %}
+                {{ chat_message(organization_application.submitted_by.username, entry.additional.response_time|parse_isoformat|format_datetime, organization_application.submitted_by.email, entry.additional.response, right=True) }}
+                {% endif %}
+              </div>
+            </div>
+          </div>
+          {% endif %}
+        {% else %}
+        <i>No information requests or internal notes yet.</i>
         {% endfor %}
-        </div>
-      </div>
-    </div>
-
-    {% set notes = organization_application.notes %}
-    <div class="col-md-9 col-lg-6 offset-md-3">
-      <div class="card">
-        <div class="card-header with-border">
-          <h3 class="card-title">Internal Notes</h3>
-        </div>
-        <div class="card-body">
-          <div class="direct-chat-messages unset-height">
-            {% for note in notes %}
-            <div class="direct-chat-msg">
-              <div class="direct-chat-infos clearfix">
-                <span class="direct-chat-name float-left">{{ note.observer.parent.username }}</span>
-                <span class="direct-chat-timestamp float-right">{{ note.created|format_datetime }}</span>
-              </div>
-              <img class="direct-chat-img" src="{{ gravatar(request, note.observer.parent.email, size=128) }}" alt="Admin User Image">
-              <div class="direct-chat-text preserve-line-breaks">{{ note.payload.message }}</div>
-            </div>
-            {% else %}
-            <i>No internal notes yet.</i>
-            {% endfor %}
-          </div>
         </div>
       </div>
     </div>

--- a/warehouse/admin/templates/admin/organization_applications/detail.html
+++ b/warehouse/admin/templates/admin/organization_applications/detail.html
@@ -51,6 +51,17 @@
           <div class="form-group">
             <button
               type="button"
+              class="btn btn-secondary btn-block"
+              data-toggle="modal"
+              data-hotkey-binding=78
+              data-target="#addNoteModal" {{ 'disabled' if not request.has_permission(Permissions.AdminOrganizationsWrite) }}
+              title="Add an internal note to this organization request"
+            >
+              <i class="icon fa fa-note-sticky"></i> Add Note
+            </button>
+
+            <button
+              type="button"
               class="btn btn-primary btn-block"
               data-toggle="modal"
               data-hotkey-binding=65
@@ -318,6 +329,41 @@
               </form>
             </div>
 
+            <div class="modal fade" id="addNoteModal" tabindex="-1" role="dialog">
+              <form method="POST" action="{{ request.route_path('admin.organization_application.addnote', organization_application_id=organization_application.id) }}">
+                <input name="csrf_token" type="hidden" value="{{ request.session.get_csrf_token() }}">
+                <div class="modal-dialog" role="document">
+                  <div class="modal-content">
+                    <div class="modal-header">
+                      <h4 class="modal-title" id="addNoteModalLabel">
+                        Add Internal Note to {{ organization_application.name }}?
+                      </h4>
+                      <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                        <span aria-hidden="true">&times;</span>
+                      </button>
+                    </div>
+                    <div class="modal-body">
+                      <p>
+                        This note is for internal admin reference only. It will not be emailed to the applicant.
+                      </p>
+                      <div class="form-group">
+                        <label for="addNoteModalMessage">
+                          Note
+                        </label>
+                        <textarea id="addNoteModalMessage" class="form-control" name="message" placeholder="Internal note" rows=6></textarea>
+                      </div>
+                    </div>
+                    <div class="modal-footer justify-content-between">
+                      <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+                      <button type="submit" class="btn btn-secondary">
+                        <i class="icon fa fa-note-sticky"></i> Add Note
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </form>
+            </div>
+
             {% endif %}
           </div>
           <div class="form-group">
@@ -534,6 +580,31 @@
           </div>
         </div>
         {% endfor %}
+        </div>
+      </div>
+    </div>
+
+    {% set notes = organization_application.notes %}
+    <div class="col-md-9 col-lg-6 offset-md-3">
+      <div class="card">
+        <div class="card-header with-border">
+          <h3 class="card-title">Internal Notes</h3>
+        </div>
+        <div class="card-body">
+          <div class="direct-chat-messages unset-height">
+            {% for note in notes %}
+            <div class="direct-chat-msg">
+              <div class="direct-chat-infos clearfix">
+                <span class="direct-chat-name float-left">{{ note.observer.parent.username }}</span>
+                <span class="direct-chat-timestamp float-right">{{ note.created|format_datetime }}</span>
+              </div>
+              <img class="direct-chat-img" src="{{ gravatar(request, note.observer.parent.email, size=128) }}" alt="Admin User Image">
+              <div class="direct-chat-text preserve-line-breaks">{{ note.payload.message }}</div>
+            </div>
+            {% else %}
+            <i>No internal notes yet.</i>
+            {% endfor %}
+          </div>
         </div>
       </div>
     </div>

--- a/warehouse/admin/templates/admin/organization_applications/detail.html
+++ b/warehouse/admin/templates/admin/organization_applications/detail.html
@@ -62,13 +62,13 @@
           <div class="form-group">
             <button
               type="button"
-              class="btn btn-secondary btn-block"
+              class="btn btn-warning btn-block"
               data-toggle="modal"
               data-hotkey-binding=78
               data-target="#addNoteModal" {{ 'disabled' if not request.has_permission(Permissions.AdminOrganizationsWrite) }}
               title="Add an internal note to this organization request"
             >
-              <i class="icon fa fa-note-sticky"></i> Add Note
+              <i class="icon fa fa-note-sticky text-white"></i> Add Note
             </button>
 
             <button
@@ -361,13 +361,13 @@
                         <label for="addNoteModalMessage">
                           Note
                         </label>
-                        <textarea id="addNoteModalMessage" class="form-control" name="message" placeholder="Internal note" rows=6></textarea>
+                        <textarea id="addNoteModalMessage" class="form-control" name="message" placeholder="Internal note" rows=6 required></textarea>
                       </div>
                     </div>
                     <div class="modal-footer justify-content-between">
                       <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
-                      <button type="submit" class="btn btn-secondary">
-                        <i class="icon fa fa-note-sticky"></i> Add Note
+                      <button type="submit" class="btn btn-warning">
+                        <i class="icon fa fa-note-sticky text-white"></i> Add Note
                       </button>
                     </div>
                   </div>

--- a/warehouse/admin/views/observations.py
+++ b/warehouse/admin/views/observations.py
@@ -58,6 +58,7 @@ _KIND_TO_MODEL: dict[str, type[Observation]] = {
     "account_recovery": User.Observation,
     "email_unverified": User.Observation,
     "information_request": OrganizationApplication.Observation,
+    "admin_note": OrganizationApplication.Observation,
 }
 
 _KIND_TO_ADMIN_ROUTE: dict[str, str] = {
@@ -69,6 +70,7 @@ _KIND_TO_ADMIN_ROUTE: dict[str, str] = {
     "account_recovery": "admin.user.detail",
     "email_unverified": "admin.user.detail",
     "information_request": "admin.organization_application.detail",
+    "admin_note": "admin.organization_application.detail",
 }
 
 # Allowlist of DataTables `columns[i][name]` values that may drive ORDER BY.

--- a/warehouse/admin/views/organizations.py
+++ b/warehouse/admin/views/organizations.py
@@ -833,6 +833,43 @@ def organization_application_decline(request):
 
 
 @view_config(
+    route_name="admin.organization_application.addnote",
+    require_methods=["POST"],
+    permission=Permissions.AdminOrganizationsWrite,
+    has_translations=True,
+    uses_session=True,
+    require_csrf=True,
+)
+def organization_application_add_note(request):
+    organization_service = request.find_service(IOrganizationService, context=None)
+
+    organization_application_id = request.matchdict["organization_application_id"]
+    organization_application = organization_service.get_organization_application(
+        organization_application_id
+    )
+    if organization_application is None:
+        raise HTTPNotFound
+
+    try:
+        organization_service.add_organization_application_note(
+            organization_application.id, request
+        )
+        request.session.flash(
+            f'Note added to "{organization_application.name}" application',
+            queue="success",
+        )
+    except ValueError:
+        request.session.flash("No note text provided", queue="error")
+
+    return HTTPSeeOther(
+        request.route_path(
+            "admin.organization_application.detail",
+            organization_application_id=organization_application.id,
+        )
+    )
+
+
+@view_config(
     route_name="admin.organization.add_role",
     permission=Permissions.AdminRoleAdd,
     request_method="POST",

--- a/warehouse/observations/models.py
+++ b/warehouse/observations/models.py
@@ -117,6 +117,7 @@ class ObservationKind(enum.Enum):
 
     # Organization Applications
     InformationRequest = ("information_request", "Information Request")
+    AdminNote = ("admin_note", "Admin Note")
 
 
 # A reverse-lookup map by the string value stored in the database

--- a/warehouse/organizations/models.py
+++ b/warehouse/organizations/models.py
@@ -761,7 +761,7 @@ class OrganizationApplication(OrganizationMixin, HasObservations, db.Model):
             observations = [
                 observation
                 for observation in observations
-                if observation.kind == observations.value[0]
+                if observation.kind == kind.value[0]
             ]
 
         return sorted(observations, key=lambda x: x.created, reverse=True)

--- a/warehouse/organizations/models.py
+++ b/warehouse/organizations/models.py
@@ -765,6 +765,18 @@ class OrganizationApplication(OrganizationMixin, HasObservations, db.Model):
             reverse=True,
         )
 
+    @property
+    def notes(self):
+        return sorted(
+            [
+                observation
+                for observation in self.observations
+                if observation.kind == ObservationKind.AdminNote.value[0]
+            ],
+            key=lambda x: x.created,
+            reverse=True,
+        )
+
     def __lt__(self, other: OrganizationApplication) -> bool:
         return self.name < other.name
 

--- a/warehouse/organizations/models.py
+++ b/warehouse/organizations/models.py
@@ -777,6 +777,14 @@ class OrganizationApplication(OrganizationMixin, HasObservations, db.Model):
             reverse=True,
         )
 
+    @property
+    def conversation(self):
+        """
+        Information requests and internal notes, merged into a single
+        chronological (oldest first) thread for admin display.
+        """
+        return sorted(self.information_requests + self.notes, key=lambda x: x.created)
+
     def __lt__(self, other: OrganizationApplication) -> bool:
         return self.name < other.name
 

--- a/warehouse/organizations/models.py
+++ b/warehouse/organizations/models.py
@@ -753,16 +753,12 @@ class OrganizationApplication(OrganizationMixin, HasObservations, db.Model):
         back_populates="application", viewonly=True
     )
 
-    def get_observations(
-        self, kind: ObservationKind | None = None
-    ) -> list[Observation]:
-        observations = list(self.observations)
-        if kind is not None:
-            observations = [
-                observation
-                for observation in observations
-                if observation.kind == kind.value[0]
-            ]
+    def get_observations(self, kind: ObservationKind) -> list[Observation]:
+        observations = [
+            observation
+            for observation in self.observations
+            if observation.kind == kind.value[0]
+        ]
 
         return sorted(observations, key=lambda x: x.created, reverse=True)
 

--- a/warehouse/organizations/models.py
+++ b/warehouse/organizations/models.py
@@ -35,7 +35,7 @@ from warehouse import db
 from warehouse.accounts.models import TermsOfServiceEngagement, User
 from warehouse.authnz import Permissions
 from warehouse.events.models import HasEvents
-from warehouse.observations.models import HasObservations, ObservationKind
+from warehouse.observations.models import HasObservations, Observation, ObservationKind
 from warehouse.utils.attrs import make_repr
 from warehouse.utils.db import orm_session_from_obj
 from warehouse.utils.db.types import TZDateTime, bool_false, datetime_now
@@ -753,29 +753,26 @@ class OrganizationApplication(OrganizationMixin, HasObservations, db.Model):
         back_populates="application", viewonly=True
     )
 
+    def get_observations(
+        self, kind: ObservationKind | None = None
+    ) -> list[Observation]:
+        observations = list(self.observations)
+        if kind is not None:
+            observations = [
+                observation
+                for observation in observations
+                if observation.kind == observations.value[0]
+            ]
+
+        return sorted(observations, key=lambda x: x.created, reverse=True)
+
     @property
     def information_requests(self):
-        return sorted(
-            [
-                observation
-                for observation in self.observations
-                if observation.kind == ObservationKind.InformationRequest.value[0]
-            ],
-            key=lambda x: x.created,
-            reverse=True,
-        )
+        return self.get_observations(ObservationKind.InformationRequest)
 
     @property
     def notes(self):
-        return sorted(
-            [
-                observation
-                for observation in self.observations
-                if observation.kind == ObservationKind.AdminNote.value[0]
-            ],
-            key=lambda x: x.created,
-            reverse=True,
-        )
+        return self.get_observations(ObservationKind.AdminNote)
 
     @property
     def conversation(self):

--- a/warehouse/organizations/services.py
+++ b/warehouse/organizations/services.py
@@ -282,6 +282,29 @@ class DatabaseOrganizationService:
 
         return organization_application
 
+    def add_organization_application_note(self, organization_application_id, request):
+        """
+        Records an internal admin note on an OrganizationApplication
+        """
+        organization_application = self.get_organization_application(
+            organization_application_id
+        )
+
+        message = request.params.get("message", "")
+
+        if not message:
+            raise ValueError
+
+        organization_application.record_observation(
+            request=request,
+            actor=request.user,
+            summary="Admin note added",
+            kind=ObservationKind.AdminNote,
+            payload={"message": message},
+        )
+
+        return organization_application
+
     def decline_organization_application(self, organization_application_id, request):
         """
         Performs operations necessary to decline an OrganizationApplication

--- a/warehouse/organizations/services.py
+++ b/warehouse/organizations/services.py
@@ -260,27 +260,23 @@ class DatabaseOrganizationService:
             OrganizationApplicationStatus.MoreInformationNeeded
         )
 
-        message = request.params.get("message", "")
-
-        if not message:
-            raise ValueError
-
-        organization_application.record_observation(
-            request=request,
-            actor=request.user,
-            summary="Organization request needs more information",
-            kind=ObservationKind.InformationRequest,
-            payload={"message": message},
-        )
-        send_new_organization_moreinformationneeded_email(
-            request,
-            organization_application.submitted_by,
-            organization_name=organization_application.name,
-            organization_application_id=organization_application.id,
-            message=message,
-        )
-
-        return organization_application
+        if message := request.params.get("message", ""):
+            organization_application.record_observation(
+                request=request,
+                actor=request.user,
+                summary="Organization request needs more information",
+                kind=ObservationKind.InformationRequest,
+                payload={"message": message},
+            )
+            send_new_organization_moreinformationneeded_email(
+                request,
+                organization_application.submitted_by,
+                organization_name=organization_application.name,
+                organization_application_id=organization_application.id,
+                message=message,
+            )
+            return organization_application
+        raise ValueError
 
     def add_organization_application_note(self, organization_application_id, request):
         """
@@ -290,20 +286,16 @@ class DatabaseOrganizationService:
             organization_application_id
         )
 
-        message = request.params.get("message", "")
-
-        if not message:
-            raise ValueError
-
-        organization_application.record_observation(
-            request=request,
-            actor=request.user,
-            summary="Admin note added",
-            kind=ObservationKind.AdminNote,
-            payload={"message": message},
-        )
-
-        return organization_application
+        if message := request.params.get("message", ""):
+            organization_application.record_observation(
+                request=request,
+                actor=request.user,
+                summary="Admin note added",
+                kind=ObservationKind.AdminNote,
+                payload={"message": message},
+            )
+            return organization_application
+        raise ValueError
 
     def decline_organization_application(self, organization_application_id, request):
         """


### PR DESCRIPTION
Addresses Issue #20131

Most of this is reusing Observations, which were already used for Information Requests, with the difference of now sending any emails/notifications whatsoever. They are rendered in the same list view of Information Requests.

Extracted some of the presentation logic to be used across Information Requests and Internal 

<img width="554" height="714" alt="Screenshot from 2026-07-20 18-11-55" src="https://github.com/user-attachments/assets/049f3236-e4d4-4eeb-83d1-d80e1fa36447" />

<img width="824" height="593" alt="Screenshot from 2026-07-21 17-45-20" src="https://github.com/user-attachments/assets/8eedb192-0c83-4590-8914-73adb4f574f1" />
