### PR TITLE
Add pagination to admin user projects list

### DIFF
--- a/tests/unit/admin/views/test_users.py
+++ b/tests/unit/admin/views/test_users.py
@@ -149,17 +149,41 @@ class TestUserDetail:
         assert result["roles"] == roles
         assert result["emails_form"].emails[0].primary.data
         assert result["submitted_by_journals"] == journal_entries[:5]
-        assert result["user_projects"] == [
-            {
-                "name": project.name,
-                "normalized_name": project.normalized_name,
-                "releases_count": 0,
-                "total_size": 0,
-                "lifecycle_status": None,
-                "role_name": "Owner",
-            }
-        ]
+        assert len(result["user_projects"]) == 1
+
+        user_project = result["user_projects"][0]
+
+        assert user_project.name == project.name
+        assert user_project.normalized_name == project.normalized_name
+        assert user_project.releases_count == 0
+        assert user_project.total_size == 0
+        assert user_project.lifecycle_status is None
+        assert user_project.role_name == "Owner"
         assert result["sole_owned_organizations"] == []
+
+    def test_gets_user_with_project_pagination(self, db_request):
+        user = UserFactory.create()
+
+        projects = []
+        for i in range(30):
+            project = ProjectFactory.create(name=f"project{i}")
+            RoleFactory(project=project, user=user, role_name="Owner")
+            projects.append(project)
+
+        db_request.matchdict["username"] = user.username
+        db_request.GET["page"] = "2"
+        db_request.POST = NoVars()
+
+        breach_service = pretend.stub(get_email_breach_count=lambda count: 0)
+        db_request.find_service = lambda interface, **kwargs: {
+            IEmailBreachedService: breach_service,
+        }[interface]
+
+        result = views.user_detail(user, db_request)
+
+        assert len(result["user_projects"]) == 5
+        assert result["user_projects"].page == 2
+        assert result["user_projects"].items_per_page == 25
 
     def test_gets_user_with_sole_owned_organizations(self, db_request):
         user = UserFactory.create()

--- a/warehouse/admin/templates/admin/users/detail.html
+++ b/warehouse/admin/templates/admin/users/detail.html
@@ -988,6 +988,18 @@
             {% endfor %}
             </tbody>
           </table>
+        
+          <div class="row mt-3">
+            <div class="col-sm-5">
+              {{ pagination.summary(user_projects) }}
+            </div>
+            <div class="col-sm-7">
+              <div class="float-right">
+                {{ pagination.paginate(user_projects) }}
+              </div>
+            </div>
+          </div>
+
           {% else %}
           No roles available.
           {% endif %}

--- a/warehouse/admin/views/users.py
+++ b/warehouse/admin/views/users.py
@@ -159,6 +159,10 @@ def user_detail(user, request):
     if user.username != request.matchdict.get("username", user.username):
         return HTTPMovedPermanently(request.current_route_path(username=user.username))
 
+    try:
+        page_num = int(request.params.get("page", 1))
+    except ValueError:
+        raise HTTPBadRequest("'page' must be an integer.") from None
     roles = (
         request.db.query(Role)
         .join(User)
@@ -192,18 +196,18 @@ def user_detail(user, request):
         .all()
     )
 
-    stmt = (
-        select(
-            Project.name,
-            Project.normalized_name,
-            Project.lifecycle_status,
-            Project.total_size,
-            Role.role_name,
-            func.count(Release.id),
+    projects_query = (
+        request.db.query(
+            Project.name.label("name"),
+            Project.normalized_name.label("normalized_name"),
+            Project.lifecycle_status.label("lifecycle_status"),
+            Project.total_size.label("total_size"),
+            Role.role_name.label("role_name"),
+            func.count(Release.id).label("releases_count"),
         )
         .join(Role, Project.id == Role.project_id)
         .outerjoin(Release, Project.id == Release.project_id)
-        .where(Role.user_id == user.id)
+        .filter(Role.user_id == user.id)
         .group_by(
             Project.name,
             Project.normalized_name,
@@ -214,19 +218,12 @@ def user_detail(user, request):
         .order_by(Project.normalized_name.asc())
     )
 
-    user_projects = []
-
-    for row in request.db.execute(stmt):
-        project = {
-            "name": row.name,
-            "normalized_name": row.normalized_name,
-            "lifecycle_status": row.lifecycle_status,
-            "total_size": row.total_size,
-            "role_name": row.role_name,
-            "releases_count": row.count,
-        }
-
-        user_projects.append(project)
+    user_projects = SQLAlchemyORMPage(
+        projects_query,
+        page=page_num,
+        items_per_page=25,
+        url_maker=paginate_url_factory(request),
+    )
 
     return {
         "user": user,


### PR DESCRIPTION
Fixes #20295

## What
Adds pagination to the list of projects shown on a user's admin detail page (`/admin/users/<username>/`), so admins no longer have to scroll through a long, unpaginated list for users who own many projects.

## Why
As described in #20295, some users have a large number of projects, which makes the admin UI hard to use — you end up scrolling for a long time to find what you need. This PR paginates that list to make it manageable.

## How
- **`warehouse/admin/views/users.py`**
  - Reads a `page` query param (defaulting to `1`) and raises `HTTPBadRequest` if it isn't a valid integer.
  - Converts the raw `select()` execution for `user_projects` into a `request.db.query(...)` so it can be wrapped in `SQLAlchemyORMPage` (25 items per page), using `paginate_url_factory(request)` to build page links.
  - `user_projects` is now a paginated page object rather than a plain list of dicts.
- **`warehouse/admin/templates/admin/users/detail.html`**
  - Adds a pagination summary and control row below the projects table, using the existing `pagination.summary()` / `pagination.paginate()` macros.
- **`tests/unit/admin/views/test_users.py`**
  - Updates assertions to check attributes on row objects instead of dicts.
  - Adds `test_gets_user_with_project_pagination` covering page 2 of 30 projects.

## Testing
Added/updated unit tests covering both the default and paginated cases.

## Notes
Org admin pagination (also mentioned in the issue) is not addressed here and could be a good follow-up.

## Screenshots
   Page 1:

<img width="1904" height="964" alt="Screenshot 2026-07-28 010340" src="https://github.com/user-attachments/assets/63982290-4bf9-45ad-b721-c4a699c81557" />

   Page 2 (pagination working):

<img width="1337" height="609" alt="Screenshot 2026-07-28 125752" src="https://github.com/user-attachments/assets/bd88a0c3-cc64-41b2-91d3-aa69164cebd0" />
