### PR TITLE
fix: re-send unrecognized-login email on repeat login attempts

### DIFF
--- a/docs/dev/development/email.md
+++ b/docs/dev/development/email.md
@@ -45,6 +45,10 @@ Calling a function with the `_email` decorator does the following:
   send within `repeat_window`), a `warehouse.emails.skipped` metric is sent
   with the same tags plus a `reason` tag.
 
+Callers may pass a `repeat_window` keyword argument to override the
+decorator's value for a single call — pass `None` for a send that must
+always go out, e.g. notifying a newly-seen device.
+
 ## Testing e-mails
 
 When an email is sent in the development environment, it's printed in the

--- a/tests/unit/accounts/test_services.py
+++ b/tests/unit/accounts/test_services.py
@@ -2262,6 +2262,17 @@ class TestFastlyDomainStatusService:
 
 
 class TestDeviceIsKnown:
+    def _new_device_events(self, user_service, user):
+        """The user's recorded LoginNewDevice events."""
+        return (
+            user_service.db.query(User.Event)
+            .filter(
+                User.Event.source_id == user.id,
+                User.Event.tag == EventTag.Account.LoginNewDevice,
+            )
+            .all()
+        )
+
     def test_device_is_known(self, user_service, db_request):
         user = UserFactory.create()
         UserUniqueLoginFactory.create(
@@ -2300,6 +2311,7 @@ class TestDeviceIsKnown:
         )
         assert unique_login.expires is not None
 
+        # A new device has no valid token outstanding, so no throttling
         assert send_email.calls == [
             pretend.call(
                 user_service.request,
@@ -2307,6 +2319,7 @@ class TestDeviceIsKnown:
                 ip_address=REMOTE_ADDR,
                 user_agent="Firefox (Ubuntu)",
                 token="fake_token",
+                repeat_window=None,
             )
         ]
 
@@ -2337,14 +2350,7 @@ class TestDeviceIsKnown:
         )
 
         # Verify a LoginNewDevice event was recorded with the 2FA method
-        events = (
-            user_service.db.query(User.Event)
-            .filter(
-                User.Event.source_id == user.id,
-                User.Event.tag == EventTag.Account.LoginNewDevice,
-            )
-            .all()
-        )
+        events = self._new_device_events(user_service, user)
         assert len(events) == 1
         assert events[0].ip_address == ip_address
         assert events[0].additional["two_factor_method"] == two_factor_method
@@ -2361,29 +2367,49 @@ class TestDeviceIsKnown:
         assert user_service.device_is_known(user.id, db_request)
 
         # Verify no LoginNewDevice event was recorded
-        events = (
-            user_service.db.query(User.Event)
-            .filter(
-                User.Event.source_id == user.id,
-                User.Event.tag == EventTag.Account.LoginNewDevice,
-            )
-            .all()
-        )
-        assert len(events) == 0
+        assert self._new_device_events(user_service, user) == []
 
-    def test_device_is_pending_not_expired(self, user_service, monkeypatch, db_request):
+    def test_device_is_pending_not_expired_resends_email(
+        self, user_service, monkeypatch, db_request
+    ):
         user = UserFactory.create(with_verified_primary_email=True)
