### PR TITLE
test: flaky coverage in email MX-domain validation

### DIFF
--- a/tests/unit/manage/test_forms.py
+++ b/tests/unit/manage/test_forms.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+from types import SimpleNamespace
+
 import pretend
 import pytest
 import wtforms
@@ -14,6 +16,27 @@ from ...common.constants import REMOTE_ADDR
 from ...common.db.accounts import OAuthAccountAssociationFactory, UserFactory
 from ...common.db.organizations import OrganizationFactory
 from ...common.db.packaging import ProjectFactory
+
+
+def _stub_mx_ptr_resolution(monkeypatch, ptr_host):
+    """
+    Stub ``dns.resolver`` so the MX-record-to-PTR lookup in email validation
+    runs deterministically without live network queries.
+
+    Without this, coverage of the PTR-resolution branch in
+    ``warehouse/accounts/forms.py`` depends on CI DNS resolving real MX hosts,
+    which is non-deterministic and produces flaky coverage failures.
+    """
+    monkeypatch.setattr(
+        "dns.resolver.resolve",
+        lambda *a, **kw: [SimpleNamespace(address="192.0.2.1")],
+    )
+    monkeypatch.setattr(
+        "dns.resolver.resolve_address",
+        lambda *a, **kw: [
+            SimpleNamespace(target=SimpleNamespace(to_text=lambda: ptr_host))
+        ],
+    )
 
 
 class TestCreateRoleForm:
@@ -238,14 +261,23 @@ class TestAddEmailForm:
         )
 
     @pytest.mark.parametrize(
-        ("email_address", "mx_record_domain", "prohibited_domain"),
+        ("email_address", "mx_record_domain", "mx_ptr_host", "prohibited_domain"),
         [
-            ("foo@wutang.net", "in.mail.net", "mail.net"),
-            ("foo@wutang.net", "in.mail.net", "in.mail.net"),
+            # Prohibited via the MX record's own domain
+            ("foo@wutang.net", "in.mail.net", "ptr.example.org", "mail.net"),
+            ("foo@wutang.net", "in.mail.net", "ptr.example.org", "in.mail.net"),
             (
                 "foo@outlook.com",
                 "outlook-com.mail.protection.outlook.com",
+                "ptr.example.org",
                 "outlook.com",
+            ),
+            # Prohibited via the domain the MX host's IP resolves back to (PTR)
+            (
+                "foo@wutang.net",
+                "in.someisp.com",
+                "mx1.prohibited-ptr.net",
+                "prohibited-ptr.net",
             ),
         ],
     )
@@ -255,10 +287,16 @@ class TestAddEmailForm:
         db_request,
         email_address,
         mx_record_domain,
+        mx_ptr_host,
         prohibited_domain,
     ):
         """
         Similar to `test_prohibited_email_error()`, checking the MX domain.
+
+        Both the MX record's own domain and the domain its IP points back to
+        (via a PTR lookup) are checked against the prohibited list. DNS
+        resolution is stubbed so coverage of the PTR-resolution branch does not
+        depend on live network lookups.
         """
         mock_deliverability_info = {"mx": [(10, mx_record_domain)]}
 
@@ -269,6 +307,7 @@ class TestAddEmailForm:
             "email_validator.deliverability.validate_email_deliverability",
             mock_function,
         )
+        _stub_mx_ptr_resolution(monkeypatch, mx_ptr_host)
 
         prohibited_mx_domain = ProhibitedEmailDomain(
             domain=prohibited_domain,
@@ -325,6 +364,7 @@ class TestAddEmailForm:
             "email_validator.deliverability.validate_email_deliverability",
             mock_function,
         )
+        _stub_mx_ptr_resolution(monkeypatch, "ptr.example.org")
 
         prohibited_mx_domain = ProhibitedEmailDomain(
             domain=prohibited_domain,


### PR DESCRIPTION
The MX-to-PTR branch in `NewEmailMixin.validate_email` reports coverage when CI's DNS cooperated. Both tests that reach it mock the MX deliverability info but leave `dns.resolver` alone, so they fire real DNS queries at hosts like `in.mail.net`.
Resolve succeeds, the branch runs, coverage passes; resolve times out or `NXDOMAIN`s, `contextlib.suppress` eats it, the lines go uncovered, and the 100% gate trips.

The assertions don't depend on the PTR lookup at all, since the prohibited match comes from the MX record's own domain, so the tests stayed green while coverage flaked underneath them.

Stub `dns.resolver` in both `test_prohibited_mx_domain_*` tests so the PTR branch runs offline, and add a case that trips prohibition via the PTR-derived domain so that path gets exercised on purpose rather than by accident.

Refs: #16814
Refs: #20273
Resolves #20284
Closes #20285