### PR TITLE
feat(admin): add project lifecycle to user and org projects 

### DIFF
--- a/warehouse/admin/static/js/tabulator.js
+++ b/warehouse/admin/static/js/tabulator.js
@@ -1,0 +1,29 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+import { TabulatorFull as Tabulator } from "tabulator-tables";
+
+import filesize from "./utils/filesize";
+
+// Cells hold raw byte counts so `tabulator-sorter="number"` orders them
+// correctly, while the column still displays a human-readable size.
+Tabulator.extendModule("format", "formatters", {
+  filesize: (cell) => filesize(cell.getValue()),
+});
+
+// Opt a server-rendered table in with `data-tabulator`. Everything else comes
+// from `tabulator-*` attributes on the <table> and its <th> elements, so
+// adding a table needs no JavaScript of its own. Tabulator takes column
+// titles from the header text and derives each field from it ("Total Size"
+// becomes `total_size`), and takes cell values from the cell's innerHTML.
+// Columns carrying links or badges need `tabulator-formatter="html"` to render
+// as markup rather than as escaped text; only reach for it where the cell holds
+// template-rendered markup, since the value is re-injected as innerHTML.
+//
+// `tabulator-responsiveLayout="collapse"` folds columns that do not fit into a
+// labelled block under each row, ordered by per-column `tabulator-responsive`
+// priorities (higher numbers fold first). It has no effect under
+// `tabulator-layout="fitColumns"`, which shrinks columns instead of ever
+// overflowing — pair it with `fitDataFill`.
+document.querySelectorAll("table[data-tabulator]").forEach(function (table) {
+  new Tabulator(table);
+});

--- a/warehouse/admin/static/js/utils/filesize.js
+++ b/warehouse/admin/static/js/utils/filesize.js
@@ -1,0 +1,20 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+const UNITS = ["B", "KiB", "MiB", "GiB", "TiB"];
+
+/**
+ * Render a byte count in binary units, e.g. 1288490188 -> "1.2 GiB".
+ *
+ * Accepts strings so it can format values read out of table cells. Whole
+ * bytes are shown without a decimal, larger units with one.
+ */
+export default function filesize(bytes) {
+  let size = Number(bytes);
+  let unit = 0;
+  while (size >= 1024 && unit < UNITS.length - 1) {
+    size /= 1024;
+    unit++;
+  }
+
+  return `${unit === 0 ? size : size.toFixed(1)} ${UNITS[unit]}`;
+}

--- a/warehouse/admin/static/js/warehouse.js
+++ b/warehouse/admin/static/js/warehouse.js
@@ -28,6 +28,7 @@ import "./journals";
 
 // Get our timeago function
 import timeAgo from "warehouse/utils/timeago";
+import filesize from "./utils/filesize";
 
 // Human-readable timestamps
 $(document).ready(function() {
@@ -388,11 +389,7 @@ if (userFilesModal.length) {
         let content = data.files.join("\n");
         $("#userFilesContent").text(content);
 
-        let sizes = ["B", "KiB", "MiB", "GiB", "TiB"];
-        let size = data.total_size;
-        let i = 0;
-        while (size >= 1024 && i < sizes.length - 1) { size /= 1024; i++; }
-        let sizeStr = (i === 0 ? size : size.toFixed(1)) + " " + sizes[i];
+        let sizeStr = filesize(data.total_size);
 
         $("#userFilesSummary").html(
           "<strong>" + data.file_count + "</strong> files (" +

--- a/warehouse/admin/static/js/warehouse.js
+++ b/warehouse/admin/static/js/warehouse.js
@@ -25,6 +25,7 @@ import "./treeview";
 import "./observer_charts";
 import "./project_charts";
 import "./journals";
+import "./tabulator";
 
 // Get our timeago function
 import timeAgo from "warehouse/utils/timeago";

--- a/warehouse/admin/templates/admin/organizations/detail.html
+++ b/warehouse/admin/templates/admin/organizations/detail.html
@@ -697,18 +697,26 @@
 
         <div class="card-body">
           {% if organization.projects %}
-          <table class="table table-hover">
+          <table class="table table-hover"
+                 data-tabulator
+                 tabulator-layout="fitDataFill"
+                 tabulator-responsiveLayout="collapse"
+                 tabulator-pagination="true"
+                 tabulator-paginationSize="25"
+                 tabulator-placeholder="No matching projects">
             <thead>
               <tr>
-                <th>Project Name</th>
-                <th>Total Size</th>
+                <th tabulator-formatter="html" tabulator-headerFilter="input">Project Name</th>
+                <th tabulator-formatter="html" tabulator-headerFilter="input">Lifecycle Status</th>
+                <th tabulator-formatter="filesize" tabulator-sorter="number" tabulator-responsive="2">Total Size</th>
               </tr>
             </thead>
             <tbody>
             {% for project in organization.projects %}
               <tr>
                 <td><a href="{{ request.route_path('admin.project.detail', project_name=project.normalized_name) }}">{{ project.name }}</a></td>
-                <td>{{ project.total_size | filesizeformat(binary=True) }}</td>
+                <td>{% if project.lifecycle_status %}<span class="badge {{ 'badge-warning' if project.lifecycle_status == 'quarantine-enter' else 'badge-secondary' }}">{{ project.lifecycle_status }}</span>{% endif %}</td>
+                <td>{{ project.total_size or 0 }}</td>
               </tr>
             {% endfor %}
             </tbody>

--- a/warehouse/admin/templates/admin/users/detail.html
+++ b/warehouse/admin/templates/admin/users/detail.html
@@ -970,12 +970,20 @@
 
         <div class="card-body">
           {% if roles %}
-          <table class="table table-hover" id="projects">
+          <table class="table table-hover" id="projects"
+                 data-tabulator
+                 tabulator-layout="fitDataFill"
+                 tabulator-responsiveLayout="collapse"
+                 tabulator-pagination="true"
+                 tabulator-paginationSize="25"
+                 tabulator-placeholder="No matching projects">
             <thead>
               <tr>
-                <th>Project Name</th>
-                <th>Role</th>
-                <th>Total Size</th>
+                <th tabulator-formatter="html" tabulator-headerFilter="input">Project Name</th>
+                <th tabulator-headerFilter="input" tabulator-responsive="2">Role</th>
+                <th tabulator-formatter="html" tabulator-headerFilter="input">Lifecycle Status</th>
+                <th tabulator-sorter="number" tabulator-responsive="4">Releases</th>
+                <th tabulator-formatter="filesize" tabulator-sorter="number" tabulator-responsive="3">Total Size</th>
               </tr>
             </thead>
             <tbody>
@@ -983,7 +991,9 @@
               <tr>
                 <td><a href="{{ request.route_path('admin.project.detail', project_name=project.normalized_name) }}">{{ project.name }}</a></td>
                 <td>{{ project.role_name }}</td>
-                <td>{{ project.total_size | filesizeformat(binary=True) }}</td>
+                <td>{% if project.lifecycle_status %}<span class="badge {{ 'badge-warning' if project.lifecycle_status == 'quarantine-enter' else 'badge-secondary' }}">{{ project.lifecycle_status }}</span>{% endif %}</td>
+                <td>{{ project.releases_count }}</td>
+                <td>{{ project.total_size or 0 }}</td>
               </tr>
             {% endfor %}
             </tbody>


### PR DESCRIPTION
Converts Project card's table to a generic Tabulator table.

Drops the use of `filesizeformat` jinja helper here, since then the data isn't sortable as an integer, and uses the `filesize` client-side formatter instead.

Resolves #20295
Closes #20335