-        UserUniqueLoginFactory.create(
-            user=user, ip_address=db_request.ip_address, status="pending"
+        unique_login = UserUniqueLoginFactory.create(
+            user=user,
+            ip_address=db_request.ip_address,
+            status="pending",
+            # A future expiry, as device_is_known always sets on pending logins
+            expires=datetime.datetime.now(datetime.UTC) + datetime.timedelta(hours=1),
         )
+        original_expires = unique_login.expires
         send_email = pretend.call_recorder(lambda *a, **kw: None)
         monkeypatch.setattr(services, "send_unrecognized_login_email", send_email)
         token_service = pretend.stub(dumps=lambda d: "fake_token", max_age=60)
         user_service.request = db_request
         db_request.find_service = lambda *a, **kw: token_service
+        db_request.headers = {
+            "User-Agent": (
+                "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:15.0) "
+                "Gecko/20100101 Firefox/15.0.1"
+            )
+        }
 
         assert not user_service.device_is_known(user.id, user_service.request)
-        assert send_email.calls == []
+        # The pending login's expiry is untouched, but the email is re-sent,
+        # throttled by the email's own repeat_window since the earlier
+        # email's token still works (hence no repeat_window override here).
+        assert unique_login.expires == original_expires
+        assert send_email.calls == [
+            pretend.call(
+                user_service.request,
+                user,
+                ip_address=REMOTE_ADDR,
+                user_agent="Firefox (Ubuntu)",
+                token="fake_token",
+            )
+        ]
+
+        # A repeat attempt from a known-but-pending device is not a new device
+        assert self._new_device_events(user_service, user) == []
 
     def test_device_is_pending_and_expired(self, user_service, monkeypatch, db_request):
         user = UserFactory.create(with_verified_primary_email=True)
@@ -2407,6 +2433,8 @@ class TestDeviceIsKnown:
         }
 
         assert not user_service.device_is_known(user.id, user_service.request)
+        # A lapsed confirmation window invalidated the earlier token, so the
+        # fresh email must not be throttled
         assert send_email.calls == [
             pretend.call(
                 user_service.request,
@@ -2414,6 +2442,7 @@ class TestDeviceIsKnown:
                 ip_address=REMOTE_ADDR,
                 user_agent="Firefox (Ubuntu)",
                 token="fake_token",
+                repeat_window=None,
             )
         ]
 
@@ -2444,5 +2473,6 @@ class TestDeviceIsKnown:
                 ip_address=REMOTE_ADDR,
                 user_agent=ua_string or "Unknown User-Agent",
                 token="fake_token",
+                repeat_window=None,
             )
         ]

--- a/tests/unit/accounts/test_views.py
+++ b/tests/unit/accounts/test_views.py
@@ -5662,7 +5662,7 @@ class TestConfirmLogin:
         pyramid_request.user = None
         pyramid_request.params = {}
         result = views.confirm_login(pyramid_request)
-        assert result == {}
+        assert result == {"repeat_window_minutes": 15}
 
     @pytest.mark.parametrize(
         ("exception", "message"),

--- a/tests/unit/email/test_init.py
+++ b/tests/unit/email/test_init.py
@@ -6443,6 +6443,115 @@ class TestSendUnrecognizedLoginEmail:
             )
         ]
 
+    def test_send_unrecognized_login_email_throttled_within_repeat_window(
+        self,
+        pyramid_request,
+        metrics,
+        email_service,
+        send_email,
+        make_email_renderers,
+        mocker,
+    ):
+        stub_user = pretend.stub(
+            id="id",
+            username="username",
+            name="",
+            email="email@example.com",
+            primary_email=pretend.stub(email="email@example.com", verified=True),
+        )
+        make_email_renderers("unrecognized-login")
+
+        # The same email went out moments ago, e.g. on a previous login attempt
+        last_sent = mocker.patch.object(
+            email_service,
+            "last_sent",
+            autospec=True,
+            return_value=datetime.datetime.now() - datetime.timedelta(minutes=1),
+        )
+
+        email.send_unrecognized_login_email(
+            pyramid_request,
+            stub_user,
+            ip_address="127.0.0.1",
+            user_agent="Test Browser",
+            token="test-token",
+        )
+
+        last_sent.assert_called_once_with(to=stub_user.email, subject="Email Subject")
+        assert pyramid_request.task.calls == []
+        assert send_email.delay.calls == []
+        assert metrics.increment.calls == [
+            pretend.call(
+                "warehouse.emails.skipped",
+                tags=[
+                    "template_name:unrecognized-login",
+                    "allow_unverified:True",
+                    "repeat_window:900.0",
+                    "reason:repeat-window",
+                ],
+            )
+        ]
+
+    def test_send_unrecognized_login_email_repeat_window_override(
+        self,
+        pyramid_request,
+        metrics,
+        email_service,
+        send_email,
+        make_email_renderers,
+        mocker,
+    ):
+        """A per-call repeat_window of None bypasses the decorator's throttle."""
+        stub_user = pretend.stub(
+            id="id",
+            username="username",
+            name="",
+            email="email@example.com",
+            primary_email=pretend.stub(email="email@example.com", verified=True),
+        )
+        make_email_renderers("unrecognized-login")
+
+        # The same email went out moments ago, e.g. for a different device
+        last_sent = mocker.patch.object(
+            email_service,
+            "last_sent",
+            autospec=True,
+            return_value=datetime.datetime.now() - datetime.timedelta(minutes=1),
+        )
+
+        pyramid_request.db = pretend.stub(
+            query=lambda a: pretend.stub(
+                filter=lambda *a: pretend.stub(
+                    one=lambda: pretend.stub(user_id=stub_user.id)
+                )
+            ),
+        )
+        pyramid_request.user = stub_user
+
+        email.send_unrecognized_login_email(
+            pyramid_request,
+            stub_user,
+            ip_address="127.0.0.1",
+            user_agent="Test Browser",
+            token="test-token",
+            repeat_window=None,
+        )
+
+        # The throttle was never consulted and the email was scheduled
+        last_sent.assert_not_called()
+        assert pyramid_request.task.calls == [pretend.call(send_email)]
+        assert len(send_email.delay.calls) == 1
+        assert metrics.increment.calls == [
+            pretend.call(
+                "warehouse.emails.scheduled",
+                tags=[
+                    "template_name:unrecognized-login",
+                    "allow_unverified:True",
+                    "repeat_window:none",
+                ],
+            )
+        ]
+
 
 class TestAccountAssociationAddedEmail:
     def test_send_account_association_added_email(

--- a/warehouse/accounts/services.py
+++ b/warehouse/accounts/services.py
@@ -762,14 +762,13 @@ class DatabaseUserService:
             )
             .one_or_none()
         )
