### PR TITLE
Deduplicate password validation user lookup

### DIFF
--- a/tests/unit/accounts/test_forms.py
+++ b/tests/unit/accounts/test_forms.py
@@ -1220,7 +1220,9 @@ class TestReAuthenticateForm:
 
     def test_validate_ignores_posted_username(self):
         user_service = pretend.stub(
-            find_userid=pretend.call_recorder(lambda username: 2),
+            find_userid=pretend.call_recorder(
+                pretend.raiser(AssertionError("find_userid should not be called"))
+            ),
             check_password=pretend.call_recorder(
                 lambda userid, password, tags=None: True
             ),

--- a/warehouse/accounts/forms.py
+++ b/warehouse/accounts/forms.py
@@ -194,11 +194,14 @@ class PasswordMixin:
         self._check_password_metrics_tags = check_password_metrics_tags
         super().__init__(*args, **kwargs)
 
+    def _get_password_userid(self):
+        return self.user_service.find_userid(self.username.data)
+
     def validate_password(self, field):
         if field.errors:
             return
 
-        userid = self.user_service.find_userid(self.username.data)
+        userid = self._get_password_userid()
         if userid is not None:
             try:
                 if not self.user_service.check_password(
@@ -581,34 +584,8 @@ class ReAuthenticateForm(PasswordMixin, wtforms.Form):
         self.user_id = user_id
         self.user_service = user_service
 
-    def validate_password(self, field):
-        if field.errors:
-            return
-
-        try:
-            if not self.user_service.check_password(
-                self.user_id,
-                field.data,
-                tags=self._check_password_metrics_tags,
-            ):
-                user = self.user_service.get_user(self.user_id)
-                user.record_event(
-                    tag=f"account:{self.action}:failure",
-                    request=self.request,
-                    additional={"reason": "invalid_password"},
-                )
-                raise wtforms.validators.ValidationError(INVALID_PASSWORD_MESSAGE)
-        except TooManyFailedLogins as err:
-            raise wtforms.validators.ValidationError(
-                _(
-                    "There have been too many unsuccessful login attempts. "
-                    "You have been locked out for ${time}. "
-                    "Please try again later.",
-                    mapping={
-                        "time": humanize.naturaldelta(err.resets_in.total_seconds())
-                    },
-                )
-            ) from None
+    def _get_password_userid(self):
+        return self.user_id
 
 
 class RecoveryCodeAuthenticationForm(


### PR DESCRIPTION
This removes the duplicated `validate_password` implementation between `PasswordMixin` and `ReAuthenticateForm`.

`PasswordMixin.validate_password` now calls a small overridable helper to resolve the user id before `check_password`. The default helper preserves the existing username-based lookup with `self.user_service.find_userid(self.username.data)`, so `LoginForm` and manage forms continue using their current password validation path.

`ReAuthenticateForm` now overrides only that helper to return the server-supplied `self.user_id`, preserving its existing behavior of avoiding identity resolution from client-submitted username data while reusing the shared password-checking, failure-event, and lockout-message logic.

Files changed:
- `warehouse/accounts/forms.py`
- `tests/unit/accounts/test_forms.py`

`ruff check tests/unit/accounts/test_forms.py warehouse/accounts/forms.py` reports no new findings on the changed files.
Ran `pytest -x` locally with no new failures.
