### PR TITLE
Stripe: Nightly reconciliation fails

### DIFF
--- a/tests/unit/organizations/test_tasks.py
+++ b/tests/unit/organizations/test_tasks.py
@@ -2,6 +2,8 @@
 
 import datetime
 
+import stripe
+
 from warehouse.accounts.interfaces import ITokenService, TokenExpired
 from warehouse.events.tags import EventTag
 from warehouse.organizations.models import (
@@ -17,7 +19,6 @@ from warehouse.organizations.tasks import (
     update_organization_invitation_status,
     update_organziation_subscription_usage_record,
 )
-from warehouse.subscriptions.interfaces import IBillingService
 from warehouse.subscriptions.models import StripeSubscriptionStatus
 
 from ...common.db.organizations import (
@@ -207,7 +208,7 @@ class TestUpdateOrganizationSubscriptionUsage:
         )
         StripeSubscriptionItemFactory.create(subscription=subscription)
 
-        mocker.patch.object(
+        create_usage_record = mocker.patch.object(
             billing_service,
             "create_or_update_usage_record",
             return_value={
@@ -215,11 +216,63 @@ class TestUpdateOrganizationSubscriptionUsage:
                 "organization_member_count": "5",
             },
         )
-        find_service = mocker.spy(db_request, "find_service")
 
         update_organziation_subscription_usage_record(db_request)
 
-        find_service.assert_called_once_with(IBillingService, context=None)
+        # Only the active subscription is reported; the canceled one is skipped.
+        create_usage_record.assert_called_once()
+
+    def test_continues_when_a_subscription_fails(
+        self, db_request, billing_service, metrics, mocker
+    ):
+        # First usage report raises; the batch must still report the second org.
+        for _ in range(2):
+            organization = OrganizationFactory.create()
+            OrganizationRoleFactory(
+                organization=organization,
+                user=UserFactory.create(),
+                role_name=OrganizationRoleType.Owner,
+            )
+            stripe_customer = StripeCustomerFactory.create()
+            OrganizationStripeCustomerFactory.create(
+                organization=organization, customer=stripe_customer
+            )
+            subscription_price = StripeSubscriptionPriceFactory.create(
+                subscription_product=StripeSubscriptionProductFactory.create()
+            )
+            subscription = StripeSubscriptionFactory.create(
+                customer=stripe_customer, subscription_price=subscription_price
+            )
+            OrganizationStripeSubscriptionFactory.create(
+                organization=organization, subscription=subscription
+            )
+            StripeSubscriptionItemFactory.create(subscription=subscription)
+
+        create_usage_record = mocker.patch.object(
+            billing_service,
+            "create_or_update_usage_record",
+            side_effect=[
+                stripe.error.InvalidRequestError(
+                    "Cannot create the usage record because the subscription "
+                    "has been canceled.",
+                    None,
+                ),
+                {"subscription_item_id": "si_1234", "organization_member_count": "1"},
+            ],
+        )
+        increment = mocker.spy(metrics, "increment")
+
+        update_organziation_subscription_usage_record(db_request)
+
+        # Both subscriptions are attempted even though the first one raised.
+        assert create_usage_record.call_count == 2
+        increment.assert_any_call(
+            "warehouse.organizations.subscription.usage_record.error",
+            tags=["error_type:InvalidRequestError"],
+        )
+        increment.assert_any_call(
+            "warehouse.organizations.subscription.usage_record.updated"
+        )
 
 
 class TestNotifyOrganizationsRequiringSubscription:

--- a/warehouse/organizations/tasks.py
+++ b/warehouse/organizations/tasks.py
@@ -1,6 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import datetime
+import logging
+
+import stripe
 
 from sqlalchemy.orm import joinedload
 
@@ -8,6 +11,7 @@ from warehouse import tasks
 from warehouse.accounts.interfaces import ITokenService, TokenExpired
 from warehouse.email import send_organization_subscription_required_email
 from warehouse.events.tags import EventTag
+from warehouse.metrics import IMetricsService
 from warehouse.organizations.models import (
     Organization,
     OrganizationApplication,
@@ -22,6 +26,8 @@ from warehouse.subscriptions.models import StripeSubscriptionStatus
 
 CLEANUP_AFTER = datetime.timedelta(days=30)
 SUBSCRIPTION_GRACE_PERIOD = datetime.timedelta(days=30)
+
+logger = logging.getLogger(__name__)
 
 
 @tasks.task(ignore_result=True, acks_late=True)
@@ -77,13 +83,33 @@ def update_organziation_subscription_usage_record(request):
     # Get organizations with a subscription
     organization_subscriptions = request.db.query(OrganizationStripeSubscription).all()
 
+    billing_service = request.find_service(IBillingService, context=None)
+    metrics = request.find_service(IMetricsService, context=None)
+
     # Call the Billing API to update the usage record of this subscription item
     for org_subscription in organization_subscriptions:
-        if org_subscription.subscription.status != StripeSubscriptionStatus.Canceled:
-            billing_service = request.find_service(IBillingService, context=None)
+        if org_subscription.subscription.status == StripeSubscriptionStatus.Canceled:
+            continue
+        try:
             billing_service.create_or_update_usage_record(
                 org_subscription.subscription.subscription_item.subscription_item_id,
                 len(org_subscription.organization.users),
+            )
+        except stripe.error.StripeError as exc:
+            # Isolate per-subscription failures so one (e.g. canceled on Stripe with a
+            # stale local status) can't abort usage reporting for every other org.
+            logger.exception(
+                "Failed to update usage record for organization %r (subscription %s)",
+                org_subscription.organization.name,
+                org_subscription.subscription.subscription_id,
+            )
+            metrics.increment(
+                "warehouse.organizations.subscription.usage_record.error",
+                tags=[f"error_type:{exc.__class__.__name__}"],
+            )
+        else:
+            metrics.increment(
+                "warehouse.organizations.subscription.usage_record.updated"
             )
 
 


### PR DESCRIPTION
we report each org's seat count to Stripe, and Stripe bills whatever we report. 

Problem: the loop has no per-item error handling. so whenever one sub is canceled on Stripe but still active in our DB, the usage call raises `InvalidRequestError`, it goes unhandled, and the whole loop dies. Every org after that row neveer gets reported usage → Stripe bills 0 seats → $0.

Adds metrics and err handling

Followup needs to be: reconciling the stale local statuses