### PR TITLE
fix: reject percent-encoded dots in URL verification

### DIFF
--- a/tests/unit/oidc/test_urls.py
+++ b/tests/unit/oidc/test_urls.py
@@ -33,6 +33,34 @@ from warehouse.oidc.urls import verify_url_from_reference
             r"https://github.com/myorg/myproject/..\x/../evil_org/evil_project/",
             False,
         ),
+        # Percent-encoded dot bypass: rfc3986 leaves "%2e" literal, but per
+        # WHATWG a browser treats ".%2e", "%2e." and "%2e%2e" as double-dot
+        # segments and walks off-path.
+        (
+            "https://example.com/path1",
+            "https://example.com/path1/%2e%2e/malicious",
+            False,
+        ),
+        (
+            "https://example.com/path1",
+            "https://example.com/path1/%2E%2E/malicious",
+            False,
+        ),
+        (
+            "https://example.com/path1",
+            "https://example.com/path1/.%2e/malicious",
+            False,
+        ),
+        (
+            "https://example.com/path1",
+            "https://example.com/path1/%2e./malicious",
+            False,
+        ),
+        (
+            "https://github.com/myorg/myproject",
+            "https://github.com/myorg/myproject/%2e%2e/%2e%2e/evil_org/evil_project",
+            False,
+        ),
     ],
 )
 def test_verify_url_from_reference(reference: str, url: str, expected: bool):

--- a/warehouse/oidc/urls.py
+++ b/warehouse/oidc/urls.py
@@ -19,7 +19,12 @@ def verify_url_from_reference(*, reference_url: str, url: str) -> bool:
     # not. So "..\x/.." can walk past the reference path in a browser while
     # normalizing to a subpath here, which means the URL we verify and the
     # URL the user lands on can diverge. Reject backslashes.
-    if "\\" in url:
+    #
+    # WHATWG also counts ".%2e", "%2e." and "%2e%2e" as double-dot segments,
+    # while rfc3986 leaves "%2e" literal, so the same divergence applies.
+    # Reject percent-encoded dots. Note "%2f" needs no such guard: WHATWG does
+    # not decode it into a path separator, so it never forms a dot segment.
+    if "\\" in url or "%2e" in url.lower():
         return False
 
     reference_uri = rfc3986.api.uri_reference(reference_url).normalize()


### PR DESCRIPTION
Previously PyPI started rejecting backslashes as verifiable URLs. Browsers treat `\` as `/` per WHATWG, rfc3986 doesn't, so a URL can be verified as a subpath of the publisher and still send users elsewhere. Percent-encoded dots do the same thing.
WHATWG counts `.%2e`, `%2e.` and `%2e%2e` as double-dot segments; rfc3986 leaves them literal.

`%2f` needs no guard. Browsers don't decode it into a path separator, so it never forms a dot segment.

Refs: https://url.spec.whatwg.org/#path-state
Refs: https://url.spec.whatwg.org/#double-dot-path-segment
Refs: https://url.spec.whatwg.org/#shorten-a-urls-path
Refs #20035