### PR TITLE
feat: emit warehouse.emails.skipped with reason

### DIFF
--- a/docs/dev/development/email.md
+++ b/docs/dev/development/email.md
@@ -40,7 +40,10 @@ Calling a function with the `_email` decorator does the following:
 - A security log is added to the user's account
 - The email is sent using Amazon SES (on production environment)
 - A metric is sent to Datadog named `warehouse.emails.scheduled` with the tags
-  `template_name`, `allow_unverified`, and `repeat_window`.
+  `template_name`, `allow_unverified`, and `repeat_window`. If the email is
+  skipped instead (missing email address, unverified address, or a repeat
+  send within `repeat_window`), a `warehouse.emails.skipped` metric is sent
+  with the same tags plus a `reason` tag.
 
 ## Testing e-mails
 

--- a/tests/unit/email/test_init.py
+++ b/tests/unit/email/test_init.py
@@ -193,6 +193,21 @@ class TestSendEmailToUser:
         assert request.task.calls == []
         assert task.delay.calls == []
 
+    def test_doesnt_send_without_email_address(self):
+        """A user with no primary email address is skipped."""
+        task = pretend.stub(delay=pretend.call_recorder(lambda *a, **kw: None))
+        request = pretend.stub(task=pretend.call_recorder(lambda x: task))
+
+        user = pretend.stub(primary_email=None)
+
+        msg = EmailMessage(subject="My Subject", body_text="My Body")
+
+        skip_reason = email._send_email_to_user(request, user, msg)
+
+        assert skip_reason == "no-email-address"
+        assert request.task.calls == []
+        assert task.delay.calls == []
+
     def test_doesnt_send_within_repeat_window(self, pyramid_request, pyramid_services):
         email_service = pretend.stub(
             last_sent=pretend.call_recorder(
@@ -1409,7 +1424,7 @@ class TestAccountDeletionEmail:
         ]
 
     def test_account_deletion_email_unverified(
-        self, pyramid_request, pyramid_config, monkeypatch
+        self, pyramid_request, pyramid_config, metrics, monkeypatch
     ):
         stub_user = pretend.stub(
             id="id",
@@ -1455,6 +1470,17 @@ class TestAccountDeletionEmail:
         html_renderer.assert_(username=stub_user.username)
         assert pyramid_request.task.calls == []
         assert send_email.delay.calls == []
+        assert metrics.increment.calls == [
+            pretend.call(
+                "warehouse.emails.skipped",
+                tags=[
+                    "template_name:account-deleted",
+                    "allow_unverified:False",
+                    "repeat_window:none",
+                    "reason:unverified-email",
+                ],
+            )
+        ]
 
 
 class TestPrimaryEmailChangeEmail:

--- a/warehouse/email/__init__.py
+++ b/warehouse/email/__init__.py
@@ -22,7 +22,6 @@ from warehouse.email.interfaces import IEmailSender
 from warehouse.email.services import EmailMessage
 from warehouse.email.ses.tasks import cleanup as ses_cleanup
 from warehouse.events.tags import EventTag
-from warehouse.metrics.interfaces import IMetricsService
 
 if typing.TYPE_CHECKING:
     from pyramid.request import Request
@@ -87,7 +86,11 @@ def _send_email_to_user(
     allow_unverified=False,
     repeat_window=None,
     override_from=None,
-):
+) -> str | None:
+    """
+    Schedule the email for delivery, returning the reason it was skipped (if
+    it was) or None (if it was scheduled).
+    """
     # If we were not given a specific email object, then we'll default to using
     # the User's primary email address.
     if email is None:
@@ -97,15 +100,17 @@ def _send_email_to_user(
     # have to skip sending email to them. If we have an email for them, then we will
     # check to see if it is verified, if it is not then we will also skip sending email
     # to them **UNLESS** we've been told to allow unverified emails.
-    if email is None or not (email.verified or allow_unverified):
-        return
+    if email is None:
+        return "no-email-address"
+    if not (email.verified or allow_unverified):
+        return "unverified-email"
 
     # If we've already sent this email within the repeat_window, don't send it.
     if repeat_window is not None:
         sender = request.find_service(IEmailSender)
         last_sent = sender.last_sent(to=email.email, subject=msg.subject)
         if last_sent and (datetime.datetime.now() - last_sent) <= repeat_window:
-            return
+            return "repeat-window"
 
     request.task(send_email).delay(
         _compute_recipient(user, email.email),
@@ -130,6 +135,8 @@ def _send_email_to_user(
             },
         },
     )
+
+    return None
 
 
 def _email(
@@ -181,13 +188,23 @@ def _email(
             context = fn(request, user_or_users, **kwargs)
             msg = EmailMessage.from_template(name, context, request=request)
 
+            tags = [
+                f"template_name:{name}",
+                f"allow_unverified:{allow_unverified}",
+                (
+                    f"repeat_window:{repeat_window.total_seconds()}"
+                    if repeat_window
+                    else "repeat_window:none"
+                ),
+            ]
+
             for recipient in recipients:
                 if isinstance(recipient, tuple):
                     user, email = recipient
                 else:
                     user, email = recipient, None
 
-                _send_email_to_user(
+                skip_reason = _send_email_to_user(
                     request,
                     user,
                     msg,
@@ -196,19 +213,13 @@ def _email(
                     repeat_window=repeat_window,
                     override_from=override_from,
                 )
-                metrics = request.find_service(IMetricsService, context=None)
-                metrics.increment(
-                    "warehouse.emails.scheduled",
-                    tags=[
-                        f"template_name:{name}",
-                        f"allow_unverified:{allow_unverified}",
-                        (
-                            f"repeat_window:{repeat_window.total_seconds()}"
-                            if repeat_window
-                            else "repeat_window:none"
-                        ),
-                    ],
-                )
+                if skip_reason is None:
+                    request.metrics.increment("warehouse.emails.scheduled", tags=tags)
+                else:
+                    request.metrics.increment(
+                        "warehouse.emails.skipped",
+                        tags=[*tags, f"reason:{skip_reason}"],
+                    )
 
             return context
 


### PR DESCRIPTION
The `warehouse.emails.scheduled` metric was incremented even when the email was never handed to the task queue, so silently skipped emails were indistinguishable from delivered ones.

`_send_email_to_user` now reports why a send was skipped; the decorator emits a metric only for emails actually queued, tagged with the reason otherwise.