### PR TITLE
Let users know when their pending Trusted Publisher is about to expire 

### DIFF
--- a/tests/unit/email/test_init.py
+++ b/tests/unit/email/test_init.py
@@ -5613,20 +5613,42 @@ class TestTrustedPublisherEmails:
         pyramid_request.user = stub_user
         pyramid_request.registry.settings = {"mail.sender": "noreply@example.com"}
 
+        stub_publisher = pretend.stub(
+            publisher_name="GitHub",
+            created=datetime.datetime(2024, 1, 1),
+            expires_at=datetime.datetime(2024, 1, 31),
+        )
+
         result = email.send_pending_trusted_publisher_expired_email(
             pyramid_request,
             stub_user,
             project_name="test_project",
+            publisher=stub_publisher,
             days=30,
         )
 
         assert result == {
             "project_name": "test_project",
+            "publisher": stub_publisher,
             "days": 30,
+            "created_date": "2024-01-01",
+            "expiry_date": "2024-01-31",
         }
         subject_renderer.assert_()
-        body_renderer.assert_(project_name="test_project", days=30)
-        html_renderer.assert_(project_name="test_project", days=30)
+        body_renderer.assert_(
+            project_name="test_project",
+            publisher=stub_publisher,
+            days=30,
+            created_date="2024-01-01",
+            expiry_date="2024-01-31",
+        )
+        html_renderer.assert_(
+            project_name="test_project",
+            publisher=stub_publisher,
+            days=30,
+            created_date="2024-01-01",
+            expiry_date="2024-01-31",
+        )
 
     def test_pending_trusted_publisher_expiration_reminder_email(
         self, pyramid_request, pyramid_config, monkeypatch
@@ -5667,20 +5689,46 @@ class TestTrustedPublisherEmails:
         pyramid_request.user = stub_user
         pyramid_request.registry.settings = {"mail.sender": "noreply@example.com"}
 
+        stub_publisher = pretend.stub(
+            publisher_name="GitHub",
+            created=datetime.datetime(2024, 1, 1),
+            expires_at=datetime.datetime(2024, 1, 31),
+        )
+
         result = email.send_pending_trusted_publisher_expiration_reminder_email(
             pyramid_request,
             stub_user,
             project_name="test_project",
+            publisher=stub_publisher,
             days_remaining=5,
+            expiry_days=30,
         )
 
         assert result == {
             "project_name": "test_project",
+            "publisher": stub_publisher,
             "days_remaining": 5,
+            "expiry_days": 30,
+            "created_date": "2024-01-01",
+            "expiry_date": "2024-01-31",
         }
         subject_renderer.assert_()
-        body_renderer.assert_(project_name="test_project", days_remaining=5)
-        html_renderer.assert_(project_name="test_project", days_remaining=5)
+        body_renderer.assert_(
+            project_name="test_project",
+            publisher=stub_publisher,
+            days_remaining=5,
+            expiry_days=30,
+            created_date="2024-01-01",
+            expiry_date="2024-01-31",
+        )
+        html_renderer.assert_(
+            project_name="test_project",
+            publisher=stub_publisher,
+            days_remaining=5,
+            expiry_days=30,
+            created_date="2024-01-01",
+            expiry_date="2024-01-31",
+        )
 
     def test_pending_trusted_publisher_reified_email(
         self, pyramid_request, pyramid_config, monkeypatch

--- a/tests/unit/oidc/models/test_core.py
+++ b/tests/unit/oidc/models/test_core.py
@@ -1,12 +1,17 @@
 # SPDX-License-Identifier: Apache-2.0
 
+from datetime import UTC, datetime, timedelta
+
 import pretend
 import psycopg
 import pytest
 
+from tests.common.db.accounts import UserFactory
 from tests.common.db.oidc import PendingGitHubPublisherFactory
+from tests.common.db.organizations import OrganizationFactory, OrganizationRoleFactory
 from warehouse.oidc import errors
 from warehouse.oidc.models import _core
+from warehouse.organizations.models import OrganizationRoleType
 
 
 def test_check_claim_binary():
@@ -45,6 +50,62 @@ class TestPendingOIDCPublisher:
         publisher = PendingGitHubPublisherFactory(project_name=valid_project_name)
 
         assert publisher.project_name == valid_project_name
+
+    def test_expires_at(self, db_session):
+        publisher = PendingGitHubPublisherFactory()
+
+        assert publisher.expires_at == publisher.created + timedelta(
+            days=_core.PENDING_PUBLISHER_EXPIRY_DAYS
+        )
+
+    def test_days_until_expiry(self, db_session):
+        publisher = PendingGitHubPublisherFactory()
+        publisher.created = datetime.now(UTC).replace(tzinfo=None) - timedelta(days=10)
+
+        assert publisher.days_until_expiry == _core.PENDING_PUBLISHER_EXPIRY_DAYS - 10
+
+    def test_days_until_expiry_clamped_at_zero(self, db_session):
+        publisher = PendingGitHubPublisherFactory()
+        publisher.created = datetime.now(UTC).replace(tzinfo=None) - timedelta(days=100)
+
+        assert publisher.days_until_expiry == 0
+
+    def test_notification_recipients_no_organization(self, db_session):
+        publisher = PendingGitHubPublisherFactory()
+
+        assert publisher.notification_recipients() == {publisher.added_by}
+
+    def test_notification_recipients_organization_scoped(self, db_session):
+        organization = OrganizationFactory.create()
+        owner_role = OrganizationRoleFactory.create(
+            organization=organization, role_name=OrganizationRoleType.Owner
+        )
+        manager_role = OrganizationRoleFactory.create(
+            organization=organization, role_name=OrganizationRoleType.Manager
+        )
+        # A member should NOT be included.
+        OrganizationRoleFactory.create(
+            organization=organization, role_name=OrganizationRoleType.Member
+        )
+        publisher = PendingGitHubPublisherFactory(organization_id=organization.id)
+
+        assert publisher.notification_recipients() == {
+            publisher.added_by,
+            owner_role.user,
+            manager_role.user,
+        }
+
+    def test_notification_recipients_uses_precomputed_org_recipients(self, db_session):
+        organization = OrganizationFactory.create()
+        publisher = PendingGitHubPublisherFactory(organization_id=organization.id)
+        other_user = UserFactory.create()
+
+        # A precomputed org_recipients set is trusted as-is, instead of
+        # re-querying the organization's owners/managers.
+        assert publisher.notification_recipients(org_recipients={other_user}) == {
+            publisher.added_by,
+            other_user,
+        }
 
 
 class TestOIDCPublisher:

--- a/tests/unit/oidc/test_tasks.py
+++ b/tests/unit/oidc/test_tasks.py
@@ -11,14 +11,17 @@ from warehouse.oidc.models import PendingOIDCPublisher
 from warehouse.oidc.tasks import (
     PENDING_PUBLISHER_EXPIRY_DAYS,
     PENDING_PUBLISHER_REMINDER_DAYS,
+    _cached_org_recipients,
     compute_oidc_metrics,
     delete_expired_oidc_macaroons,
     delete_expired_pending_publishers,
     pending_publisher_cutoff,
     send_pending_publisher_expiration_reminders,
 )
+from warehouse.organizations.models import OrganizationRoleType
 
 from ...common.db.oidc import GitHubPublisherFactory, PendingGitHubPublisherFactory
+from ...common.db.organizations import OrganizationFactory, OrganizationRoleFactory
 from ...common.db.packaging import (
     FileEventFactory,
     FileFactory,
@@ -26,6 +29,25 @@ from ...common.db.packaging import (
     ReleaseFactory,
     UserFactory,
 )
+
+
+def _organization_with_owner_and_manager():
+    """Create an organization with one owner, one manager, and one member.
+
+    Returns (organization, owner_role, manager_role) -- the member role is
+    created only to prove members are excluded from notifications.
+    """
+    organization = OrganizationFactory.create()
+    owner_role = OrganizationRoleFactory.create(
+        organization=organization, role_name=OrganizationRoleType.Owner
+    )
+    manager_role = OrganizationRoleFactory.create(
+        organization=organization, role_name=OrganizationRoleType.Manager
+    )
+    OrganizationRoleFactory.create(
+        organization=organization, role_name=OrganizationRoleType.Member
+    )
+    return organization, owner_role, manager_role
 
 
 def test_compute_oidc_metrics(db_request, metrics):
@@ -212,8 +234,9 @@ def test_delete_expired_pending_publishers(db_request, metrics, monkeypatch):
     assert send_email.calls == [
         pretend.call(
             db_request,
-            expired_publisher.added_by,
+            {expired_publisher.added_by},
             project_name="expired-project",
+            publisher=expired_publisher,
             days=PENDING_PUBLISHER_EXPIRY_DAYS,
         ),
     ]
@@ -239,6 +262,70 @@ def test_delete_expired_pending_publishers(db_request, metrics, monkeypatch):
     assert metrics.gauge.calls == [
         pretend.call("warehouse.oidc.expired_pending_publishers_deleted", 1),
     ]
+
+
+def test_delete_expired_pending_publishers_organization_scoped(
+    db_request, metrics, monkeypatch
+):
+    """
+    Org-scoped pending publishers also notify the organization's owners and
+    managers, not just the user who registered it.
+    """
+    send_email = pretend.call_recorder(lambda *a, **kw: None)
+    monkeypatch.setattr(
+        "warehouse.oidc.tasks.send_pending_trusted_publisher_expired_email",
+        send_email,
+    )
+
+    organization, owner_role, manager_role = _organization_with_owner_and_manager()
+
+    expired_publisher = PendingGitHubPublisherFactory.create(
+        project_name="expired-org-project",
+        organization_id=organization.id,
+        created=pending_publisher_cutoff(PENDING_PUBLISHER_EXPIRY_DAYS)
+        - datetime.timedelta(seconds=1),
+    )
+
+    delete_expired_pending_publishers(db_request)
+
+    assert send_email.calls == [
+        pretend.call(
+            db_request,
+            {expired_publisher.added_by, owner_role.user, manager_role.user},
+            project_name="expired-org-project",
+            publisher=expired_publisher,
+            days=PENDING_PUBLISHER_EXPIRY_DAYS,
+        ),
+    ]
+
+
+def test_cached_org_recipients_no_organization(db_request):
+    """A publisher with no organization has no org recipients to cache."""
+    publisher = PendingGitHubPublisherFactory.create()
+
+    assert _cached_org_recipients(publisher, {}) is None
+
+
+def test_cached_org_recipients_memoizes_per_organization(db_request):
+    """
+    Publishers scoped to the same organization share one cached recipient
+    set, instead of re-querying that organization's owners/managers once per
+    publisher.
+    """
+    organization, owner_role, manager_role = _organization_with_owner_and_manager()
+    first_publisher = PendingGitHubPublisherFactory.create(
+        organization_id=organization.id
+    )
+    second_publisher = PendingGitHubPublisherFactory.create(
+        organization_id=organization.id
+    )
+    cache: dict = {}
+
+    first_result = _cached_org_recipients(first_publisher, cache)
+    second_result = _cached_org_recipients(second_publisher, cache)
+
+    assert first_result == {owner_role.user, manager_role.user}
+    assert second_result is first_result
 
 
 def test_delete_expired_pending_publishers_none_expired(
@@ -289,9 +376,11 @@ def test_send_pending_publisher_expiration_reminders(db_request, metrics, monkey
     assert send_email.calls == [
         pretend.call(
             db_request,
-            needs_reminder.added_by,
+            {needs_reminder.added_by},
             project_name="needs-reminder",
+            publisher=needs_reminder,
             days_remaining=PENDING_PUBLISHER_REMINDER_DAYS,
+            expiry_days=PENDING_PUBLISHER_EXPIRY_DAYS,
         ),
     ]
 
@@ -301,6 +390,44 @@ def test_send_pending_publisher_expiration_reminders(db_request, metrics, monkey
 
     assert metrics.gauge.calls == [
         pretend.call("warehouse.oidc.pending_publisher_expiration_reminders_sent", 1),
+    ]
+
+
+def test_send_pending_publisher_expiration_reminders_organization_scoped(
+    db_request, metrics, monkeypatch
+):
+    """
+    Org-scoped pending publishers also notify the organization's owners and
+    managers, not just the user who registered it.
+    """
+    send_email = pretend.call_recorder(lambda *a, **kw: None)
+    monkeypatch.setattr(
+        "warehouse.oidc.tasks.send_pending_trusted_publisher_expiration_reminder_email",
+        send_email,
+    )
+
+    organization, owner_role, manager_role = _organization_with_owner_and_manager()
+
+    reminder_cutoff = pending_publisher_cutoff(
+        PENDING_PUBLISHER_EXPIRY_DAYS - PENDING_PUBLISHER_REMINDER_DAYS
+    )
+    needs_reminder = PendingGitHubPublisherFactory.create(
+        project_name="needs-reminder-org",
+        organization_id=organization.id,
+        created=reminder_cutoff - datetime.timedelta(seconds=1),
+    )
+
+    send_pending_publisher_expiration_reminders(db_request)
+
+    assert send_email.calls == [
+        pretend.call(
+            db_request,
+            {needs_reminder.added_by, owner_role.user, manager_role.user},
+            project_name="needs-reminder-org",
+            publisher=needs_reminder,
+            days_remaining=PENDING_PUBLISHER_REMINDER_DAYS,
+            expiry_days=PENDING_PUBLISHER_EXPIRY_DAYS,
+        ),
     ]
 
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -329,6 +329,7 @@ def test_configure(monkeypatch, mocker, settings, environment):
         "warehouse.packaging.project_create_ip_ratelimit_string": "40 per hour",
         "warehouse.search.ratelimit_string": "5 per second",
         "oidc.backend": "warehouse.oidc.services.OIDCPublisherService",
+        "warehouse.oidc.pending_publisher_expiry_warning_days": 5,
         "integrity.backend": "warehouse.attestations.services.IntegrityService",
         "warehouse.organizations.max_undecided_organization_applications": 3,
         "reconcile_file_storages.batch_size": 100,

--- a/warehouse/config.py
+++ b/warehouse/config.py
@@ -595,6 +595,13 @@ def configure(settings=None):
 
     # OIDC feature flags and settings
     maybe_set(settings, "warehouse.oidc.audience", "OIDC_AUDIENCE")
+    maybe_set(
+        settings,
+        "warehouse.oidc.pending_publisher_expiry_warning_days",
+        "OIDC_PENDING_PUBLISHER_EXPIRY_WARNING_DAYS",
+        coercer=int,
+        default=5,
+    )
 
     maybe_set(
         settings,

--- a/warehouse/email/__init__.py
+++ b/warehouse/email/__init__.py
@@ -1067,20 +1067,29 @@ def send_pending_trusted_publisher_invalidated_email(request, user, project_name
 
 
 @_email("pending-trusted-publisher-expired")
-def send_pending_trusted_publisher_expired_email(request, user, project_name, days):
+def send_pending_trusted_publisher_expired_email(
+    request, user, project_name, publisher, days
+):
     return {
         "project_name": project_name,
+        "publisher": publisher,
         "days": days,
+        "created_date": publisher.created.strftime("%Y-%m-%d"),
+        "expiry_date": publisher.expires_at.strftime("%Y-%m-%d"),
     }
 
 
 @_email("pending-trusted-publisher-expiration-reminder")
 def send_pending_trusted_publisher_expiration_reminder_email(
-    request, user, project_name, days_remaining
+    request, user, project_name, publisher, days_remaining, expiry_days
 ):
     return {
         "project_name": project_name,
+        "publisher": publisher,
         "days_remaining": days_remaining,
+        "expiry_days": expiry_days,
+        "created_date": publisher.created.strftime("%Y-%m-%d"),
+        "expiry_date": publisher.expires_at.strftime("%Y-%m-%d"),
     }
 
 

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -3733,7 +3733,7 @@ msgstr ""
 #: warehouse/templates/manage/manage_base.html:72
 #: warehouse/templates/manage/manage_base.html:91
 #: warehouse/templates/manage/manage_base.html:95
-#: warehouse/templates/manage/manage_base.html:613
+#: warehouse/templates/manage/manage_base.html:629
 #: warehouse/templates/manage/organization/roles.html:276
 #: warehouse/templates/manage/organization/roles.html:280
 #: warehouse/templates/manage/organization/roles.html:291
@@ -4585,22 +4585,38 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
-#: warehouse/templates/manage/manage_base.html:618
+#: warehouse/templates/manage/manage_base.html:611
+#, python-format
+msgid "<b>Registered:</b> %(registered_date)s"
+msgstr ""
+
+#: warehouse/templates/manage/manage_base.html:614
+#, python-format
+msgid "<b>Expires in:</b> %(count)s day"
+msgid_plural "<b>Expires in:</b> %(count)s days"
+msgstr[0] ""
+msgstr[1] ""
+
+#: warehouse/templates/manage/manage_base.html:621
+msgid "Expires soon"
+msgstr ""
+
+#: warehouse/templates/manage/manage_base.html:634
 msgid "Remove trusted publisher"
 msgstr ""
 
-#: warehouse/templates/manage/manage_base.html:621
+#: warehouse/templates/manage/manage_base.html:637
 #, python-format
 msgid ""
 "Removing this %(publisher_name)s trusted publisher will prevent automated"
 " package uploads from this source. You can re-add it later if needed."
 msgstr ""
 
-#: warehouse/templates/manage/manage_base.html:627
+#: warehouse/templates/manage/manage_base.html:643
 msgid "Remove publisher"
 msgstr ""
 
-#: warehouse/templates/manage/manage_base.html:631
+#: warehouse/templates/manage/manage_base.html:647
 #: warehouse/templates/manage/organization/history.html:113
 #: warehouse/templates/manage/organization/history.html:179
 #: warehouse/templates/manage/project/history.html:27
@@ -4614,7 +4630,7 @@ msgstr ""
 msgid "Added by:"
 msgstr ""
 
-#: warehouse/templates/manage/manage_base.html:633
+#: warehouse/templates/manage/manage_base.html:649
 #: warehouse/templates/manage/organization/history.html:121
 #: warehouse/templates/manage/organization/history.html:184
 #: warehouse/templates/manage/project/history.html:46
@@ -4626,24 +4642,24 @@ msgstr ""
 msgid "Removed by:"
 msgstr ""
 
-#: warehouse/templates/manage/manage_base.html:635
+#: warehouse/templates/manage/manage_base.html:651
 msgid "Submitted by:"
 msgstr ""
 
-#: warehouse/templates/manage/manage_base.html:638
+#: warehouse/templates/manage/manage_base.html:654
 #: warehouse/templates/manage/project/history.html:224
 msgid "Workflow:"
 msgstr ""
 
-#: warehouse/templates/manage/manage_base.html:640
+#: warehouse/templates/manage/manage_base.html:656
 msgid "Specifier:"
 msgstr ""
 
-#: warehouse/templates/manage/manage_base.html:642
+#: warehouse/templates/manage/manage_base.html:658
 msgid "Publisher:"
 msgstr ""
 
-#: warehouse/templates/manage/manage_base.html:644
+#: warehouse/templates/manage/manage_base.html:660
 #: warehouse/templates/manage/project/history.html:36
 #: warehouse/templates/manage/project/history.html:89
 msgid "URL:"

--- a/warehouse/oidc/models/__init__.py
+++ b/warehouse/oidc/models/__init__.py
@@ -1,6 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
-from warehouse.oidc.models._core import OIDCPublisher, PendingOIDCPublisher
+from warehouse.oidc.models._core import (
+    PENDING_PUBLISHER_EXPIRY_DAYS,
+    OIDCPublisher,
+    PendingOIDCPublisher,
+)
 from warehouse.oidc.models.activestate import (
     ACTIVESTATE_OIDC_ISSUER_URL,
     ActiveStatePublisher,
@@ -27,6 +31,7 @@ __all__ = [
     "GITHUB_OIDC_ISSUER_URL",
     "GITLAB_OIDC_ISSUER_URL",
     "GOOGLE_OIDC_ISSUER_URL",
+    "PENDING_PUBLISHER_EXPIRY_DAYS",
     "ActiveStatePublisher",
     "GitHubPublisher",
     "GitLabPublisher",

--- a/warehouse/oidc/models/_core.py
+++ b/warehouse/oidc/models/_core.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any, Self, TypedDict, TypeVar, Unpack
 from uuid import UUID
 
@@ -388,6 +389,10 @@ class OIDCPublisher(OIDCPublisherMixin, db.Model):
     }
 
 
+# Pending publishers expire after this many days.
+PENDING_PUBLISHER_EXPIRY_DAYS = 30
+
+
 class PendingOIDCPublisher(OIDCPublisherMixin, db.Model):
     """
     A "pending" OIDC publisher, i.e. one that's been registered by a user
@@ -426,6 +431,38 @@ class PendingOIDCPublisher(OIDCPublisherMixin, db.Model):
         "polymorphic_identity": "pending_oidc_publishers",
         "polymorphic_on": OIDCPublisherMixin.discriminator,
     }
+
+    @property
+    def expires_at(self) -> datetime:
+        return self.created + timedelta(days=PENDING_PUBLISHER_EXPIRY_DAYS)
+
+    @property
+    def days_until_expiry(self) -> int:
+        # Compare calendar dates, not exact timestamps: a publisher created
+        # "10 days ago" should read as having 20 days left all day today,
+        # not drop to 19 after the moment-of-day it was originally created.
+        today = datetime.now(UTC).date()
+        return max((self.expires_at.date() - today).days, 0)
+
+    def notification_recipients(
+        self, *, org_recipients: set[User] | None = None
+    ) -> set[User]:
+        """
+        Return the users who should be notified about this pending publisher:
+        the user who registered it, plus, for publishers scoped to an
+        organization, that organization's owners and managers.
+
+        Callers processing many publishers at once may pass a pre-computed
+        `org_recipients` (that organization's owners union managers) to avoid
+        re-querying the same organization's roles once per publisher.
+        """
+        if self.pypi_organization is None:
+            return {self.added_by}
+        if org_recipients is None:
+            org_recipients = set(self.pypi_organization.owners) | set(
+                self.pypi_organization.managers
+            )
+        return {self.added_by} | org_recipients
 
     def reify(self, session: Session) -> OIDCPublisher:  # pragma: no cover
         """

--- a/warehouse/oidc/tasks.py
+++ b/warehouse/oidc/tasks.py
@@ -15,14 +15,15 @@ from warehouse.email import (
 )
 from warehouse.events.tags import EventTag
 from warehouse.macaroons.models import Macaroon
-from warehouse.oidc.models import OIDCPublisher, PendingOIDCPublisher
+from warehouse.oidc.models import (
+    PENDING_PUBLISHER_EXPIRY_DAYS,
+    OIDCPublisher,
+    PendingOIDCPublisher,
+)
 from warehouse.packaging.models import File, Project, Release
 
 if typing.TYPE_CHECKING:
     from pyramid.request import Request
-
-# Pending publishers expire after this many days.
-PENDING_PUBLISHER_EXPIRY_DAYS = 30
 
 # Pending publishers receive a reminder email this many days before expiry.
 PENDING_PUBLISHER_REMINDER_DAYS = 5
@@ -34,6 +35,25 @@ def pending_publisher_cutoff(days: int) -> datetime:
     Returned as naive UTC to match the naive `created` column for in-Python comparisons.
     """
     return datetime.now(tz=UTC).replace(tzinfo=None) - timedelta(days=days)
+
+
+def _cached_org_recipients(publisher: PendingOIDCPublisher, cache: dict) -> set | None:
+    """
+    Return the owners and managers of a pending publisher's organization, or
+    `None` if it isn't scoped to one.
+
+    Memoized per organization ID so that a batch containing several pending
+    publishers scoped to the same organization only queries that
+    organization's roles once, rather than once per publisher.
+    """
+    if publisher.pypi_organization is None:
+        return None
+    if publisher.organization_id not in cache:
+        organization = publisher.pypi_organization
+        cache[publisher.organization_id] = set(organization.owners) | set(
+            organization.managers
+        )
+    return cache[publisher.organization_id]
 
 
 @tasks.task(ignore_result=True, acks_late=True)
@@ -119,11 +139,15 @@ def delete_expired_pending_publishers(request: Request) -> None:
         select(PendingOIDCPublisher).where(PendingOIDCPublisher.created < cutoff)
     ).all()
 
+    org_recipients_cache: dict = {}
     for publisher in expired_publishers:
         send_pending_trusted_publisher_expired_email(
             request,
-            publisher.added_by,
+            publisher.notification_recipients(
+                org_recipients=_cached_org_recipients(publisher, org_recipients_cache)
+            ),
             project_name=publisher.project_name,
+            publisher=publisher,
             days=PENDING_PUBLISHER_EXPIRY_DAYS,
         )
         publisher.added_by.record_event(
@@ -163,12 +187,17 @@ def send_pending_publisher_expiration_reminders(request: Request) -> None:
         )
     ).all()
 
+    org_recipients_cache: dict = {}
     for publisher in publishers:
         send_pending_trusted_publisher_expiration_reminder_email(
             request,
-            publisher.added_by,
+            publisher.notification_recipients(
+                org_recipients=_cached_org_recipients(publisher, org_recipients_cache)
+            ),
             project_name=publisher.project_name,
+            publisher=publisher,
             days_remaining=PENDING_PUBLISHER_REMINDER_DAYS,
+            expiry_days=PENDING_PUBLISHER_EXPIRY_DAYS,
         )
         publisher.expiration_reminded = True
 

--- a/warehouse/organizations/models.py
+++ b/warehouse/organizations/models.py
@@ -404,20 +404,30 @@ class Organization(OrganizationMixin, HasEvents, db.Model):
         back_populates="pypi_organization",
     )
 
-    @property
-    def owners(self):
-        """Return all users who are owners of the organization."""
+    def _users_with_role(self, role_name):
         session = orm_session_from_obj(self)
-        owner_roles = (
+        role_holders = (
             session.query(User.id)
             .join(OrganizationRole.user)
             .filter(
-                OrganizationRole.role_name == OrganizationRoleType.Owner,
+                OrganizationRole.role_name == role_name,
                 OrganizationRole.organization == self,
             )
             .subquery()
         )
-        return session.query(User).join(owner_roles, User.id == owner_roles.c.id).all()
+        return (
+            session.query(User).join(role_holders, User.id == role_holders.c.id).all()
+        )
+
+    @property
+    def owners(self):
+        """Return all users who are owners of the organization."""
+        return self._users_with_role(OrganizationRoleType.Owner)
+
+    @property
+    def managers(self):
+        """Return all users who are managers of the organization."""
+        return self._users_with_role(OrganizationRoleType.Manager)
 
     def record_event(self, *, tag, request: Request = None, additional=None):
         """Record organization name in events in case organization is ever deleted."""

--- a/warehouse/templates/email/_pending_publisher.txt
+++ b/warehouse/templates/email/_pending_publisher.txt
@@ -1,0 +1,16 @@
+{# SPDX-License-Identifier: Apache-2.0 -#}
+{% macro pending_publisher_manage_url(request, publisher) -%}
+  {%- set domain = request.registry.settings.get('warehouse.domain') -%}
+  {%- if publisher.pypi_organization -%}
+    {{ request.route_url('manage.organization.publishing', organization_name=publisher.pypi_organization.name, _host=domain) }}
+  {%- else -%}
+    {{ request.route_url('manage.account.publishing', _host=domain) }}
+  {%- endif -%}
+{%- endmacro %}
+{% macro pending_publisher_specifics(publisher) -%}
+  {%- if publisher.publisher_name == "GitHub" %} ({{ publisher.repository }} / {{ publisher.workflow_filename }})
+  {%- elif publisher.publisher_name == "GitLab" %} ({{ publisher.project_path }} / {{ publisher.workflow_filepath }})
+  {%- elif publisher.publisher_name == "Google" %} ({{ publisher.email }})
+  {%- elif publisher.publisher_name == "ActiveState" %} ({{ publisher.organization }} / {{ publisher.project }})
+  {%- endif -%}
+{%- endmacro %}

--- a/warehouse/templates/email/pending-trusted-publisher-expiration-reminder/body.html
+++ b/warehouse/templates/email/pending-trusted-publisher-expiration-reminder/body.html
@@ -1,15 +1,23 @@
 {# SPDX-License-Identifier: Apache-2.0 -#}
 {% extends "email/_base/body.html" %}
+{% from "email/_pending_publisher.txt" import pending_publisher_manage_url, pending_publisher_specifics %}
+{% set manage_url = pending_publisher_manage_url(request, publisher) %}
 {% block content %}
   <p>
-    The pending trusted publisher you registered for the project
-    <strong>{{ project_name }}</strong> will expire in
-    <strong>{{ days_remaining }} days</strong> if it has not been used to
-    publish.
+    You registered a pending trusted publisher on <strong>{{ created_date }}</strong>.
+    It hasn't published a release yet.
   </p>
   <p>
-    If you still want to use this trusted publisher, publish a release
-    through it before it expires. Otherwise, you can register it again
-    later.
+    Pending publishers are removed after {{ expiry_days }} days of inactivity.
+    This one expires on <strong>{{ expiry_date }}</strong>.
   </p>
+  <ul>
+    <li>project: {{ project_name }}</li>
+    <li>publisher: {{ publisher.publisher_name }}{{ pending_publisher_specifics(publisher) }}</li>
+  </ul>
+  <p>
+    To keep it, publish a release with it before then, or
+    <a href="{{ manage_url }}">re-register it afterward</a>.
+  </p>
+  <p>PyPI will never ask for your password or 2FA codes by email.</p>
 {% endblock %}

--- a/warehouse/templates/email/pending-trusted-publisher-expiration-reminder/body.txt
+++ b/warehouse/templates/email/pending-trusted-publisher-expiration-reminder/body.txt
@@ -1,13 +1,22 @@
 {# SPDX-License-Identifier: Apache-2.0 -#}
 
 {% extends "email/_base/body.txt" %}
+{% from "email/_pending_publisher.txt" import pending_publisher_manage_url, pending_publisher_specifics %}
+
+{% set manage_url = pending_publisher_manage_url(request, publisher) %}
 
 {% block content %}
-The pending trusted publisher you registered for the project
-{{ project_name }} will expire in {{ days_remaining }} days if it has not
-been used to publish.
+You registered a pending trusted publisher on {{ created_date }}. It hasn't
+published a release yet.
 
-If you still want to use this trusted publisher, publish a release
-through it before it expires. Otherwise, you can register it again
-later.
+Pending publishers are removed after {{ expiry_days }} days of inactivity.
+This one expires on {{ expiry_date }}.
+
+    project: {{ project_name }}
+    publisher: {{ publisher.publisher_name }}{{ pending_publisher_specifics(publisher) }}
+
+To keep it, publish a release with it before then, or re-register it
+afterward. Review it here: {{ manage_url }}
+
+PyPI will never ask for your password or 2FA codes by email.
 {% endblock %}

--- a/warehouse/templates/email/pending-trusted-publisher-expiration-reminder/subject.txt
+++ b/warehouse/templates/email/pending-trusted-publisher-expiration-reminder/subject.txt
@@ -2,4 +2,4 @@
 
 {% extends "email/_base/subject.txt" %}
 
-{% block subject %}Pending trusted publisher for {{ project_name }} expiring soon{% endblock %}
+{% block subject %}Your pending trusted publisher for "{{ project_name }}" expires in {{ days_remaining }} days{% endblock %}

--- a/warehouse/templates/email/pending-trusted-publisher-expired/body.html
+++ b/warehouse/templates/email/pending-trusted-publisher-expired/body.html
@@ -1,10 +1,20 @@
 {# SPDX-License-Identifier: Apache-2.0 -#}
 {% extends "email/_base/body.html" %}
+{% from "email/_pending_publisher.txt" import pending_publisher_manage_url, pending_publisher_specifics %}
+{% set manage_url = pending_publisher_manage_url(request, publisher) %}
 {% block content %}
   <p>
-    You registered a pending trusted publisher for a project
-    (<strong>{{ project_name }}</strong>), but it has expired because the
-    project was not created within {{ days }} days.
+    The pending trusted publisher you registered on <strong>{{ created_date }}</strong>
+    expired on <strong>{{ expiry_date }}</strong> after {{ days }} days unused, and
+    has been removed.
   </p>
-  <p>If you still want to use this trusted publisher, you can register it again.</p>
+  <ul>
+    <li>project: {{ project_name }}</li>
+    <li>publisher: {{ publisher.publisher_name }}{{ pending_publisher_specifics(publisher) }}</li>
+  </ul>
+  <p>
+    Still want it? <a href="{{ manage_url }}">Register a new one here</a>. No other
+    action is needed.
+  </p>
+  <p>PyPI will never ask for your password or 2FA codes by email.</p>
 {% endblock %}

--- a/warehouse/templates/email/pending-trusted-publisher-expired/body.txt
+++ b/warehouse/templates/email/pending-trusted-publisher-expired/body.txt
@@ -1,11 +1,19 @@
 {# SPDX-License-Identifier: Apache-2.0 -#}
 
 {% extends "email/_base/body.txt" %}
+{% from "email/_pending_publisher.txt" import pending_publisher_manage_url, pending_publisher_specifics %}
+
+{% set manage_url = pending_publisher_manage_url(request, publisher) %}
 
 {% block content %}
-You registered a pending trusted publisher for a project
-({{ project_name }}), but it has expired because the project was not
-created within {{ days }} days.
+The pending trusted publisher you registered on {{ created_date }} expired
+on {{ expiry_date }} after {{ days }} days unused, and has been removed.
 
-If you still want to use this trusted publisher, you can register it again.
+    project: {{ project_name }}
+    publisher: {{ publisher.publisher_name }}{{ pending_publisher_specifics(publisher) }}
+
+Still want it? Register a new one here: {{ manage_url }}. No other action
+is needed.
+
+PyPI will never ask for your password or 2FA codes by email.
 {% endblock %}

--- a/warehouse/templates/email/pending-trusted-publisher-expired/subject.txt
+++ b/warehouse/templates/email/pending-trusted-publisher-expired/subject.txt
@@ -2,4 +2,4 @@
 
 {% extends "email/_base/subject.txt" %}
 
-{% block subject %}Pending trusted publisher expired for {{ project_name }}{% endblock %}
+{% block subject %}Your pending trusted publisher for "{{ project_name }}" was removed{% endblock %}

--- a/warehouse/templates/manage/manage_base.html
+++ b/warehouse/templates/manage/manage_base.html
@@ -606,6 +606,22 @@
         {% else %}
           -
         {% endif %}
+        {% if publisher.project_name is defined %}
+          <br>
+          {% trans registered_date=humanize(publisher.created) %}<b>Registered:</b> {{ registered_date }}{% endtrans %}
+          <br>
+          {% set days_left = publisher.days_until_expiry %}
+          {% trans count=days_left %}<b>Expires in:</b> {{ count }} day
+        {% pluralize %}
+          <b>Expires in:</b> {{ count }} days{% endtrans %}
+          {% set expiry_warning_days = request.registry.settings.get('warehouse.oidc.pending_publisher_expiry_warning_days', 5) | int %}
+          {% if days_left <= expiry_warning_days %}
+            <span class="badge badge--warning">
+              <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
+              {% trans %}Expires soon{% endtrans %}
+            </span>
+          {% endif %}
+        {% endif %}
       </small>
     </td>
     <td scope="row">


### PR DESCRIPTION
This PR follows the directions on  #20115 to add metadata to pending Trusted Publishers (TPs) to show creation date, expiry date,  a visual indicator when expiration is near, all on platform.

It also updates the emails we send out when expiration approaches, to link to the manage page where they can verify this information. These emails are sent to the user that registered the pending TPs for standalone projects, and to organization owners and managers for organization-based TPs.

Added a setting (`OIDC_PENDING_PUBLISHER_EXPIRY_WARNING_DAYS`) to have this value be configurable.

New and updated tests to validate the new behavior.

<details>
<summary>Screenshots</summary>
<img width="838" height="558" alt="Screenshot from 2026-07-22 15-48-30" src="https://github.com/user-attachments/assets/3b6b2bbf-b97c-44e2-ad1a-05f47498859b" />
<img width="927" height="504" alt="Screenshot from 2026-07-22 16-17-38" src="https://github.com/user-attachments/assets/de6199c8-ab68-42d9-adc9-437add3fcdb8" />
<img width="1040" height="427" alt="Screenshot from 2026-07-22 16-17-51" src="https://github.com/user-attachments/assets/e6d500a3-3fa8-49bf-b8c5-035abfb3360d" />

</details>