### PR TITLE
Update organization accounts intro

### DIFF
--- a/docs/user/organization-accounts/index.md
+++ b/docs/user/organization-accounts/index.md
@@ -4,10 +4,8 @@ title: About
 
 # PyPI Organization Accounts
 
-Organization accounts are coming to PyPI.
-In an organization account,
-users from an organization or community project
-can assemble into teams and collaborate on projects.
+PyPI organization accounts let users from an organization or community project
+assemble into teams and collaborate on projects.
 
 ## Motivation
 


### PR DESCRIPTION
## Summary

Updates the organization accounts documentation intro to remove stale future-tense wording.

The page previously said:

> Organization accounts are coming to PyPI.

Organization accounts are now available on PyPI, so this PR updates the intro to describe them as an existing feature.

Closes #19413

## Testing

Documentation-only change.

Ran:

```bash
git diff --check
```

Result: 
no output.