-        should_send_email = False
-
         # Check if we've seen this device and it's been confirmed
         if unique_login and unique_login.status == UniqueLoginStatus.CONFIRMED:
             return True
 
         # Create a new login if we haven't seen this device before
-        if not unique_login:
+        is_new_device = unique_login is None
+        if is_new_device:
             unique_login = UserUniqueLogin(
                 user_id=userid,
                 ip_address=request.ip_address,
@@ -779,8 +778,6 @@ class DatabaseUserService:
             )
             request.db.add(unique_login)
             request.db.flush()  # generaten token id  # ast-grep-ignore: db-flush
-            should_send_email = True
-
             user.record_event(
                 tag=EventTag.Account.LoginNewDevice,
                 request=request,
@@ -788,19 +785,15 @@ class DatabaseUserService:
             )
 
         # Check if the login had expired
-        if unique_login.expires and unique_login.expires < datetime.datetime.now(
-            datetime.UTC
-        ):
-            # The previous token has expired, update the expiry for
-            # the login and re-send the email
+        window_lapsed = (
+            unique_login.expires is not None
+            and unique_login.expires < datetime.datetime.now(datetime.UTC)
+        )
+        if window_lapsed:
+            # The previous confirmation window has lapsed, extend the expiry
             unique_login.expires = datetime.datetime.now(
                 datetime.UTC
             ) + datetime.timedelta(seconds=token_service.max_age)
-            should_send_email = True
-
-        # If we don't need to send an email, short-circuit
-        if not should_send_email:
-            return False
 
         # Get User Agent Information
         user_agent_info_data = {}
@@ -836,13 +829,17 @@ class DatabaseUserService:
             }
         )
 
-        # Send the email
+        # The email is (re-)sent on every unconfirmed login attempt so that a
+        # lost, delayed, or bounced email doesn't strand the user.
         send_unrecognized_login_email(
             request,
             user,
             ip_address=str(request.ip_address.ip_address),
             user_agent=user_agent_info.display(),
             token=token,
+            # A new device or lapsed window means no valid token is
+            # outstanding, so disable the email's repeat_window throttle
+            **({"repeat_window": None} if is_new_device or window_lapsed else {}),
         )
 
         return False

