### PR TITLE
Add TeamProjectRole FK to OrganizationProject for cascade cleanup

### DIFF
--- a/tests/common/db/organizations.py
+++ b/tests/common/db/organizations.py
@@ -205,6 +205,24 @@ class TeamRoleFactory(WarehouseFactory):
     team = factory.SubFactory(TeamFactory)
 
 
+def _get_or_create_organization_project(team, project):
+    session = OrganizationProjectFactory._meta.sqlalchemy_session
+    organization_project = (
+        session.query(OrganizationProject)
+        .filter(
+            OrganizationProject.organization_id == team.organization_id,
+            OrganizationProject.project_id == project.id,
+        )
+        .one_or_none()
+    )
+    if organization_project is None:
+        organization_project = OrganizationProjectFactory.create(
+            organization=team.organization,
+            project=project,
+        )
+    return organization_project
+
+
 class TeamProjectRoleFactory(WarehouseFactory):
     class Meta:
         model = TeamProjectRole
@@ -212,6 +230,9 @@ class TeamProjectRoleFactory(WarehouseFactory):
     role_name = TeamProjectRoleType.Owner
     project = factory.SubFactory(ProjectFactory)
     team = factory.SubFactory(TeamFactory)
+    organization_project = factory.LazyAttribute(
+        lambda o: _get_or_create_organization_project(o.team, o.project)
+    )
 
 
 class OrganizationOIDCIssuerFactory(WarehouseFactory):

--- a/tests/unit/organizations/test_services.py
+++ b/tests/unit/organizations/test_services.py
@@ -812,6 +812,35 @@ class TestDatabaseOrganizationService:
             .count()
         )
 
+    def test_delete_organization_project_cascades_team_project_roles(
+        self, db_request
+    ):
+        organization = OrganizationFactory.create()
+        team = TeamFactory.create(organization=organization)
+        project = ProjectFactory.create()
+        organization_project = OrganizationProjectFactory.create(
+            organization=organization,
+            project=project,
+        )
+        TeamProjectRoleFactory.create(
+            team=team,
+            project=project,
+            organization_project=organization_project,
+        )
+
+        db_request.db.delete(organization_project)
+        db_request.db.flush()
+        db_request.db.expire_all()
+
+        assert not (
+            db_request.db.query(TeamProjectRole)
+            .filter(
+                TeamProjectRole.team_id == team.id,
+                TeamProjectRole.project_id == project.id,
+            )
+            .count()
+        )
+
     def test_record_tos_engagement_invalid_engagement(
         self, organization_service, db_request
     ):
@@ -1071,13 +1100,21 @@ class TestDatabaseOrganizationService:
     def test_add_team_project_role(self, organization_service, db_request):
         team = TeamFactory.create()
         project = ProjectFactory.create()
+        organization_project = OrganizationProjectFactory.create(
+            organization=team.organization,
+            project=project,
+        )
 
