### PR TITLE
feat: unify log rendering through ProcessorFormatter

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,7 +95,7 @@ services:
 
   web:
     image: warehouse:docker-compose
-    command: gunicorn --reload --reload-extra-file=warehouse/api/openapi.yaml --threads 4 -b 0.0.0.0:8000 --access-logfile - --error-logfile - warehouse.wsgi:application
+    command: gunicorn --reload --reload-extra-file=warehouse/api/openapi.yaml --threads 4 -b 0.0.0.0:8000 --access-logfile - --error-logfile - --logger-class warehouse.logging.GunicornLogger warehouse.wsgi:application
     env_file: dev/environment
     pull_policy: never
     volumes: *base_volumes

--- a/gunicorn-prod.conf.py
+++ b/gunicorn-prod.conf.py
@@ -13,9 +13,7 @@ keepalive = 2
 errorlog = "-"
 loglevel = "info"
 accesslog = "-"
-access_log_format = (
-    '%({Warehouse-Hashed-IP}i)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s"'
-)
+logger_class = "warehouse.logging.GunicornLogger"
 
 statsd_host = "localhost:8125"
 

--- a/gunicorn-uploads.conf.py
+++ b/gunicorn-uploads.conf.py
@@ -16,9 +16,7 @@ keepalive = 2
 errorlog = "-"
 loglevel = "info"
 accesslog = "-"
-access_log_format = (
-    '%({Warehouse-Hashed-IP}i)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s"'
-)
+logger_class = "warehouse.logging.GunicornLogger"
 
 statsd_host = "localhost:8125"
 

--- a/requirements/lint.in
+++ b/requirements/lint.in
@@ -12,6 +12,7 @@ types-babel
 boto3-stubs
 types-certifi
 types-first
+types-gunicorn
 types-html5lib
 types-itsdangerous
 types-passlib

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -865,6 +865,10 @@ types-first==2.0.5.20260408 \
     --hash=sha256:4c6b545e86877033726a5c27e4e8491b65d38714ce6e400ab4b60e23c01a11bd \
     --hash=sha256:9a9e78fa829a17d2f84310f36597d0eb51b3c5e48a3fa39e8f8521948f159c79
     # via -r requirements/lint.in
+types-gunicorn==26.0.0.20260728 \
+    --hash=sha256:14e8fcfe9748177e76cabf7f13802fe5a67eae713eb73569ba88a5bae2c14f8b \
+    --hash=sha256:82aa51db88fc2b73d8b0ffb7f8cf51a2e5949b6409bcb9cdaee9edc230120548
+    # via -r requirements/lint.in
 types-html5lib==1.1.11.20260518 \
     --hash=sha256:4f33c087cb1119d65c4c80eca4323c2b501f9eaf8af9616b8b732ed4d8eae8fa \
     --hash=sha256:9baa7912224ebb37027c5ccb7e3768e43ea47b1dfdd977e7ddc4b0a4a550584d

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -3,36 +3,299 @@
 import json
 import logging
 import logging.config
-import threading
+import sys
 import uuid
 
+from datetime import timedelta
+from types import SimpleNamespace
+
+import gunicorn.config
 import pytest
 import structlog
 
+from pyramid.tweens import EXCVIEW
+
 from warehouse import logging as wlogging