--- a/warehouse/accounts/views.py
+++ b/warehouse/accounts/views.py
@@ -64,6 +64,7 @@ from warehouse.authnz import Permissions
 from warehouse.cache.origin import origin_cache
 from warehouse.captcha.interfaces import ICaptchaService
 from warehouse.email import (
+    UNRECOGNIZED_LOGIN_REPEAT_WINDOW,
     send_added_as_collaborator_email,
     send_added_as_organization_member_email,
     send_collaborator_added_email,
@@ -973,7 +974,11 @@ def confirm_login(request):
 
     if not request.params.get("token"):
         # Show a generic page for when a non-logged-in user lands here without a token
-        return {}
+        return {
+            "repeat_window_minutes": int(
+                UNRECOGNIZED_LOGIN_REPEAT_WINDOW.total_seconds() // 60
+            )
+        }
 
     user_service = request.find_service(IUserService, context=None)
     token_service = request.find_service(ITokenService, name="confirm_login")

--- a/warehouse/email/__init__.py
+++ b/warehouse/email/__init__.py
@@ -159,7 +159,10 @@ def _email(
     Functions that are decorated by this need to accept two positional arguments, the
     first argument is the Pyramid request object, and the second argument is either
     a single User, or a list of Users. These users represent the recipients of this
-    email. Additional keyword arguments are supported, but are not otherwise restricted.
+    email.
+    Additional keyword arguments are passed through to the decorated function,
+    except ``repeat_window``, which the wrapper consumes as a per-call override
+    of the decorator's value (``None`` disables throttling).
 
     Functions decorated by this must return a mapping of context variables that will
     ultimately be returned, but which will also be used to render the templates for
@@ -179,7 +182,7 @@ def _email(
 
     def inner(fn):
         @functools.wraps(fn)
-        def wrapper(request, user_or_users, **kwargs):
+        def wrapper(request, user_or_users, *, repeat_window=repeat_window, **kwargs):
             if isinstance(user_or_users, (list, set)):
                 recipients = user_or_users
             else:
@@ -1040,7 +1043,14 @@ def send_recovery_code_reminder_email(request, user):
     return {"username": user.username}
 
 
-@_email("unrecognized-login", allow_unverified=True)
+UNRECOGNIZED_LOGIN_REPEAT_WINDOW = datetime.timedelta(minutes=15)
+
+
+@_email(
+    "unrecognized-login",
+    allow_unverified=True,
+    repeat_window=UNRECOGNIZED_LOGIN_REPEAT_WINDOW,
+)
 def send_unrecognized_login_email(request, user, *, ip_address, user_agent, token):
     return {
         "username": user.username,

--- a/warehouse/locale/messages.pot
+++ b/warehouse/locale/messages.pot
@@ -127,20 +127,20 @@ msgstr ""
 msgid "The username isn't valid. Try again."
 msgstr ""
 
-#: warehouse/accounts/views.py:120
+#: warehouse/accounts/views.py:121
 msgid ""
 "There have been too many unsuccessful login attempts. You have been "
 "locked out for Please try again later."
 msgstr ""
 
-#: warehouse/accounts/views.py:140
+#: warehouse/accounts/views.py:141
 #, python-brace-format
 msgid ""
 "Too many emails have been added to this account without verifying them. "
 "Check your inbox and follow the verification links. (IP: ${ip})"
 msgstr ""
 
-#: warehouse/accounts/views.py:152
+#: warehouse/accounts/views.py:153
 #, python-brace-format
 msgid ""
 "Too many password resets have been requested for this account without "
@@ -148,195 +148,195 @@ msgid ""
 " ${ip})"
 msgstr ""
 
-#: warehouse/accounts/views.py:375 warehouse/accounts/views.py:443
-#: warehouse/accounts/views.py:445 warehouse/accounts/views.py:474
-#: warehouse/accounts/views.py:476 warehouse/accounts/views.py:592
+#: warehouse/accounts/views.py:376 warehouse/accounts/views.py:444
+#: warehouse/accounts/views.py:446 warehouse/accounts/views.py:475
+#: warehouse/accounts/views.py:477 warehouse/accounts/views.py:593
 msgid "Invalid or expired two factor login."
 msgstr ""
 
-#: warehouse/accounts/views.py:437
+#: warehouse/accounts/views.py:438
 msgid "Already authenticated"
 msgstr ""
 
-#: warehouse/accounts/views.py:511
+#: warehouse/accounts/views.py:512
 msgid "Successful WebAuthn assertion"
 msgstr ""
 
-#: warehouse/accounts/views.py:622 warehouse/manage/views/__init__.py:953
+#: warehouse/accounts/views.py:623 warehouse/manage/views/__init__.py:953
 msgid "Recovery code accepted. The supplied code cannot be used again."
 msgstr ""
 
-#: warehouse/accounts/views.py:719
+#: warehouse/accounts/views.py:720
 msgid ""
 "New user registration temporarily disabled. See https://pypi.org/help"
 "#admin-intervention for details."
 msgstr ""
 
-#: warehouse/accounts/views.py:880
+#: warehouse/accounts/views.py:881
 msgid "Expired token: request a new password reset link"
 msgstr ""
 
-#: warehouse/accounts/views.py:882
+#: warehouse/accounts/views.py:883
 msgid "Invalid token: request a new password reset link"
 msgstr ""
 
-#: warehouse/accounts/views.py:884 warehouse/accounts/views.py:993
-#: warehouse/accounts/views.py:1058 warehouse/accounts/views.py:1164
-#: warehouse/accounts/views.py:1335
+#: warehouse/accounts/views.py:885 warehouse/accounts/views.py:998
+#: warehouse/accounts/views.py:1063 warehouse/accounts/views.py:1169
+#: warehouse/accounts/views.py:1340
 msgid "Invalid token: no token supplied"
 msgstr ""
 
-#: warehouse/accounts/views.py:888
+#: warehouse/accounts/views.py:889
 msgid "Invalid token: not a password reset token"
 msgstr ""
 
-#: warehouse/accounts/views.py:893 warehouse/accounts/views.py:1002
+#: warehouse/accounts/views.py:894 warehouse/accounts/views.py:1007
 msgid "Invalid token: user not found"
 msgstr ""
 
-#: warehouse/accounts/views.py:904
+#: warehouse/accounts/views.py:905
 msgid "Invalid token: user has logged in since this token was requested"
 msgstr ""
 
-#: warehouse/accounts/views.py:922
+#: warehouse/accounts/views.py:923
 msgid ""
 "Invalid token: password has already been changed since this token was "
 "requested"
 msgstr ""
 
-#: warehouse/accounts/views.py:953
+#: warehouse/accounts/views.py:954
 msgid "You have reset your password"
 msgstr ""
 
-#: warehouse/accounts/views.py:989
+#: warehouse/accounts/views.py:994
 msgid "Expired token: please try to login again"
 msgstr ""
 
-#: warehouse/accounts/views.py:991
+#: warehouse/accounts/views.py:996
 msgid "Invalid token: please try to login again"
 msgstr ""
 
-#: warehouse/accounts/views.py:997
+#: warehouse/accounts/views.py:1002
 msgid "Invalid token: not a login confirmation token"
 msgstr ""
 
-#: warehouse/accounts/views.py:1012
+#: warehouse/accounts/views.py:1017
 msgid "Invalid login attempt."
 msgstr ""
 
-#: warehouse/accounts/views.py:1017
+#: warehouse/accounts/views.py:1022
 msgid ""
 "Device details didn't match, please try again from the device you "
 "originally used to log in."
 msgstr ""
 
-#: warehouse/accounts/views.py:1028
+#: warehouse/accounts/views.py:1033
 msgid "Your login has been confirmed and this device is now recognized."
 msgstr ""
 
-#: warehouse/accounts/views.py:1054
+#: warehouse/accounts/views.py:1059
 msgid "Expired token: request a new email verification link"
 msgstr ""
 
-#: warehouse/accounts/views.py:1056
+#: warehouse/accounts/views.py:1061
 msgid "Invalid token: request a new email verification link"
 msgstr ""
 
-#: warehouse/accounts/views.py:1062
+#: warehouse/accounts/views.py:1067
 msgid "Invalid token: not an email verification token"
 msgstr ""
 
-#: warehouse/accounts/views.py:1071
+#: warehouse/accounts/views.py:1076
 msgid "Email not found"
 msgstr ""
 
-#: warehouse/accounts/views.py:1074
+#: warehouse/accounts/views.py:1079
 msgid "Email already verified"
 msgstr ""
 
-#: warehouse/accounts/views.py:1094
+#: warehouse/accounts/views.py:1099
 msgid "You can now set this email as your primary address"
 msgstr ""
 
-#: warehouse/accounts/views.py:1097
+#: warehouse/accounts/views.py:1102
 msgid "This is your primary address"
 msgstr ""
 
-#: warehouse/accounts/views.py:1103
+#: warehouse/accounts/views.py:1108
 #, python-brace-format
 msgid "Email address ${email_address} verified. ${confirm_message}."
 msgstr ""
 
-#: warehouse/accounts/views.py:1160
+#: warehouse/accounts/views.py:1165
 msgid "Expired token: request a new organization invitation"
 msgstr ""
 
-#: warehouse/accounts/views.py:1162
+#: warehouse/accounts/views.py:1167
 msgid "Invalid token: request a new organization invitation"
 msgstr ""
 
-#: warehouse/accounts/views.py:1168
+#: warehouse/accounts/views.py:1173
 msgid "Invalid token: not an organization invitation token"
 msgstr ""
 
-#: warehouse/accounts/views.py:1172 warehouse/accounts/views.py:1183
+#: warehouse/accounts/views.py:1177 warehouse/accounts/views.py:1188
 msgid "Organization invitation is not valid."
 msgstr ""
 
-#: warehouse/accounts/views.py:1181
+#: warehouse/accounts/views.py:1186
 msgid "Organization invitation no longer exists."
 msgstr ""
 
-#: warehouse/accounts/views.py:1235
+#: warehouse/accounts/views.py:1240
 #, python-brace-format
 msgid "Invitation for '${organization_name}' is declined."
 msgstr ""
 
-#: warehouse/accounts/views.py:1298
+#: warehouse/accounts/views.py:1303
 #, python-brace-format
 msgid "You are now ${role} of the '${organization_name}' organization."
 msgstr ""
 
-#: warehouse/accounts/views.py:1331
+#: warehouse/accounts/views.py:1336
 msgid "Expired token: request a new project role invitation"
 msgstr ""
 
-#: warehouse/accounts/views.py:1333
+#: warehouse/accounts/views.py:1338
 msgid "Invalid token: request a new project role invitation"
 msgstr ""
 
-#: warehouse/accounts/views.py:1339
+#: warehouse/accounts/views.py:1344
 msgid "Invalid token: not a collaboration invitation token"
 msgstr ""
 
-#: warehouse/accounts/views.py:1343 warehouse/accounts/views.py:1363
+#: warehouse/accounts/views.py:1348 warehouse/accounts/views.py:1368
 msgid "Role invitation is not valid."
 msgstr ""
 
-#: warehouse/accounts/views.py:1350
+#: warehouse/accounts/views.py:1355
 msgid "Invalid token: project does not exist"
 msgstr ""
 
-#: warehouse/accounts/views.py:1361
+#: warehouse/accounts/views.py:1366
 msgid "Role invitation no longer exists."
 msgstr ""
 
-#: warehouse/accounts/views.py:1395
+#: warehouse/accounts/views.py:1400
 #, python-brace-format
 msgid "Invitation for '${project_name}' is declined."
 msgstr ""
 
-#: warehouse/accounts/views.py:1461
+#: warehouse/accounts/views.py:1466
 #, python-brace-format
 msgid "You are now ${role} of the '${project_name}' project."
 msgstr ""
 
-#: warehouse/accounts/views.py:1572
+#: warehouse/accounts/views.py:1577
 #, python-brace-format
 msgid "Please review our updated <a href=\"${tos_url}\">Terms of Service</a>."
 msgstr ""
 
-#: warehouse/accounts/views.py:1793 warehouse/accounts/views.py:2061
+#: warehouse/accounts/views.py:1798 warehouse/accounts/views.py:2066
 #: warehouse/manage/views/oidc_publishers.py:126
 #: warehouse/manage/views/organizations.py:1721
 msgid ""
@@ -344,22 +344,22 @@ msgid ""
 "#admin-intervention for details."
 msgstr ""
 
-#: warehouse/accounts/views.py:1814
+#: warehouse/accounts/views.py:1819
 #: warehouse/manage/views/organizations.py:1744
 msgid "disabled. See https://pypi.org/help#admin-intervention for details."
 msgstr ""
 
-#: warehouse/accounts/views.py:1830
+#: warehouse/accounts/views.py:1835
 msgid ""
 "You must have a verified email in order to register a pending trusted "
 "publisher. See https://pypi.org/help#openid-connect for details."
 msgstr ""
 
-#: warehouse/accounts/views.py:1843
+#: warehouse/accounts/views.py:1848
 msgid "You can't register more than 3 pending trusted publishers at once."
 msgstr ""
 
-#: warehouse/accounts/views.py:1858
+#: warehouse/accounts/views.py:1863
 #: warehouse/manage/views/oidc_publishers.py:308
 #: warehouse/manage/views/oidc_publishers.py:423
 #: warehouse/manage/views/oidc_publishers.py:539
@@ -369,7 +369,7 @@ msgid ""
 "again later."
 msgstr ""
 
-#: warehouse/accounts/views.py:1868
+#: warehouse/accounts/views.py:1873
 #: warehouse/manage/views/oidc_publishers.py:321
 #: warehouse/manage/views/oidc_publishers.py:436
 #: warehouse/manage/views/oidc_publishers.py:552
@@ -378,30 +378,30 @@ msgstr ""
 msgid "The trusted publisher could not be registered"
 msgstr ""
 
-#: warehouse/accounts/views.py:1883
+#: warehouse/accounts/views.py:1888
 msgid ""
 "This trusted publisher has already been registered. Please contact PyPI's"
 " admins if this wasn't intentional."
 msgstr ""
 
-#: warehouse/accounts/views.py:1908
+#: warehouse/accounts/views.py:1913
 msgid ""
 "A pending trusted publisher matching this configuration has already been "
 "registered for a different project name. Please contact PyPI's admins if "
 "this wasn't intentional."
 msgstr ""
 
-#: warehouse/accounts/views.py:1931
+#: warehouse/accounts/views.py:1936
 #: warehouse/manage/views/organizations.py:1812
 msgid "Registered a new pending publisher to create "
 msgstr ""
 
-#: warehouse/accounts/views.py:2074 warehouse/accounts/views.py:2087
-#: warehouse/accounts/views.py:2094
+#: warehouse/accounts/views.py:2079 warehouse/accounts/views.py:2092
+#: warehouse/accounts/views.py:2099
 msgid "Invalid publisher ID"
 msgstr ""
 
-#: warehouse/accounts/views.py:2101
+#: warehouse/accounts/views.py:2106
 msgid "Removed trusted publisher for project "
 msgstr ""
 

--- a/warehouse/templates/accounts/unrecognized-device.html
+++ b/warehouse/templates/accounts/unrecognized-device.html
@@ -11,6 +11,12 @@
       </p>
       <p>
         You should have received an email from <strong>noreply@{{ domain }}</strong> with the subject line "<strong>Unrecognized login to your {{ sitename }} account</strong>".
+        The email may have been sent when we first noticed this device, so be sure to check your spam or junk folder as well.
+      </p>
+      <p>
+        If you can't find the email, attempt to log in again and a new confirmation
+        email will be sent. To protect your inbox, sending may be limited to one
+        email every {{ repeat_window_minutes }} minutes.
       </p>
       <p>
         In the future, you can automatically trust new devices without needing email


### PR DESCRIPTION
Once a pending UserUniqueLogin existed for a user+IP, repeat logins
within the confirmation window never sent another email. If the first
email was lost or bounced, the user was stuck until the pending login
expired.

Now every unconfirmed login attempt re-sends the email, throttled to
one per 15 minutes at the email layer so retries can't flood an inbox.

The throttle is skipped for a new device or a lapsed window: the user
holds no valid token in either case, so that email must always go out.
device_is_known disables it via a new per-call repeat_window override
on the _email wrapper.

Fixes #20312

Signed-off-by: Mike Fiedler <miketheman@gmail.com>