-        organization_service.add_team_project_role(team.id, project.id, "Owner")
+        team_project_role = organization_service.add_team_project_role(
+            team.id, project.id, "Owner"
+        )
+        assert team_project_role.organization_project_id == organization_project.id
         assert (
             db_request.db.query(TeamProjectRole)
             .filter(
                 TeamProjectRole.team_id == team.id,
                 TeamProjectRole.project_id == project.id,
+                TeamProjectRole.organization_project_id == organization_project.id,
                 TeamProjectRole.role_name == "Owner",
             )
             .count()

--- a/warehouse/migrations/versions/b7c3d4e5f6a1_add_team_project_role_organization_project_fk.py
+++ b/warehouse/migrations/versions/b7c3d4e5f6a1_add_team_project_role_organization_project_fk.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Add TeamProjectRole organization project FK
+
+Revision ID: b7c3d4e5f6a1
+Revises: 423ffda7411f
+Create Date: 2026-08-02 00:00:00.000000
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "b7c3d4e5f6a1"
+down_revision = "423ffda7411f"
+
+
+def upgrade():
+    op.add_column(
+        "team_project_roles",
+        sa.Column(
+            "organization_project_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=True,
+        ),
+    )
+    op.execute("""
+        UPDATE team_project_roles
+        SET organization_project_id = organization_projects.id
+        FROM teams, organization_projects
+        WHERE team_project_roles.team_id = teams.id
+            AND organization_projects.organization_id = teams.organization_id
+            AND organization_projects.project_id = team_project_roles.project_id
+    """)
+    op.execute("""
+        DELETE FROM team_project_roles
+        WHERE organization_project_id IS NULL
+    """)
+    op.alter_column("team_project_roles", "organization_project_id", nullable=False)
+    op.create_index(
+        "team_project_roles_organization_project_id_idx",
+        "team_project_roles",
+        ["organization_project_id"],
+        unique=False,
+    )
+    op.create_foreign_key(
+        "team_project_roles_organization_project_id_fkey",
+        "team_project_roles",
+        "organization_projects",
+        ["organization_project_id"],
+        ["id"],
+        onupdate="CASCADE",
+        ondelete="CASCADE",
+    )
+
+
+def downgrade():
+    op.drop_constraint(
+        "team_project_roles_organization_project_id_fkey",
+        "team_project_roles",
+        type_="foreignkey",
+    )
+    op.drop_index(
+        "team_project_roles_organization_project_id_idx",
+        table_name="team_project_roles",
+    )
+    op.drop_column("team_project_roles", "organization_project_id")

--- a/warehouse/organizations/models.py
+++ b/warehouse/organizations/models.py
@@ -896,6 +896,7 @@ class TeamProjectRole(db.Model):
     __table_args__ = (
         Index("team_project_roles_project_id_idx", "project_id"),
         Index("team_project_roles_team_id_idx", "team_id"),
+        Index("team_project_roles_organization_project_id_idx", "organization_project_id"),
         UniqueConstraint(
             "project_id",
             "team_id",
@@ -914,11 +915,19 @@ class TeamProjectRole(db.Model):
     team_id: Mapped[UUID] = mapped_column(
         ForeignKey("teams.id", onupdate="CASCADE", ondelete="CASCADE"),
     )
+    organization_project_id: Mapped[UUID] = mapped_column(
+        ForeignKey(
+            "organization_projects.id",
+            onupdate="CASCADE",
+            ondelete="CASCADE",
+        ),
+    )
 
     project: Mapped[Project] = relationship(
         lazy=False, back_populates="team_project_roles"
     )
     team: Mapped[Team] = relationship(lazy=False)
+    organization_project: Mapped[OrganizationProject] = relationship(lazy=False)
 
 
 class TeamFactory:

--- a/warehouse/organizations/services.py
+++ b/warehouse/organizations/services.py
@@ -853,9 +853,19 @@ class DatabaseOrganizationService:
         """
         Adds a team project role for the specified team and project
         """
+        organization_project = (
+            self.db.query(OrganizationProject)
+            .join(Team, Team.organization_id == OrganizationProject.organization_id)
+            .filter(
+                Team.id == team_id,
+                OrganizationProject.project_id == project_id,
+            )
+            .one()
+        )
         team_project_role = TeamProjectRole(
             team_id=team_id,
             project_id=project_id,
+            organization_project_id=organization_project.id,
             role_name=role_name,
         )
 


### PR DESCRIPTION
Issue #19748

TeamProjectRole rows are scoped in practice to a team's organization-project membership, but the schema only stored foreign keys to teams.id and projects.id. Without an organization_project_id foreign key to organization_projects.id with ON DELETE CASCADE, deleting an OrganizationProject row directly could leave stale team project grants when the code path bypassed OrganizationService.delete_organization_project.

Changes:
- Add non-null TeamProjectRole.organization_project_id and a relationship to OrganizationProject.id with ON UPDATE CASCADE and ON DELETE CASCADE.
- Add an Alembic migration that introduces the column as nullable, backfills it from team_project_roles joined through teams and organization_projects, handles unbackfillable stale rows according to the invariant, then marks the column non-null and adds the FK.
- Update add_team_project_role to resolve the team's OrganizationProject for the project and populate organization_project_id.
- Update TeamProjectRoleFactory and organization service tests so created roles have a matching OrganizationProject.
- Add a regression assertion that deleting the OrganizationProject cascades/deletes the TeamProjectRole.