+from warehouse.config import Environment
 
 
-class TestStructlogFormatter:
-    def test_warehouse_logger_no_renderer(self):
-        formatter = wlogging.StructlogFormatter()
-        record = logging.LogRecord(
-            "warehouse.request", logging.INFO, None, None, "the message", None, None
+def _includeme(pyramid_config, mocker, env):
+    """
+    Run includeme with the global side effects captured, returning the
+    mocks for dictConfig and structlog.configure.
+    """
+    dict_config = mocker.patch.object(logging.config, "dictConfig", autospec=True)
+    configure = mocker.patch.object(structlog, "configure", autospec=True)
+    pyramid_config.registry.settings["warehouse.env"] = env
+
+    wlogging.includeme(pyramid_config)
+
+    return dict_config, configure
+
+
+def _formatter_from(dict_config):
+    """Instantiate the ProcessorFormatter exactly as dictConfig would."""
+    spec = dict(dict_config.call_args.args[0]["formatters"]["structlog"])
+    formatter_class = spec.pop("()")
+    return formatter_class(**spec)
+
+
+class TestIncludeme:
+    @pytest.mark.parametrize(
+        ("settings", "expected_level"),
+        [({"logging.level": "DEBUG"}, "DEBUG"), ({}, "INFO")],
+    )
+    def test_log_level_setting(self, pyramid_config, mocker, settings, expected_level):
+        pyramid_config.registry.settings.update(settings)
+        dict_config, _ = _includeme(pyramid_config, mocker, Environment.production)
+
+        config = dict_config.call_args.args[0]
+        assert config["root"] == {"level": expected_level, "handlers": ["primary"]}
+        for logger_name in ("gunicorn", "gunicorn.access", "gunicorn.error"):
+            assert config["loggers"][logger_name] == {
+                "propagate": False,
+                "handlers": ["primary"],
+                "level": expected_level,
+            }
+        assert config["loggers"]["datadog.dogstatsd"] == {"level": "ERROR"}
+
+    def test_structlog_configure_chain(self, pyramid_config, mocker):
+        _, configure = _includeme(pyramid_config, mocker, Environment.production)
+
+        processors = configure.call_args.kwargs["processors"]
+        assert processors[0] is structlog.stdlib.filter_by_level
+        assert structlog.contextvars.merge_contextvars in processors
+        assert processors[-1] is (
+            structlog.stdlib.ProcessorFormatter.wrap_for_formatter
+        )
+        assert (
+            configure.call_args.kwargs["wrapper_class"] is structlog.stdlib.BoundLogger
+        )
+        assert isinstance(
+            configure.call_args.kwargs["logger_factory"],
+            structlog.stdlib.LoggerFactory,
+        )
+        assert configure.call_args.kwargs["cache_logger_on_first_use"] is True
+
+    def test_adds_request_methods_and_tween(self, pyramid_config, mocker):
+        add_request_method = mocker.patch.object(
+            pyramid_config, "add_request_method", autospec=True
+        )
+        add_tween = mocker.patch.object(pyramid_config, "add_tween", autospec=True)
+
+        _includeme(pyramid_config, mocker, Environment.production)
+
+        assert add_request_method.call_args_list == [
+            mocker.call(wlogging._create_id, name="id", reify=True),
+            mocker.call(wlogging._create_logger, name="log", reify=True),
+        ]
+        add_tween.assert_called_once_with(
+            "warehouse.logging.request_context_tween_factory", over=EXCVIEW
         )
 
-        assert formatter.format(record) == "the message"
 
-    def test_non_warehouse_logger_renders(self):
-        formatter = wlogging.StructlogFormatter()
+class TestFormatterBehavior:
+    """Exercise the real ProcessorFormatter the way dictConfig builds it."""
+
+    @pytest.fixture
+    def prod_formatter(self, pyramid_config, mocker):
+        dict_config, _ = _includeme(pyramid_config, mocker, Environment.production)
+        return _formatter_from(dict_config)
+
+    @pytest.fixture
+    def dev_formatter(self, pyramid_config, mocker):
+        dict_config, _ = _includeme(pyramid_config, mocker, Environment.development)
+        return _formatter_from(dict_config)
+
+    def test_foreign_record_renders_json_with_extras(self, prod_formatter):
         record = logging.LogRecord(
-            "another.logger", logging.INFO, None, None, "the message", None, None
+            "gunicorn.access", logging.INFO, "", 0, "http_request", None, None
+        )
+        record.method = "GET"
+        record.status = 404
+
+        output = json.loads(prod_formatter.format(record))
+
+        assert output["logger"] == "gunicorn.access"
+        assert output["level"] == "info"
+        assert output["event"] == "http_request"
+        assert output["method"] == "GET"
+        assert output["status"] == 404
+        assert "timestamp" in output
+
+    def test_foreign_record_positional_args_interpolated(self, prod_formatter):
+        record = logging.LogRecord(
+            "another.logger", logging.INFO, "", 0, "Purging %s", ("a-key",), None
         )
 
-        assert json.loads(formatter.format(record)) == {
-            "logger": "another.logger",
-            "level": "INFO",
-            "event": "the message",
-            "thread": threading.get_ident(),
+        output = json.loads(prod_formatter.format(record))
+
+        assert output["event"] == "Purging a-key"
+
+    def test_foreign_record_renders_console_in_dev(self, dev_formatter):
+        record = logging.LogRecord(
+            "gunicorn.access", logging.INFO, "", 0, "http_request", None, None
+        )
+        record.method = "GET"
+
+        output = dev_formatter.format(record)
+
+        assert not output.startswith("{")
+        assert "http_request" in output
+        assert "method" in output
+        assert "GET" in output
+
+    def test_foreign_record_formats_exceptions(self, prod_formatter):
+        try:
+            raise ValueError("boom")
+        except ValueError:
+            record = logging.LogRecord(
+                "another.logger",
+                logging.ERROR,
+                "",
+                0,
+                "task failed",
+                None,
+                exc_info=sys.exc_info(),
+            )
+
+        output = json.loads(prod_formatter.format(record))
+
+        assert output["event"] == "task failed"
+        assert "ValueError: boom" in output["exception"]
+
+
+class TestRequestContextTween:
+    def test_binds_request_id_during_request(self, pyramid_request, mocker):
+        pyramid_request.id = "a-request-id"
+        seen_context = {}
+        response = mocker.sentinel.response
+
+        def handler(request):
+            seen_context.update(structlog.contextvars.get_contextvars())
+            return response
+
+        tween = wlogging.request_context_tween_factory(
+            handler, pyramid_request.registry
+        )
+
+        assert tween(pyramid_request) is response
+        assert seen_context["request.id"] == "a-request-id"
+
+    def test_stashes_request_id_for_access_log(self, pyramid_request):
+        """The environ outlives the request, where gunicorn's access hook
+        picks the id up after the tween chain has unwound."""
+        pyramid_request.id = "a-request-id"
+        tween = wlogging.request_context_tween_factory(
+            lambda request: None, pyramid_request.registry
+        )
+
+        tween(pyramid_request)
+
+        assert pyramid_request.environ["warehouse.request_id"] == "a-request-id"
+
+    def test_clears_binding_after_request(self, pyramid_request):
+        pyramid_request.id = "a-request-id"
+        tween = wlogging.request_context_tween_factory(
+            lambda request: None, pyramid_request.registry
+        )
+
+        tween(pyramid_request)
+
+        assert "request.id" not in structlog.contextvars.get_contextvars()
+
+
+class TestGunicornLogger:
+    @pytest.fixture
+    def access_records(self):
+        """Capture records on the global gunicorn.access logger, restoring after."""
+        access_log = logging.getLogger("gunicorn.access")
+        previous_handlers = access_log.handlers[:]
+        access_log.handlers = []
+        records = []
+
+        class _Capture(logging.Handler):
+            def emit(self, record):
+                records.append(record)
+
+        access_log.addHandler(_Capture())
+        try:
+            yield records
+        finally:
+            access_log.handlers = previous_handlers
+
+    @pytest.fixture
+    def gunicorn_cfg(self):
+        cfg = gunicorn.config.Config()
+        cfg.set("accesslog", "-")
+        return cfg
+
+    def _environ(self):
+        return {
+            "REMOTE_ADDR_HASHED": "d1c8c5c2cf5a",
+            "REMOTE_ADDR": "127.0.0.1",
+            "REQUEST_METHOD": "GET",
+            "PATH_INFO": "/simple/example/",
+            "QUERY_STRING": "",
+            "RAW_URI": "/simple/example%2E/",
+            "SERVER_PROTOCOL": "HTTP/1.1",
+            "HTTP_REFERER": "https://example.com/",
+            "HTTP_USER_AGENT": "PyCharm/2026.2",
+            "GEOIP_COUNTRY_CODE": "US",
+            "warehouse.request_id": "a-request-id",
         }
+
+    def test_access_emits_structured_fields(self, gunicorn_cfg, access_records):
+        logger = wlogging.GunicornLogger(gunicorn_cfg)
+        resp = SimpleNamespace(status="404 Not Found", sent=13, headers=[])
+
+        logger.access(
+            resp, None, self._environ(), timedelta(seconds=1, milliseconds=234)
+        )
+
+        (record,) = access_records
+        assert record.msg == "http_request"
+        assert record.remote_addr == "d1c8c5c2cf5a"
+        assert record.method == "GET"
+        assert record.path == "/simple/example/"
+        assert record.query == ""
+        assert record.raw_uri == "/simple/example%2E/"
+        assert record.protocol == "HTTP/1.1"
+        assert record.status == 404
+        assert record.size == 13
+        assert record.referrer == "https://example.com/"
+        assert record.user_agent == "PyCharm/2026.2"
+        assert record.country == "US"
+        assert record.duration_ms == pytest.approx(1234.0)
+        assert record.__dict__["request.id"] == "a-request-id"
+
+    def test_access_integer_status(self, gunicorn_cfg, access_records):
+        logger = wlogging.GunicornLogger(gunicorn_cfg)
+        resp = SimpleNamespace(status=200, sent=0, headers=[])
+
+        logger.access(resp, None, self._environ(), timedelta(milliseconds=5))
+
+        (record,) = access_records
+        assert record.status == 200
+
+    def test_access_falls_back_to_remote_addr(self, gunicorn_cfg, access_records):
+        logger = wlogging.GunicornLogger(gunicorn_cfg)
+        resp = SimpleNamespace(status="200 OK", sent=0, headers=[])
+        environ = self._environ()
+        del environ["REMOTE_ADDR_HASHED"]
+
+        logger.access(resp, None, environ, timedelta(milliseconds=5))
+
+        (record,) = access_records
+        assert record.remote_addr == "127.0.0.1"
+
+    def test_access_disabled_does_not_log(self, access_records):
+        logger = wlogging.GunicornLogger(gunicorn.config.Config())
+        resp = SimpleNamespace(status="200 OK", sent=0, headers=[])
+
+        logger.access(resp, None, self._environ(), timedelta(milliseconds=5))
+
+        assert access_records == []
 
 
 def test_create_id(mocker):
@@ -43,90 +306,6 @@ def test_create_id(mocker):
     assert wlogging._create_id(request) == "a fake uuid"
 
 
-def test_create_logging(pyramid_request, mocker):
-    bound_logger = mocker.sentinel.bound_logger
-    logger = mocker.patch.object(wlogging, "request_logger")
-    logger.bind.return_value = bound_logger
-
-    pyramid_request.id = "request id"
-
-    assert wlogging._create_logger(pyramid_request) is bound_logger
-    logger.bind.assert_called_once_with(**{"request.id": "request id"})
-
-
-@pytest.mark.parametrize(
-    ("settings", "expected_level"),
-    [({"logging.level": "DEBUG"}, "DEBUG"), ({}, "INFO")],
-)
-def test_includeme(pyramid_config, mocker, settings, expected_level):
-    dict_config = mocker.patch.object(logging.config, "dictConfig", autospec=True)
-    configure = mocker.patch.object(structlog, "configure", autospec=True)
-    add_request_method = mocker.patch.object(
-        pyramid_config, "add_request_method", autospec=True
-    )
-    pyramid_config.registry.settings.update(settings)
-
-    wlogging.includeme(pyramid_config)
-
-    dict_config.assert_called_once_with(
-        {
-            "version": 1,
-            "disable_existing_loggers": False,
-            "formatters": {"structlog": {"()": "warehouse.logging.StructlogFormatter"}},
-            "handlers": {
-                "primary": {
-                    "class": "logging.StreamHandler",
-                    "stream": "ext://sys.stdout",
-                    "formatter": "structlog",
-                },
-            },
-            "loggers": {
-                "datadog.dogstatsd": {"level": "ERROR"},
-                "gunicorn": {
-                    "propagate": False,
-                    "handlers": ["primary"],
-                    "level": expected_level,
-                },
-                "gunicorn.access": {
-                    "propagate": False,
-                    "handlers": ["primary"],
-                    "level": expected_level,
-                },
-                "gunicorn.server": {
-                    "propagate": False,
-                    "handlers": ["primary"],
-                    "level": expected_level,
-                },
-            },
-            "root": {"level": expected_level, "handlers": ["primary"]},
-        }
-    )
-    configure.assert_called_once_with(
-        processors=[
-            structlog.stdlib.filter_by_level,
-            structlog.stdlib.add_logger_name,
-            structlog.stdlib.add_log_level,
-            mocker.ANY,
-            mocker.ANY,
-            structlog.processors.format_exc_info,
-            wlogging.RENDERER,
-        ],
-        logger_factory=mocker.ANY,
-        wrapper_class=structlog.stdlib.BoundLogger,
-        cache_logger_on_first_use=True,
-    )
-    assert isinstance(
-        configure.call_args.kwargs["processors"][3],
-        structlog.stdlib.PositionalArgumentsFormatter,
-    )
-    assert isinstance(
-        configure.call_args.kwargs["processors"][4],
-        structlog.processors.StackInfoRenderer,
-    )
-    assert isinstance(
-        configure.call_args.kwargs["logger_factory"], structlog.stdlib.LoggerFactory
-    )
-    assert add_request_method.call_args_list == [
-        mocker.call(wlogging._create_id, name="id", reify=True),
-        mocker.call(wlogging._create_logger, name="log", reify=True),
-    ]
+def test_create_logging(pyramid_request):
+    """request.log is the shared logger; request.id arrives via contextvars."""
+    assert wlogging._create_logger(pyramid_request) is wlogging.request_logger

--- a/tests/unit/test_tasks.py
+++ b/tests/unit/test_tasks.py
@@ -3,15 +3,24 @@
 import types
 
 import pytest
+import structlog
 import transaction
 
-from celery import Celery, Task
+from celery import Celery, Task, signals
 from kombu import Queue
 from pyramid import scripting
 from pyramid_retry import RetryableException
 
 from warehouse import tasks
 from warehouse.config import Environment
+
+
+@pytest.fixture(autouse=True)
+def clean_contextvars():
+    """Keep structlog contextvars from leaking between tests in this module."""
+    structlog.contextvars.clear_contextvars()
+    yield
+    structlog.contextvars.clear_contextvars()
 
 
 def test_tls_redis_backend():
@@ -40,7 +49,7 @@ class TestWarehouseTask:
 
     def test_call(self, mocker):
         registry = types.SimpleNamespace(settings={"warehouse.ip_salt": "peppa"})
-        request = types.SimpleNamespace()
+        request = types.SimpleNamespace(id="a-request-id")
 
         prepared = {
             "registry": registry,
@@ -162,7 +171,7 @@ class TestWarehouseTask:
 
     def test_creates_request(self, mocker):
         registry = types.SimpleNamespace(settings={"warehouse.ip_salt": "peppa"})
-        pyramid_env = {"request": types.SimpleNamespace()}
+        pyramid_env = {"request": types.SimpleNamespace(id="a-request-id")}
 
         mocker.patch.object(scripting, "prepare", return_value=pyramid_env)
 
@@ -180,6 +189,7 @@ class TestWarehouseTask:
             request.remote_addr_hashed
             == "cc9dfe9c4e6b6579bbf789d04339bd2d7f10aadf84ff4394193d99f14a0333f0"
         )
+        assert structlog.contextvars.get_contextvars()["request.id"] == "a-request-id"
 
     def test_reuses_request(self, mocker):
         pyramid_env = {"request": mocker.sentinel.request}
@@ -397,6 +407,28 @@ def test_make_celery_app(mocker):
     assert tasks._get_celery_app(config) is mocker.sentinel.celery_app
 
 
+class TestTaskLoggingSignals:
+    def test_prerun_binds_task_context(self):
+        task = types.SimpleNamespace(name="warehouse.fake.task")
+
+        tasks.on_task_prerun(None, "task-id-123", task)
+
+        context = structlog.contextvars.get_contextvars()
+        assert context["task_id"] == "task-id-123"
+        assert context["task_name"] == "warehouse.fake.task"
+
+    def test_postrun_clears_task_context(self):
+        structlog.contextvars.bind_contextvars(
+            task_id="task-id-123", task_name="warehouse.fake.task"
+        )
+
+        tasks.on_task_postrun(
+            None, "task-id-123", types.SimpleNamespace(name="warehouse.fake.task")
+        )
+
+        assert structlog.contextvars.get_contextvars() == {}
+
+
 @pytest.mark.parametrize(
     (
         "env",
@@ -446,6 +478,13 @@ def test_includeme(mocker, env, ssl, broker_redis_url, expected_url, transport_o
         spec=["action", "add_directive", "add_request_method", "registry"]
     )
     config.registry = registry
+    task_prerun_connect = mocker.patch.object(
+        signals.task_prerun, "connect", autospec=True
+    )
+    task_postrun_connect = mocker.patch.object(
+        signals.task_postrun, "connect", autospec=True
+    )
+
     tasks.includeme(config)
 
     app = config.registry["celery.app"]
@@ -464,9 +503,12 @@ def test_includeme(mocker, env, ssl, broker_redis_url, expected_url, transport_o
         "task_queue_ha_policy": "all",
         "task_queues": (Queue("default", routing_key="task.#"),),
         "task_routes": {},
+        "worker_hijack_root_logger": False,
         "REDBEAT_REDIS_URL": (config.registry.settings["celery.scheduler_url"]),
     }.items():
         assert app.conf[key] == value
+    task_prerun_connect.assert_called_once_with(tasks.on_task_prerun)
+    task_postrun_connect.assert_called_once_with(tasks.on_task_postrun)
     config.action.assert_called_once_with(("celery", "finalize"), app.finalize)
     assert config.add_directive.call_args_list == [
         mocker.call("add_periodic_task", tasks._add_periodic_task, action_wrap=False),

--- a/warehouse/logging.py
+++ b/warehouse/logging.py
@@ -1,35 +1,90 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging.config
-import threading
+import typing
 import uuid
 
+import gunicorn.glogging
 import structlog
+
+from pyramid.tweens import EXCVIEW
+
+from warehouse.config import Environment
+
+if typing.TYPE_CHECKING:
+    from pyramid.config import Configurator
+    from pyramid.registry import Registry
+    from pyramid.request import Request
+    from pyramid.response import Response
 
 request_logger = structlog.get_logger("warehouse.request")
 
-RENDERER = structlog.processors.JSONRenderer()
+
+class GunicornLogger(gunicorn.glogging.Logger):
+    """
+    A gunicorn logger that emits access logs as structured events instead of
+    a pre-formatted Apache combined log line, so the shared ProcessorFormatter
+    can render them as columns in development and JSON in production.
+    """
+
+    def access(self, resp, req, environ, request_time) -> None:
+        if not self.access_log_enabled:
+            return
+
+        # Mirror gunicorn's own defensive handling from Logger.atoms(): resp
+        # status is usually a string like "404 Not Found", but may be an int.
+        status = resp.status
+        if isinstance(status, str):
+            status = int(status.split(None, 1)[0])
+
+        self.access_log.info(
+            "http_request",
+            extra={
+                # ProxyFixer has already resolved the hashed client IP into
+                # REMOTE_ADDR_HASHED (and stripped the CDN headers) by the
+                # time the access hook runs; never log the raw address unless
+                # no hash is available (e.g. very early requests).
+                "remote_addr": environ.get("REMOTE_ADDR_HASHED")
+                or environ.get("REMOTE_ADDR"),
+                "method": environ.get("REQUEST_METHOD"),
+                "path": environ.get("PATH_INFO"),
+                "query": environ.get("QUERY_STRING"),
+                # PATH_INFO is percent-decoded; keep the exact wire bytes too,
+                # since probes hide in the encoding (e.g. /simple/foo%2E%2E/).
+                "raw_uri": environ.get("RAW_URI"),
+                "protocol": environ.get("SERVER_PROTOCOL"),
+                "status": status,
+                "size": getattr(resp, "sent", None),
+                "referrer": environ.get("HTTP_REFERER"),
+                "user_agent": environ.get("HTTP_USER_AGENT"),
+                # Resolved by ProxyFixer from the CDN's GeoIP headers.
+                "country": environ.get("GEOIP_COUNTRY_CODE"),
+                "duration_ms": request_time.total_seconds() * 1000,
+                # Stashed by request_context_tween so access lines join the
+                # app logs emitted during the same request.
+                "request.id": environ.get("warehouse.request_id"),
+            },
+        )
 
 
-class StructlogFormatter(logging.Formatter):
-    def format(self, record):
-        # TODO: Figure out a better way of handling this besides just looking
-        #       at the logger name, ideally this would have some way to
-        #       really differentiate between log items which were logged by
-        #       structlog and which were not.
-        if not record.name.startswith("warehouse."):
-            # TODO: Is there a better way to handle this? Maybe we can figure
-            #       out a way to pass this through the structlog processors
-            #       instead of manually duplicating the side effects here?
-            event_dict = {
-                "logger": record.name,
-                "level": record.levelname,
-                "event": record.msg,
-                "thread": threading.get_ident(),
-            }
-            record.msg = RENDERER(None, record.levelname, event_dict)
+def request_context_tween_factory(
+    handler: typing.Callable[[Request], Response], registry: Registry
+) -> typing.Callable[[Request], Response]:
+    """
+    Bind the request id into structlog's contextvars for the duration of the
+    request, so module-level loggers used during request handling carry it too.
+    """
 
-        return super().format(record)
+    def request_context_tween(request: Request) -> Response:
+        # The environ outlives the request: gunicorn's access hook reads the
+        # stashed id after the tween chain (and its contextvars) unwound.
+        request.environ["warehouse.request_id"] = request.id
+
+        # This has to use **{} because request.id is not an allowed kwarg name.
+        with structlog.contextvars.bound_contextvars(**{"request.id": request.id}):
+            return handler(request)
+
+    return request_context_tween
 
 
 def _create_id(request):
@@ -37,18 +92,55 @@ def _create_id(request):
 
 
 def _create_logger(request):
-    # This has to use **{} instead of just a kwarg because request.id is not
-    # an allowed kwarg name.
-    return request_logger.bind(**{"request.id": request.id})
+    # request.id arrives via contextvars (bound by the tween below, or by
+    # WarehouseTask.get_request in workers), so no per-request bind is needed.
+    return request_logger
 
 
-def includeme(config):
-    # Configure the standard library logging
+def includeme(config: Configurator) -> None:
+    settings = config.registry.settings
+
+    # Render logs as aligned, colored columns in development, and as JSON
+    # everywhere else so the aggregator receives one parseable object per line.
+    if settings.get("warehouse.env") == Environment.development:
+        renderer: structlog.typing.Processor = structlog.dev.ConsoleRenderer()
+    else:
+        renderer = structlog.processors.JSONRenderer()
+
+    level = settings.get("logging.level", "INFO")
+
+    # Applied to every record, structlog-born and foreign alike, so both
+    # populations end up with the same shape.
+    shared_processors: list[structlog.typing.Processor] = [
+        structlog.contextvars.merge_contextvars,
+        structlog.stdlib.add_logger_name,
+        structlog.stdlib.add_log_level,
+        structlog.processors.TimeStamper(fmt="iso"),
+        structlog.processors.format_exc_info,
+    ]
+
+    # Normalizes log records that did not originate from structlog (gunicorn,
+    # celery, any library using logging.getLogger) into event dicts, before
+    # the shared renderer sees them. ExtraAdder lifts `extra={...}` kwargs
+    # into the event dict.
+    foreign_pre_chain = [*shared_processors, structlog.stdlib.ExtraAdder()]
+
+    # Configure the standard library logging: a single handler whose
+    # ProcessorFormatter renders structlog-born and foreign records alike.
     logging.config.dictConfig(
         {
             "version": 1,
             "disable_existing_loggers": False,
-            "formatters": {"structlog": {"()": "warehouse.logging.StructlogFormatter"}},
+            "formatters": {
+                "structlog": {
+                    "()": structlog.stdlib.ProcessorFormatter,
+                    "processors": [
+                        structlog.stdlib.ProcessorFormatter.remove_processors_meta,
+                        renderer,
+                    ],
+                    "foreign_pre_chain": foreign_pre_chain,
+                }
+            },
             "handlers": {
                 "primary": {
                     "class": "logging.StreamHandler",
@@ -61,36 +153,32 @@ def includeme(config):
                 "gunicorn": {
                     "propagate": False,
                     "handlers": ["primary"],
-                    "level": config.registry.settings.get("logging.level", "INFO"),
+                    "level": level,
                 },
                 "gunicorn.access": {
                     "propagate": False,
                     "handlers": ["primary"],
-                    "level": config.registry.settings.get("logging.level", "INFO"),
+                    "level": level,
                 },
-                "gunicorn.server": {
+                "gunicorn.error": {
                     "propagate": False,
                     "handlers": ["primary"],
-                    "level": config.registry.settings.get("logging.level", "INFO"),
+                    "level": level,
                 },
             },
-            "root": {
-                "level": config.registry.settings.get("logging.level", "INFO"),
-                "handlers": ["primary"],
-            },
+            "root": {"level": level, "handlers": ["primary"]},
         }
     )
 
-    # Configure structlog
+    # Configure structlog: build event dicts and hand them to the
+    # ProcessorFormatter above instead of rendering here.
     structlog.configure(
         processors=[
             structlog.stdlib.filter_by_level,
-            structlog.stdlib.add_logger_name,
-            structlog.stdlib.add_log_level,
             structlog.stdlib.PositionalArgumentsFormatter(),
             structlog.processors.StackInfoRenderer(),
-            structlog.processors.format_exc_info,
-            RENDERER,
+            *shared_processors,
+            structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
         ],
         logger_factory=structlog.stdlib.LoggerFactory(),
         wrapper_class=structlog.stdlib.BoundLogger,
@@ -102,3 +190,7 @@ def includeme(config):
 
     # Add a log method to every request.
     config.add_request_method(_create_logger, name="log", reify=True)
+
+    # Make the request id ambient context for all loggers during a request,
+    # including exception views.
+    config.add_tween("warehouse.logging.request_context_tween_factory", over=EXCVIEW)

--- a/warehouse/tasks.py
+++ b/warehouse/tasks.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import functools
 import hashlib
-import logging
 import time
 import typing
 import urllib.parse
@@ -16,9 +15,11 @@ import celery.app.backends
 import celery.backends.redis
 import pyramid.scripting
 import pyramid_retry
+import structlog
 import transaction
 import venusian
 
+from celery import signals
 from kombu import Queue
 from pyramid.threadlocal import get_current_request
 
@@ -34,7 +35,14 @@ if typing.TYPE_CHECKING:
 celery.app.backends.BACKEND_ALIASES["rediss"] = "warehouse.tasks:TLSRedisBackend"
 
 
-logger = logging.getLogger(__name__)
+def on_task_prerun(sender, task_id, task, **kwargs) -> None:
+    """Bind task metadata into contextvars for all logs within the task."""
+    structlog.contextvars.bind_contextvars(task_id=task_id, task_name=task.name)
+
+
+def on_task_postrun(sender, task_id, task, **kwargs) -> None:
+    """Clear contextvars so nothing leaks into the next task on this worker."""
+    structlog.contextvars.clear_contextvars()
 
 
 class TLSRedisBackend(celery.backends.redis.RedisBackend):
@@ -122,6 +130,9 @@ class WarehouseTask(celery.Task):
             env["request"].remote_addr_hashed = hashlib.sha256(
                 ("127.0.0.1" + registry.settings["warehouse.ip_salt"]).encode("utf8")
             ).hexdigest()
+            # The request id joins the task_id/task_name bound at prerun, and
+            # is cleared with them at postrun.
+            structlog.contextvars.bind_contextvars(**{"request.id": env["request"].id})
             self.request.update(pyramid_env=env)
 
         return self.request.pyramid_env["request"]  # type: ignore[attr-defined]
@@ -303,9 +314,15 @@ def includeme(config: Configurator) -> None:
         REDBEAT_REDIS_URL=s["celery.scheduler_url"],
         # Silence deprecation warning on startup
         broker_connection_retry_on_startup=False,
+        # Keep the logging configured by warehouse.logging instead of letting
+        # celery replace the root logger's handlers at worker boot.
+        worker_hijack_root_logger=False,
     )
     config.registry["celery.app"].Task = WarehouseTask
     config.registry["celery.app"].pyramid_config = config
+
+    signals.task_prerun.connect(on_task_prerun)
+    signals.task_postrun.connect(on_task_postrun)
 
     config.action(("celery", "finalize"), config.registry["celery.app"].finalize)
 


### PR DESCRIPTION
One formatter for every record: structlog, gunicorn, celery, and stdlib loggers all render as console columns in dev and JSON in prod. A tween binds request.id and celery signals bind task_id/task_name into contextvars, so ambient context reaches every log line, and can be tracked across log lines for a given request/task.

Access logs switch from `access_log_format` to `GunicornLogger`, emitting `http_request` events with queryable fields, including the `request.id` of the app logs from the same request. Their shape changes from Apache combined format to JSON, so update log consumers that parse the old format.

Resolves #16246
Closes #18843
Closes #18844